### PR TITLE
Add current_realm_record, replacing running_execution_context

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -182,7 +182,7 @@ impl Agent {
         // realm.[[GlobalEnv]].[[GlobalThisValue]].
         //
         // This property has the attributes { [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }.
-        let gtv = { self.current_realm_record().unwrap().borrow().global_env.as_ref().unwrap().get_this_binding() };
+        let gtv = self.current_realm_record().unwrap().borrow().global_env.as_ref().unwrap().get_this_binding();
         global_data!("globalThis", gtv, true, false, true);
 
         // Infinity

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,9 +1,10 @@
 use super::environment_record::GlobalEnvironmentRecord;
 use super::execution_context::{get_global_object, ExecutionContext};
 use super::object::{define_property_or_throw, ordinary_object_create, Object, PotentialPropertyDescriptor};
-use super::realm::{create_realm, IntrinsicId};
+use super::realm::{create_realm, IntrinsicId, Realm};
 use super::strings::JSString;
 use super::values::{ECMAScriptValue, Symbol, SymbolInternals};
+use std::cell::RefCell;
 use std::rc::Rc;
 
 // Agents
@@ -27,7 +28,7 @@ use std::rc::Rc;
 pub struct Agent {
     execution_context_stack: Vec<ExecutionContext>,
     pub symbols: WellKnownSymbols,
-    pub obj_id: usize,
+    obj_id: usize,
     pub symbol_id: usize,
 }
 
@@ -56,25 +57,11 @@ impl Agent {
         }
     }
 
-    pub fn running_execution_context(&self) -> Option<&ExecutionContext> {
-        let len = self.execution_context_stack.len();
-        if len > 0 {
-            Some(&self.execution_context_stack[len - 1])
-        } else {
-            None
+    pub fn active_function_object(&self) -> Option<Object> {
+        match self.execution_context_stack.len() {
+            0 => None,
+            n => self.execution_context_stack[n - 1].function.clone(),
         }
-    }
-    pub fn running_execution_context_mut(&mut self) -> Option<&mut ExecutionContext> {
-        let len = self.execution_context_stack.len();
-        if len > 0 {
-            Some(&mut self.execution_context_stack[len - 1])
-        } else {
-            None
-        }
-    }
-
-    pub fn active_function_object(&mut self) -> Option<Object> {
-        self.running_execution_context().and_then(|ec| ec.function.as_ref().cloned())
     }
 
     pub fn next_object_id(&mut self) -> usize {
@@ -118,8 +105,17 @@ impl Agent {
         .clone()
     }
 
+    pub fn current_realm_record(&self) -> Option<Rc<RefCell<Realm>>> {
+        match self.execution_context_stack.len() {
+            0 => None,
+            n => Some(self.execution_context_stack[n - 1].realm.clone()),
+        }
+    }
+
     pub fn intrinsic(&self, id: IntrinsicId) -> Object {
-        self.running_execution_context().unwrap().realm.borrow().intrinsics.get(id)
+        let realm_ref = self.current_realm_record().unwrap();
+        let realm = realm_ref.borrow();
+        realm.intrinsics.get(id)
     }
 
     // SetRealmGlobalObject ( realmRec, globalObj, thisValue )
@@ -142,11 +138,12 @@ impl Agent {
             ordinary_object_create(self, Some(object_proto), &[])
         });
         let tv = this_value.unwrap_or_else(|| go.clone());
-        let mut realm = self.running_execution_context().unwrap().realm.borrow_mut();
+        let realm_ref = self.current_realm_record().unwrap();
+        let mut realm = realm_ref.borrow_mut();
 
         realm.global_object = Some(go.clone());
         let new_global_env = GlobalEnvironmentRecord::new(go, tv);
-        realm.global_env = Some(new_global_env);
+        realm.global_env = Some(Rc::new(new_global_env));
     }
 
     // SetDefaultGlobalBindings ( realmRec )
@@ -185,10 +182,7 @@ impl Agent {
         // realm.[[GlobalEnv]].[[GlobalThisValue]].
         //
         // This property has the attributes { [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }.
-        let gtv = {
-            let global_env = &self.running_execution_context().unwrap().realm.borrow().global_env;
-            global_env.as_ref().unwrap().get_this_binding()
-        };
+        let gtv = { self.current_realm_record().unwrap().borrow().global_env.as_ref().unwrap().get_this_binding() };
         global_data!("globalThis", gtv, true, false, true);
 
         // Infinity

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -45,7 +45,7 @@ fn agent_pop_execution_context() {
     agent.initialize_host_defined_realm();
     let realm_ref = agent.current_realm_record().unwrap();
     // build a new EC, and add it to the EC stack
-    let test_ec = ExecutionContext::new(None, realm_ref.clone(), Some(ScriptOrModule::Script(Rc::new(ScriptRecord {}))));
+    let test_ec = ExecutionContext::new(None, realm_ref, Some(ScriptOrModule::Script(Rc::new(ScriptRecord {}))));
     agent.push_execution_context(test_ec);
     // now pop it.
     agent.pop_execution_context();

--- a/src/arrays/mod.rs
+++ b/src/arrays/mod.rs
@@ -311,7 +311,8 @@ pub fn array_species_create(agent: &mut Agent, original_array: &Object, length: 
     let mut c = get(agent, original_array, &"constructor".into())?;
     if is_constructor(&c) {
         let c_obj = Object::try_from(&c).unwrap();
-        let this_realm = agent.running_execution_context().unwrap().realm.clone();
+        //let this_realm = agent.running_execution_context().unwrap().realm.clone();
+        let this_realm = agent.current_realm_record().unwrap();
         let realm_c = get_function_realm(agent, &c_obj)?;
         if Rc::ptr_eq(&this_realm, &realm_c) && c_obj == realm_c.borrow().intrinsics.array {
             c = ECMAScriptValue::Undefined;

--- a/src/arrays/mod.rs
+++ b/src/arrays/mod.rs
@@ -311,7 +311,6 @@ pub fn array_species_create(agent: &mut Agent, original_array: &Object, length: 
     let mut c = get(agent, original_array, &"constructor".into())?;
     if is_constructor(&c) {
         let c_obj = Object::try_from(&c).unwrap();
-        //let this_realm = agent.running_execution_context().unwrap().realm.clone();
         let this_realm = agent.current_realm_record().unwrap();
         let realm_c = get_function_realm(agent, &c_obj)?;
         if Rc::ptr_eq(&this_realm, &realm_c) && c_obj == realm_c.borrow().intrinsics.array {

--- a/src/execution_context/mod.rs
+++ b/src/execution_context/mod.rs
@@ -38,10 +38,6 @@ impl ExecutionContext {
 //
 //  1. Let currentRealm be the current Realm Record.
 //  2. Return currentRealm.[[GlobalObject]].
-pub fn get_global_object(agent: &mut Agent) -> Option<Object> {
-    let ec = agent.running_execution_context();
-    ec.and_then(|ec| {
-        let g = &ec.realm.borrow().global_object;
-        g.as_ref().cloned()
-    })
+pub fn get_global_object(agent: &Agent) -> Option<Object> {
+    agent.current_realm_record()?.borrow().global_object.clone()
 }

--- a/src/function_object/mod.rs
+++ b/src/function_object/mod.rs
@@ -437,13 +437,10 @@ impl CallableObject for BuiltInFunctionObject {
     //          | suspended and retained by an accessible generator object for later resumption.
     fn call(&self, agent: &mut Agent, self_object: &Object, this_argument: &ECMAScriptValue, arguments_list: &[ECMAScriptValue]) -> Completion {
         assert_eq!(self.id(), self_object.o.id());
-        let caller_context = agent.running_execution_context_mut().unwrap();
-        caller_context.suspend();
         let callee_context = ExecutionContext::new(Some(self_object.clone()), self.builtin_data.borrow().realm.clone(), None);
         agent.push_execution_context(callee_context);
         let result = (self.builtin_data.borrow().steps)(agent, this_argument.clone(), None, arguments_list);
         agent.pop_execution_context();
-        agent.running_execution_context_mut().unwrap().resume();
 
         result
     }
@@ -461,13 +458,10 @@ impl ConstructableObject for BuiltInFunctionObject {
     //     newTarget provides the NewTarget value.
     fn construct(&self, agent: &mut Agent, self_object: &Object, arguments_list: &[ECMAScriptValue], new_target: &Object) -> Completion {
         assert_eq!(self.id(), self_object.o.id());
-        let caller_context = agent.running_execution_context_mut().unwrap();
-        caller_context.suspend();
         let callee_context = ExecutionContext::new(Some(self_object.clone()), self.builtin_data.borrow().realm.clone(), None);
         agent.push_execution_context(callee_context);
         let result = (self.builtin_data.borrow().steps)(agent, ECMAScriptValue::Undefined, Some(new_target), arguments_list);
         agent.pop_execution_context();
-        agent.running_execution_context_mut().unwrap().resume();
 
         result
     }
@@ -515,7 +509,7 @@ pub fn create_builtin_function(
     prototype: Option<Object>,
     prefix: Option<JSString>,
 ) -> Object {
-    let realm_to_use = realm.unwrap_or_else(|| agent.running_execution_context().unwrap().realm.clone());
+    let realm_to_use = realm.unwrap_or_else(|| agent.current_realm_record().unwrap().clone());
     let prototype_to_use = prototype.unwrap_or_else(|| realm_to_use.borrow().intrinsics.function_prototype.clone());
     let func = BuiltInFunctionObject::object(agent, Some(prototype_to_use), true, realm_to_use, None, behavior, is_constructor);
     set_function_length(agent, &func, length);

--- a/src/function_object/mod.rs
+++ b/src/function_object/mod.rs
@@ -509,7 +509,7 @@ pub fn create_builtin_function(
     prototype: Option<Object>,
     prefix: Option<JSString>,
 ) -> Object {
-    let realm_to_use = realm.unwrap_or_else(|| agent.current_realm_record().unwrap().clone());
+    let realm_to_use = realm.unwrap_or_else(|| agent.current_realm_record().unwrap());
     let prototype_to_use = prototype.unwrap_or_else(|| realm_to_use.borrow().intrinsics.function_prototype.clone());
     let func = BuiltInFunctionObject::object(agent, Some(prototype_to_use), true, realm_to_use, None, behavior, is_constructor);
     set_function_length(agent, &func, length);

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -2059,7 +2059,7 @@ pub fn get_function_realm(agent: &mut Agent, obj: &Object) -> AltCompletion<Rc<R
         // Add the proxy check
         eprintln!("GetFunctionRealm: Skipping over bound-function and proxy checks...");
 
-        Ok(agent.current_realm_record().unwrap().clone())
+        Ok(agent.current_realm_record().unwrap())
     }
 }
 

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -2059,7 +2059,7 @@ pub fn get_function_realm(agent: &mut Agent, obj: &Object) -> AltCompletion<Rc<R
         // Add the proxy check
         eprintln!("GetFunctionRealm: Skipping over bound-function and proxy checks...");
 
-        Ok(agent.running_execution_context().unwrap().realm.clone())
+        Ok(agent.current_realm_record().unwrap().clone())
     }
 }
 

--- a/src/object/tests.rs
+++ b/src/object/tests.rs
@@ -2322,7 +2322,7 @@ mod to_property_descriptor {
         ECMAScriptValue::from(TestObject::object(agent, &[FunctionId::GetOwnProperty(Some(PropertyKey::from(name)))]))
     }
     fn create_getter_error(agent: &mut Agent, name: &str) -> ECMAScriptValue {
-        let realm = agent.current_realm_record().unwrap().clone();
+        let realm = agent.current_realm_record().unwrap();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let obj = ordinary_object_create(agent, Some(object_prototype), &[]);
         let function_proto = agent.intrinsic(IntrinsicId::FunctionPrototype);

--- a/src/object/tests.rs
+++ b/src/object/tests.rs
@@ -2322,7 +2322,7 @@ mod to_property_descriptor {
         ECMAScriptValue::from(TestObject::object(agent, &[FunctionId::GetOwnProperty(Some(PropertyKey::from(name)))]))
     }
     fn create_getter_error(agent: &mut Agent, name: &str) -> ECMAScriptValue {
-        let realm = agent.running_execution_context().unwrap().realm.clone();
+        let realm = agent.current_realm_record().unwrap().clone();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let obj = ordinary_object_create(agent, Some(object_prototype), &[]);
         let function_proto = agent.intrinsic(IntrinsicId::FunctionPrototype);

--- a/src/object_object/tests.rs
+++ b/src/object_object/tests.rs
@@ -88,7 +88,7 @@ mod constructor {
     #[test_case(|a| {
         let obj = ordinary_object_create(a, None, &[]);
         let realm = a.current_realm_record().unwrap();
-        a.push_execution_context(ExecutionContext::new(Some(obj.clone()), realm, None));
+        a.push_execution_context(ExecutionContext::new(Some(obj), realm, None));
         Some(ordinary_object_create(a, None, &[]))
     }, &[ECMAScriptValue::from(12)] => "[object Object]"; "unrelated new target")]
     #[test_case(|_| None, &[ECMAScriptValue::Null] => "[object Object]"; "null value")]

--- a/src/realm/mod.rs
+++ b/src/realm/mod.rs
@@ -269,7 +269,7 @@ pub struct Realm {
     // testing, only one realm is ever made, so it's not a huge issue.)
     pub intrinsics: Intrinsics,
     pub global_object: Option<Object>,
-    pub global_env: Option<GlobalEnvironmentRecord>,
+    pub global_env: Option<Rc<GlobalEnvironmentRecord>>,
     // TemplateMap: later, when needed
 }
 

--- a/src/realm/tests.rs
+++ b/src/realm/tests.rs
@@ -68,7 +68,9 @@ fn intrinsics_debug() {
 #[test]
 fn intrinsics_get() {
     let agent = test_agent();
-    let intrinsics = &agent.running_execution_context().unwrap().realm.borrow().intrinsics;
+    let realm_ptr = agent.current_realm_record().unwrap();
+    let realm = realm_ptr.borrow();
+    let intrinsics = &realm.intrinsics;
     assert_eq!(intrinsics.get(IntrinsicId::Array), intrinsics.array);
     assert_eq!(intrinsics.get(IntrinsicId::ArrayPrototype), intrinsics.array_prototype);
     assert_eq!(intrinsics.get(IntrinsicId::Boolean), intrinsics.boolean);
@@ -98,7 +100,9 @@ fn intrinsics_get() {
 #[test]
 fn realm_debug() {
     let agent = test_agent();
-    assert_ne!(format!("{:?}", agent.running_execution_context().unwrap()), "");
+    let realm_ptr = agent.current_realm_record().unwrap();
+    let realm = realm_ptr.borrow();
+    assert_ne!(format!("{:?}", realm), "");
 }
 
 #[test]

--- a/src/reference/tests.rs
+++ b/src/reference/tests.rs
@@ -409,7 +409,7 @@ mod put_value {
         let value = ECMAScriptValue::from("Test Value for Unresolvable, non-strict writes");
         let reference = Reference::new(Base::Unresolvable, "blue", false, None);
         put_value(&mut agent, Ok(SuperValue::from(reference)), Ok(value.clone())).unwrap();
-        let global = get_global_object(&mut agent).unwrap();
+        let global = get_global_object(&agent).unwrap();
         let from_global = get(&mut agent, &global, &PropertyKey::from("blue")).unwrap();
         assert_eq!(from_global, value);
     }
@@ -419,7 +419,7 @@ mod put_value {
         let value = ECMAScriptValue::from("Test Value");
         let reference = Reference::new(Base::Unresolvable, "thrower", false, None);
         let thrower = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError));
-        let global = get_global_object(&mut agent).unwrap();
+        let global = get_global_object(&agent).unwrap();
         define_property_or_throw(
             &mut agent,
             &global,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -494,8 +494,8 @@ pub fn faux_errors(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target:
     Err(create_type_error(agent, "Test Sentinel"))
 }
 
-use crate::realm::{create_realm, Realm};
 use crate::object::define_property_or_throw;
+use crate::realm::{create_realm, Realm};
 
 pub fn create_named_realm(agent: &mut Agent, name: &str) -> Rc<RefCell<Realm>> {
     let r = create_realm(agent);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -493,3 +493,19 @@ impl AdaptableObject {
 pub fn faux_errors(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
     Err(create_type_error(agent, "Test Sentinel"))
 }
+
+use crate::realm::{create_realm, Realm};
+use crate::object::define_property_or_throw;
+
+pub fn create_named_realm(agent: &mut Agent, name: &str) -> Rc<RefCell<Realm>> {
+    let r = create_realm(agent);
+    let op = r.borrow().intrinsics.get(IntrinsicId::ObjectPrototype);
+    define_property_or_throw(agent, &op, "name", PotentialPropertyDescriptor::new().value(name).writable(false).enumerable(false).configurable(false)).unwrap();
+
+    r
+}
+pub fn get_realm_name(agent: &mut Agent, realm: &Realm) -> String {
+    let op = realm.intrinsics.get(IntrinsicId::ObjectPrototype);
+    let name = get(agent, &op, &"name".into()).unwrap();
+    to_string(agent, name).unwrap().into()
+}

--- a/src/values/tests.rs
+++ b/src/values/tests.rs
@@ -841,7 +841,7 @@ enum FauxKind {
     Error,
 }
 fn make_test_obj(agent: &mut Agent, valueof: FauxKind, tostring: FauxKind) -> Object {
-    let realm = agent.running_execution_context().unwrap().realm.clone();
+    let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
     let target = ordinary_object_create(agent, Some(object_prototype), &[]);
@@ -880,7 +880,7 @@ fn make_test_obj(agent: &mut Agent, valueof: FauxKind, tostring: FauxKind) -> Ob
 }
 fn make_tostring_getter_error(agent: &mut Agent) -> Object {
     // valueOf returns 123456; tostring is a getter that errors
-    let realm = agent.running_execution_context().unwrap().realm.clone();
+    let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
     let target = ordinary_object_create(agent, Some(object_prototype), &[]);
@@ -907,7 +907,7 @@ fn make_tostring_getter_error(agent: &mut Agent) -> Object {
     target
 }
 fn make_test_obj_uncallable(agent: &mut Agent) -> Object {
-    let realm = agent.running_execution_context().unwrap().realm.clone();
+    let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let target = ordinary_object_create(agent, Some(object_prototype), &[]);
     let mut connect = |name| {
@@ -1049,7 +1049,7 @@ fn exotic_to_prim(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target:
     }
 }
 fn make_toprimitive_obj(agent: &mut Agent, steps: fn(&mut Agent, ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion) -> Object {
-    let realm = agent.running_execution_context().unwrap().realm.clone();
+    let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
     let target = ordinary_object_create(agent, Some(object_prototype), &[]);
@@ -1078,7 +1078,7 @@ fn to_primitive_uses_exotics() {
     assert_eq!(result, ECMAScriptValue::from("Saw string"));
 }
 fn exotic_returns_object(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
-    let realm = agent.running_execution_context().unwrap().realm.clone();
+    let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let target = ordinary_object_create(agent, Some(object_prototype), &[]);
     Ok(ECMAScriptValue::from(target))
@@ -1107,7 +1107,7 @@ fn to_primitive_exotic_throws() {
 #[test]
 fn to_primitive_exotic_getter_throws() {
     let mut agent = test_agent();
-    let realm = agent.running_execution_context().unwrap().realm.clone();
+    let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
     let target = ordinary_object_create(&mut agent, Some(object_prototype), &[]);


### PR DESCRIPTION
I was having pointer aliasing trouble, this switch is part of the fix.
(Rather than getting an internal pointer to a realm and then cloning
that, we just return a cloned realm. No longer any need for consumers to
also have that internal pointer.)