### PR TITLE
Change API for NewTarget (now Option<&Object>)

### DIFF
--- a/src/object/tests.rs
+++ b/src/object/tests.rs
@@ -1075,7 +1075,7 @@ fn ordinary_get_04() {
     let result = ordinary_get(&mut agent, &obj, &key, &ECMAScriptValue::Undefined).unwrap();
     assert_eq!(result, ECMAScriptValue::from(0));
 }
-fn test_getter(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: ECMAScriptValue, _arguments: &[ECMAScriptValue]) -> Completion {
+fn test_getter(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
     // This is a getter; it is essentially:
     // function() { return this.result; }
     let obj = to_object(agent, this_value)?;
@@ -1293,7 +1293,7 @@ fn ordinary_set_with_own_descriptor_09() {
     let item = get(&mut agent, &obj, &key).unwrap();
     assert_eq!(item, value);
 }
-fn test_setter(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: ECMAScriptValue, arguments: &[ECMAScriptValue]) -> Completion {
+fn test_setter(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
     // This is a setter; it is essentially:
     // function(val) { this.value = val; }
     let obj = to_object(agent, this_value)?;

--- a/src/object_object/mod.rs
+++ b/src/object_object/mod.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 // When the valueOf method is called, the following steps are taken:
 //
 //      1. Return ? ToObject(this value).
-fn object_prototype_value_of(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: ECMAScriptValue, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_prototype_value_of(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
     to_object(agent, this_value).map(ECMAScriptValue::from)
 }
 
@@ -47,7 +47,7 @@ fn object_prototype_value_of(agent: &mut Agent, this_value: ECMAScriptValue, _ne
 use super::arrays::is_array;
 use super::object::get;
 use super::strings::JSString;
-fn object_prototype_to_string(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: ECMAScriptValue, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_prototype_to_string(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
     if this_value.is_undefined() {
         return Ok(ECMAScriptValue::from("[object Undefined]"));
     }

--- a/src/realm/mod.rs
+++ b/src/realm/mod.rs
@@ -500,7 +500,7 @@ pub fn add_restricted_function_properties(agent: &mut Agent, f: &Object, realm: 
 //
 // The "name" property of a %ThrowTypeError% function has the attributes { [[Writable]]: false, [[Enumerable]]: false,
 // [[Configurable]]: false }.
-fn throw_type_error(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: ECMAScriptValue, _arguments: &[ECMAScriptValue]) -> Completion {
+fn throw_type_error(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
     Err(create_type_error(agent, "Generic TypeError"))
 }
 

--- a/src/realm/tests.rs
+++ b/src/realm/tests.rs
@@ -82,7 +82,7 @@ fn realm_debug() {
 #[test]
 fn throw_type_error_test() {
     let mut agent = test_agent();
-    let err = throw_type_error(&mut agent, ECMAScriptValue::Undefined, ECMAScriptValue::Undefined, &[]).unwrap_err();
+    let err = throw_type_error(&mut agent, ECMAScriptValue::Undefined, None, &[]).unwrap_err();
     let msg = unwind_type_error(&mut agent, err);
     assert_eq!(msg, "Generic TypeError");
 }

--- a/src/values/tests.rs
+++ b/src/values/tests.rs
@@ -454,7 +454,7 @@ fn to_string_09() {
     let result = to_string(&mut agent, ECMAScriptValue::from(obj)).unwrap_err();
     assert_eq!(unwind_type_error(&mut agent, result), "Cannot convert object to primitive value");
 }
-fn tostring_symbol(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: ECMAScriptValue, _arguments: &[ECMAScriptValue]) -> Completion {
+fn tostring_symbol(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
     let sym = Symbol::new(agent, None);
     Ok(ECMAScriptValue::from(sym))
 }
@@ -542,21 +542,21 @@ fn to_object_08() {
 // * object value & object string -> type error
 
 // non-object number
-fn faux_makes_number(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: ECMAScriptValue, _arguments: &[ECMAScriptValue]) -> Completion {
+fn faux_makes_number(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
     Ok(ECMAScriptValue::from(123456))
 }
 // non-object string
-fn faux_makes_string(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: ECMAScriptValue, _arguments: &[ECMAScriptValue]) -> Completion {
+fn faux_makes_string(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
     Ok(ECMAScriptValue::from("test result"))
 }
 // object value
-fn faux_makes_obj(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: ECMAScriptValue, _arguments: &[ECMAScriptValue]) -> Completion {
+fn faux_makes_obj(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
     let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(agent, Some(&object_prototype), &[]);
     Ok(ECMAScriptValue::from(obj))
 }
 // error
-fn faux_errors(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: ECMAScriptValue, _arguments: &[ECMAScriptValue]) -> Completion {
+fn faux_errors(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
     Err(create_type_error(agent, "Test Sentinel"))
 }
 enum FauxKind {
@@ -761,7 +761,7 @@ fn to_primitive_prefer_number() {
     let result = to_primitive(&mut agent, &test_value, Some(ConversionHint::String)).unwrap();
     assert_eq!(result, ECMAScriptValue::from("test result"));
 }
-fn exotic_to_prim(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: ECMAScriptValue, arguments: &[ECMAScriptValue]) -> Completion {
+fn exotic_to_prim(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
     if arguments.len() == 1 {
         if let ECMAScriptValue::String(s) = &arguments[0] {
             Ok(ECMAScriptValue::from(format!("Saw {}", s)))
@@ -772,7 +772,7 @@ fn exotic_to_prim(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target:
         Ok(ECMAScriptValue::from(format!("Incorrect arg count: there were {} elements, should have been 1", arguments.len())))
     }
 }
-fn make_toprimitive_obj(agent: &mut Agent, steps: fn(&mut Agent, ECMAScriptValue, ECMAScriptValue, &[ECMAScriptValue]) -> Completion) -> Object {
+fn make_toprimitive_obj(agent: &mut Agent, steps: fn(&mut Agent, ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion) -> Object {
     let realm = agent.running_execution_context().unwrap().realm.clone();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
@@ -801,7 +801,7 @@ fn to_primitive_uses_exotics() {
     let result = to_primitive(&mut agent, &test_value, Some(ConversionHint::String)).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Saw string"));
 }
-fn exotic_returns_object(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: ECMAScriptValue, _arguments: &[ECMAScriptValue]) -> Completion {
+fn exotic_returns_object(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
     let realm = agent.running_execution_context().unwrap().realm.clone();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let target = ordinary_object_create(agent, Some(&object_prototype), &[]);
@@ -816,7 +816,7 @@ fn to_primitive_exotic_returns_object() {
     let result = to_primitive(&mut agent, &test_value, None).unwrap_err();
     assert_eq!(unwind_type_error(&mut agent, result), "Cannot convert object to primitive value");
 }
-fn exotic_throws(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: ECMAScriptValue, _arguments: &[ECMAScriptValue]) -> Completion {
+fn exotic_throws(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
     Err(create_type_error(agent, "Test Sentinel"))
 }
 #[test]


### PR DESCRIPTION
NewTarget used to be an `ECMAScriptValue`, but in truth was really only ever an `Object` or `Undefined`. The rest of the potential values just make no sense, and result in unreachable code in the required match statements. This API change just simplifies all that.