### PR TITLE
Change the API for early errors to thrash less

### DIFF
--- a/src/parser/additive_operators/mod.rs
+++ b/src/parser/additive_operators/mod.rs
@@ -133,7 +133,7 @@ impl AdditiveExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/additive_operators/tests.rs
+++ b/src/parser/additive_operators/tests.rs
@@ -138,5 +138,5 @@ fn additive_expression_test_all_private_identifiers_valid(src: &str) -> bool {
 #[should_panic(expected = "not yet implemented")]
 fn additive_expression_test_early_errors() {
     let mut agent = test_agent();
-    AdditiveExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, true);
+    AdditiveExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, &mut vec![], true);
 }

--- a/src/parser/arrow_function_definitions/mod.rs
+++ b/src/parser/arrow_function_definitions/mod.rs
@@ -73,7 +73,7 @@ impl ArrowFunction {
         self.parameters.all_private_identifiers_valid(names) && self.body.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -165,7 +165,7 @@ impl ArrowParameters {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -238,7 +238,7 @@ impl ArrowFormalParameters {
         self.0.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -333,7 +333,7 @@ impl ConciseBody {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -402,7 +402,7 @@ impl ExpressionBody {
         self.expression.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/arrow_function_definitions/tests.rs
+++ b/src/parser/arrow_function_definitions/tests.rs
@@ -97,7 +97,7 @@ fn arrow_function_test_all_private_identifiers_valid(src: &str) -> bool {
 #[should_panic(expected = "not yet implemented")]
 fn arrow_function_test_early_errors() {
     let mut agent = test_agent();
-    ArrowFunction::parse(&mut newparser("x => x"), Scanner::new(), true, false, false).unwrap().0.early_errors(&mut agent, true);
+    ArrowFunction::parse(&mut newparser("x => x"), Scanner::new(), true, false, false).unwrap().0.early_errors(&mut agent, &mut vec![], true);
 }
 
 // ARROW PARAMETERS
@@ -183,7 +183,7 @@ fn arrow_parameters_test_all_private_identifiers_valid(src: &str) -> bool {
 #[should_panic(expected = "not yet implemented")]
 fn arrow_parameters_test_early_errors() {
     let mut agent = test_agent();
-    ArrowParameters::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, true);
+    ArrowParameters::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, &mut vec![], true);
 }
 
 // CONCISE BODY
@@ -267,7 +267,7 @@ fn concise_body_test_all_private_identifiers_valid(src: &str) -> bool {
 #[should_panic(expected = "not yet implemented")]
 fn concise_body_test_early_errors() {
     let mut agent = test_agent();
-    ConciseBody::parse(&mut newparser("x"), Scanner::new(), true).unwrap().0.early_errors(&mut agent, true);
+    ConciseBody::parse(&mut newparser("x"), Scanner::new(), true).unwrap().0.early_errors(&mut agent, &mut vec![], true);
 }
 
 // EXPRESSION BODY
@@ -321,7 +321,7 @@ fn expression_body_test_all_private_identifiers_valid(src: &str) -> bool {
 #[should_panic(expected = "not yet implemented")]
 fn expression_body_test_early_errors() {
     let mut agent = test_agent();
-    ExpressionBody::parse(&mut newparser("x => x"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, true);
+    ExpressionBody::parse(&mut newparser("x => x"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, &mut vec![], true);
 }
 
 // ARROW FORMAL PARAMETERS
@@ -379,5 +379,5 @@ fn arrow_formal_parameters_test_all_private_identifiers_valid(src: &str) -> bool
 #[should_panic(expected = "not yet implemented")]
 fn arrow_formal_parameters_test_early_errors() {
     let mut agent = test_agent();
-    ArrowFormalParameters::parse(&mut newparser("(a)"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, true);
+    ArrowFormalParameters::parse(&mut newparser("(a)"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, &mut vec![], true);
 }

--- a/src/parser/assignment_operators/mod.rs
+++ b/src/parser/assignment_operators/mod.rs
@@ -267,7 +267,7 @@ impl AssignmentExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -399,7 +399,7 @@ impl AssignmentPattern {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -526,7 +526,7 @@ impl ObjectAssignmentPattern {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -682,7 +682,7 @@ impl ArrayAssignmentPattern {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -739,7 +739,7 @@ impl AssignmentRestProperty {
         self.0.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -828,7 +828,7 @@ impl AssignmentPropertyList {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -917,7 +917,7 @@ impl AssignmentElementList {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -991,7 +991,7 @@ impl AssignmentElisionElement {
         self.element.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1102,7 +1102,7 @@ impl AssignmentProperty {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1185,7 +1185,7 @@ impl AssignmentElement {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1242,7 +1242,7 @@ impl AssignmentRestElement {
         self.0.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1321,7 +1321,7 @@ impl DestructuringAssignmentTarget {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/assignment_operators/tests.rs
+++ b/src/parser/assignment_operators/tests.rs
@@ -590,7 +590,7 @@ fn assignment_expression_test_all_private_identifiers_valid(src: &str) -> bool {
 #[should_panic(expected = "not yet implemented")]
 fn assignment_expression_test_early_errors() {
     let mut agent = test_agent();
-    AssignmentExpression::parse(&mut newparser("a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut agent, true);
+    AssignmentExpression::parse(&mut newparser("a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut agent, &mut vec![], true);
 }
 
 #[test]
@@ -705,7 +705,7 @@ mod assignment_pattern {
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
         let mut agent = test_agent();
-        AssignmentPattern::parse(&mut newparser("{}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, true);
+        AssignmentPattern::parse(&mut newparser("{}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, &mut vec![], true);
     }
 }
 
@@ -811,7 +811,7 @@ mod object_assignment_pattern {
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
         let mut agent = test_agent();
-        ObjectAssignmentPattern::parse(&mut newparser("{}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, true);
+        ObjectAssignmentPattern::parse(&mut newparser("{}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, &mut vec![], true);
     }
 }
 
@@ -961,7 +961,7 @@ mod array_assignment_pattern {
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
         let mut agent = test_agent();
-        ArrayAssignmentPattern::parse(&mut newparser("[]"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, true);
+        ArrayAssignmentPattern::parse(&mut newparser("[]"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, &mut vec![], true);
     }
 }
 
@@ -1018,7 +1018,7 @@ mod assignment_rest_property {
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
         let mut agent = test_agent();
-        AssignmentRestProperty::parse(&mut newparser("...a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, true);
+        AssignmentRestProperty::parse(&mut newparser("...a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut agent, &mut vec![], true);
     }
 }
 
@@ -1087,7 +1087,7 @@ mod assignment_property_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        AssignmentPropertyList::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        AssignmentPropertyList::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1156,7 +1156,7 @@ mod assignment_element_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        AssignmentElementList::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        AssignmentElementList::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1222,7 +1222,7 @@ mod assignment_elision_element {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        AssignmentElisionElement::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        AssignmentElisionElement::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1302,7 +1302,7 @@ mod assignment_property {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        AssignmentProperty::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        AssignmentProperty::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1370,7 +1370,7 @@ mod assignment_element {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        AssignmentElement::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        AssignmentElement::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1423,7 +1423,7 @@ mod assignment_rest_element {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        AssignmentRestElement::parse(&mut newparser("...a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        AssignmentRestElement::parse(&mut newparser("...a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1489,6 +1489,6 @@ mod destructuring_assignment_target {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        DestructuringAssignmentTarget::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        DestructuringAssignmentTarget::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/async_arrow_function_definitions/mod.rs
+++ b/src/parser/async_arrow_function_definitions/mod.rs
@@ -131,7 +131,7 @@ impl AsyncArrowFunction {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -191,7 +191,7 @@ impl AsyncArrowHead {
         self.0.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -286,7 +286,7 @@ impl AsyncConciseBody {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -331,7 +331,7 @@ impl AsyncArrowBindingIdentifier {
         self.0.contains(kind)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -395,7 +395,7 @@ impl CoverCallExpressionAndAsyncArrowHead {
         self.expression.contains(kind) || self.args.contains(kind)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/async_arrow_function_definitions/tests.rs
+++ b/src/parser/async_arrow_function_definitions/tests.rs
@@ -155,7 +155,7 @@ fn async_arrow_function_test_all_private_identifiers_valid(src: &str) -> bool {
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn async_arrow_function_test_early_errors() {
-    AsyncArrowFunction::parse(&mut newparser("async x => x"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+    AsyncArrowFunction::parse(&mut newparser("async x => x"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
 }
 
 // ASYNC CONCISE BODY
@@ -237,7 +237,7 @@ fn async_concise_body_test_all_private_identifiers_valid(src: &str) -> bool {
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn async_concise_body_test_early_errors() {
-    AsyncConciseBody::parse(&mut newparser("x"), Scanner::new(), true).unwrap().0.early_errors(&mut test_agent(), true);
+    AsyncConciseBody::parse(&mut newparser("x"), Scanner::new(), true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
 }
 
 // ASYNC ARROW BINDING IDENTIFIER
@@ -272,7 +272,7 @@ fn async_arrow_binding_identifier_test_contains_01() {
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn async_arrow_binding_identifier_test_early_errors() {
-    AsyncArrowBindingIdentifier::parse(&mut newparser("x"), Scanner::new(), true).unwrap().0.early_errors(&mut test_agent(), true);
+    AsyncArrowBindingIdentifier::parse(&mut newparser("x"), Scanner::new(), true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
 }
 
 // COVER CALL EXPRESSION AND ASYNC ARROW HEAD
@@ -328,7 +328,7 @@ fn cceaaah_test_contains_03() {
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn cceaaah_test_early_errors() {
-    CoverCallExpressionAndAsyncArrowHead::parse(&mut newparser("x()"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+    CoverCallExpressionAndAsyncArrowHead::parse(&mut newparser("x()"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
 }
 
 // ASYNC ARROW HEAD
@@ -381,5 +381,5 @@ fn async_arrow_head_test_all_private_identifiers_valid(src: &str) -> bool {
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn async_arrow_head_test_early_errors() {
-    AsyncArrowHead::parse(&mut newparser("async(a)"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), true);
+    AsyncArrowHead::parse(&mut newparser("async(a)"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
 }

--- a/src/parser/async_function_definitions/mod.rs
+++ b/src/parser/async_function_definitions/mod.rs
@@ -110,7 +110,7 @@ impl AsyncFunctionDeclaration {
         self.params.all_private_identifiers_valid(names) && self.body.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -206,7 +206,7 @@ impl AsyncFunctionExpression {
         self.params.all_private_identifiers_valid(names) && self.body.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -304,7 +304,7 @@ impl AsyncMethod {
         self.params.contains(ParseNodeKind::SuperCall) || self.body.contains(ParseNodeKind::SuperCall)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -383,7 +383,7 @@ impl AsyncFunctionBody {
         self.0.lexically_declared_names()
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -449,7 +449,7 @@ impl AwaitExpression {
         boxed.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/async_function_definitions/tests.rs
+++ b/src/parser/async_function_definitions/tests.rs
@@ -140,7 +140,7 @@ fn async_function_declaration_test_all_private_identifiers_valid(src: &str) -> b
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn async_function_declaration_test_early_errors() {
-    AsyncFunctionDeclaration::parse(&mut newparser("async function a(){}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+    AsyncFunctionDeclaration::parse(&mut newparser("async function a(){}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
 }
 
 // ASYNC FUNCTION EXPRESSION
@@ -266,7 +266,7 @@ fn async_function_expression_test_all_private_identifiers_valid(src: &str) -> bo
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn async_function_expression_test_early_errors() {
-    AsyncFunctionExpression::parse(&mut newparser("async function a(){}"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), true);
+    AsyncFunctionExpression::parse(&mut newparser("async function a(){}"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
 }
 
 // ASYNC METHOD
@@ -396,7 +396,7 @@ mod async_method {
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn async_method_test_early_errors() {
-    AsyncMethod::parse(&mut newparser("async a(){}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+    AsyncMethod::parse(&mut newparser("async a(){}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
 }
 
 // ASYNC FUNCTION BODY
@@ -464,7 +464,7 @@ fn async_function_body_test_lexically_declared_names(src: &str) -> Vec<JSString>
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn async_function_body_test_early_errors() {
-    AsyncFunctionBody::parse(&mut newparser("yield 8;"), Scanner::new()).0.early_errors(&mut test_agent(), true);
+    AsyncFunctionBody::parse(&mut newparser("yield 8;"), Scanner::new()).0.early_errors(&mut test_agent(), &mut vec![], true);
 }
 
 // AWAIT EXPRESSION
@@ -513,5 +513,5 @@ fn await_expression_test_all_private_identifiers_valid(src: &str) -> bool {
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn await_expression_test_early_errors() {
-    AwaitExpression::parse(&mut newparser("await a"), Scanner::new(), true).unwrap().0.early_errors(&mut test_agent(), true);
+    AwaitExpression::parse(&mut newparser("await a"), Scanner::new(), true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
 }

--- a/src/parser/async_generator_function_definitions/mod.rs
+++ b/src/parser/async_generator_function_definitions/mod.rs
@@ -104,7 +104,7 @@ impl AsyncGeneratorMethod {
         self.params.contains(ParseNodeKind::SuperCall) || self.body.contains(ParseNodeKind::SuperCall)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -216,7 +216,7 @@ impl AsyncGeneratorDeclaration {
         self.params.all_private_identifiers_valid(names) && self.body.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -314,7 +314,7 @@ impl AsyncGeneratorExpression {
         self.params.all_private_identifiers_valid(names) && self.body.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -379,7 +379,7 @@ impl AsyncGeneratorBody {
         self.0.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/async_generator_function_definitions/tests.rs
+++ b/src/parser/async_generator_function_definitions/tests.rs
@@ -125,7 +125,7 @@ mod async_generator_method {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        AsyncGeneratorMethod::parse(&mut newparser("async *a(){}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        AsyncGeneratorMethod::parse(&mut newparser("async *a(){}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -262,7 +262,7 @@ mod async_generator_declaration {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        AsyncGeneratorDeclaration::parse(&mut newparser("async function *a(){}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        AsyncGeneratorDeclaration::parse(&mut newparser("async function *a(){}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -380,7 +380,7 @@ mod async_generator_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        AsyncGeneratorExpression::parse(&mut newparser("async function *a(){}"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), true);
+        AsyncGeneratorExpression::parse(&mut newparser("async function *a(){}"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -432,6 +432,6 @@ mod async_generator_body {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        AsyncGeneratorBody::parse(&mut newparser("yield 3;"), Scanner::new()).0.early_errors(&mut test_agent(), true);
+        AsyncGeneratorBody::parse(&mut newparser("yield 3;"), Scanner::new()).0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/binary_bitwise_operators/mod.rs
+++ b/src/parser/binary_bitwise_operators/mod.rs
@@ -118,7 +118,7 @@ impl BitwiseANDExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -234,7 +234,7 @@ impl BitwiseXORExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -361,7 +361,7 @@ impl BitwiseORExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/binary_bitwise_operators/tests.rs
+++ b/src/parser/binary_bitwise_operators/tests.rs
@@ -97,7 +97,7 @@ mod bitwise_and_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        BitwiseANDExpression::parse(&mut newparser("0"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        BitwiseANDExpression::parse(&mut newparser("0"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -194,7 +194,7 @@ mod bitwise_xor_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        BitwiseXORExpression::parse(&mut newparser("0"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        BitwiseXORExpression::parse(&mut newparser("0"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -299,6 +299,6 @@ mod bitwise_or_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        BitwiseORExpression::parse(&mut newparser("0"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        BitwiseORExpression::parse(&mut newparser("0"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/binary_logical_operators/mod.rs
+++ b/src/parser/binary_logical_operators/mod.rs
@@ -118,7 +118,7 @@ impl LogicalANDExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -234,7 +234,7 @@ impl LogicalORExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -321,7 +321,7 @@ impl CoalesceExpression {
         self.head.all_private_identifiers_valid(names) && self.tail.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -393,7 +393,7 @@ impl CoalesceExpressionHead {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -496,7 +496,7 @@ impl ShortCircuitExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/binary_logical_operators/tests.rs
+++ b/src/parser/binary_logical_operators/tests.rs
@@ -104,7 +104,7 @@ mod logical_and_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        LogicalANDExpression::parse(&mut newparser("0"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        LogicalANDExpression::parse(&mut newparser("0"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -208,7 +208,7 @@ mod logical_or_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        LogicalORExpression::parse(&mut newparser("0"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        LogicalORExpression::parse(&mut newparser("0"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -283,7 +283,7 @@ mod coalesce_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        CoalesceExpression::parse(&mut newparser("0??b"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        CoalesceExpression::parse(&mut newparser("0??b"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -364,7 +364,7 @@ mod coalesce_expression_head {
     fn early_errors() {
         let (item_ce, _) = CoalesceExpression::parse(&mut newparser("item.#valid ?? a"), Scanner::new(), true, false, false).unwrap();
         let item = &item_ce.head;
-        item.early_errors(&mut test_agent(), true);
+        item.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -454,6 +454,6 @@ mod short_circuit_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ShortCircuitExpression::parse(&mut newparser("0??b"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ShortCircuitExpression::parse(&mut newparser("0??b"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/bitwise_shift_operators/mod.rs
+++ b/src/parser/bitwise_shift_operators/mod.rs
@@ -140,7 +140,7 @@ impl ShiftExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/bitwise_shift_operators/tests.rs
+++ b/src/parser/bitwise_shift_operators/tests.rs
@@ -185,6 +185,6 @@ mod shift_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ShiftExpression::parse(&mut newparser("3"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ShiftExpression::parse(&mut newparser("3"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/block/mod.rs
+++ b/src/parser/block/mod.rs
@@ -83,7 +83,7 @@ impl BlockStatement {
         node.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -210,7 +210,7 @@ impl Block {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -408,7 +408,7 @@ impl StatementList {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -562,7 +562,7 @@ impl StatementListItem {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/block/tests.rs
+++ b/src/parser/block/tests.rs
@@ -85,7 +85,7 @@ mod block_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        BlockStatement::parse(&mut newparser("{a;}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        BlockStatement::parse(&mut newparser("{a;}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -218,7 +218,7 @@ mod block {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        Block::parse(&mut newparser("{a;}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        Block::parse(&mut newparser("{a;}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -416,7 +416,7 @@ mod statement_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        StatementList::parse(&mut newparser("0;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        StatementList::parse(&mut newparser("0;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -605,6 +605,6 @@ mod statement_list_item {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        StatementListItem::parse(&mut newparser("0;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        StatementListItem::parse(&mut newparser("0;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/break_statement/mod.rs
+++ b/src/parser/break_statement/mod.rs
@@ -77,7 +77,7 @@ impl BreakStatement {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/break_statement/tests.rs
+++ b/src/parser/break_statement/tests.rs
@@ -106,6 +106,6 @@ mod break_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        BreakStatement::parse(&mut newparser("break;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        BreakStatement::parse(&mut newparser("break;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/class_definitions/mod.rs
+++ b/src/parser/class_definitions/mod.rs
@@ -105,7 +105,7 @@ impl ClassDeclaration {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -186,7 +186,7 @@ impl ClassExpression {
         self.tail.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -297,7 +297,7 @@ impl ClassTail {
         self.heritage.as_ref().map_or(true, |node| node.all_private_identifiers_valid(names)) && self.body.as_ref().map_or(true, |node| node.all_private_identifiers_valid(names))
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -355,7 +355,7 @@ impl ClassHeritage {
         self.0.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -422,7 +422,7 @@ impl ClassBody {
         self.0.all_private_identifiers_valid(&new_names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -537,7 +537,7 @@ impl ClassElementList {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -701,7 +701,7 @@ impl ClassElement {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -791,7 +791,7 @@ impl FieldDefinition {
         self.name.all_private_identifiers_valid(names) && self.init.as_ref().map_or(true, |init| init.all_private_identifiers_valid(names))
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -887,7 +887,7 @@ impl ClassElementName {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -949,7 +949,7 @@ impl ClassStaticBlock {
         self.0.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -999,7 +999,7 @@ impl ClassStaticBlockBody {
         self.0.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1051,7 +1051,7 @@ impl ClassStaticBlockStatementList {
         self.0.as_ref().map_or(true, |sl| sl.all_private_identifiers_valid(names))
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/class_definitions/tests.rs
+++ b/src/parser/class_definitions/tests.rs
@@ -96,7 +96,7 @@ mod class_declaration {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ClassDeclaration::parse(&mut newparser("class {}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ClassDeclaration::parse(&mut newparser("class {}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -178,7 +178,7 @@ mod class_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ClassExpression::parse(&mut newparser("class {}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ClassExpression::parse(&mut newparser("class {}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -305,7 +305,7 @@ mod class_tail {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ClassTail::parse(&mut newparser("{}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ClassTail::parse(&mut newparser("{}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -357,7 +357,7 @@ mod class_heritage {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ClassHeritage::parse(&mut newparser("extends a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ClassHeritage::parse(&mut newparser("extends a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -420,7 +420,7 @@ mod class_body {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ClassBody::parse(&mut newparser(";"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ClassBody::parse(&mut newparser(";"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -526,7 +526,7 @@ mod class_element_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ClassElementList::parse(&mut newparser("a(){}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ClassElementList::parse(&mut newparser("a(){}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -781,7 +781,7 @@ mod class_element {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ClassElement::parse(&mut newparser("a(){}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ClassElement::parse(&mut newparser("a(){}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -886,7 +886,7 @@ mod field_definition {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        FieldDefinition::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        FieldDefinition::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -979,7 +979,7 @@ mod class_element_name {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ClassElementName::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ClassElementName::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1025,7 +1025,7 @@ mod class_static_block {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ClassStaticBlock::parse(&mut newparser("static { a; }"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), true);
+        ClassStaticBlock::parse(&mut newparser("static { a; }"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1060,7 +1060,7 @@ mod class_static_block_body {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ClassStaticBlockBody::parse(&mut newparser("a;"), Scanner::new()).0.early_errors(&mut test_agent(), true);
+        ClassStaticBlockBody::parse(&mut newparser("a;"), Scanner::new()).0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1106,6 +1106,6 @@ mod class_static_block_statement_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ClassStaticBlockStatementList::parse(&mut newparser("a;"), Scanner::new()).0.early_errors(&mut test_agent(), true);
+        ClassStaticBlockStatementList::parse(&mut newparser("a;"), Scanner::new()).0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/comma_operator/mod.rs
+++ b/src/parser/comma_operator/mod.rs
@@ -131,7 +131,7 @@ impl Expression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/comma_operator/tests.rs
+++ b/src/parser/comma_operator/tests.rs
@@ -106,6 +106,6 @@ mod expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        Expression::parse(&mut newparser("0"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        Expression::parse(&mut newparser("0"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/conditional_operator/mod.rs
+++ b/src/parser/conditional_operator/mod.rs
@@ -126,7 +126,7 @@ impl ConditionalExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/conditional_operator/tests.rs
+++ b/src/parser/conditional_operator/tests.rs
@@ -115,6 +115,6 @@ mod conditional_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ConditionalExpression::parse(&mut newparser("0"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ConditionalExpression::parse(&mut newparser("0"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/continue_statement/mod.rs
+++ b/src/parser/continue_statement/mod.rs
@@ -77,7 +77,7 @@ impl ContinueStatement {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/continue_statement/tests.rs
+++ b/src/parser/continue_statement/tests.rs
@@ -98,6 +98,6 @@ mod continue_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ContinueStatement::parse(&mut newparser("continue;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ContinueStatement::parse(&mut newparser("continue;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/debugger_statement/mod.rs
+++ b/src/parser/debugger_statement/mod.rs
@@ -49,7 +49,7 @@ impl DebuggerStatement {
         false
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/debugger_statement/tests.rs
+++ b/src/parser/debugger_statement/tests.rs
@@ -48,6 +48,6 @@ mod debugger_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        DebuggerStatement::parse(&mut newparser("debugger;"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), true);
+        DebuggerStatement::parse(&mut newparser("debugger;"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/declarations_and_variables/mod.rs
+++ b/src/parser/declarations_and_variables/mod.rs
@@ -93,7 +93,7 @@ impl LexicalDeclaration {
         node.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -236,7 +236,7 @@ impl BindingList {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -351,7 +351,7 @@ impl LexicalBinding {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -424,7 +424,7 @@ impl VariableStatement {
         node.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -537,7 +537,7 @@ impl VariableDeclarationList {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -654,7 +654,7 @@ impl VariableDeclaration {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -747,7 +747,7 @@ impl BindingPattern {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -896,7 +896,7 @@ impl ObjectBindingPattern {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1102,7 +1102,7 @@ impl ArrayBindingPattern {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1173,7 +1173,7 @@ impl BindingRestProperty {
         node.contains(kind)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1275,7 +1275,7 @@ impl BindingPropertyList {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1384,7 +1384,7 @@ impl BindingElementList {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1469,7 +1469,7 @@ impl BindingElisionElement {
         n.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1568,7 +1568,7 @@ impl BindingProperty {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1699,7 +1699,7 @@ impl BindingElement {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1805,7 +1805,7 @@ impl SingleNameBinding {
         initializer.is_none()
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1902,7 +1902,7 @@ impl BindingRestElement {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/declarations_and_variables/tests.rs
+++ b/src/parser/declarations_and_variables/tests.rs
@@ -80,7 +80,7 @@ mod lexical_declaration {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        LexicalDeclaration::parse(&mut newparser("let a;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        LexicalDeclaration::parse(&mut newparser("let a;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -171,7 +171,7 @@ mod binding_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        BindingList::parse(&mut newparser("a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        BindingList::parse(&mut newparser("a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -268,7 +268,7 @@ mod lexical_binding {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        LexicalBinding::parse(&mut newparser("a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        LexicalBinding::parse(&mut newparser("a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -331,7 +331,7 @@ mod variable_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        VariableStatement::parse(&mut newparser("var a;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        VariableStatement::parse(&mut newparser("var a;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -420,7 +420,7 @@ mod variable_declaration_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        VariableDeclarationList::parse(&mut newparser("a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        VariableDeclarationList::parse(&mut newparser("a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -522,7 +522,7 @@ mod variable_declaration {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        VariableDeclaration::parse(&mut newparser("a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        VariableDeclaration::parse(&mut newparser("a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -604,7 +604,7 @@ mod binding_pattern {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        BindingPattern::parse(&mut newparser("{a}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        BindingPattern::parse(&mut newparser("{a}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -770,7 +770,7 @@ mod object_binding_pattern {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ObjectBindingPattern::parse(&mut newparser("{}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ObjectBindingPattern::parse(&mut newparser("{}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1050,7 +1050,7 @@ mod array_binding_pattern {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ArrayBindingPattern::parse(&mut newparser("[]"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ArrayBindingPattern::parse(&mut newparser("[]"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1096,7 +1096,7 @@ mod binding_rest_property {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        BindingRestProperty::parse(&mut newparser("...a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        BindingRestProperty::parse(&mut newparser("...a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1188,7 +1188,7 @@ mod binding_property_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        BindingPropertyList::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        BindingPropertyList::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1280,7 +1280,7 @@ mod binding_element_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        BindingElementList::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        BindingElementList::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1349,7 +1349,7 @@ mod binding_elision_element {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        BindingElisionElement::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        BindingElisionElement::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1441,7 +1441,7 @@ mod binding_property {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        BindingProperty::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        BindingProperty::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1561,7 +1561,7 @@ mod binding_element {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        BindingElement::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        BindingElement::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1643,7 +1643,7 @@ mod single_name_binding {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        SingleNameBinding::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        SingleNameBinding::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1723,6 +1723,6 @@ mod binding_rest_element {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        BindingRestElement::parse(&mut newparser("...a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        BindingRestElement::parse(&mut newparser("...a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/empty_statement/mod.rs
+++ b/src/parser/empty_statement/mod.rs
@@ -44,7 +44,7 @@ impl EmptyStatement {
         false
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/empty_statement/tests.rs
+++ b/src/parser/empty_statement/tests.rs
@@ -36,6 +36,6 @@ mod empty_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        EmptyStatement::parse(&mut newparser(";"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), true);
+        EmptyStatement::parse(&mut newparser(";"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/equality_operators/mod.rs
+++ b/src/parser/equality_operators/mod.rs
@@ -152,7 +152,7 @@ impl EqualityExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/equality_operators/tests.rs
+++ b/src/parser/equality_operators/tests.rs
@@ -218,6 +218,6 @@ mod equality_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        EqualityExpression::parse(&mut newparser("a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        EqualityExpression::parse(&mut newparser("a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/exponentiation_operator/mod.rs
+++ b/src/parser/exponentiation_operator/mod.rs
@@ -119,7 +119,7 @@ impl ExponentiationExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/exponentiation_operator/tests.rs
+++ b/src/parser/exponentiation_operator/tests.rs
@@ -108,6 +108,6 @@ mod exponentiation_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ExponentiationExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ExponentiationExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/expression_statement/mod.rs
+++ b/src/parser/expression_statement/mod.rs
@@ -94,7 +94,7 @@ impl ExpressionStatement {
         node.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/expression_statement/tests.rs
+++ b/src/parser/expression_statement/tests.rs
@@ -90,6 +90,6 @@ mod expression_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ExpressionStatement::parse(&mut newparser("a;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ExpressionStatement::parse(&mut newparser("a;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/function_definitions/mod.rs
+++ b/src/parser/function_definitions/mod.rs
@@ -116,7 +116,7 @@ impl FunctionDeclaration {
         self.params.all_private_identifiers_valid(names) && self.body.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -208,7 +208,7 @@ impl FunctionExpression {
         self.params.all_private_identifiers_valid(names) && self.body.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -297,7 +297,7 @@ impl FunctionBody {
         self.statements.lexically_declared_names()
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -388,7 +388,7 @@ impl FunctionStatementList {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/function_definitions/tests.rs
+++ b/src/parser/function_definitions/tests.rs
@@ -123,7 +123,7 @@ mod function_declaration {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        FunctionDeclaration::parse(&mut newparser("function a(){}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        FunctionDeclaration::parse(&mut newparser("function a(){}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -225,7 +225,7 @@ mod function_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        FunctionExpression::parse(&mut newparser("function a(){}"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), true);
+        FunctionExpression::parse(&mut newparser("function a(){}"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -295,7 +295,7 @@ mod function_body {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        FunctionBody::parse(&mut newparser("a;"), Scanner::new(), true, true).0.early_errors(&mut test_agent(), true);
+        FunctionBody::parse(&mut newparser("a;"), Scanner::new(), true, true).0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -368,6 +368,6 @@ mod function_statement_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        FunctionStatementList::parse(&mut newparser("a;"), Scanner::new(), true, true).0.early_errors(&mut test_agent(), true);
+        FunctionStatementList::parse(&mut newparser("a;"), Scanner::new(), true, true).0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/generator_function_definitions/mod.rs
+++ b/src/parser/generator_function_definitions/mod.rs
@@ -102,7 +102,7 @@ impl GeneratorMethod {
         self.params.contains(ParseNodeKind::SuperCall) || self.body.contains(ParseNodeKind::SuperCall)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -204,7 +204,7 @@ impl GeneratorDeclaration {
         self.params.all_private_identifiers_valid(names) && self.body.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -298,7 +298,7 @@ impl GeneratorExpression {
         self.params.all_private_identifiers_valid(names) && self.body.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -363,7 +363,7 @@ impl GeneratorBody {
         self.0.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -471,7 +471,7 @@ impl YieldExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/generator_function_definitions/tests.rs
+++ b/src/parser/generator_function_definitions/tests.rs
@@ -107,7 +107,7 @@ mod generator_method {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        GeneratorMethod::parse(&mut newparser("*a(){}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        GeneratorMethod::parse(&mut newparser("*a(){}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -224,7 +224,7 @@ mod generator_declaration {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        GeneratorDeclaration::parse(&mut newparser("function *a(){}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        GeneratorDeclaration::parse(&mut newparser("function *a(){}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -325,7 +325,7 @@ mod generator_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        GeneratorExpression::parse(&mut newparser("function *a(){}"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), true);
+        GeneratorExpression::parse(&mut newparser("function *a(){}"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -377,7 +377,7 @@ mod generator_body {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        GeneratorBody::parse(&mut newparser("a;"), Scanner::new()).0.early_errors(&mut test_agent(), true);
+        GeneratorBody::parse(&mut newparser("a;"), Scanner::new()).0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -509,6 +509,6 @@ mod yield_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        YieldExpression::parse(&mut newparser("yield a;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        YieldExpression::parse(&mut newparser("yield a;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/identifiers/mod.rs
+++ b/src/parser/identifiers/mod.rs
@@ -109,7 +109,7 @@ impl Identifier {
         false
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, strict: bool, in_module: bool) -> Vec<Object> {
+    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, in_module: bool) {
         // Static Semantics: Early Errors
         //      Identifier : IdentifierName but not ReservedWord
         //  * It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of IdentifierName
@@ -119,7 +119,6 @@ impl Identifier {
         //  * It is a Syntax Error if StringValue of IdentifierName is the same String value as the StringValue of any
         //    ReservedWord except for yield or await.
         let id = &self.name;
-        let mut errs = Vec::new();
 
         if strict
             && (id.string_value == "implements"
@@ -176,7 +175,6 @@ impl Identifier {
         {
             errs.push(create_syntax_error_object(agent, format!("‘{}’ is a reserved word and may not be used as an identifier", id.string_value).as_str()));
         }
-        errs
     }
 }
 
@@ -315,9 +313,8 @@ impl IdentifierReference {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
-        let mut errs = vec![];
         match &self.kind {
             IdentifierReferenceKind::Identifier(id) => {
                 // IdentifierReference : Identifier
@@ -330,7 +327,7 @@ impl IdentifierReference {
                 if self.await_flag && sv == "await" {
                     errs.push(create_syntax_error_object(agent, "identifier 'await' not allowed when await expressions are valid"));
                 }
-                errs.extend(id.early_errors(agent, strict, self.in_module));
+                id.early_errors(agent, errs, strict, self.in_module);
             }
             IdentifierReferenceKind::Yield => {
                 // IdentifierReference : yield
@@ -347,7 +344,6 @@ impl IdentifierReference {
                 }
             }
         }
-        errs
     }
 }
 
@@ -466,9 +462,8 @@ impl BindingIdentifier {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
-        let mut errs = vec![];
         match &self.kind {
             BindingIdentifierKind::Identifier(id) => {
                 // BindingIdentifier : Identifier
@@ -486,7 +481,7 @@ impl BindingIdentifier {
                 if self.await_flag && sv == "await" {
                     errs.push(create_syntax_error_object(agent, "identifier 'await' not allowed when await expressions are valid"));
                 }
-                errs.extend(id.early_errors(agent, strict, self.in_module));
+                id.early_errors(agent, errs, strict, self.in_module);
             }
             BindingIdentifierKind::Yield => {
                 // BindingIdentifier : yield
@@ -511,7 +506,6 @@ impl BindingIdentifier {
                 }
             }
         }
-        errs
     }
 }
 
@@ -619,9 +613,8 @@ impl LabelIdentifier {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
-        let mut errs = vec![];
         match &self.kind {
             LabelIdentifierKind::Identifier(id) => {
                 // LabelIdentifier : Identifier
@@ -634,7 +627,7 @@ impl LabelIdentifier {
                 if self.await_flag && sv == "await" {
                     errs.push(create_syntax_error_object(agent, "identifier 'await' not allowed when await expressions are valid"));
                 }
-                errs.extend(id.early_errors(agent, strict, self.in_module));
+                id.early_errors(agent, errs, strict, self.in_module);
             }
             LabelIdentifierKind::Yield => {
                 // LabelIdentifier : yield
@@ -651,7 +644,6 @@ impl LabelIdentifier {
                 }
             }
         }
-        errs
     }
 }
 

--- a/src/parser/identifiers/tests.rs
+++ b/src/parser/identifiers/tests.rs
@@ -210,7 +210,8 @@ mod identifier {
         fn strict(id: &str, strict: bool) -> Result<(), String> {
             let mut agent = test_agent();
             let (identifier, _) = Identifier::parse(&mut newparser(uify_first_ch(id).as_str()), Scanner::new()).unwrap();
-            let mut errs = identifier.early_errors(&mut agent, strict, false);
+            let mut errs = vec![];
+            identifier.early_errors(&mut agent, &mut errs, strict, false);
             if errs.is_empty() {
                 Ok(())
             } else {
@@ -258,7 +259,8 @@ mod identifier {
         fn keyword(id: &str) -> String {
             let mut agent = test_agent();
             let (identifier, _) = Identifier::parse(&mut newparser(uify_first_ch(id).as_str()), Scanner::new()).unwrap();
-            let mut errs = identifier.early_errors(&mut agent, false, false);
+            let mut errs = vec![];
+            identifier.early_errors(&mut agent, &mut errs, false, false);
             assert_eq!(errs.len(), 1);
             unwind_syntax_error_object(&mut agent, errs.swap_remove(0))
         }
@@ -268,7 +270,8 @@ mod identifier {
         fn module(src: &str, in_module: bool) -> Result<(), String> {
             let mut agent = test_agent();
             let (ident, _) = Identifier::parse(&mut newparser(src), Scanner::new()).unwrap();
-            let mut errs = ident.early_errors(&mut agent, false, in_module);
+            let mut errs = vec![];
+            ident.early_errors(&mut agent, &mut errs, false, in_module);
             if errs.is_empty() {
                 Ok(())
             } else {
@@ -523,7 +526,8 @@ mod identifier_reference {
             let mut agent = test_agent();
             let goal = if in_module { ParseGoal::Module } else { ParseGoal::Script };
             let (item, _) = IdentifierReference::parse(&mut Parser::new(src, strict, false, goal), Scanner::new(), yield_expr_allowed, await_expr_allowed).unwrap();
-            let errs = item.early_errors(&mut agent, strict);
+            let mut errs = vec![];
+            item.early_errors(&mut agent, &mut errs, strict);
             AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
         }
     }
@@ -769,7 +773,8 @@ mod binding_identifier {
             let mut agent = test_agent();
             let goal = if in_module { ParseGoal::Module } else { ParseGoal::Script };
             let (item, _) = BindingIdentifier::parse(&mut Parser::new(src, strict, false, goal), Scanner::new(), yield_expr_allowed, await_expr_allowed).unwrap();
-            let errs = item.early_errors(&mut agent, strict);
+            let mut errs = vec![];
+            item.early_errors(&mut agent, &mut errs, strict);
             AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
         }
     }
@@ -992,7 +997,8 @@ mod label_identifier {
             let mut agent = test_agent();
             let goal = if in_module { ParseGoal::Module } else { ParseGoal::Script };
             let (item, _) = LabelIdentifier::parse(&mut Parser::new(src, strict, false, goal), Scanner::new(), yield_expr_allowed, await_expr_allowed).unwrap();
-            let errs = item.early_errors(&mut agent, strict);
+            let mut errs = vec![];
+            item.early_errors(&mut agent, &mut errs, strict);
             AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
         }
     }

--- a/src/parser/if_statement/mod.rs
+++ b/src/parser/if_statement/mod.rs
@@ -140,7 +140,7 @@ impl IfStatement {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/if_statement/tests.rs
+++ b/src/parser/if_statement/tests.rs
@@ -181,6 +181,6 @@ mod if_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        IfStatement::parse(&mut newparser("if(a){}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        IfStatement::parse(&mut newparser("if(a){}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/iteration_statements/mod.rs
+++ b/src/parser/iteration_statements/mod.rs
@@ -145,7 +145,7 @@ impl IterationStatement {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -240,7 +240,7 @@ impl DoWhileStatement {
         s.all_private_identifiers_valid(names) && e.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -331,7 +331,7 @@ impl WhileStatement {
         e.all_private_identifiers_valid(names) && s.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -596,7 +596,7 @@ impl ForStatement {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -918,7 +918,7 @@ impl ForInOfStatement {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1033,7 +1033,7 @@ impl ForDeclaration {
         node.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1132,7 +1132,7 @@ impl ForBinding {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/iteration_statements/tests.rs
+++ b/src/parser/iteration_statements/tests.rs
@@ -226,7 +226,7 @@ mod iteration_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        IterationStatement::parse(&mut newparser("do{}while(1);"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        IterationStatement::parse(&mut newparser("do{}while(1);"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -331,7 +331,7 @@ mod do_while_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        DoWhileStatement::parse(&mut newparser("do{}while(1);"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        DoWhileStatement::parse(&mut newparser("do{}while(1);"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -424,7 +424,7 @@ mod while_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        WhileStatement::parse(&mut newparser("while(1);"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        WhileStatement::parse(&mut newparser("while(1);"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1060,7 +1060,7 @@ mod for_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ForStatement::parse(&mut newparser("for(;;){}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ForStatement::parse(&mut newparser("for(;;){}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1763,7 +1763,7 @@ mod for_in_of_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ForInOfStatement::parse(&mut newparser("for(x in y);"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ForInOfStatement::parse(&mut newparser("for(x in y);"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1833,7 +1833,7 @@ mod for_declaration {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ForDeclaration::parse(&mut newparser("let a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ForDeclaration::parse(&mut newparser("let a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1923,6 +1923,6 @@ mod for_binding {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ForBinding::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ForBinding::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/labelled_statements/mod.rs
+++ b/src/parser/labelled_statements/mod.rs
@@ -108,7 +108,7 @@ impl LabelledStatement {
         self.item.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -241,7 +241,7 @@ impl LabelledItem {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/labelled_statements/tests.rs
+++ b/src/parser/labelled_statements/tests.rs
@@ -122,7 +122,7 @@ mod labelled_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        LabelledStatement::parse(&mut newparser("a:b;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        LabelledStatement::parse(&mut newparser("a:b;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -276,6 +276,6 @@ mod labelled_item {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        LabelledItem::parse(&mut newparser("b;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        LabelledItem::parse(&mut newparser("b;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/left_hand_side_expressions/mod.rs
+++ b/src/parser/left_hand_side_expressions/mod.rs
@@ -317,7 +317,7 @@ impl MemberExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -416,7 +416,7 @@ impl SuperProperty {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -504,7 +504,7 @@ impl MetaProperty {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -620,7 +620,7 @@ impl Arguments {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -810,7 +810,7 @@ impl ArgumentList {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -932,7 +932,7 @@ impl NewExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -993,7 +993,7 @@ impl CallMemberExpression {
         self.member_expression.all_private_identifiers_valid(names) && self.arguments.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1052,7 +1052,7 @@ impl SuperCall {
         self.arguments.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1115,7 +1115,7 @@ impl ImportCall {
         self.assignment_expression.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1341,7 +1341,7 @@ impl CallExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1467,7 +1467,7 @@ impl LeftHandSideExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1587,7 +1587,7 @@ impl OptionalExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1837,7 +1837,7 @@ impl OptionalChain {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/left_hand_side_expressions/tests.rs
+++ b/src/parser/left_hand_side_expressions/tests.rs
@@ -344,7 +344,7 @@ mod member_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        MemberExpression::parse(&mut newparser("b"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        MemberExpression::parse(&mut newparser("b"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -442,7 +442,7 @@ mod super_property {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        SuperProperty::parse(&mut newparser("super.b"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        SuperProperty::parse(&mut newparser("super.b"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -522,7 +522,7 @@ mod meta_property {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        MetaProperty::parse(&mut newparser("new.target"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), true);
+        MetaProperty::parse(&mut newparser("new.target"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -639,7 +639,7 @@ mod arguments {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        Arguments::parse(&mut newparser("()"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        Arguments::parse(&mut newparser("()"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -811,7 +811,7 @@ mod argument_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ArgumentList::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ArgumentList::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -923,7 +923,7 @@ mod new_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        NewExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        NewExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -982,7 +982,7 @@ mod call_member_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        CallMemberExpression::parse(&mut newparser("a()"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        CallMemberExpression::parse(&mut newparser("a()"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1037,7 +1037,7 @@ mod super_call {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        SuperCall::parse(&mut newparser("super()"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        SuperCall::parse(&mut newparser("super()"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1097,7 +1097,7 @@ mod import_call {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ImportCall::parse(&mut newparser("import(a)"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ImportCall::parse(&mut newparser("import(a)"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1415,7 +1415,7 @@ mod call_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        CallExpression::parse(&mut newparser("b(a)"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        CallExpression::parse(&mut newparser("b(a)"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1555,7 +1555,7 @@ mod optional_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        OptionalExpression::parse(&mut newparser("a?.b"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        OptionalExpression::parse(&mut newparser("a?.b"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1924,7 +1924,7 @@ mod optional_chain {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        OptionalChain::parse(&mut newparser("?.a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        OptionalChain::parse(&mut newparser("?.a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -2049,6 +2049,6 @@ mod left_hand_side_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        LeftHandSideExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        LeftHandSideExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/method_definitions/mod.rs
+++ b/src/parser/method_definitions/mod.rs
@@ -259,7 +259,7 @@ impl MethodDefinition {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -314,7 +314,7 @@ impl PropertySetParameterList {
         self.node.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/method_definitions/tests.rs
+++ b/src/parser/method_definitions/tests.rs
@@ -431,7 +431,7 @@ mod method_definition {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        MethodDefinition::parse(&mut newparser("a(){}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        MethodDefinition::parse(&mut newparser("a(){}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -477,6 +477,6 @@ mod property_set_parameter_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        PropertySetParameterList::parse(&mut newparser("a"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), true);
+        PropertySetParameterList::parse(&mut newparser("a"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -422,7 +422,8 @@ pub fn parse_text(agent: &mut Agent, src: &str, goal_symbol: ParseGoal) -> Parse
                     ParsedText::Errors(vec![syntax_error])
                 }
                 Ok((node, _)) => {
-                    let errs = node.early_errors(agent);
+                    let mut errs = vec![];
+                    node.early_errors(agent, &mut errs);
                     if errs.is_empty() {
                         ParsedText::Script(node)
                     } else {

--- a/src/parser/multiplicative_operators/mod.rs
+++ b/src/parser/multiplicative_operators/mod.rs
@@ -171,7 +171,7 @@ impl MultiplicativeExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/multiplicative_operators/tests.rs
+++ b/src/parser/multiplicative_operators/tests.rs
@@ -174,6 +174,6 @@ mod multiplicative_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        MultiplicativeExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        MultiplicativeExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/parameter_lists/mod.rs
+++ b/src/parser/parameter_lists/mod.rs
@@ -70,7 +70,7 @@ impl UniqueFormalParameters {
         self.formals.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -269,7 +269,7 @@ impl FormalParameters {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -397,7 +397,7 @@ impl FormalParameterList {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -460,7 +460,7 @@ impl FunctionRestParameter {
         self.element.bound_names()
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -542,7 +542,7 @@ impl FormalParameter {
         self.element.bound_names()
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/parameter_lists/tests.rs
+++ b/src/parser/parameter_lists/tests.rs
@@ -52,7 +52,7 @@ mod unique_formal_parameters {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        UniqueFormalParameters::parse(&mut newparser("a"), Scanner::new(), true, true).0.early_errors(&mut test_agent(), true);
+        UniqueFormalParameters::parse(&mut newparser("a"), Scanner::new(), true, true).0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -245,7 +245,7 @@ mod formal_parameters {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        FormalParameters::parse(&mut newparser("a"), Scanner::new(), true, true).0.early_errors(&mut test_agent(), true);
+        FormalParameters::parse(&mut newparser("a"), Scanner::new(), true, true).0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -345,7 +345,7 @@ mod formal_parameter_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        FormalParameterList::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        FormalParameterList::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -398,7 +398,7 @@ mod function_rest_parameter {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        FunctionRestParameter::parse(&mut newparser("...a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        FunctionRestParameter::parse(&mut newparser("...a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -465,6 +465,6 @@ mod formal_parameter {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        FormalParameter::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        FormalParameter::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/primary_expressions/mod.rs
+++ b/src/parser/primary_expressions/mod.rs
@@ -369,7 +369,7 @@ impl PrimaryExpression {
         matches!(&self.kind, PrimaryExpressionKind::ArrayLiteral(_) | PrimaryExpressionKind::ObjectLiteral(_))
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -442,7 +442,7 @@ impl Elisions {
         false
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -506,7 +506,7 @@ impl SpreadElement {
         boxed.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -721,7 +721,7 @@ impl ElementList {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -860,7 +860,7 @@ impl ArrayLiteral {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -936,7 +936,7 @@ impl Initializer {
         node.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1001,7 +1001,7 @@ impl CoverInitializedName {
         izer.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1067,7 +1067,7 @@ impl ComputedPropertyName {
         n.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1134,7 +1134,7 @@ impl LiteralPropertyName {
         false
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1226,7 +1226,7 @@ impl PropertyName {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1370,7 +1370,7 @@ impl PropertyDefinition {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1459,7 +1459,7 @@ impl PropertyDefinitionList {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1561,7 +1561,7 @@ impl ObjectLiteral {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1673,7 +1673,7 @@ impl Literal {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1773,7 +1773,7 @@ impl TemplateLiteral {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1842,7 +1842,7 @@ impl SubstitutionTemplate {
         self.expression.all_private_identifiers_valid(names) && self.template_spans.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -1941,7 +1941,7 @@ impl TemplateSpans {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -2048,7 +2048,7 @@ impl TemplateMiddleList {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -2129,7 +2129,7 @@ impl ParenthesizedExpression {
         e.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -2337,7 +2337,7 @@ impl CoverParenthesizedExpressionAndArrowParameterList {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/primary_expressions/tests.rs
+++ b/src/parser/primary_expressions/tests.rs
@@ -459,7 +459,7 @@ mod primary_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        PrimaryExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        PrimaryExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -592,7 +592,7 @@ mod literal {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        Literal::parse(&mut newparser("3"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), true);
+        Literal::parse(&mut newparser("3"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -643,7 +643,7 @@ mod elision {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        Elisions::parse(&mut newparser(","), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), true);
+        Elisions::parse(&mut newparser(","), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -697,7 +697,7 @@ mod spread_element {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        SpreadElement::parse(&mut newparser("...a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        SpreadElement::parse(&mut newparser("...a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1002,7 +1002,7 @@ mod element_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ElementList::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ElementList::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1179,7 +1179,7 @@ mod array_literal {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ArrayLiteral::parse(&mut newparser("[]"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ArrayLiteral::parse(&mut newparser("[]"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1237,7 +1237,7 @@ mod initializer {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        Initializer::parse(&mut newparser("=a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        Initializer::parse(&mut newparser("=a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1290,7 +1290,7 @@ mod cover_initialized_name {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        CoverInitializedName::parse(&mut newparser("b=a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        CoverInitializedName::parse(&mut newparser("b=a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1347,7 +1347,7 @@ mod computed_property_name {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ComputedPropertyName::parse(&mut newparser("[a]"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ComputedPropertyName::parse(&mut newparser("[a]"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1429,7 +1429,7 @@ mod literal_property_name {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        LiteralPropertyName::parse(&mut newparser("b"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), true);
+        LiteralPropertyName::parse(&mut newparser("b"), Scanner::new()).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1518,7 +1518,7 @@ mod property_name {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        PropertyName::parse(&mut newparser("b"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        PropertyName::parse(&mut newparser("b"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1700,7 +1700,7 @@ mod property_definition {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        PropertyDefinition::parse(&mut newparser("b"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        PropertyDefinition::parse(&mut newparser("b"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1794,7 +1794,7 @@ mod property_definition_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        PropertyDefinitionList::parse(&mut newparser("b"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        PropertyDefinitionList::parse(&mut newparser("b"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1909,7 +1909,7 @@ mod object_literal {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ObjectLiteral::parse(&mut newparser("{}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ObjectLiteral::parse(&mut newparser("{}"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -1968,7 +1968,7 @@ mod parenthesized_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ParenthesizedExpression::parse(&mut newparser("(a)"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ParenthesizedExpression::parse(&mut newparser("(a)"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -2066,7 +2066,7 @@ mod template_middle_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        TemplateMiddleList::parse(&mut newparser("}${a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        TemplateMiddleList::parse(&mut newparser("}${a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -2141,7 +2141,7 @@ mod template_spans {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        TemplateSpans::parse(&mut newparser("}`"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        TemplateSpans::parse(&mut newparser("}`"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -2205,7 +2205,7 @@ mod substitution_template {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        SubstitutionTemplate::parse(&mut newparser("`${a}`"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        SubstitutionTemplate::parse(&mut newparser("`${a}`"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -2291,7 +2291,7 @@ mod template_literal {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        TemplateLiteral::parse(&mut newparser("`${a}`"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        TemplateLiteral::parse(&mut newparser("`${a}`"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -2534,6 +2534,6 @@ mod cover_parenthesized_expression_and_arrow_parameter_list {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        CoverParenthesizedExpressionAndArrowParameterList::parse(&mut newparser("()"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        CoverParenthesizedExpressionAndArrowParameterList::parse(&mut newparser("()"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/relational_operators/mod.rs
+++ b/src/parser/relational_operators/mod.rs
@@ -214,7 +214,7 @@ impl RelationalExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/relational_operators/tests.rs
+++ b/src/parser/relational_operators/tests.rs
@@ -350,6 +350,6 @@ mod relational_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        RelationalExpression::parse(&mut newparser("a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        RelationalExpression::parse(&mut newparser("a"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/return_statement/mod.rs
+++ b/src/parser/return_statement/mod.rs
@@ -82,7 +82,7 @@ impl ReturnStatement {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/return_statement/tests.rs
+++ b/src/parser/return_statement/tests.rs
@@ -96,6 +96,6 @@ mod return_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ReturnStatement::parse(&mut newparser("return;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ReturnStatement::parse(&mut newparser("return;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/scripts/mod.rs
+++ b/src/parser/scripts/mod.rs
@@ -95,7 +95,7 @@ impl Script {
                 }
                 body.early_errors(agent, errs);
             }
-            None => {},
+            None => {}
         }
     }
 
@@ -202,7 +202,6 @@ impl ScriptBody {
         let needle = JSString::from("use strict");
         prologue.iter().any(|string_tok| string_tok.raw.is_none() && string_tok.value == needle)
     }
-
 }
 
 #[cfg(test)]

--- a/src/parser/scripts/mod.rs
+++ b/src/parser/scripts/mod.rs
@@ -80,10 +80,9 @@ impl Script {
     // * It is a Syntax Error if the LexicallyDeclaredNames of ScriptBody contains any duplicate entries.
     // * It is a Syntax Error if any element of the LexicallyDeclaredNames of ScriptBody also occurs in the
     //   VarDeclaredNames of ScriptBody.
-    pub fn early_errors(&self, agent: &mut Agent) -> Vec<Object> {
+    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>) {
         match &self.0 {
             Some(body) => {
-                let mut errs: Vec<Object> = Vec::new();
                 let lex_names = body.lexically_declared_names();
                 let var_names = body.var_declared_names();
                 if !has_unique_elements(lex_names.clone()) {
@@ -94,10 +93,9 @@ impl Script {
                 if !lex_names_set.is_disjoint(&var_names_set) {
                     errs.push(create_syntax_error_object(agent, "Name defined both lexically and var-style"));
                 }
-                errs.extend(body.early_errors(agent));
-                errs
+                body.early_errors(agent, errs);
             }
-            None => vec![],
+            None => {},
         }
     }
 
@@ -167,8 +165,7 @@ impl ScriptBody {
     //  * It is a Syntax Error if ContainsUndefinedContinueTarget of StatementList with arguments « » and « » is true.
     //  * It is a Syntax Error if AllPrivateIdentifiersValid of StatementList with argument « » is false unless the
     //    source code containing ScriptBody is eval code that is being processed by a direct eval.
-    pub fn early_errors(&self, agent: &mut Agent) -> Vec<Object> {
-        let mut errs = vec![];
+    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>) {
         if !self.direct {
             if self.statement_list.contains(ParseNodeKind::Super) {
                 errs.push(create_syntax_error_object(agent, "`super' not allowed in top-level code"));
@@ -189,8 +186,7 @@ impl ScriptBody {
         if !self.direct && !self.statement_list.all_private_identifiers_valid(&[]) {
             errs.push(create_syntax_error_object(agent, "invalid private identifier detected"));
         }
-        //errs.extend(self.statement_list.early_errors(agent));
-        errs
+        self.statement_list.early_errors(agent, errs, self.contains_use_strict());
     }
 
     pub fn contains(&self, kind: ParseNodeKind) -> bool {
@@ -200,6 +196,13 @@ impl ScriptBody {
     pub fn directive_prologue(&self) -> Vec<StringToken> {
         self.statement_list.initial_string_tokens()
     }
+
+    pub fn contains_use_strict(&self) -> bool {
+        let prologue = self.directive_prologue();
+        let needle = JSString::from("use strict");
+        prologue.iter().any(|string_tok| string_tok.raw.is_none() && string_tok.value == needle)
+    }
+
 }
 
 #[cfg(test)]

--- a/src/parser/scripts/tests.rs
+++ b/src/parser/scripts/tests.rs
@@ -73,43 +73,54 @@ fn script_test_early_errors_01() {
     let mut agent = Agent::new();
     agent.initialize_host_defined_realm();
     let (item, _) = Script::parse(&mut newparser(""), Scanner::new()).unwrap();
-    assert_eq!(item.early_errors(&mut agent), &[] as &[Object]);
+    let mut errs = vec![];
+    item.early_errors(&mut agent, &mut errs);
+    assert_eq!(errs, &[] as &[Object]);
 }
 #[test]
+#[should_panic(expected = "not yet implemented")]
 fn script_test_early_errors_02() {
     let mut agent = Agent::new();
     agent.initialize_host_defined_realm();
     let (item, _) = Script::parse(&mut newparser("0;"), Scanner::new()).unwrap();
-    assert_eq!(item.early_errors(&mut agent), &[] as &[Object]);
+    let mut errs = vec![];
+    item.early_errors(&mut agent, &mut errs);
+    assert_eq!(errs, &[] as &[Object]);
 }
 #[test]
+#[should_panic(expected = "not yet implemented")]
 fn script_test_early_errors_03() {
     let mut agent = Agent::new();
     agent.initialize_host_defined_realm();
     let (item, _) = Script::parse(&mut newparser("let x; const x=10;"), Scanner::new()).unwrap();
-    let mut errs = item.early_errors(&mut agent);
+    let mut errs = vec![];
+    item.early_errors(&mut agent, &mut errs);
     assert_eq!(errs.len(), 1);
     let err = errs.pop().unwrap();
     let msg = unwind_syntax_error_object(&mut agent, err);
     assert_eq!(msg, "Duplicate lexically declared names");
 }
 #[test]
+#[should_panic(expected = "not yet implemented")]
 fn script_test_early_errors_04() {
     let mut agent = Agent::new();
     agent.initialize_host_defined_realm();
     let (item, _) = Script::parse(&mut newparser("let x; var x=10;"), Scanner::new()).unwrap();
-    let mut errs = item.early_errors(&mut agent);
+    let mut errs = vec![];
+    item.early_errors(&mut agent, &mut errs);
     assert_eq!(errs.len(), 1);
     let err = errs.pop().unwrap();
     let msg = unwind_syntax_error_object(&mut agent, err);
     assert_eq!(msg, "Name defined both lexically and var-style");
 }
 #[test]
+#[should_panic(expected = "not yet implemented")]
 fn script_test_early_errors_05() {
     let mut agent = Agent::new();
     agent.initialize_host_defined_realm();
     let (item, _) = Script::parse(&mut newparser("break a;"), Scanner::new()).unwrap();
-    let mut errs = item.early_errors(&mut agent);
+    let mut errs = vec![];
+    item.early_errors(&mut agent, &mut errs);
     assert_eq!(errs.len(), 1);
     let err = errs.pop().unwrap();
     let msg = unwind_syntax_error_object(&mut agent, err);
@@ -155,7 +166,8 @@ fn script_body_ee_check_core(p: &mut Parser, desired: Option<&str>) {
     let (item, _) = ScriptBody::parse(p, Scanner::new()).unwrap();
     let mut agent = Agent::new();
     agent.initialize_host_defined_realm();
-    let mut errs = item.early_errors(&mut agent);
+    let mut errs = vec![];
+    item.early_errors(&mut agent, &mut errs);
     match desired {
         Some(expected_message) => {
             assert_eq!(errs.len(), 1);
@@ -178,38 +190,47 @@ fn script_body_ee_check_direct(src: &str, desired: Option<&str>) {
     script_body_ee_check_core(&mut p, desired);
 }
 #[test]
+#[should_panic(expected = "not yet implemented")]
 fn script_body_test_early_errors_01() {
     script_body_ee_check("super();", Some("`super' not allowed in top-level code"));
 }
 #[test]
+#[should_panic(expected = "not yet implemented")]
 fn script_body_test_early_errors_02() {
     script_body_ee_check("b=new.target;", Some("`new.target` not allowed in top-level code"));
 }
 #[test]
+#[should_panic(expected = "not yet implemented")]
 fn script_body_test_early_errors_03() {
     script_body_ee_check("break t;", Some("undefined break target detected"));
 }
 #[test]
+#[should_panic(expected = "not yet implemented")]
 fn script_body_test_early_errors_04() {
     script_body_ee_check_direct("super();", None);
 }
 #[test]
+#[should_panic(expected = "not yet implemented")]
 fn script_body_test_early_errors_05() {
     script_body_ee_check_direct("a=new.target;", None);
 }
 #[test]
+#[should_panic(expected = "not yet implemented")]
 fn script_body_test_early_errors_06() {
     script_body_ee_check(";", None);
 }
 #[test]
+#[should_panic(expected = "not yet implemented")]
 fn script_body_test_early_errors_07() {
     script_body_ee_check("t:{t:;}", Some("duplicate labels detected"));
 }
 #[test]
+#[should_panic(expected = "not yet implemented")]
 fn script_body_test_early_errors_08() {
     script_body_ee_check("continue bob;", Some("undefined continue target detected"));
 }
 #[test]
+#[should_panic(expected = "not yet implemented")]
 fn script_body_test_early_errors_09() {
     script_body_ee_check("a.#mystery;", Some("invalid private identifier detected"));
 }
@@ -234,4 +255,16 @@ fn script_body_test_directive_prologue_02() {
 
     let dp = item.directive_prologue();
     assert_eq!(dp, &[]);
+}
+mod script_body {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case("a;" => false; "no prologue")]
+    #[test_case("'a'; func();" => false; "prologue without clause")]
+    #[test_case("'a'; 'use strict'; b();" => true; "prologue with clause")]
+    #[test_case("'a'; 'use\\x20strict'; b();" => false; "prologue with escape")]
+    fn contains_use_strict(src: &str) -> bool {
+        ScriptBody::parse(&mut newparser(src), Scanner::new()).unwrap().0.contains_use_strict()
+    }
 }

--- a/src/parser/statements_and_declarations/mod.rs
+++ b/src/parser/statements_and_declarations/mod.rs
@@ -336,7 +336,7 @@ impl Statement {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -435,7 +435,7 @@ impl Declaration {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -546,7 +546,7 @@ impl HoistableDeclaration {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -659,7 +659,7 @@ impl BreakableStatement {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/statements_and_declarations/tests.rs
+++ b/src/parser/statements_and_declarations/tests.rs
@@ -480,7 +480,7 @@ mod statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        Statement::parse(&mut newparser(";"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        Statement::parse(&mut newparser(";"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -580,7 +580,7 @@ mod declaration {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        Declaration::parse(&mut newparser("let a;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        Declaration::parse(&mut newparser("let a;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -712,7 +712,7 @@ mod hoistable_declaration {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        HoistableDeclaration::parse(&mut newparser("function a(){}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        HoistableDeclaration::parse(&mut newparser("function a(){}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -823,6 +823,6 @@ mod breakable_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        BreakableStatement::parse(&mut newparser("while(1);"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        BreakableStatement::parse(&mut newparser("while(1);"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/switch_statement/mod.rs
+++ b/src/parser/switch_statement/mod.rs
@@ -87,7 +87,7 @@ impl SwitchStatement {
         self.expression.all_private_identifiers_valid(names) && self.case_block.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -282,7 +282,7 @@ impl CaseBlock {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -401,7 +401,7 @@ impl CaseClauses {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -515,7 +515,7 @@ impl CaseClause {
             }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -622,7 +622,7 @@ impl DefaultClause {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/switch_statement/tests.rs
+++ b/src/parser/switch_statement/tests.rs
@@ -75,7 +75,7 @@ mod switch_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        SwitchStatement::parse(&mut newparser("switch(a){default:;}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        SwitchStatement::parse(&mut newparser("switch(a){default:;}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -265,7 +265,7 @@ mod case_block {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        CaseBlock::parse(&mut newparser("{}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        CaseBlock::parse(&mut newparser("{}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -365,7 +365,7 @@ mod case_clauses {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        CaseClauses::parse(&mut newparser("case 0:;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        CaseClauses::parse(&mut newparser("case 0:;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -464,7 +464,7 @@ mod case_clause {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        CaseClause::parse(&mut newparser("case 0:;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        CaseClause::parse(&mut newparser("case 0:;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -557,6 +557,6 @@ mod default_clause {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        DefaultClause::parse(&mut newparser("default:;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        DefaultClause::parse(&mut newparser("default:;"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -517,6 +517,7 @@ fn parse_node_kind_01() {
     assert_eq!(p1, p1.clone());
 }
 #[test]
+#[should_panic(expected = "not yet implemented")]
 fn parse_text_01() {
     let mut agent = Agent::new();
     agent.initialize_host_defined_realm();
@@ -531,6 +532,7 @@ fn parse_text_02() {
     assert!(matches!(res, ParsedText::Errors(_)));
 }
 #[test]
+#[should_panic(expected = "not yet implemented")]
 fn parse_text_03() {
     let mut agent = Agent::new();
     agent.initialize_host_defined_realm();

--- a/src/parser/throw_statement/mod.rs
+++ b/src/parser/throw_statement/mod.rs
@@ -63,7 +63,7 @@ impl ThrowStatement {
         self.0.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/throw_statement/tests.rs
+++ b/src/parser/throw_statement/tests.rs
@@ -47,6 +47,6 @@ mod throw_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        ThrowStatement::parse(&mut newparser("throw 1;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        ThrowStatement::parse(&mut newparser("throw 1;"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/try_statement/mod.rs
+++ b/src/parser/try_statement/mod.rs
@@ -189,7 +189,7 @@ impl TryStatement {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -288,7 +288,7 @@ impl Catch {
         self.parameter.as_ref().map_or(true, |n| n.all_private_identifiers_valid(names)) && self.block.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -364,7 +364,7 @@ impl Finally {
         self.block.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -456,7 +456,7 @@ impl CatchParameter {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/try_statement/tests.rs
+++ b/src/parser/try_statement/tests.rs
@@ -162,7 +162,7 @@ mod try_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        TryStatement::parse(&mut newparser("try{}finally{}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        TryStatement::parse(&mut newparser("try{}finally{}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -273,7 +273,7 @@ mod catch {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        Catch::parse(&mut newparser("catch{}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        Catch::parse(&mut newparser("catch{}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -346,7 +346,7 @@ mod finally {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        Finally::parse(&mut newparser("finally{}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        Finally::parse(&mut newparser("finally{}"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }
 
@@ -421,6 +421,6 @@ mod catch_parameter {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        CatchParameter::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        CatchParameter::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/unary_operators/mod.rs
+++ b/src/parser/unary_operators/mod.rs
@@ -200,7 +200,7 @@ impl UnaryExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/unary_operators/tests.rs
+++ b/src/parser/unary_operators/tests.rs
@@ -349,6 +349,6 @@ mod unary_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        UnaryExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        UnaryExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/update_expressions/mod.rs
+++ b/src/parser/update_expressions/mod.rs
@@ -177,7 +177,7 @@ impl UpdateExpression {
         }
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/update_expressions/tests.rs
+++ b/src/parser/update_expressions/tests.rs
@@ -225,6 +225,6 @@ mod update_expression {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        UpdateExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        UpdateExpression::parse(&mut newparser("a"), Scanner::new(), true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }

--- a/src/parser/with_statement/mod.rs
+++ b/src/parser/with_statement/mod.rs
@@ -87,7 +87,7 @@ impl WithStatement {
         self.expression.all_private_identifiers_valid(names) && self.statement.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, _agent: &mut Agent, _strict: bool) -> Vec<Object> {
+    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/with_statement/tests.rs
+++ b/src/parser/with_statement/tests.rs
@@ -93,6 +93,6 @@ mod with_statement {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        WithStatement::parse(&mut newparser("with(a);"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), true);
+        WithStatement::parse(&mut newparser("with(a);"), Scanner::new(), true, true, true).unwrap().0.early_errors(&mut test_agent(), &mut vec![], true);
     }
 }


### PR DESCRIPTION
Just keep changing one vector, rather than joining fresh ones and
copying stuff all the time.