### PR TITLE
Add LexicallyScopedDeclarations for script nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,9 +83,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.123"
+version = "0.2.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
+checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
 
 [[package]]
 name = "memchr"

--- a/src/parser/block/mod.rs
+++ b/src/parser/block/mod.rs
@@ -1,6 +1,6 @@
 use super::scanner::{Punctuator, ScanGoal, Scanner, StringToken};
 use super::scripts::VarScopeDecl;
-use super::statements_and_declarations::{Declaration, Statement};
+use super::statements_and_declarations::{DeclPart, Declaration, Statement};
 use super::*;
 use crate::prettyprint::{pprint_token, prettypad, PrettyPrint, Spot, TokenType};
 use ahash::AHashSet;
@@ -544,6 +544,20 @@ impl StatementList {
             }
         }
     }
+
+    /// Returns the lexically-scoped declarations of this node (as if this node was at global scope)
+    ///
+    /// See [TopLevelLexicallyScopedDeclarations](https://tc39.es/ecma262/#sec-static-semantics-toplevellexicallyscopeddeclarations) in ECMA-262.
+    pub fn top_level_lexically_scoped_declarations(&self) -> Vec<DeclPart> {
+        match self {
+            StatementList::Item(sli) => sli.top_level_lexically_scoped_declarations(),
+            StatementList::List(sl, sli) => {
+                let mut list = sl.top_level_lexically_scoped_declarations();
+                list.extend(sli.top_level_lexically_scoped_declarations());
+                list
+            }
+        }
+    }
 }
 
 // StatementListItem[Yield, Await, Return] :
@@ -745,6 +759,16 @@ impl StatementListItem {
         match self {
             StatementListItem::Declaration(_) => vec![],
             StatementListItem::Statement(stmt) => stmt.var_scoped_declarations(),
+        }
+    }
+
+    /// Returns the lexically-scoped declarations of this node (as if this node was at global scope)
+    ///
+    /// See [TopLevelLexicallyScopedDeclarations](https://tc39.es/ecma262/#sec-static-semantics-toplevellexicallyscopeddeclarations) in ECMA-262.
+    pub fn top_level_lexically_scoped_declarations(&self) -> Vec<DeclPart> {
+        match self {
+            StatementListItem::Statement(_) => vec![],
+            StatementListItem::Declaration(d) => d.top_level_lexically_scoped_declarations(),
         }
     }
 }

--- a/src/parser/block/tests.rs
+++ b/src/parser/block/tests.rs
@@ -485,6 +485,12 @@ mod statement_list {
     fn top_level_var_scoped_declarations(src: &str) -> Vec<String> {
         Maker::new(src).statement_list().top_level_var_scoped_declarations().iter().map(String::from).collect::<Vec<_>>()
     }
+
+    #[test_case("let dragon=xorn;" => svec(&["let dragon = xorn ;"]); "item")]
+    #[test_case("const a=0; function b(){} class c{}" => svec(&["const a = 0 ;", "class c { }"]); "list")]
+    fn top_level_lexically_scoped_declarations(src: &str) -> Vec<String> {
+        Maker::new(src).statement_list().top_level_lexically_scoped_declarations().iter().map(String::from).collect::<Vec<_>>()
+    }
 }
 
 // STATEMENT LIST ITEM
@@ -701,5 +707,11 @@ mod statement_list_item {
     #[test_case("const rust=10;" => svec(&[]); "not hoistable")]
     fn top_level_var_scoped_declarations(src: &str) -> Vec<String> {
         Maker::new(src).statement_list_item().top_level_var_scoped_declarations().iter().map(String::from).collect::<Vec<_>>()
+    }
+
+    #[test_case("var a=27;" => svec(&[]); "statement")]
+    #[test_case("class rocket{}" => svec(&["class rocket { }"]); "declaration")]
+    fn top_level_lexically_scoped_declarations(src: &str) -> Vec<String> {
+        Maker::new(src).statement_list_item().top_level_lexically_scoped_declarations().iter().map(String::from).collect::<Vec<_>>()
     }
 }

--- a/src/parser/scripts/mod.rs
+++ b/src/parser/scripts/mod.rs
@@ -6,7 +6,7 @@ use super::generator_function_definitions::GeneratorDeclaration;
 use super::identifiers::BindingIdentifier;
 use super::iteration_statements::ForBinding;
 use super::scanner::{Scanner, StringToken};
-use super::statements_and_declarations::HoistableDeclPart;
+use super::statements_and_declarations::{DeclPart, HoistableDeclPart};
 use super::*;
 use crate::prettyprint::{prettypad, PrettyPrint, Spot};
 use ahash::AHashSet;
@@ -184,6 +184,19 @@ impl Script {
             Some(sb) => sb.var_scoped_declarations(),
         }
     }
+
+    /// Return a list of parse nodes for the lexically declared identifiers contained within the children of this node.
+    ///
+    /// For Scripts and ScriptBodies, function definitions that exist lexically at global scipe are treated as though
+    /// they are declared var-style, and as such won't be reflected here.
+    ///
+    /// See [LexicallyScopedDeclarations](https://tc39.es/ecma262/#sec-static-semantics-lexicallyscopeddeclarations) in ECMA-262.
+    pub fn lexically_scoped_declarations(&self) -> Vec<DeclPart> {
+        match &self.0 {
+            None => vec![],
+            Some(sb) => sb.lexically_scoped_declarations(),
+        }
+    }
 }
 
 // ScriptBody :
@@ -290,6 +303,16 @@ impl ScriptBody {
     /// See [VarScopedDeclarations](https://tc39.es/ecma262/#sec-static-semantics-varscopeddeclarations) in ECMA-262.
     pub fn var_scoped_declarations(&self) -> Vec<VarScopeDecl> {
         self.statement_list.top_level_var_scoped_declarations()
+    }
+
+    /// Return a list of parse nodes for the lexically declared identifiers contained within the children of this node.
+    ///
+    /// For Scripts and ScriptBodies, function definitions that exist lexically at global scipe are treated as though
+    /// they are declared var-style, and as such won't be reflected here.
+    ///
+    /// See [LexicallyScopedDeclarations](https://tc39.es/ecma262/#sec-static-semantics-lexicallyscopeddeclarations) in ECMA-262.
+    pub fn lexically_scoped_declarations(&self) -> Vec<DeclPart> {
+        self.statement_list.top_level_lexically_scoped_declarations()
     }
 }
 

--- a/src/parser/scripts/tests.rs
+++ b/src/parser/scripts/tests.rs
@@ -160,6 +160,12 @@ mod script {
     fn var_scoped_declarations(src: &str) -> Vec<String> {
         Maker::new(src).script().var_scoped_declarations().iter().map(String::from).collect::<Vec<_>>()
     }
+
+    #[test_case("" => svec(&[]); "empty")]
+    #[test_case("var a; function b(){} class q{} const h=0;" => svec(&["class q { }", "const h = 0 ;"]); "statement list")]
+    fn lexically_scoped_declarations(src: &str) -> Vec<String> {
+        Maker::new(src).script().lexically_scoped_declarations().iter().map(String::from).collect::<Vec<_>>()
+    }
 }
 
 // SCRIPT BODY
@@ -261,5 +267,10 @@ mod script_body {
     #[test_case("var a; function b(){}" => svec(&["a", "function b (  ) {  }"]); "statements")]
     fn var_scoped_declarations(src: &str) -> Vec<String> {
         Maker::new(src).script_body().var_scoped_declarations().iter().map(String::from).collect::<Vec<_>>()
+    }
+
+    #[test_case("class q{}" => svec(&["class q { }"]); "statements")]
+    fn lexically_scoped_declarations(src: &str) -> Vec<String> {
+        Maker::new(src).script_body().lexically_scoped_declarations().iter().map(String::from).collect::<Vec<_>>()
     }
 }

--- a/src/parser/statements_and_declarations/tests.rs
+++ b/src/parser/statements_and_declarations/tests.rs
@@ -581,6 +581,44 @@ mod hoistable_decl_part {
     }
 }
 
+mod decl_part {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case(DeclPart::FunctionDeclaration(Maker::new("function banana(){}").function_declaration()) => with |s| assert_ne!(s, ""); "function decl")]
+    fn debug(part: DeclPart) -> String {
+        format!("{:?}", part)
+    }
+
+    #[test_case(HoistableDeclPart::FunctionDeclaration(Maker::new("function banana(){}").function_declaration()) => "function banana (  ) {  }"; "Function Decl")]
+    #[test_case(HoistableDeclPart::GeneratorDeclaration(Maker::new("function *a(){'apple';}").generator_declaration()) => "function * a (  ) { 'apple' ; }"; "Generator Decl")]
+    #[test_case(HoistableDeclPart::AsyncFunctionDeclaration(Maker::new("async function a(strawberry){}").async_function_declaration()) => "async function a ( strawberry ) {  }"; "Async Function Decl")]
+    #[test_case(HoistableDeclPart::AsyncGeneratorDeclaration(Maker::new("async function *a(){plum();}").async_generator_declaration()) => "async function * a (  ) { plum ( ) ; }"; "Async Generator Decl")]
+    fn from_hoistable(part: HoistableDeclPart) -> String {
+        DeclPart::from(part).to_string()
+    }
+
+    #[test_case(DeclPart::FunctionDeclaration(Maker::new("function banana(){}").function_declaration()) => "function banana (  ) {  }"; "Function Decl")]
+    #[test_case(DeclPart::GeneratorDeclaration(Maker::new("function *a(){'apple';}").generator_declaration()) => "function * a (  ) { 'apple' ; }"; "Generator Decl")]
+    #[test_case(DeclPart::AsyncFunctionDeclaration(Maker::new("async function a(strawberry){}").async_function_declaration()) => "async function a ( strawberry ) {  }"; "Async Function Decl")]
+    #[test_case(DeclPart::AsyncGeneratorDeclaration(Maker::new("async function *a(){plum();}").async_generator_declaration()) => "async function * a (  ) { plum ( ) ; }"; "Async Generator Decl")]
+    #[test_case(DeclPart::ClassDeclaration(Maker::new("class rust {}").class_declaration()) => "class rust { }"; "class def")]
+    #[test_case(DeclPart::LexicalDeclaration(Maker::new("const PI = 4.0;").lexical_declaration()) => "const PI = 4 ;"; "lexical decl")]
+    fn display(part: DeclPart) -> String {
+        part.to_string()
+    }
+
+    #[test_case(DeclPart::FunctionDeclaration(Maker::new("function banana(){}").function_declaration()) => "function banana (  ) {  }"; "Function Decl")]
+    #[test_case(DeclPart::GeneratorDeclaration(Maker::new("function *a(){'apple';}").generator_declaration()) => "function * a (  ) { 'apple' ; }"; "Generator Decl")]
+    #[test_case(DeclPart::AsyncFunctionDeclaration(Maker::new("async function a(strawberry){}").async_function_declaration()) => "async function a ( strawberry ) {  }"; "Async Function Decl")]
+    #[test_case(DeclPart::AsyncGeneratorDeclaration(Maker::new("async function *a(){plum();}").async_generator_declaration()) => "async function * a (  ) { plum ( ) ; }"; "Async Generator Decl")]
+    #[test_case(DeclPart::ClassDeclaration(Maker::new("class rust {}").class_declaration()) => "class rust { }"; "class def")]
+    #[test_case(DeclPart::LexicalDeclaration(Maker::new("const PI = 4.0;").lexical_declaration()) => "const PI = 4 ;"; "lexical decl")]
+    fn string_from(part: DeclPart) -> String {
+        String::from(&part)
+    }
+}
+
 // DECLARATION
 #[test]
 fn declaration_test_01() {
@@ -693,6 +731,20 @@ mod declaration {
     #[test_case("let a=xyzzy;" => false; "Lexical (no)")]
     fn contains_arguments(src: &str) -> bool {
         Declaration::parse(&mut newparser(src), Scanner::new(), true, true).unwrap().0.contains_arguments()
+    }
+
+    #[test_case("function kobold(){}" => "function kobold (  ) {  }"; "hoistable")]
+    #[test_case("class goblin {}" => "class goblin { }"; "class def")]
+    #[test_case("const pixie = bullywug;" => "const pixie = bullywug ;"; "lexical decl")]
+    fn declaration_part(src: &str) -> String {
+        Maker::new(src).declaration().declaration_part().to_string()
+    }
+
+    #[test_case("function kobold(){}" => svec(&[]); "hoistable")]
+    #[test_case("class goblin {}" => svec(&["class goblin { }"]); "class def")]
+    #[test_case("const pixie = bullywug;" => svec(&["const pixie = bullywug ;"]); "lexical decl")]
+    fn top_level_lexically_scoped_declarations(src: &str) -> Vec<String> {
+        Maker::new(src).declaration().top_level_lexically_scoped_declarations().iter().map(String::from).collect::<Vec<_>>()
     }
 }
 

--- a/src/parser/testhelp.rs
+++ b/src/parser/testhelp.rs
@@ -15,7 +15,7 @@ use class_definitions::{
 };
 use comma_operator::Expression;
 use conditional_operator::ConditionalExpression;
-use declarations_and_variables::{VariableDeclaration, VariableDeclarationList, VariableStatement};
+use declarations_and_variables::{LexicalDeclaration, VariableDeclaration, VariableDeclarationList, VariableStatement};
 use equality_operators::EqualityExpression;
 use exponentiation_operator::ExponentiationExpression;
 use expression_statement::ExpressionStatement;
@@ -36,7 +36,7 @@ use primary_expressions::{ParenthesizedExpression, PrimaryExpression};
 use relational_operators::RelationalExpression;
 use return_statement::ReturnStatement;
 use scripts::{Script, ScriptBody};
-use statements_and_declarations::{BreakableStatement, HoistableDeclaration, Statement};
+use statements_and_declarations::{BreakableStatement, Declaration, HoistableDeclaration, Statement};
 use switch_statement::{CaseBlock, CaseClause, CaseClauses, DefaultClause, SwitchStatement};
 use throw_statement::ThrowStatement;
 use try_statement::{Catch, CatchParameter, Finally, TryStatement};
@@ -376,6 +376,10 @@ impl<'a> Maker<'a> {
     pub fn conditional_expression(self) -> Rc<ConditionalExpression> {
         ConditionalExpression::parse(&mut newparser(self.source), Scanner::new(), self.in_flag, self.yield_flag, self.await_flag).unwrap().0
     }
+    /// Use the configs in the [`Maker`] object to make a [`Declaration`] parse node.
+    pub fn declaration(self) -> Rc<Declaration> {
+        Declaration::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
+    }
     /// Use the configs in the [`Maker`] object to make a [`DefaultClause`] parse node.
     pub fn default_clause(self) -> Rc<DefaultClause> {
         DefaultClause::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag, self.return_flag).unwrap().0
@@ -503,6 +507,10 @@ impl<'a> Maker<'a> {
     /// Use the configs in the [`Maker`] object to make a [`LeftHandSideExpression`] parse node.
     pub fn left_hand_side_expression(self) -> Rc<LeftHandSideExpression> {
         LeftHandSideExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
+    }
+    /// Use the configs in the [`Maker`] object to make a [`LexicalDeclaration`] parse node.
+    pub fn lexical_declaration(self) -> Rc<LexicalDeclaration> {
+        LexicalDeclaration::parse(&mut newparser(self.source), Scanner::new(), self.in_flag, self.yield_flag, self.await_flag).unwrap().0
     }
     /// Use the configs in the [`Maker`] object to make a [`LogicalANDExpression`] parse node.
     pub fn logical_and_expression(self) -> Rc<LogicalANDExpression> {


### PR DESCRIPTION
Includes all of TopLevelLexicallyScopedDeclarations, but not all of
LexicallyScopedDeclarations, ironically.