### PR TITLE
Move the coverage builds to their own profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["profile-rustflags"]
+
 [package]
 name = "res"
 version = "0.1.0"
@@ -22,3 +24,7 @@ counter = "0.5.3"
 
 [dev-dependencies]
 test-case = "1.2.0"
+
+[profile.coverage]
+inherits = "dev"
+rustflags = [ "-Cinstrument-coverage" ]

--- a/funcs.sh
+++ b/funcs.sh
@@ -1,6 +1,6 @@
 function objects() {
     for file in $( \
-            RUSTFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="res-%m.profraw" cargo test --no-run --message-format=json 2> /dev/null | \
+            LLVM_PROFILE_FILE="res-%m.profraw" cargo test --profile coverage --no-run --message-format=json 2> /dev/null | \
                 jq -r "select(.profile.test == true) | .filenames[]" | \
                 grep -v dSYM - \
             ); do
@@ -16,7 +16,7 @@ function tst() {
   rm -f res-*.profraw
   local quiet=
   if [ $# -eq 0 ]; then quiet=-q; fi
-  RUST_BACKTRACE=1 RUSTFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="res-%m.profraw" cargo test $quiet "$@"
+  RUST_BACKTRACE=1 LLVM_PROFILE_FILE="res-%m.profraw" cargo test --profile coverage $quiet "$@"
   cargo profdata -- merge res-*.profraw --output=res.profdata
   cd $here
 }


### PR DESCRIPTION
This is _wonderful_. The debug build for coverage has been fighting
against the builds that the rust analyzer does for the IDE, causing far
too frequent recompilation.

Keeping these two separate does wonders for the responsiveness of the
IDE. This is a big win.