### PR TITLE
Change string token to remember original form

### DIFF
--- a/src/parser/left_hand_side_expressions/tests.rs
+++ b/src/parser/left_hand_side_expressions/tests.rs
@@ -46,8 +46,8 @@ fn member_expression_test_new_me_args() {
     assert!(matches!(me.kind, MemberExpressionKind::NewArguments(..)));
     // Excersize the Debug formatter, for code coverage
     format!("{:?}", me);
-    pretty_check(&*me, "MemberExpression: new shoes ( \"red\" , \"leather\" )", vec!["MemberExpression: shoes", "Arguments: ( \"red\" , \"leather\" )"]);
-    concise_check(&*me, "MemberExpression: new shoes ( \"red\" , \"leather\" )", vec!["Keyword: new", "IdentifierName: shoes", "Arguments: ( \"red\" , \"leather\" )"]);
+    pretty_check(&*me, "MemberExpression: new shoes ( 'red' , 'leather' )", vec!["MemberExpression: shoes", "Arguments: ( 'red' , 'leather' )"]);
+    concise_check(&*me, "MemberExpression: new shoes ( 'red' , 'leather' )", vec!["Keyword: new", "IdentifierName: shoes", "Arguments: ( 'red' , 'leather' )"]);
     assert_eq!(me.is_function_definition(), false);
     assert_eq!(me.assignment_target_type(), ATTKind::Invalid);
 }

--- a/src/parser/primary_expressions/mod.rs
+++ b/src/parser/primary_expressions/mod.rs
@@ -947,7 +947,7 @@ impl fmt::Display for LiteralPropertyName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             LiteralPropertyName::IdentifierName(id) => write!(f, "{}", id),
-            LiteralPropertyName::StringLiteral(s) => write!(f, "{:?}", s),
+            LiteralPropertyName::StringLiteral(s) => write!(f, "{}", s),
             LiteralPropertyName::NumericLiteral(Numeric::Number(n)) => {
                 let mut s = Vec::new();
                 number_to_string(&mut s, *n).unwrap();
@@ -972,7 +972,7 @@ impl PrettyPrint for LiteralPropertyName {
     {
         match self {
             LiteralPropertyName::IdentifierName(id) => pprint_token(writer, id, TokenType::IdentifierName, pad, state),
-            LiteralPropertyName::StringLiteral(s) => pprint_token(writer, &format!("{:?}", s), TokenType::String, pad, state),
+            LiteralPropertyName::StringLiteral(s) => pprint_token(writer, &format!("{}", s), TokenType::String, pad, state),
             LiteralPropertyName::NumericLiteral(n) => pprint_token(writer, n, TokenType::Numeric, pad, state),
         }
     }
@@ -1405,7 +1405,7 @@ impl fmt::Display for Literal {
                 write!(f, "{}", String::from_utf8(s).unwrap())
             }
             LiteralKind::NumericLiteral(Numeric::BigInt(b)) => write!(f, "{}", *b),
-            LiteralKind::StringLiteral(s) => write!(f, "{:?}", *s),
+            LiteralKind::StringLiteral(s) => write!(f, "{}", *s),
         }
     }
 }

--- a/src/parser/primary_expressions/mod.rs
+++ b/src/parser/primary_expressions/mod.rs
@@ -1,8 +1,3 @@
-use num::bigint::BigInt;
-use std::fmt;
-use std::io::Result as IoResult;
-use std::io::Write;
-
 use super::assignment_operators::AssignmentExpression;
 use super::async_function_definitions::AsyncFunctionExpression;
 use super::async_generator_function_definitions::AsyncGeneratorExpression;
@@ -13,11 +8,14 @@ use super::function_definitions::FunctionExpression;
 use super::generator_function_definitions::GeneratorExpression;
 use super::identifiers::{BindingIdentifier, IdentifierReference};
 use super::method_definitions::MethodDefinition;
-use super::scanner::{scan_token, Keyword, Punctuator, RegularExpressionData, ScanGoal, Scanner, TemplateData, Token};
+use super::scanner::{scan_token, Keyword, Punctuator, RegularExpressionData, ScanGoal, Scanner, StringToken, TemplateData, Token};
 use super::*;
 use crate::prettyprint::{pprint_token, prettypad, PrettyPrint, Spot, TokenType};
-use crate::strings::JSString;
 use crate::values::number_to_string;
+use num::bigint::BigInt;
+use std::fmt;
+use std::io::Result as IoResult;
+use std::io::Write;
 
 //////// 12.2 Primary Expression
 // PrimaryExpression[Yield, Await] :
@@ -941,7 +939,7 @@ impl ComputedPropertyName {
 #[derive(Debug)]
 pub enum LiteralPropertyName {
     IdentifierName(IdentifierData),
-    StringLiteral(JSString),
+    StringLiteral(StringToken),
     NumericLiteral(Numeric),
 }
 
@@ -1383,7 +1381,7 @@ pub enum LiteralKind {
     NullLiteral,
     BooleanLiteral(bool),
     NumericLiteral(Numeric),
-    StringLiteral(JSString),
+    StringLiteral(StringToken),
 }
 #[derive(Debug)]
 pub struct Literal {

--- a/src/parser/primary_expressions/tests.rs
+++ b/src/parser/primary_expressions/tests.rs
@@ -455,8 +455,8 @@ fn literal_test_string() {
     let (lit, scanner) = check(Literal::parse(&mut newparser("'string'"), Scanner::new()));
     chk_scan(&scanner, 8);
     assert!(matches!(lit.kind, LiteralKind::StringLiteral(_)));
-    pretty_check(&*lit, "Literal: \"string\"", vec![]);
-    concise_check(&*lit, "String: \"string\"", vec![]);
+    pretty_check(&*lit, "Literal: 'string'", vec![]);
+    concise_check(&*lit, "String: 'string'", vec![]);
 }
 #[test]
 fn literal_test_keyword() {
@@ -1177,8 +1177,8 @@ fn literal_property_name_test_02() {
     let (lpn, scanner) = check(LiteralPropertyName::parse(&mut newparser("'b'"), Scanner::new()));
     chk_scan(&scanner, 3);
     assert!(matches!(&*lpn, LiteralPropertyName::StringLiteral(_)));
-    pretty_check(&*lpn, "LiteralPropertyName: \"b\"", vec![]);
-    concise_check(&*lpn, "String: \"b\"", vec![]);
+    pretty_check(&*lpn, "LiteralPropertyName: 'b'", vec![]);
+    concise_check(&*lpn, "String: 'b'", vec![]);
 }
 #[test]
 fn literal_property_name_test_03() {

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -231,7 +231,15 @@ pub struct StringToken {
 
 impl fmt::Display for StringToken {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.value.fmt(f)
+        // The "as source" form
+        let delim = match self.delimiter {
+            StringDelimiter::Single => '\'',
+            StringDelimiter::Double => '"',
+        };
+        match &self.raw {
+            None => write!(f, "{}{}{}", delim, self.value, delim),
+            Some(s) => write!(f, "{}{}{}", delim, s, delim),
+        }
     }
 }
 
@@ -328,8 +336,8 @@ impl fmt::Display for Token {
                 number_to_string(&mut s, *val).unwrap();
                 String::from_utf8(s).unwrap().fmt(f)
             }
-            Token::BigInt(val) => val.fmt(f),                 // This needs a better "render as source" algorithm.
-            Token::String(val) => val.fmt(f),                 // This needs a better "render as source" algorithm.
+            Token::BigInt(val) => val.fmt(f), // This needs a better "render as source" algorithm.
+            Token::String(val) => val.fmt(f),
             Token::NoSubstitutionTemplate(val) => val.fmt(f), // This needs a better "render as source" algorithm.
             Token::TemplateHead(val) => val.fmt(f),
             Token::TemplateMiddle(val) => val.fmt(f),

--- a/src/scanner/tests.rs
+++ b/src/scanner/tests.rs
@@ -1401,6 +1401,11 @@ fn scanner_clone() {
 }
 
 #[test]
+fn string_token_debug() {
+    assert_ne!(format!("{:?}", StringToken { value: JSString::from("blue"), delimiter: StringDelimiter::Double, raw: None}), "");
+}
+
+#[test]
 fn token_debug() {
     assert_ne!(format!("{:?}", Token::Eof), "");
 }

--- a/src/scanner/tests.rs
+++ b/src/scanner/tests.rs
@@ -1429,7 +1429,8 @@ fn token_display() {
     assert_eq!(format!("{}", Token::Identifier(IdentifierData { string_value: JSString::from("bob"), keyword_id: None, line: 1, column: 1 })), "bob");
     assert_eq!(format!("{}", Token::Number(6.222)), "6.222");
     assert_eq!(format!("{}", Token::BigInt(BigInt::parse_bytes(b"9131551", 10).unwrap())), "9131551");
-    assert_eq!(format!("{}", Token::String(StringToken { value: JSString::from("baloney"), delimiter: StringDelimiter::Single, raw: None })), "baloney");
+    assert_eq!(format!("{}", Token::String(StringToken { value: JSString::from("baloney"), delimiter: StringDelimiter::Single, raw: None })), "'baloney'");
+    assert_eq!(format!("{}", Token::String(StringToken { value: JSString::from("baloney"), delimiter: StringDelimiter::Double, raw: Some(String::from("\\x62aloney")) })), "\"\\x62aloney\"");
     assert_eq!(format!("{}", Token::NoSubstitutionTemplate(TemplateData { tv: Some(JSString::from("rust")), trv: JSString::from("rust"), starting_index: 0, byte_length: 4 })), "rust");
     assert_eq!(format!("{}", Token::TemplateHead(TemplateData { tv: Some(JSString::from("rust")), trv: JSString::from("rust"), starting_index: 0, byte_length: 4 })), "rust");
     assert_eq!(format!("{}", Token::TemplateMiddle(TemplateData { tv: Some(JSString::from("rust")), trv: JSString::from("rust"), starting_index: 0, byte_length: 4 })), "rust");


### PR DESCRIPTION
By duplicating it into its own String, which feels sub-optimal, but
otherwise we need to pass the source around, too, which is worse.

This is still a WIP: there are some tests that are failing; looks like I
need to change how the Display trait is implemented.