### PR TITLE
Add agent params to all obj interface fcns that return errors

### DIFF
--- a/src/boolean_object/mod.rs
+++ b/src/boolean_object/mod.rs
@@ -44,7 +44,7 @@ impl ObjectInterface for BooleanObject {
         true
     }
 
-    fn get_prototype_of(&self) -> AltCompletion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &mut Agent) -> AltCompletion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
 
@@ -54,7 +54,7 @@ impl ObjectInterface for BooleanObject {
     // the following steps when called:
     //
     //  1. Return ! OrdinarySetPrototypeOf(O, V).
-    fn set_prototype_of(&self, obj: Option<&Object>) -> AltCompletion<bool> {
+    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<&Object>) -> AltCompletion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
 
@@ -64,7 +64,7 @@ impl ObjectInterface for BooleanObject {
     // when called:
     //
     //  1. Return ! OrdinaryIsExtensible(O).
-    fn is_extensible(&self) -> AltCompletion<bool> {
+    fn is_extensible(&self, _agent: &mut Agent) -> AltCompletion<bool> {
         Ok(ordinary_is_extensible(self))
     }
 
@@ -74,7 +74,7 @@ impl ObjectInterface for BooleanObject {
     // steps when called:
     //
     //  1. Return ! OrdinaryPreventExtensions(O).
-    fn prevent_extensions(&self) -> AltCompletion<bool> {
+    fn prevent_extensions(&self, _agent: &mut Agent) -> AltCompletion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
 
@@ -84,7 +84,7 @@ impl ObjectInterface for BooleanObject {
     // following steps when called:
     //
     //  1. Return ! OrdinaryGetOwnProperty(O, P).
-    fn get_own_property(&self, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(self, key))
     }
 
@@ -94,8 +94,8 @@ impl ObjectInterface for BooleanObject {
     // Property Descriptor). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
-    fn define_own_property(&self, key: &PropertyKey, desc: &PotentialPropertyDescriptor) -> AltCompletion<bool> {
-        ordinary_define_own_property(self, key, desc)
+    fn define_own_property(&self, agent: &mut Agent, key: &PropertyKey, desc: &PotentialPropertyDescriptor) -> AltCompletion<bool> {
+        ordinary_define_own_property(agent, self, key, desc)
     }
 
     // [[HasProperty]] ( P )
@@ -104,8 +104,8 @@ impl ObjectInterface for BooleanObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryHasProperty(O, P).
-    fn has_property(&self, key: &PropertyKey) -> AltCompletion<bool> {
-        ordinary_has_property(self, key)
+    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+        ordinary_has_property(agent, self, key)
     }
 
     // [[Get]] ( P, Receiver )
@@ -115,7 +115,7 @@ impl ObjectInterface for BooleanObject {
     //
     //  1. Return ? OrdinaryGet(O, P, Receiver).
     fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion {
-        ordinary_get(self, agent, key, receiver)
+        ordinary_get(agent, self, key, receiver)
     }
 
     // [[Set]] ( P, V, Receiver )
@@ -125,7 +125,7 @@ impl ObjectInterface for BooleanObject {
     //
     //  1. Return ? OrdinarySet(O, P, V, Receiver).
     fn set(&self, agent: &mut Agent, key: &PropertyKey, v: &ECMAScriptValue, receiver: &ECMAScriptValue) -> AltCompletion<bool> {
-        ordinary_set(self, agent, key, v, receiver)
+        ordinary_set(agent, self, key, v, receiver)
     }
 
     // [[Delete]] ( P )
@@ -134,8 +134,8 @@ impl ObjectInterface for BooleanObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryDelete(O, P).
-    fn delete(&self, key: &PropertyKey) -> AltCompletion<bool> {
-        ordinary_delete(self, key)
+    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+        ordinary_delete(agent, self, key)
     }
 
     // [[OwnPropertyKeys]] ( )
@@ -144,7 +144,7 @@ impl ObjectInterface for BooleanObject {
     // steps when called:
     //
     // 1. Return ! OrdinaryOwnPropertyKeys(O).
-    fn own_property_keys(&self) -> AltCompletion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, _agent: &mut Agent) -> AltCompletion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(self))
     }
 }

--- a/src/boolean_object/tests.rs
+++ b/src/boolean_object/tests.rs
@@ -81,7 +81,7 @@ fn this_boolean_value_06() {
 fn get_prototype_of_01() {
     let mut agent = test_agent();
     let bool_obj = create_boolean_object(&mut agent, true);
-    let proto = bool_obj.o.get_prototype_of().unwrap().unwrap();
+    let proto = bool_obj.o.get_prototype_of(&mut agent).unwrap().unwrap();
     assert_eq!(proto, agent.intrinsic(IntrinsicId::BooleanPrototype));
 }
 
@@ -89,16 +89,16 @@ fn get_prototype_of_01() {
 fn set_prototype_of_01() {
     let mut agent = test_agent();
     let bool_obj = create_boolean_object(&mut agent, true);
-    let res = bool_obj.o.set_prototype_of(None).unwrap();
+    let res = bool_obj.o.set_prototype_of(&mut agent, None).unwrap();
     assert!(res);
-    assert!(bool_obj.o.get_prototype_of().unwrap().is_none());
+    assert!(bool_obj.o.get_prototype_of(&mut agent).unwrap().is_none());
 }
 
 #[test]
 fn is_extensible_01() {
     let mut agent = test_agent();
     let bool_obj = create_boolean_object(&mut agent, true);
-    let res = bool_obj.o.is_extensible().unwrap();
+    let res = bool_obj.o.is_extensible(&mut agent).unwrap();
     assert!(res);
 }
 
@@ -106,19 +106,21 @@ fn is_extensible_01() {
 fn prevent_extensions_01() {
     let mut agent = test_agent();
     let bool_obj = create_boolean_object(&mut agent, true);
-    let res = bool_obj.o.prevent_extensions().unwrap();
+    let res = bool_obj.o.prevent_extensions(&mut agent).unwrap();
     assert!(res);
-    assert!(!bool_obj.o.is_extensible().unwrap());
+    assert!(!bool_obj.o.is_extensible(&mut agent).unwrap());
 }
 
 #[test]
 fn define_and_get_own_property_01() {
     let mut agent = test_agent();
     let bool_obj = create_boolean_object(&mut agent, true);
-    let res =
-        bool_obj.o.define_own_property(&PropertyKey::from("rust"), &PotentialPropertyDescriptor { value: Some(ECMAScriptValue::String("is awesome".into())), ..Default::default() }).unwrap();
+    let res = bool_obj
+        .o
+        .define_own_property(&mut agent, &PropertyKey::from("rust"), &PotentialPropertyDescriptor { value: Some(ECMAScriptValue::String("is awesome".into())), ..Default::default() })
+        .unwrap();
     assert!(res);
-    let val = bool_obj.o.get_own_property(&PropertyKey::from("rust")).unwrap().unwrap();
+    let val = bool_obj.o.get_own_property(&mut agent, &PropertyKey::from("rust")).unwrap().unwrap();
     assert_eq!(val.enumerable, false);
     assert_eq!(val.configurable, false);
     assert!(matches!(val.property, PropertyKind::Data(..)));
@@ -132,9 +134,9 @@ fn define_and_get_own_property_01() {
 fn has_property_01() {
     let mut agent = test_agent();
     let bool_obj = create_boolean_object(&mut agent, true);
-    let res = bool_obj.o.has_property(&PropertyKey::from("rust")).unwrap();
+    let res = bool_obj.o.has_property(&mut agent, &PropertyKey::from("rust")).unwrap();
     assert_eq!(res, false);
-    let res2 = bool_obj.o.has_property(&PropertyKey::from("constructor")).unwrap();
+    let res2 = bool_obj.o.has_property(&mut agent, &PropertyKey::from("constructor")).unwrap();
     assert_eq!(res2, true);
 }
 
@@ -164,7 +166,7 @@ fn set_01() {
 fn delete_01() {
     let mut agent = test_agent();
     let bool_obj = create_boolean_object(&mut agent, true);
-    let res = bool_obj.o.delete(&PropertyKey::from("rust")).unwrap();
+    let res = bool_obj.o.delete(&mut agent, &PropertyKey::from("rust")).unwrap();
     assert_eq!(res, true);
 }
 
@@ -172,7 +174,7 @@ fn delete_01() {
 fn own_keys_01() {
     let mut agent = test_agent();
     let bool_obj = create_boolean_object(&mut agent, true);
-    let res = bool_obj.o.own_property_keys().unwrap();
+    let res = bool_obj.o.own_property_keys(&mut agent).unwrap();
     assert!(res.is_empty())
 }
 

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -1,3 +1,4 @@
+use crate::agent::Agent;
 use crate::cr::AltCompletion;
 use crate::object::ObjectInterface;
 
@@ -9,9 +10,9 @@ use crate::object::ObjectInterface;
 //
 //  1. Assert: Type(O) is Object.
 //  2. Return ? O.[[IsExtensible]]().
-pub fn is_extensible<'a, T>(obj: T) -> AltCompletion<bool>
+pub fn is_extensible<'a, T>(agent: &mut Agent, obj: T) -> AltCompletion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
-    obj.into().is_extensible()
+    obj.into().is_extensible(agent)
 }

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -85,37 +85,37 @@ impl ObjectInterface for ErrorObject {
         true
     }
 
-    fn get_prototype_of(&self) -> AltCompletion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &mut Agent) -> AltCompletion<Option<Object>> {
         Ok(ordinary_get_prototype_of(&*self))
     }
-    fn set_prototype_of(&self, obj: Option<&Object>) -> AltCompletion<bool> {
+    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<&Object>) -> AltCompletion<bool> {
         Ok(ordinary_set_prototype_of(&*self, obj))
     }
-    fn is_extensible(&self) -> AltCompletion<bool> {
+    fn is_extensible(&self, _agent: &mut Agent) -> AltCompletion<bool> {
         Ok(ordinary_is_extensible(&*self))
     }
-    fn prevent_extensions(&self) -> AltCompletion<bool> {
+    fn prevent_extensions(&self, _agent: &mut Agent) -> AltCompletion<bool> {
         Ok(ordinary_prevent_extensions(&*self))
     }
-    fn get_own_property(&self, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(&*self, key))
     }
-    fn define_own_property(&self, key: &PropertyKey, desc: &PotentialPropertyDescriptor) -> AltCompletion<bool> {
-        ordinary_define_own_property(&*self, key, desc)
+    fn define_own_property(&self, agent: &mut Agent, key: &PropertyKey, desc: &PotentialPropertyDescriptor) -> AltCompletion<bool> {
+        ordinary_define_own_property(agent, &*self, key, desc)
     }
-    fn has_property(&self, key: &PropertyKey) -> AltCompletion<bool> {
-        ordinary_has_property(&*self, key)
+    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+        ordinary_has_property(agent, &*self, key)
     }
     fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion {
-        ordinary_get(&*self, agent, key, receiver)
+        ordinary_get(agent, &*self, key, receiver)
     }
     fn set(&self, agent: &mut Agent, key: &PropertyKey, v: &ECMAScriptValue, receiver: &ECMAScriptValue) -> AltCompletion<bool> {
-        ordinary_set(&*self, agent, key, v, receiver)
+        ordinary_set(agent, &*self, key, v, receiver)
     }
-    fn delete(&self, key: &PropertyKey) -> AltCompletion<bool> {
-        ordinary_delete(&*self, key)
+    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+        ordinary_delete(agent, &*self, key)
     }
-    fn own_property_keys(&self) -> AltCompletion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, _agent: &mut Agent) -> AltCompletion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(self))
     }
 }

--- a/src/function_object/mod.rs
+++ b/src/function_object/mod.rs
@@ -96,37 +96,37 @@ impl ObjectInterface for FunctionObject {
         true
     }
 
-    fn get_prototype_of(&self) -> AltCompletion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &mut Agent) -> AltCompletion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
-    fn set_prototype_of(&self, obj: Option<&Object>) -> AltCompletion<bool> {
+    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<&Object>) -> AltCompletion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
-    fn is_extensible(&self) -> AltCompletion<bool> {
+    fn is_extensible(&self, _agent: &mut Agent) -> AltCompletion<bool> {
         Ok(ordinary_is_extensible(self))
     }
-    fn prevent_extensions(&self) -> AltCompletion<bool> {
+    fn prevent_extensions(&self, _agent: &mut Agent) -> AltCompletion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
-    fn get_own_property(&self, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(self, key))
     }
-    fn define_own_property(&self, key: &PropertyKey, desc: &PotentialPropertyDescriptor) -> AltCompletion<bool> {
-        ordinary_define_own_property(self, key, desc)
+    fn define_own_property(&self, agent: &mut Agent, key: &PropertyKey, desc: &PotentialPropertyDescriptor) -> AltCompletion<bool> {
+        ordinary_define_own_property(agent, self, key, desc)
     }
-    fn has_property(&self, key: &PropertyKey) -> AltCompletion<bool> {
-        ordinary_has_property(self, key)
+    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+        ordinary_has_property(agent, self, key)
     }
     fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion {
-        ordinary_get(self, agent, key, receiver)
+        ordinary_get(agent, self, key, receiver)
     }
     fn set(&self, agent: &mut Agent, key: &PropertyKey, v: &ECMAScriptValue, receiver: &ECMAScriptValue) -> AltCompletion<bool> {
-        ordinary_set(self, agent, key, v, receiver)
+        ordinary_set(agent, self, key, v, receiver)
     }
-    fn delete(&self, key: &PropertyKey) -> AltCompletion<bool> {
-        ordinary_delete(self, key)
+    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+        ordinary_delete(agent, self, key)
     }
-    fn own_property_keys(&self) -> AltCompletion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, _agent: &mut Agent) -> AltCompletion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(self))
     }
 }
@@ -346,37 +346,37 @@ impl ObjectInterface for BuiltInFunctionObject {
         true
     }
 
-    fn get_prototype_of(&self) -> AltCompletion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &mut Agent) -> AltCompletion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
-    fn set_prototype_of(&self, obj: Option<&Object>) -> AltCompletion<bool> {
+    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<&Object>) -> AltCompletion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
-    fn is_extensible(&self) -> AltCompletion<bool> {
+    fn is_extensible(&self, _agent: &mut Agent) -> AltCompletion<bool> {
         Ok(ordinary_is_extensible(self))
     }
-    fn prevent_extensions(&self) -> AltCompletion<bool> {
+    fn prevent_extensions(&self, _agent: &mut Agent) -> AltCompletion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
-    fn get_own_property(&self, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(self, key))
     }
-    fn define_own_property(&self, key: &PropertyKey, desc: &PotentialPropertyDescriptor) -> AltCompletion<bool> {
-        ordinary_define_own_property(self, key, desc)
+    fn define_own_property(&self, agent: &mut Agent, key: &PropertyKey, desc: &PotentialPropertyDescriptor) -> AltCompletion<bool> {
+        ordinary_define_own_property(agent, self, key, desc)
     }
-    fn has_property(&self, key: &PropertyKey) -> AltCompletion<bool> {
-        ordinary_has_property(self, key)
+    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+        ordinary_has_property(agent, self, key)
     }
     fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion {
-        ordinary_get(self, agent, key, receiver)
+        ordinary_get(agent, self, key, receiver)
     }
     fn set(&self, agent: &mut Agent, key: &PropertyKey, v: &ECMAScriptValue, receiver: &ECMAScriptValue) -> AltCompletion<bool> {
-        ordinary_set(self, agent, key, v, receiver)
+        ordinary_set(agent, self, key, v, receiver)
     }
-    fn delete(&self, key: &PropertyKey) -> AltCompletion<bool> {
-        ordinary_delete(self, key)
+    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+        ordinary_delete(agent, self, key)
     }
-    fn own_property_keys(&self) -> AltCompletion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, _agent: &mut Agent) -> AltCompletion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(self))
     }
 }

--- a/src/realm/mod.rs
+++ b/src/realm/mod.rs
@@ -513,7 +513,7 @@ fn throw_type_error(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target
 fn create_throw_type_error_builtin(agent: &mut Agent, realm: Rc<RefCell<Realm>>) -> Object {
     let function_proto = realm.borrow().intrinsics.get(IntrinsicId::FunctionPrototype);
     let fcn = create_builtin_function(agent, throw_type_error, 0_f64, PropertyKey::from(""), &BUILTIN_FUNCTION_SLOTS, Some(realm.clone()), Some(function_proto), None);
-    fcn.o.prevent_extensions().unwrap();
+    fcn.o.prevent_extensions(agent).unwrap();
     let key = PropertyKey::from("length");
     let length = get(agent, &fcn, &key).unwrap();
     define_property_or_throw(


### PR DESCRIPTION
All the "ordinary object" impls can't fail, so I missed that these were
needed for _other_ objects that _can_ fail.