### PR TITLE
Add impl for Default for Scanner

### DIFF
--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -375,6 +375,11 @@ impl Scanner {
         Scanner { line: 1, column: 1, start_idx: 0 }
     }
 }
+impl Default for Scanner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl PartialOrd for Scanner {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         if self.line < other.line {


### PR DESCRIPTION
For some builds (but not all?) I'm getting a new clippy lint about
having a Default impl for types with a public new() function.