### PR TITLE
Refactor completion records

### DIFF
--- a/src/arrays/mod.rs
+++ b/src/arrays/mod.rs
@@ -1,5 +1,5 @@
 use super::agent::{Agent, WksId};
-use super::cr::{AltCompletion, Completion};
+use super::cr::Completion;
 use super::errors::{create_range_error, create_type_error};
 use super::function_object::create_builtin_function;
 use super::object::{
@@ -54,19 +54,19 @@ impl ObjectInterface for ArrayObject {
     fn id(&self) -> usize {
         self.common.borrow().objid
     }
-    fn get_prototype_of(&self, _: &mut Agent) -> AltCompletion<Option<Object>> {
+    fn get_prototype_of(&self, _: &mut Agent) -> Completion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
-    fn set_prototype_of(&self, _: &mut Agent, obj: Option<Object>) -> AltCompletion<bool> {
+    fn set_prototype_of(&self, _: &mut Agent, obj: Option<Object>) -> Completion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
-    fn is_extensible(&self, _: &mut Agent) -> AltCompletion<bool> {
+    fn is_extensible(&self, _: &mut Agent) -> Completion<bool> {
         Ok(ordinary_is_extensible(self))
     }
-    fn prevent_extensions(&self, _: &mut Agent) -> AltCompletion<bool> {
+    fn prevent_extensions(&self, _: &mut Agent) -> Completion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
-    fn get_own_property(&self, _: &mut Agent, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(self, key))
     }
     // [[DefineOwnProperty]] ( P, Desc )
@@ -92,7 +92,7 @@ impl ObjectInterface for ArrayObject {
     //          iii. Assert: succeeded is true.
     //      k. Return true.
     //  3. Return OrdinaryDefineOwnProperty(A, P, Desc).
-    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> AltCompletion<bool> {
+    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool> {
         let length_key = PropertyKey::from("length");
         if key == length_key {
             self.set_length(agent, desc)
@@ -128,19 +128,19 @@ impl ObjectInterface for ArrayObject {
             ordinary_define_own_property(agent, self, key, desc)
         }
     }
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_has_property(agent, self, key)
     }
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion {
+    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         ordinary_get(agent, self, key, receiver)
     }
-    fn set(&self, agent: &mut Agent, key: PropertyKey, value: ECMAScriptValue, receiver: &ECMAScriptValue) -> AltCompletion<bool> {
+    fn set(&self, agent: &mut Agent, key: PropertyKey, value: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
         ordinary_set(agent, self, key, value, receiver)
     }
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_delete(agent, self, key)
     }
-    fn own_property_keys(&self, agent: &mut Agent) -> AltCompletion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(agent, self))
     }
     fn is_array_object(&self) -> bool {
@@ -151,7 +151,7 @@ impl ObjectInterface for ArrayObject {
     }
 }
 
-pub fn array_create(agent: &mut Agent, length: u64, proto: Option<Object>) -> AltCompletion<Object> {
+pub fn array_create(agent: &mut Agent, length: u64, proto: Option<Object>) -> Completion<Object> {
     ArrayObject::create(agent, length, proto)
 }
 
@@ -168,7 +168,7 @@ impl ArrayObject {
     //  5. Set A.[[DefineOwnProperty]] as specified in 10.4.2.1.
     //  6. Perform ! OrdinaryDefineOwnProperty(A, "length", PropertyDescriptor { [[Value]]: 𝔽(length), [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
     //  7. Return A.
-    pub fn create(agent: &mut Agent, length: u64, proto: Option<Object>) -> AltCompletion<Object> {
+    pub fn create(agent: &mut Agent, length: u64, proto: Option<Object>) -> Completion<Object> {
         if length > 4294967295 {
             return Err(create_range_error(agent, "Array lengths greater than 4294967295 are not allowed"));
         }
@@ -223,7 +223,7 @@ impl ArrayObject {
     //
     // NOTE |   In steps 3 and 4, if Desc.[[Value]] is an object then its valueOf method is called twice. This is
     //      |   legacy behaviour that was specified with this effect starting with the 2nd Edition of this specification.
-    fn set_length(&self, agent: &mut Agent, descriptor: PotentialPropertyDescriptor) -> AltCompletion<bool> {
+    fn set_length(&self, agent: &mut Agent, descriptor: PotentialPropertyDescriptor) -> Completion<bool> {
         if descriptor.value.is_none() {
             return ordinary_define_own_property(agent, self, PropertyKey::from("length"), descriptor);
         }
@@ -303,7 +303,7 @@ impl ArrayObject {
 //      |   realm of the running execution context, then a new Array is created using the realm of the running
 //      |   execution context. This maintains compatibility with Web browsers that have historically had that behaviour
 //      |   for the Array.prototype methods that now are defined using ArraySpeciesCreate.
-pub fn array_species_create(agent: &mut Agent, original_array: &Object, length: u64) -> Completion {
+pub fn array_species_create(agent: &mut Agent, original_array: &Object, length: u64) -> Completion<ECMAScriptValue> {
     let is_array = original_array.is_array(agent)?;
     if !is_array {
         return Ok(ArrayObject::create(agent, length, None)?.into());
@@ -347,7 +347,7 @@ pub fn array_species_create(agent: &mut Agent, original_array: &Object, length: 
 //      b. Let target be argument.[[ProxyTarget]].
 //      c. Return ? IsArray(target).
 //  4. Return false.
-pub fn is_array(agent: &mut Agent, argument: &ECMAScriptValue) -> AltCompletion<bool> {
+pub fn is_array(agent: &mut Agent, argument: &ECMAScriptValue) -> Completion<bool> {
     argument.is_array(agent)
 }
 
@@ -477,112 +477,112 @@ pub fn provision_array_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>) 
     realm.borrow_mut().intrinsics.array_prototype = array_prototype;
 }
 
-fn array_constructor_function(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_constructor_function(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_from(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_from(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_is_array(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_is_array(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_of(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_of(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_at(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_at(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_concat(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_concat(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_copy_within(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_copy_within(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_entries(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_entries(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_every(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_every(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_fill(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_fill(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_filter(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_filter(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_find(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_find(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_find_index(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_find_index(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_flat(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_flat(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_flat_map(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_flat_map(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_for_each(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_for_each(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_includes(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_includes(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_index_of(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_index_of(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_join(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_join(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_keys(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_keys(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_last_index_of(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_last_index_of(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_map(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_map(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_pop(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_pop(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_push(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_push(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_reduce(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_reduce(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_reduce_right(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_reduce_right(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_reverse(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_reverse(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_shift(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_shift(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_slice(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_slice(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_some(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_some(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_sort(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_sort(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_splice(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_splice(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_to_locale_string(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_to_locale_string(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_to_string(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_to_string(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_unshift(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_unshift(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn array_prototype_values(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn array_prototype_values(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
 

--- a/src/arrays/tests.rs
+++ b/src/arrays/tests.rs
@@ -245,7 +245,7 @@ mod array_object {
         use super::*;
         use test_case::test_case;
 
-        fn value_just_once(agent: &mut Agent, this_value: ECMAScriptValue, _: Option<&Object>, _: &[ECMAScriptValue]) -> Completion {
+        fn value_just_once(agent: &mut Agent, this_value: ECMAScriptValue, _: Option<&Object>, _: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
             // The value 320 the first time, errors thrown all other times.
             let this: Object = this_value.try_into().unwrap();
             let previous = get(agent, &this, &"has_already_run".into()).unwrap();
@@ -670,7 +670,7 @@ fn defaults() {
 #[test_case(super::array_prototype_to_string => panics; "array_prototype_to_string")]
 #[test_case(super::array_prototype_unshift => panics; "array_prototype_unshift")]
 #[test_case(super::array_prototype_values => panics; "array_prototype_values")]
-fn todo(f: fn(&mut Agent, ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion) {
+fn todo(f: fn(&mut Agent, ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion<ECMAScriptValue>) {
     let mut agent = test_agent();
     f(&mut agent, ECMAScriptValue::Undefined, None, &[]).unwrap();
 }

--- a/src/boolean_object/mod.rs
+++ b/src/boolean_object/mod.rs
@@ -1,5 +1,5 @@
 use super::agent::Agent;
-use super::cr::{AltCompletion, Completion};
+use super::cr::Completion;
 use super::errors::create_type_error;
 use super::object::{
     ordinary_create_from_constructor, ordinary_define_own_property, ordinary_delete, ordinary_get, ordinary_get_own_property, ordinary_get_prototype_of, ordinary_has_property,
@@ -44,7 +44,7 @@ impl ObjectInterface for BooleanObject {
         true
     }
 
-    fn get_prototype_of(&self, _agent: &mut Agent) -> AltCompletion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &mut Agent) -> Completion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
 
@@ -54,7 +54,7 @@ impl ObjectInterface for BooleanObject {
     // the following steps when called:
     //
     //  1. Return ! OrdinarySetPrototypeOf(O, V).
-    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<Object>) -> AltCompletion<bool> {
+    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<Object>) -> Completion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
 
@@ -64,7 +64,7 @@ impl ObjectInterface for BooleanObject {
     // when called:
     //
     //  1. Return ! OrdinaryIsExtensible(O).
-    fn is_extensible(&self, _agent: &mut Agent) -> AltCompletion<bool> {
+    fn is_extensible(&self, _agent: &mut Agent) -> Completion<bool> {
         Ok(ordinary_is_extensible(self))
     }
 
@@ -74,7 +74,7 @@ impl ObjectInterface for BooleanObject {
     // steps when called:
     //
     //  1. Return ! OrdinaryPreventExtensions(O).
-    fn prevent_extensions(&self, _agent: &mut Agent) -> AltCompletion<bool> {
+    fn prevent_extensions(&self, _agent: &mut Agent) -> Completion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
 
@@ -84,7 +84,7 @@ impl ObjectInterface for BooleanObject {
     // following steps when called:
     //
     //  1. Return ! OrdinaryGetOwnProperty(O, P).
-    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(self, key))
     }
 
@@ -94,7 +94,7 @@ impl ObjectInterface for BooleanObject {
     // Property Descriptor). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
-    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> AltCompletion<bool> {
+    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool> {
         ordinary_define_own_property(agent, self, key, desc)
     }
 
@@ -104,7 +104,7 @@ impl ObjectInterface for BooleanObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryHasProperty(O, P).
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_has_property(agent, self, key)
     }
 
@@ -114,7 +114,7 @@ impl ObjectInterface for BooleanObject {
     // ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryGet(O, P, Receiver).
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion {
+    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         ordinary_get(agent, self, key, receiver)
     }
 
@@ -124,7 +124,7 @@ impl ObjectInterface for BooleanObject {
     // value), and Receiver (an ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinarySet(O, P, V, Receiver).
-    fn set(&self, agent: &mut Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> AltCompletion<bool> {
+    fn set(&self, agent: &mut Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
         ordinary_set(agent, self, key, v, receiver)
     }
 
@@ -134,7 +134,7 @@ impl ObjectInterface for BooleanObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryDelete(O, P).
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_delete(agent, self, key)
     }
 
@@ -144,7 +144,7 @@ impl ObjectInterface for BooleanObject {
     // steps when called:
     //
     // 1. Return ! OrdinaryOwnPropertyKeys(O).
-    fn own_property_keys(&self, agent: &mut Agent) -> AltCompletion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(agent, self))
     }
 }
@@ -183,7 +183,7 @@ pub fn create_boolean_object(agent: &mut Agent, b: bool) -> Object {
 //      b. Assert: Type(b) is Boolean.
 //      c. Return b.
 //  3. Throw a TypeError exception.
-pub fn this_boolean_value(agent: &mut Agent, value: &ECMAScriptValue) -> AltCompletion<bool> {
+pub fn this_boolean_value(agent: &mut Agent, value: &ECMAScriptValue) -> Completion<bool> {
     match value {
         ECMAScriptValue::Boolean(b) => Ok(*b),
         ECMAScriptValue::Object(o) => {

--- a/src/comparison/mod.rs
+++ b/src/comparison/mod.rs
@@ -1,5 +1,5 @@
 use crate::agent::Agent;
-use crate::cr::AltCompletion;
+use crate::cr::Completion;
 use crate::errors::create_type_error;
 use crate::object::ObjectInterface;
 use crate::values::ECMAScriptValue;
@@ -30,7 +30,7 @@ use crate::values::ECMAScriptValue;
 // +---------------+------------------------------+
 //
 // https://tc39.es/ecma262/#sec-requireobjectcoercible
-pub fn require_object_coercible(agent: &mut Agent, argument: &ECMAScriptValue) -> AltCompletion<()> {
+pub fn require_object_coercible(agent: &mut Agent, argument: &ECMAScriptValue) -> Completion<()> {
     match argument {
         ECMAScriptValue::Undefined | ECMAScriptValue::Null => Err(create_type_error(agent, "Undefined and null are not allowed in this context")),
         _ => Ok(()),
@@ -45,7 +45,7 @@ pub fn require_object_coercible(agent: &mut Agent, argument: &ECMAScriptValue) -
 //
 //  1. Assert: Type(O) is Object.
 //  2. Return ? O.[[IsExtensible]]().
-pub fn is_extensible<'a, T>(agent: &mut Agent, obj: T) -> AltCompletion<bool>
+pub fn is_extensible<'a, T>(agent: &mut Agent, obj: T) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {

--- a/src/cr/mod.rs
+++ b/src/cr/mod.rs
@@ -1,3 +1,4 @@
+use crate::reference::Reference;
 use crate::strings::JSString;
 use crate::values::ECMAScriptValue;
 
@@ -17,6 +18,36 @@ pub enum AbruptCompletion {
 
 pub type Completion = Result<ECMAScriptValue, AbruptCompletion>;
 pub type AltCompletion<T> = Result<T, AbruptCompletion>;
+
+pub enum NormalCompletion {
+    Empty,
+    Value(ECMAScriptValue),
+    Reference(Box<Reference>),
+}
+pub enum AbruptCompletion2 {
+    Break { value: Option<ECMAScriptValue>, target: Option<JSString> },
+    Continue { value: Option<ECMAScriptValue>, target: Option<JSString> },
+    Return { value: ECMAScriptValue },
+    Throw { value: ECMAScriptValue },
+}
+
+pub type Completion2 = Result<NormalCompletion, AbruptCompletion2>;
+
+pub fn update_empty(completion_record: Completion2, old_value: Option<ECMAScriptValue>) -> Completion2 {
+    match completion_record {
+        Ok(NormalCompletion::Empty) => match old_value {
+            None => Ok(NormalCompletion::Empty),
+            Some(v) => Ok(NormalCompletion::Value(v)),
+        },
+        Ok(_)
+        | Err(AbruptCompletion2::Return { .. })
+        | Err(AbruptCompletion2::Throw { .. })
+        | Err(AbruptCompletion2::Break { value: Some(_), .. })
+        | Err(AbruptCompletion2::Continue { value: Some(_), .. }) => completion_record,
+        Err(AbruptCompletion2::Break { value: None, target }) => Err(AbruptCompletion2::Break { value: old_value, target }),
+        Err(AbruptCompletion2::Continue { value: None, target }) => Err(AbruptCompletion2::Continue { value: old_value, target }),
+    }
+}
 
 #[cfg(test)]
 mod tests;

--- a/src/cr/tests.rs
+++ b/src/cr/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::reference::Base;
+use test_case::test_case;
 
 mod normal_completion {
     use super::*;
@@ -81,4 +82,17 @@ mod abrupt_completion {
         assert_eq!(c1 != c2, true);
         assert_eq!(c1 != c3, false);
     }
+}
+
+#[test_case(Ok(NormalCompletion::Empty), None => Ok(NormalCompletion::Empty); "empties all over")]
+#[test_case(Ok(NormalCompletion::Empty), Some(3.into()) => Ok(NormalCompletion::Value(3.into())); "old: 3, new: empty")]
+#[test_case(Ok(NormalCompletion::Value("bob".into())), Some(3.into()) => Ok(NormalCompletion::Value("bob".into())); "old: 3, new: bob")]
+#[test_case(Err(AbruptCompletion::Return{value: 1.into()}), Some(3.into()) => Err(AbruptCompletion::Return{value: 1.into()}); "Err return")]
+#[test_case(Err(AbruptCompletion::Throw{value: 1.into()}), Some(3.into()) => Err(AbruptCompletion::Throw{value: 1.into()}); "Err throw")]
+#[test_case(Err(AbruptCompletion::Break{value: Some(1.into()), target: Some("lbl".into())}), Some(3.into()) => Err(AbruptCompletion::Break{value: Some(1.into()), target: Some("lbl".into())}); "Err break with value")]
+#[test_case(Err(AbruptCompletion::Break{value: None, target: Some("xyz".into())}), Some(3.into()) => Err(AbruptCompletion::Break{value: Some(3.into()), target: Some("xyz".into())}); "Err break no value")]
+#[test_case(Err(AbruptCompletion::Continue{value: Some(1.into()), target: Some("lbl".into())}), Some(3.into()) => Err(AbruptCompletion::Continue{value: Some(1.into()), target: Some("lbl".into())}); "Err Continue with value")]
+#[test_case(Err(AbruptCompletion::Continue{value: None, target: Some("xyz".into())}), Some(3.into()) => Err(AbruptCompletion::Continue{value: Some(3.into()), target: Some("xyz".into())}); "Err Continue no value")]
+fn update_empty(new: FullCompletion, old: Option<ECMAScriptValue>) -> FullCompletion {
+    super::update_empty(new, old)
 }

--- a/src/cr/tests.rs
+++ b/src/cr/tests.rs
@@ -1,37 +1,38 @@
 use super::*;
+use crate::reference::Base;
 
-mod completion_info {
+mod normal_completion {
     use super::*;
-    #[test]
-    fn clone() {
-        let first = CompletionInfo { value: Some(ECMAScriptValue::Boolean(true)), target: Some(JSString::from("label")) };
-        let second = first.clone();
-        assert_eq!(first.value, second.value);
-        assert_eq!(first.target, second.target);
+    use test_case::test_case;
+
+    #[test_case(NormalCompletion::Empty, NormalCompletion::Value(ECMAScriptValue::Undefined) => false; "not equal")]
+    #[test_case(NormalCompletion::Value(ECMAScriptValue::from(78.0)), NormalCompletion::Value(ECMAScriptValue::from(78)) => true; "equal")]
+    fn eq(left: NormalCompletion, right: NormalCompletion) -> bool {
+        left == right
     }
 
-    #[test]
-    fn debug() {
-        // Just for coverage. Essentially, assert that we don't panic.
-        let first = CompletionInfo { value: Some(ECMAScriptValue::Boolean(true)), target: Some(JSString::from("label")) };
-        assert_ne!(format!("{:?}", first), "");
+    #[test_case(NormalCompletion::Empty, NormalCompletion::Value(ECMAScriptValue::Undefined) => true; "not equal")]
+    #[test_case(NormalCompletion::Value(ECMAScriptValue::from(78.0)), NormalCompletion::Value(ECMAScriptValue::from(78)) => false; "equal")]
+    fn ne(left: NormalCompletion, right: NormalCompletion) -> bool {
+        left != right
     }
 
-    #[test]
-    fn eq() {
-        let ci1 = CompletionInfo { value: Some(ECMAScriptValue::from("red")), target: Some(JSString::from("label")) };
-        let ci2 = CompletionInfo { value: None, target: None };
-        let ci3 = CompletionInfo { value: Some(ECMAScriptValue::from("red")), target: Some(JSString::from("label")) };
-        assert_eq!(ci1 == ci2, false);
-        assert_eq!(ci1 == ci3, true);
+    #[test_case(NormalCompletion::Empty => NormalCompletion::Empty; "empty")]
+    #[test_case(NormalCompletion::Value(ECMAScriptValue::from("alice")) => NormalCompletion::Value(ECMAScriptValue::from("alice")); "value")]
+    #[test_case(NormalCompletion::Reference(Box::new(Reference::new(Base::Unresolvable, "alice", false, None))) => NormalCompletion::Reference(Box::new(Reference::new(Base::Unresolvable, "alice", false, None))); "reference")]
+    fn clone(orig: NormalCompletion) -> NormalCompletion {
+        orig.clone()
     }
-    #[test]
-    fn ne() {
-        let ci1 = CompletionInfo { value: Some(ECMAScriptValue::from("red")), target: Some(JSString::from("label")) };
-        let ci2 = CompletionInfo { value: None, target: None };
-        let ci3 = CompletionInfo { value: Some(ECMAScriptValue::from("red")), target: Some(JSString::from("label")) };
-        assert_eq!(ci1 != ci2, true);
-        assert_eq!(ci1 != ci3, false);
+
+    #[test_case(NormalCompletion::Empty => with |s| assert_ne!(s, ""); "empty")]
+    fn debug(nc: NormalCompletion) -> String {
+        format!("{:?}", nc)
+    }
+
+    #[test_case(ECMAScriptValue::from(true) => NormalCompletion::Value(ECMAScriptValue::from(true)); "value")]
+    #[test_case(Reference::new(Base::Unresolvable, "fantastico", false, None) => NormalCompletion::Reference(Box::new(Reference::new(Base::Unresolvable, "fantastico", false, None))); "reference")]
+    fn from(value: impl Into<NormalCompletion>) -> NormalCompletion {
+        value.into()
     }
 }
 
@@ -42,13 +43,13 @@ mod abrupt_completion {
     fn clone() {
         let value = Some(ECMAScriptValue::Number(10.0));
         let target = Some(JSString::from("outer"));
-        let first = AbruptCompletion::Break(CompletionInfo { value, target });
+        let first = AbruptCompletion::Break { value, target };
         let second = first.clone();
-        assert!(matches!(second, AbruptCompletion::Break(_)));
-        if let AbruptCompletion::Break(ci) = second {
-            if let AbruptCompletion::Break(orig) = first {
-                assert_eq!(ci.value, orig.value);
-                assert_eq!(ci.target, orig.target);
+        assert!(matches!(second, AbruptCompletion::Break { .. }));
+        if let AbruptCompletion::Break { value: second_value, target: second_target } = second {
+            if let AbruptCompletion::Break { value: orig_value, target: orig_target } = first {
+                assert_eq!(second_value, orig_value);
+                assert_eq!(second_target, orig_target);
             }
         }
     }
@@ -58,24 +59,24 @@ mod abrupt_completion {
         // Just for coverage. Essentially, assert that we don't panic.
         let value = Some(ECMAScriptValue::Number(10.0));
         let target = Some(JSString::from("outer"));
-        let first = AbruptCompletion::Break(CompletionInfo { value, target });
+        let first = AbruptCompletion::Break { value, target };
         assert_ne!(format!("{:?}", first), "");
     }
 
     #[test]
     fn eq() {
-        let c1 = AbruptCompletion::Throw(CompletionInfo { value: Some(ECMAScriptValue::from("error message")), target: None });
-        let c2 = AbruptCompletion::Return(CompletionInfo { value: Some(ECMAScriptValue::from(27)), target: None });
-        let c3 = AbruptCompletion::Throw(CompletionInfo { value: Some(ECMAScriptValue::from("error message")), target: None });
+        let c1 = AbruptCompletion::Throw { value: ECMAScriptValue::from("error message") };
+        let c2 = AbruptCompletion::Return { value: ECMAScriptValue::from(27) };
+        let c3 = AbruptCompletion::Throw { value: ECMAScriptValue::from("error message") };
 
         assert_eq!(c1 == c2, false);
         assert_eq!(c1 == c3, true);
     }
     #[test]
     fn ne() {
-        let c1 = AbruptCompletion::Throw(CompletionInfo { value: Some(ECMAScriptValue::from("error message")), target: None });
-        let c2 = AbruptCompletion::Return(CompletionInfo { value: Some(ECMAScriptValue::from(27)), target: None });
-        let c3 = AbruptCompletion::Throw(CompletionInfo { value: Some(ECMAScriptValue::from("error message")), target: None });
+        let c1 = AbruptCompletion::Throw { value: ECMAScriptValue::from("error message") };
+        let c2 = AbruptCompletion::Return { value: ECMAScriptValue::from(27) };
+        let c3 = AbruptCompletion::Throw { value: ECMAScriptValue::from("error message") };
 
         assert_eq!(c1 != c2, true);
         assert_eq!(c1 != c3, false);

--- a/src/cr/tests.rs
+++ b/src/cr/tests.rs
@@ -22,6 +22,7 @@ mod normal_completion {
     #[test_case(NormalCompletion::Value(ECMAScriptValue::from("alice")) => NormalCompletion::Value(ECMAScriptValue::from("alice")); "value")]
     #[test_case(NormalCompletion::Reference(Box::new(Reference::new(Base::Unresolvable, "alice", false, None))) => NormalCompletion::Reference(Box::new(Reference::new(Base::Unresolvable, "alice", false, None))); "reference")]
     fn clone(orig: NormalCompletion) -> NormalCompletion {
+        #[allow(clippy::redundant_clone)]
         orig.clone()
     }
 

--- a/src/environment_record/mod.rs
+++ b/src/environment_record/mod.rs
@@ -1,6 +1,6 @@
 use super::agent::{Agent, WksId};
 use super::comparison::is_extensible;
-use super::cr::{AltCompletion, Completion};
+use super::cr::Completion;
 use super::errors::{create_reference_error, create_type_error};
 use super::function_object::ThisMode;
 use super::object::{define_property_or_throw, get, has_own_property, has_property, set, DescriptorKind, Object, PotentialPropertyDescriptor};
@@ -113,13 +113,13 @@ use std::rc::Rc;
 // +------------------------------+------------------------------------------------------------------------------------+
 
 pub trait EnvironmentRecord: Debug {
-    fn has_binding(&self, agent: &mut Agent, name: &JSString) -> AltCompletion<bool>;
-    fn create_mutable_binding(&self, agent: &mut Agent, name: JSString, deletable: bool) -> AltCompletion<()>;
-    fn create_immutable_binding(&self, agent: &mut Agent, name: JSString, strict: bool) -> AltCompletion<()>;
-    fn initialize_binding(&self, agent: &mut Agent, name: &JSString, value: ECMAScriptValue) -> AltCompletion<()>;
-    fn set_mutable_binding(&self, agent: &mut Agent, name: JSString, value: ECMAScriptValue, strict: bool) -> AltCompletion<()>;
-    fn get_binding_value(&self, agent: &mut Agent, name: &JSString, strict: bool) -> Completion;
-    fn delete_binding(&self, agent: &mut Agent, name: &JSString) -> AltCompletion<bool>;
+    fn has_binding(&self, agent: &mut Agent, name: &JSString) -> Completion<bool>;
+    fn create_mutable_binding(&self, agent: &mut Agent, name: JSString, deletable: bool) -> Completion<()>;
+    fn create_immutable_binding(&self, agent: &mut Agent, name: JSString, strict: bool) -> Completion<()>;
+    fn initialize_binding(&self, agent: &mut Agent, name: &JSString, value: ECMAScriptValue) -> Completion<()>;
+    fn set_mutable_binding(&self, agent: &mut Agent, name: JSString, value: ECMAScriptValue, strict: bool) -> Completion<()>;
+    fn get_binding_value(&self, agent: &mut Agent, name: &JSString, strict: bool) -> Completion<ECMAScriptValue>;
+    fn delete_binding(&self, agent: &mut Agent, name: &JSString) -> Completion<bool>;
     fn has_this_binding(&self) -> bool;
     fn has_super_binding(&self) -> bool;
     fn with_base_object(&self) -> Option<Object>;
@@ -193,7 +193,7 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
     //
     // 1. If envRec has a binding for the name that is the value of N, return true.
     // 2. Return false.
-    fn has_binding(&self, _agent: &mut Agent, name: &JSString) -> AltCompletion<bool> {
+    fn has_binding(&self, _agent: &mut Agent, name: &JSString) -> Completion<bool> {
         Ok(self.bindings.borrow().contains_key(name))
     }
 
@@ -208,7 +208,7 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
     //  2. Create a mutable binding in envRec for N and record that it is uninitialized. If D is true, record that the
     //     newly created binding may be deleted by a subsequent DeleteBinding call.
     //  3. Return NormalCompletion(empty).
-    fn create_mutable_binding(&self, _agent: &mut Agent, name: JSString, deletable: bool) -> AltCompletion<()> {
+    fn create_mutable_binding(&self, _agent: &mut Agent, name: JSString, deletable: bool) -> Completion<()> {
         let removable = Removability::from(deletable);
         self.bindings.borrow_mut().insert(name, Binding { value: None, mutability: Mutability::Mutable(removable) });
         Ok(())
@@ -225,7 +225,7 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
     // 2. Create an immutable binding in envRec for N and record that it is uninitialized. If S is true, record that the
     //    newly created binding is a strict binding.
     // 3. Return NormalCompletion(empty).
-    fn create_immutable_binding(&self, _agent: &mut Agent, name: JSString, strict: bool) -> AltCompletion<()> {
+    fn create_immutable_binding(&self, _agent: &mut Agent, name: JSString, strict: bool) -> Completion<()> {
         let strictness = Strictness::from(strict);
         self.bindings.borrow_mut().insert(name, Binding { value: None, mutability: Mutability::Immutable(strictness) });
         Ok(())
@@ -242,7 +242,7 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
     // 2. Set the bound value for N in envRec to V.
     // 3. Record that the binding for N in envRec has been initialized.
     // 4. Return NormalCompletion(empty).
-    fn initialize_binding(&self, _agent: &mut Agent, name: &JSString, value: ECMAScriptValue) -> AltCompletion<()> {
+    fn initialize_binding(&self, _agent: &mut Agent, name: &JSString, value: ECMAScriptValue) -> Completion<()> {
         self.bindings.borrow_mut().get_mut(name).unwrap().value = Some(value);
         Ok(())
     }
@@ -270,7 +270,7 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
     //
     // NOTE     An example of ECMAScript code that results in a missing binding at step 1 is:
     //              function f() { eval("var x; x = (delete x, 0);"); }
-    fn set_mutable_binding(&self, agent: &mut Agent, name: JSString, value: ECMAScriptValue, strict: bool) -> AltCompletion<()> {
+    fn set_mutable_binding(&self, agent: &mut Agent, name: JSString, value: ECMAScriptValue, strict: bool) -> Completion<()> {
         let mut bindings = self.bindings.borrow_mut();
         let maybe_item = bindings.get_mut(&name);
         match maybe_item {
@@ -310,7 +310,7 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
     //  1. Assert: envRec has a binding for N.
     //  2. If the binding for N in envRec is an uninitialized binding, throw a ReferenceError exception.
     //  3. Return the value currently bound to N in envRec.
-    fn get_binding_value(&self, agent: &mut Agent, name: &JSString, _strict: bool) -> Completion {
+    fn get_binding_value(&self, agent: &mut Agent, name: &JSString, _strict: bool) -> Completion<ECMAScriptValue> {
         let bindings = self.bindings.borrow();
         let maybe_value = &bindings.get(name).unwrap().value;
         match maybe_value {
@@ -329,7 +329,7 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
     //  2. If the binding for N in envRec cannot be deleted, return false.
     //  3. Remove the binding for N from envRec.
     //  4. Return true.
-    fn delete_binding(&self, _agent: &mut Agent, name: &JSString) -> AltCompletion<bool> {
+    fn delete_binding(&self, _agent: &mut Agent, name: &JSString) -> Completion<bool> {
         let mut bindings = self.bindings.borrow_mut();
         let item = bindings.get(name).unwrap();
         if item.mutability != Mutability::Mutable(Removability::Deletable) {
@@ -444,7 +444,7 @@ impl EnvironmentRecord for ObjectEnvironmentRecord {
     //      a. Let blocked be ! ToBoolean(? Get(unscopables, N)).
     //      b. If blocked is true, return false.
     //  7. Return true.
-    fn has_binding(&self, agent: &mut Agent, name: &JSString) -> AltCompletion<bool> {
+    fn has_binding(&self, agent: &mut Agent, name: &JSString) -> Completion<bool> {
         let name_key = PropertyKey::from(name);
         let binding_object = &self.binding_object;
         let found_binding = has_property(agent, binding_object, &name_key)?;
@@ -478,7 +478,7 @@ impl EnvironmentRecord for ObjectEnvironmentRecord {
     //
     // NOTE     Normally envRec will not have a binding for N but if it does, the semantics of DefinePropertyOrThrow may
     //          result in an existing binding being replaced or shadowed or cause an abrupt completion to be returned.
-    fn create_mutable_binding(&self, agent: &mut Agent, name: JSString, deletable: bool) -> AltCompletion<()> {
+    fn create_mutable_binding(&self, agent: &mut Agent, name: JSString, deletable: bool) -> Completion<()> {
         let binding_object = &self.binding_object;
         let desc = PotentialPropertyDescriptor::new().value(ECMAScriptValue::Undefined).writable(true).enumerable(true).configurable(deletable);
         define_property_or_throw(agent, binding_object, name, desc)
@@ -488,7 +488,7 @@ impl EnvironmentRecord for ObjectEnvironmentRecord {
     //
     // The CreateImmutableBinding concrete method of an object Environment Record is never used within this
     // specification.
-    fn create_immutable_binding(&self, _agent: &mut Agent, _name: JSString, _strict: bool) -> AltCompletion<()> {
+    fn create_immutable_binding(&self, _agent: &mut Agent, _name: JSString, _strict: bool) -> Completion<()> {
         unreachable!()
     }
 
@@ -503,7 +503,7 @@ impl EnvironmentRecord for ObjectEnvironmentRecord {
     // NOTE     In this specification, all uses of CreateMutableBinding for object Environment Records are immediately
     //          followed by a call to InitializeBinding for the same name. Hence, this specification does not explicitly
     //          track the initialization state of bindings in object Environment Records.
-    fn initialize_binding(&self, agent: &mut Agent, name: &JSString, value: ECMAScriptValue) -> AltCompletion<()> {
+    fn initialize_binding(&self, agent: &mut Agent, name: &JSString, value: ECMAScriptValue) -> Completion<()> {
         self.set_mutable_binding(agent, name.clone(), value, false)
     }
 
@@ -519,7 +519,7 @@ impl EnvironmentRecord for ObjectEnvironmentRecord {
     //  2. Let stillExists be ? HasProperty(bindingObject, N).
     //  3. If stillExists is false and S is true, throw a ReferenceError exception.
     //  4. Return ? Set(bindingObject, N, V, S).
-    fn set_mutable_binding(&self, agent: &mut Agent, name: JSString, value: ECMAScriptValue, strict: bool) -> AltCompletion<()> {
+    fn set_mutable_binding(&self, agent: &mut Agent, name: JSString, value: ECMAScriptValue, strict: bool) -> Completion<()> {
         let name_key = PropertyKey::from(name);
         let binding_object = &self.binding_object;
         let still_exists = has_property(agent, binding_object, &name_key)?;
@@ -543,7 +543,7 @@ impl EnvironmentRecord for ObjectEnvironmentRecord {
     //  3. If value is false, then
     //      a. If S is false, return the value undefined; otherwise throw a ReferenceError exception.
     //  4. Return ? Get(bindingObject, N).
-    fn get_binding_value(&self, agent: &mut Agent, name: &JSString, strict: bool) -> Completion {
+    fn get_binding_value(&self, agent: &mut Agent, name: &JSString, strict: bool) -> Completion<ECMAScriptValue> {
         let name_key = PropertyKey::from(name);
         let binding_object = &self.binding_object;
         let has_prop = has_property(agent, binding_object, &name_key)?;
@@ -566,7 +566,7 @@ impl EnvironmentRecord for ObjectEnvironmentRecord {
     //
     //  1. Let bindingObject be envRec.[[BindingObject]].
     //  2. Return ? bindingObject.[[Delete]](N).
-    fn delete_binding(&self, agent: &mut Agent, name: &JSString) -> AltCompletion<bool> {
+    fn delete_binding(&self, agent: &mut Agent, name: &JSString) -> Completion<bool> {
         let name_key = PropertyKey::from(name);
         let binding_object = &self.binding_object;
         binding_object.o.delete(agent, &name_key)
@@ -675,25 +675,25 @@ pub struct FunctionEnvironmentRecord {
 impl EnvironmentRecord for FunctionEnvironmentRecord {
     // Function Environment Records support all of the declarative Environment Record methods listed in Table 17 and share
     // the same specifications for all of those methods except for HasThisBinding and HasSuperBinding.
-    fn has_binding(&self, agent: &mut Agent, name: &JSString) -> AltCompletion<bool> {
+    fn has_binding(&self, agent: &mut Agent, name: &JSString) -> Completion<bool> {
         self.base.has_binding(agent, name)
     }
-    fn create_mutable_binding(&self, agent: &mut Agent, name: JSString, deletable: bool) -> AltCompletion<()> {
+    fn create_mutable_binding(&self, agent: &mut Agent, name: JSString, deletable: bool) -> Completion<()> {
         self.base.create_mutable_binding(agent, name, deletable)
     }
-    fn create_immutable_binding(&self, agent: &mut Agent, name: JSString, strict: bool) -> AltCompletion<()> {
+    fn create_immutable_binding(&self, agent: &mut Agent, name: JSString, strict: bool) -> Completion<()> {
         self.base.create_immutable_binding(agent, name, strict)
     }
-    fn initialize_binding(&self, agent: &mut Agent, name: &JSString, value: ECMAScriptValue) -> AltCompletion<()> {
+    fn initialize_binding(&self, agent: &mut Agent, name: &JSString, value: ECMAScriptValue) -> Completion<()> {
         self.base.initialize_binding(agent, name, value)
     }
-    fn set_mutable_binding(&self, agent: &mut Agent, name: JSString, value: ECMAScriptValue, strict: bool) -> AltCompletion<()> {
+    fn set_mutable_binding(&self, agent: &mut Agent, name: JSString, value: ECMAScriptValue, strict: bool) -> Completion<()> {
         self.base.set_mutable_binding(agent, name, value, strict)
     }
-    fn get_binding_value(&self, agent: &mut Agent, name: &JSString, strict: bool) -> Completion {
+    fn get_binding_value(&self, agent: &mut Agent, name: &JSString, strict: bool) -> Completion<ECMAScriptValue> {
         self.base.get_binding_value(agent, name, strict)
     }
-    fn delete_binding(&self, agent: &mut Agent, name: &JSString) -> AltCompletion<bool> {
+    fn delete_binding(&self, agent: &mut Agent, name: &JSString) -> Completion<bool> {
         self.base.delete_binding(agent, name)
     }
     fn with_base_object(&self) -> Option<Object> {
@@ -762,7 +762,7 @@ impl FunctionEnvironmentRecord {
     //  3. Set envRec.[[ThisValue]] to V.
     //  4. Set envRec.[[ThisBindingStatus]] to initialized.
     //  5. Return V.
-    pub fn bind_this_value(&mut self, agent: &mut Agent, val: ECMAScriptValue) -> Completion {
+    pub fn bind_this_value(&mut self, agent: &mut Agent, val: ECMAScriptValue) -> Completion<ECMAScriptValue> {
         assert_ne!(self.this_binding_status, BindingStatus::Lexical);
         if self.this_binding_status == BindingStatus::Initialized {
             Err(create_reference_error(agent, "This value already bound"))
@@ -781,7 +781,7 @@ impl FunctionEnvironmentRecord {
     //  1. Assert: envRec.[[ThisBindingStatus]] is not lexical.
     //  2. If envRec.[[ThisBindingStatus]] is uninitialized, throw a ReferenceError exception.
     //  3. Return envRec.[[ThisValue]].
-    pub fn get_this_binding(&self, agent: &mut Agent) -> Completion {
+    pub fn get_this_binding(&self, agent: &mut Agent) -> Completion<ECMAScriptValue> {
         if self.this_binding_status == BindingStatus::Uninitialized {
             Err(create_reference_error(agent, "This binding uninitialized"))
         } else {
@@ -798,7 +798,7 @@ impl FunctionEnvironmentRecord {
     //  2. If home has the value undefined, return undefined.
     //  3. Assert: Type(home) is Object.
     //  4. Return ? home.[[GetPrototypeOf]]().
-    pub fn get_super_base(&self, agent: &mut Agent) -> AltCompletion<Option<Object>> {
+    pub fn get_super_base(&self, agent: &mut Agent) -> Completion<Option<Object>> {
         let fo = self.function_object.o.to_function_obj().unwrap();
         let home = &fo.function_data().borrow().home_object;
         match home {
@@ -944,7 +944,7 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     //  2. If DclRec.HasBinding(N) is true, return true.
     //  3. Let ObjRec be envRec.[[ObjectRecord]].
     //  4. Return ? ObjRec.HasBinding(N).
-    fn has_binding(&self, agent: &mut Agent, name: &JSString) -> AltCompletion<bool> {
+    fn has_binding(&self, agent: &mut Agent, name: &JSString) -> Completion<bool> {
         Ok(self.declarative_record.has_binding(agent, name).unwrap() || self.object_record.has_binding(agent, name)?)
     }
 
@@ -958,7 +958,7 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     //  1. Let DclRec be envRec.[[DeclarativeRecord]].
     //  2. If DclRec.HasBinding(N) is true, throw a TypeError exception.
     //  3. Return DclRec.CreateMutableBinding(N, D).
-    fn create_mutable_binding(&self, agent: &mut Agent, name: JSString, deletable: bool) -> AltCompletion<()> {
+    fn create_mutable_binding(&self, agent: &mut Agent, name: JSString, deletable: bool) -> Completion<()> {
         if self.declarative_record.has_binding(agent, &name).unwrap() {
             Err(create_type_error(agent, "Binding already exists"))
         } else {
@@ -976,7 +976,7 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     //  1. Let DclRec be envRec.[[DeclarativeRecord]].
     //  2. If DclRec.HasBinding(N) is true, throw a TypeError exception.
     //  3. Return DclRec.CreateImmutableBinding(N, S).
-    fn create_immutable_binding(&self, agent: &mut Agent, name: JSString, strict: bool) -> AltCompletion<()> {
+    fn create_immutable_binding(&self, agent: &mut Agent, name: JSString, strict: bool) -> Completion<()> {
         if self.declarative_record.has_binding(agent, &name).unwrap() {
             Err(create_type_error(agent, "Binding already exists"))
         } else {
@@ -997,7 +997,7 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     //  3. Assert: If the binding exists, it must be in the object Environment Record.
     //  4. Let ObjRec be envRec.[[ObjectRecord]].
     //  5. Return ? ObjRec.InitializeBinding(N, V).
-    fn initialize_binding(&self, agent: &mut Agent, name: &JSString, value: ECMAScriptValue) -> AltCompletion<()> {
+    fn initialize_binding(&self, agent: &mut Agent, name: &JSString, value: ECMAScriptValue) -> Completion<()> {
         if self.declarative_record.has_binding(agent, name).unwrap() {
             self.declarative_record.initialize_binding(agent, name, value)
         } else {
@@ -1018,7 +1018,7 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     //      a. Return DclRec.SetMutableBinding(N, V, S).
     //  3. Let ObjRec be envRec.[[ObjectRecord]].
     //  4. Return ? ObjRec.SetMutableBinding(N, V, S).
-    fn set_mutable_binding(&self, agent: &mut Agent, name: JSString, value: ECMAScriptValue, strict: bool) -> AltCompletion<()> {
+    fn set_mutable_binding(&self, agent: &mut Agent, name: JSString, value: ECMAScriptValue, strict: bool) -> Completion<()> {
         if self.declarative_record.has_binding(agent, &name).unwrap() {
             self.declarative_record.set_mutable_binding(agent, name, value, strict)
         } else {
@@ -1039,7 +1039,7 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     //      a. Return DclRec.GetBindingValue(N, S).
     //  3. Let ObjRec be envRec.[[ObjectRecord]].
     //  4. Return ? ObjRec.GetBindingValue(N, S).
-    fn get_binding_value(&self, agent: &mut Agent, name: &JSString, strict: bool) -> Completion {
+    fn get_binding_value(&self, agent: &mut Agent, name: &JSString, strict: bool) -> Completion<ECMAScriptValue> {
         if self.declarative_record.has_binding(agent, name).unwrap() {
             self.declarative_record.get_binding_value(agent, name, strict)
         } else {
@@ -1066,7 +1066,7 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     //          ii. If N is an element of varNames, remove that element from the varNames.
     //      c. Return status.
     //  7. Return true.
-    fn delete_binding(&self, agent: &mut Agent, name: &JSString) -> AltCompletion<bool> {
+    fn delete_binding(&self, agent: &mut Agent, name: &JSString) -> Completion<bool> {
         if self.declarative_record.has_binding(agent, name).unwrap() {
             self.declarative_record.delete_binding(agent, name)
         } else {
@@ -1175,7 +1175,7 @@ impl GlobalEnvironmentRecord {
     //          var or function declaration. A global lexical binding may not be created that has the same name as a
     //          non-configurable property of the global object. The global property "undefined" is an example of such a
     //          property.
-    pub fn has_restricted_global_property(&self, agent: &mut Agent, name: &JSString) -> AltCompletion<bool> {
+    pub fn has_restricted_global_property(&self, agent: &mut Agent, name: &JSString) -> Completion<bool> {
         let global_object = &self.object_record.binding_object;
         let existing_prop = global_object.o.get_own_property(agent, &name.clone().into())?;
         match existing_prop {
@@ -1196,7 +1196,7 @@ impl GlobalEnvironmentRecord {
     //  3. Let hasProperty be ? HasOwnProperty(globalObject, N).
     //  4. If hasProperty is true, return true.
     //  5. Return ? IsExtensible(globalObject).
-    pub fn can_declare_global_var(&self, agent: &mut Agent, name: &JSString) -> AltCompletion<bool> {
+    pub fn can_declare_global_var(&self, agent: &mut Agent, name: &JSString) -> Completion<bool> {
         let global_object = &self.object_record.binding_object;
         Ok(has_own_property(agent, global_object, &name.clone().into())? || is_extensible(agent, global_object)?)
     }
@@ -1214,7 +1214,7 @@ impl GlobalEnvironmentRecord {
     //  5. If existingProp.[[Configurable]] is true, return true.
     //  6. If IsDataDescriptor(existingProp) is true and existingProp has attribute values { [[Writable]]: true, [[Enumerable]]: true }, return true.
     //  7. Return false.
-    pub fn can_declare_global_function(&self, agent: &mut Agent, name: &JSString) -> AltCompletion<bool> {
+    pub fn can_declare_global_function(&self, agent: &mut Agent, name: &JSString) -> Completion<bool> {
         let global_object = &self.object_record.binding_object;
         let existing_prop = global_object.o.get_own_property(agent, &name.clone().into())?;
         match existing_prop {
@@ -1241,7 +1241,7 @@ impl GlobalEnvironmentRecord {
     //  7. If varDeclaredNames does not contain N, then
     //      a. Append N to varDeclaredNames.
     //  8. Return NormalCompletion(empty).
-    pub fn create_global_var_binding(&self, agent: &mut Agent, name: JSString, deletable: bool) -> AltCompletion<()> {
+    pub fn create_global_var_binding(&self, agent: &mut Agent, name: JSString, deletable: bool) -> Completion<()> {
         let global_object = &self.object_record.binding_object;
         let has_property = has_own_property(agent, global_object, &name.clone().into())?;
         let extensible = is_extensible(agent, global_object)?;
@@ -1279,7 +1279,7 @@ impl GlobalEnvironmentRecord {
     //          an existing own property is reconfigured to have a standard set of attribute values. Step 7 is
     //          equivalent to what calling the InitializeBinding concrete method would do and if globalObject is a Proxy
     //          will produce the same sequence of Proxy trap calls.
-    pub fn create_global_function_binding(&self, agent: &mut Agent, name: JSString, val: ECMAScriptValue, deletable: bool) -> AltCompletion<()> {
+    pub fn create_global_function_binding(&self, agent: &mut Agent, name: JSString, val: ECMAScriptValue, deletable: bool) -> Completion<()> {
         let global_object = &self.object_record.binding_object;
         let prop_key = PropertyKey::from(name.clone());
         let existing_prop = global_object.o.get_own_property(agent, &prop_key)?;
@@ -1329,7 +1329,7 @@ impl GlobalEnvironmentRecord {
 //  4. Else,
 //      a. Let outer be env.[[OuterEnv]].
 //      b. Return ? GetIdentifierReference(outer, name, strict).
-pub fn get_identifier_reference(agent: &mut Agent, environment: Option<Rc<dyn EnvironmentRecord>>, name: JSString, strict: bool) -> AltCompletion<Reference> {
+pub fn get_identifier_reference(agent: &mut Agent, environment: Option<Rc<dyn EnvironmentRecord>>, name: JSString, strict: bool) -> Completion<Reference> {
     match environment {
         None => Ok(Reference::new(Base::Unresolvable, name, strict, None)),
         Some(env) => {

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -1,5 +1,5 @@
 use super::agent::Agent;
-use super::cr::{AbruptCompletion, AltCompletion, Completion, CompletionInfo};
+use super::cr::{AbruptCompletion, Completion};
 use super::function_object::{create_builtin_function, Arguments};
 use super::object::{
     define_property_or_throw, get, ordinary_create_from_constructor, ordinary_define_own_property, ordinary_delete, ordinary_get, ordinary_get_own_property, ordinary_get_prototype_of,
@@ -26,7 +26,7 @@ pub fn create_type_error_object(agent: &mut Agent, message: impl Into<JSString>)
 }
 
 pub fn create_type_error(agent: &mut Agent, message: impl Into<JSString>) -> AbruptCompletion {
-    AbruptCompletion::Throw(CompletionInfo { value: Some(ECMAScriptValue::Object(create_type_error_object(agent, message))), target: None })
+    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_type_error_object(agent, message)) }
 }
 
 pub fn create_reference_error_object(agent: &mut Agent, message: impl Into<JSString>) -> Object {
@@ -35,7 +35,7 @@ pub fn create_reference_error_object(agent: &mut Agent, message: impl Into<JSStr
 }
 
 pub fn create_reference_error(agent: &mut Agent, message: impl Into<JSString>) -> AbruptCompletion {
-    AbruptCompletion::Throw(CompletionInfo { value: Some(ECMAScriptValue::Object(create_reference_error_object(agent, message))), target: None })
+    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_reference_error_object(agent, message)) }
 }
 
 pub fn create_syntax_error_object(agent: &mut Agent, message: impl Into<JSString>) -> Object {
@@ -44,7 +44,7 @@ pub fn create_syntax_error_object(agent: &mut Agent, message: impl Into<JSString
 }
 
 pub fn create_syntax_error(agent: &mut Agent, message: impl Into<JSString>) -> AbruptCompletion {
-    AbruptCompletion::Throw(CompletionInfo { value: Some(ECMAScriptValue::Object(create_syntax_error_object(agent, message))), target: None })
+    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_syntax_error_object(agent, message)) }
 }
 
 pub fn create_range_error_object(agent: &mut Agent, message: impl Into<JSString>) -> Object {
@@ -53,7 +53,7 @@ pub fn create_range_error_object(agent: &mut Agent, message: impl Into<JSString>
 }
 
 pub fn create_range_error(agent: &mut Agent, message: impl Into<JSString>) -> AbruptCompletion {
-    AbruptCompletion::Throw(CompletionInfo { value: Some(ECMAScriptValue::Object(create_range_error_object(agent, message))), target: None })
+    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_range_error_object(agent, message)) }
 }
 
 pub fn create_eval_error_object(agent: &mut Agent, message: impl Into<JSString>) -> Object {
@@ -62,7 +62,7 @@ pub fn create_eval_error_object(agent: &mut Agent, message: impl Into<JSString>)
 }
 
 pub fn create_eval_error(agent: &mut Agent, message: impl Into<JSString>) -> AbruptCompletion {
-    AbruptCompletion::Throw(CompletionInfo { value: Some(ECMAScriptValue::Object(create_eval_error_object(agent, message))), target: None })
+    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_eval_error_object(agent, message)) }
 }
 
 pub fn create_uri_error_object(agent: &mut Agent, message: impl Into<JSString>) -> Object {
@@ -71,7 +71,7 @@ pub fn create_uri_error_object(agent: &mut Agent, message: impl Into<JSString>) 
 }
 
 pub fn create_uri_error(agent: &mut Agent, message: impl Into<JSString>) -> AbruptCompletion {
-    AbruptCompletion::Throw(CompletionInfo { value: Some(ECMAScriptValue::Object(create_uri_error_object(agent, message))), target: None })
+    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_uri_error_object(agent, message)) }
 }
 
 #[derive(Debug)]
@@ -108,37 +108,37 @@ impl ObjectInterface for ErrorObject {
         true
     }
 
-    fn get_prototype_of(&self, _agent: &mut Agent) -> AltCompletion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &mut Agent) -> Completion<Option<Object>> {
         Ok(ordinary_get_prototype_of(&*self))
     }
-    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<Object>) -> AltCompletion<bool> {
+    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<Object>) -> Completion<bool> {
         Ok(ordinary_set_prototype_of(&*self, obj))
     }
-    fn is_extensible(&self, _agent: &mut Agent) -> AltCompletion<bool> {
+    fn is_extensible(&self, _agent: &mut Agent) -> Completion<bool> {
         Ok(ordinary_is_extensible(&*self))
     }
-    fn prevent_extensions(&self, _agent: &mut Agent) -> AltCompletion<bool> {
+    fn prevent_extensions(&self, _agent: &mut Agent) -> Completion<bool> {
         Ok(ordinary_prevent_extensions(&*self))
     }
-    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(&*self, key))
     }
-    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> AltCompletion<bool> {
+    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool> {
         ordinary_define_own_property(agent, &*self, key, desc)
     }
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_has_property(agent, &*self, key)
     }
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion {
+    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         ordinary_get(agent, &*self, key, receiver)
     }
-    fn set(&self, agent: &mut Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> AltCompletion<bool> {
+    fn set(&self, agent: &mut Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
         ordinary_set(agent, &*self, key, v, receiver)
     }
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_delete(agent, &*self, key)
     }
-    fn own_property_keys(&self, agent: &mut Agent) -> AltCompletion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(agent, self))
     }
 }
@@ -249,7 +249,7 @@ pub fn provision_error_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>) 
 //             [[Configurable]]: true }.
 //          c. Perform ! DefinePropertyOrThrow(O, "message", msgDesc).
 //      4. Return O.
-pub fn error_constructor_function(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+pub fn error_constructor_function(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::Error)
 }
 
@@ -266,7 +266,7 @@ pub fn error_constructor_function(agent: &mut Agent, this_value: ECMAScriptValue
 //      7. If name is the empty String, return msg.
 //      8. If msg is the empty String, return name.
 //      9. Return the string-concatenation of name, the code unit 0x003A (COLON), the code unit 0x0020 (SPACE), and msg.
-pub fn error_prototype_tostring(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+pub fn error_prototype_tostring(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     if let ECMAScriptValue::Object(o) = this_value {
         let name_prop = get(agent, &o, &PropertyKey::from("name"))?;
         let name = if name_prop.is_undefined() { JSString::from("Error") } else { to_string(agent, name_prop)? };
@@ -288,7 +288,7 @@ fn provision_native_error_intrinsics(
     agent: &mut Agent,
     realm: &Rc<RefCell<Realm>>,
     name: &str,
-    native_error_constructor_function: fn(&mut Agent, ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion,
+    native_error_constructor_function: fn(&mut Agent, ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion<ECMAScriptValue>,
 ) -> (Object, Object) {
     let error = realm.borrow().intrinsics.error.clone();
     let error_prototype = realm.borrow().intrinsics.error_prototype.clone();
@@ -381,7 +381,13 @@ fn provision_native_error_intrinsics(
 // The actual value of the string passed in step 2 is either "%EvalError.prototype%", "%RangeError.prototype%",
 // "%ReferenceError.prototype%", "%SyntaxError.prototype%", "%TypeError.prototype%", or "%URIError.prototype%"
 // corresponding to which NativeError constructor is being defined.
-fn native_error_constructor_function(agent: &mut Agent, _this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue], intrinsic_id: IntrinsicId) -> Completion {
+fn native_error_constructor_function(
+    agent: &mut Agent,
+    _this_value: ECMAScriptValue,
+    new_target: Option<&Object>,
+    arguments: &[ECMAScriptValue],
+    intrinsic_id: IntrinsicId,
+) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let message = args.next_arg();
     let afo: Object;
@@ -402,22 +408,22 @@ fn native_error_constructor_function(agent: &mut Agent, _this_value: ECMAScriptV
     Ok(ECMAScriptValue::from(o))
 }
 
-fn type_error_constructor_function(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn type_error_constructor_function(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::TypeErrorPrototype)
 }
-fn eval_error_constructor_function(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn eval_error_constructor_function(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::EvalErrorPrototype)
 }
-fn range_error_constructor_function(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn range_error_constructor_function(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::RangeErrorPrototype)
 }
-fn reference_error_constructor_function(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn reference_error_constructor_function(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::ReferenceErrorPrototype)
 }
-fn syntax_error_constructor_function(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn syntax_error_constructor_function(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::SyntaxErrorPrototype)
 }
-fn uri_error_constructor_function(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn uri_error_constructor_function(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::URIErrorPrototype)
 }
 

--- a/src/errors/tests.rs
+++ b/src/errors/tests.rs
@@ -36,10 +36,8 @@ fn create_type_error_01() {
     let mut agent = test_agent();
 
     let result = create_type_error(&mut agent, "A");
-    assert!(matches!(result, AbruptCompletion::Throw(_)));
-    if let AbruptCompletion::Throw(ci) = result {
-        assert!(ci.target.is_none());
-        let objval = ci.value.unwrap();
+    assert!(matches!(result, AbruptCompletion::Throw { .. }));
+    if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
@@ -65,10 +63,8 @@ fn create_eval_error_01() {
     let mut agent = test_agent();
 
     let result = create_eval_error(&mut agent, "A");
-    assert!(matches!(result, AbruptCompletion::Throw(_)));
-    if let AbruptCompletion::Throw(ci) = result {
-        assert!(ci.target.is_none());
-        let objval = ci.value.unwrap();
+    assert!(matches!(result, AbruptCompletion::Throw { .. }));
+    if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
@@ -94,10 +90,8 @@ fn create_reference_error_01() {
     let mut agent = test_agent();
 
     let result = create_reference_error(&mut agent, "A");
-    assert!(matches!(result, AbruptCompletion::Throw(_)));
-    if let AbruptCompletion::Throw(ci) = result {
-        assert!(ci.target.is_none());
-        let objval = ci.value.unwrap();
+    assert!(matches!(result, AbruptCompletion::Throw { .. }));
+    if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
@@ -123,10 +117,8 @@ fn create_range_error_01() {
     let mut agent = test_agent();
 
     let result = create_range_error(&mut agent, "A");
-    assert!(matches!(result, AbruptCompletion::Throw(_)));
-    if let AbruptCompletion::Throw(ci) = result {
-        assert!(ci.target.is_none());
-        let objval = ci.value.unwrap();
+    assert!(matches!(result, AbruptCompletion::Throw { .. }));
+    if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
@@ -152,10 +144,8 @@ fn create_syntax_error_01() {
     let mut agent = test_agent();
 
     let result = create_syntax_error(&mut agent, "A");
-    assert!(matches!(result, AbruptCompletion::Throw(_)));
-    if let AbruptCompletion::Throw(ci) = result {
-        assert!(ci.target.is_none());
-        let objval = ci.value.unwrap();
+    assert!(matches!(result, AbruptCompletion::Throw { .. }));
+    if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
@@ -181,10 +171,8 @@ fn create_uri_error_01() {
     let mut agent = test_agent();
 
     let result = create_uri_error(&mut agent, "A");
-    assert!(matches!(result, AbruptCompletion::Throw(_)));
-    if let AbruptCompletion::Throw(ci) = result {
-        assert!(ci.target.is_none());
-        let objval = ci.value.unwrap();
+    assert!(matches!(result, AbruptCompletion::Throw { .. }));
+    if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());

--- a/src/number_object/mod.rs
+++ b/src/number_object/mod.rs
@@ -1,6 +1,6 @@
 use super::agent::Agent;
 use super::comparison::is_integral_number;
-use super::cr::{AltCompletion, Completion};
+use super::cr::Completion;
 use super::dtoa_r::{dtoa, dtoa_fixed, dtoa_precise};
 use super::errors::{create_range_error, create_type_error};
 use super::function_object::{create_builtin_function, Arguments};
@@ -48,7 +48,7 @@ impl ObjectInterface for NumberObject {
         true
     }
 
-    fn get_prototype_of(&self, _agent: &mut Agent) -> AltCompletion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &mut Agent) -> Completion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
 
@@ -58,7 +58,7 @@ impl ObjectInterface for NumberObject {
     // the following steps when called:
     //
     //  1. Return ! OrdinarySetPrototypeOf(O, V).
-    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<Object>) -> AltCompletion<bool> {
+    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<Object>) -> Completion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
 
@@ -68,7 +68,7 @@ impl ObjectInterface for NumberObject {
     // when called:
     //
     //  1. Return ! OrdinaryIsExtensible(O).
-    fn is_extensible(&self, _agent: &mut Agent) -> AltCompletion<bool> {
+    fn is_extensible(&self, _agent: &mut Agent) -> Completion<bool> {
         Ok(ordinary_is_extensible(self))
     }
 
@@ -78,7 +78,7 @@ impl ObjectInterface for NumberObject {
     // steps when called:
     //
     //  1. Return ! OrdinaryPreventExtensions(O).
-    fn prevent_extensions(&self, _agent: &mut Agent) -> AltCompletion<bool> {
+    fn prevent_extensions(&self, _agent: &mut Agent) -> Completion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
 
@@ -88,7 +88,7 @@ impl ObjectInterface for NumberObject {
     // following steps when called:
     //
     //  1. Return ! OrdinaryGetOwnProperty(O, P).
-    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(self, key))
     }
 
@@ -98,7 +98,7 @@ impl ObjectInterface for NumberObject {
     // Property Descriptor). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
-    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> AltCompletion<bool> {
+    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool> {
         ordinary_define_own_property(agent, self, key, desc)
     }
 
@@ -108,7 +108,7 @@ impl ObjectInterface for NumberObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryHasProperty(O, P).
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_has_property(agent, self, key)
     }
 
@@ -118,7 +118,7 @@ impl ObjectInterface for NumberObject {
     // ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryGet(O, P, Receiver).
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion {
+    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         ordinary_get(agent, self, key, receiver)
     }
 
@@ -128,7 +128,7 @@ impl ObjectInterface for NumberObject {
     // value), and Receiver (an ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinarySet(O, P, V, Receiver).
-    fn set(&self, agent: &mut Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> AltCompletion<bool> {
+    fn set(&self, agent: &mut Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
         ordinary_set(agent, self, key, v, receiver)
     }
 
@@ -138,7 +138,7 @@ impl ObjectInterface for NumberObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryDelete(O, P).
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_delete(agent, self, key)
     }
 
@@ -148,7 +148,7 @@ impl ObjectInterface for NumberObject {
     // steps when called:
     //
     // 1. Return ! OrdinaryOwnPropertyKeys(O).
-    fn own_property_keys(&self, agent: &mut Agent) -> AltCompletion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(agent, self))
     }
 }
@@ -362,7 +362,7 @@ pub fn create_number_object(agent: &mut Agent, n: f64) -> Object {
 //      4. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%Number.prototype%", « [[NumberData]] »).
 //      5. Set O.[[NumberData]] to n.
 //      6. Return O.
-fn number_constructor_function(agent: &mut Agent, _this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn number_constructor_function(agent: &mut Agent, _this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let n = if args.count() >= 1 {
         let value = args.next_arg();
@@ -392,7 +392,7 @@ fn number_constructor_function(agent: &mut Agent, _this_value: ECMAScriptValue, 
 //      1. If Type(number) is not Number, return false.
 //      2. If number is NaN, +∞𝔽, or -∞𝔽, return false.
 //      3. Otherwise, return true.
-fn number_is_finite(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn number_is_finite(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let number = args.next_arg();
     Ok(ECMAScriptValue::from(match number {
@@ -406,7 +406,7 @@ fn number_is_finite(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_targe
 // When Number.isInteger is called with one argument number, the following steps are taken:
 //
 //      1. Return ! IsIntegralNumber(number).
-fn number_is_integer(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn number_is_integer(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let number = args.next_arg();
     Ok(ECMAScriptValue::from(is_integral_number(&number)))
@@ -422,7 +422,7 @@ fn number_is_integer(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_targ
 //
 // NOTE     This function differs from the global isNaN function (19.2.3) in that it does not convert its argument to a
 //          Number before determining whether it is NaN.
-fn number_is_nan(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn number_is_nan(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let number = args.next_arg();
     Ok(ECMAScriptValue::from(match number {
@@ -438,7 +438,7 @@ fn number_is_nan(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: 
 //      1. If ! IsIntegralNumber(number) is true, then
 //          a. If abs(ℝ(number)) ≤ 2**53 - 1, return true.
 //      2. Return false.
-fn number_is_safe_integer(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn number_is_safe_integer(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let number = args.next_arg();
     Ok(ECMAScriptValue::from(match number {
@@ -458,7 +458,7 @@ fn number_is_safe_integer(_agent: &mut Agent, _this_value: ECMAScriptValue, _new
 //
 // The phrase “this Number value” within the specification of a method refers to the result returned by calling the
 // abstract operation thisNumberValue with the this value of the method invocation passed as the argument.
-fn this_number_value(agent: &mut Agent, value: ECMAScriptValue) -> AltCompletion<f64> {
+fn this_number_value(agent: &mut Agent, value: ECMAScriptValue) -> Completion<f64> {
     match value {
         ECMAScriptValue::Number(x) => Ok(x),
         ECMAScriptValue::Object(o) if o.o.is_number_object() => {
@@ -528,7 +528,7 @@ fn this_number_value(agent: &mut Agent, value: ECMAScriptValue) -> AltCompletion
 //             small as possible. If there are multiple possibilities for n, choose the value of n for which 𝔽(n × 10e
 //             - f) is closest in value to 𝔽(x). If there are two such possible values of n, choose the one that is
 //             even.
-fn number_prototype_to_exponential(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn number_prototype_to_exponential(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let fraction_digits = args.next_arg();
 
@@ -633,7 +633,7 @@ fn number_prototype_to_exponential(agent: &mut Agent, this_value: ECMAScriptValu
 //                  (1000000000000000128).toString() returns "1000000000000000100", while
 //                  (1000000000000000128).toFixed(0) returns "1000000000000000128".
 //
-fn number_prototype_to_fixed(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn number_prototype_to_fixed(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let fraction_digits = args.next_arg();
     let value = this_number_value(agent, this_value)?;
@@ -704,7 +704,7 @@ fn number_prototype_to_fixed(agent: &mut Agent, this_value: ECMAScriptValue, _ne
 //
 // The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations
 // that do not include ECMA-402 support must not use those parameter positions for anything else.
-fn number_prototype_to_locale_string(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn number_prototype_to_locale_string(agent: &mut Agent, this_value: ECMAScriptValue, new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     number_prototype_to_string(agent, this_value, new_target, &[]) // Don't send the args along, because reserved1 & 2 are not meaningful
 }
 
@@ -756,7 +756,7 @@ fn number_prototype_to_locale_string(agent: &mut Agent, this_value: ECMAScriptVa
 //      a. Set m to the string-concatenation of the code unit 0x0030 (DIGIT ZERO), the code unit 0x002E (FULL STOP),
 //         -(e + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and the String m.
 //  14. Return the string-concatenation of s and m.
-fn number_prototype_to_precision(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn number_prototype_to_precision(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let precision = args.next_arg();
     let value = this_number_value(agent, this_value)?;
@@ -992,7 +992,7 @@ pub fn double_to_radix_string(val: f64, radix: i32) -> String {
 // object. Therefore, it cannot be transferred to other kinds of objects for use as a method.
 //
 // The "length" property of the toString method is 1𝔽.
-fn number_prototype_to_string(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn number_prototype_to_string(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let radix = args.next_arg();
     let x = this_number_value(agent, this_value)?;
@@ -1011,7 +1011,7 @@ fn number_prototype_to_string(agent: &mut Agent, this_value: ECMAScriptValue, _n
 
 // Number.prototype.valueOf ( )
 //  1. Return ? thisNumberValue(this value).
-fn number_prototype_value_of(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn number_prototype_value_of(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     this_number_value(agent, this_value).map(ECMAScriptValue::Number)
 }
 

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -2,7 +2,7 @@ use super::agent::Agent;
 use super::arrays::{array_create, ArrayObject};
 use super::boolean_object::{BooleanObject, BooleanObjectInterface};
 use super::comparison::is_extensible;
-use super::cr::{ Completion};
+use super::cr::Completion;
 use super::errors::create_type_error;
 use super::errors::ErrorObject;
 use super::function_object::{BuiltinFunctionInterface, CallableObject, ConstructableObject, FunctionObjectData};

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -2,7 +2,7 @@ use super::agent::Agent;
 use super::arrays::{array_create, ArrayObject};
 use super::boolean_object::{BooleanObject, BooleanObjectInterface};
 use super::comparison::is_extensible;
-use super::cr::{AltCompletion, Completion};
+use super::cr::{ Completion};
 use super::errors::create_type_error;
 use super::errors::ErrorObject;
 use super::function_object::{BuiltinFunctionInterface, CallableObject, ConstructableObject, FunctionObjectData};
@@ -308,7 +308,7 @@ pub fn from_property_descriptor(agent: &mut Agent, desc: Option<PropertyDescript
 //  15. If desc.[[Get]] is present or desc.[[Set]] is present, then
 //      a. If desc.[[Value]] is present or desc.[[Writable]] is present, throw a TypeError exception.
 //  16. Return desc.
-fn get_pd_prop(agent: &mut Agent, obj: &Object, key: impl Into<PropertyKey>) -> AltCompletion<Option<ECMAScriptValue>> {
+fn get_pd_prop(agent: &mut Agent, obj: &Object, key: impl Into<PropertyKey>) -> Completion<Option<ECMAScriptValue>> {
     Ok({
         let key = key.into();
         if has_property(agent, obj, &key)? {
@@ -318,10 +318,10 @@ fn get_pd_prop(agent: &mut Agent, obj: &Object, key: impl Into<PropertyKey>) -> 
         }
     })
 }
-fn get_pd_bool(agent: &mut Agent, obj: &Object, key: &str) -> AltCompletion<Option<bool>> {
+fn get_pd_bool(agent: &mut Agent, obj: &Object, key: &str) -> Completion<Option<bool>> {
     Ok(get_pd_prop(agent, obj, key)?.map(to_boolean))
 }
-pub fn to_property_descriptor(agent: &mut Agent, obj: &ECMAScriptValue) -> AltCompletion<PotentialPropertyDescriptor> {
+pub fn to_property_descriptor(agent: &mut Agent, obj: &ECMAScriptValue) -> Completion<PotentialPropertyDescriptor> {
     match obj {
         ECMAScriptValue::Object(obj) => {
             let enumerable = get_pd_bool(agent, obj, "enumerable")?;
@@ -479,7 +479,7 @@ where
 //  1. Let current be ? O.[[GetOwnProperty]](P).
 //  2. Let extensible be ? IsExtensible(O).
 //  3. Return ValidateAndApplyPropertyDescriptor(O, P, extensible, Desc, current).
-pub fn ordinary_define_own_property<'a, T>(agent: &mut Agent, o: T, p: PropertyKey, desc: PotentialPropertyDescriptor) -> AltCompletion<bool>
+pub fn ordinary_define_own_property<'a, T>(agent: &mut Agent, o: T, p: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -666,7 +666,7 @@ where
 //  5. If parent is not null, then
 //      a. Return ? parent.[[HasProperty]](P).
 //  6. Return false.
-pub fn ordinary_has_property<'a, T>(agent: &mut Agent, o: T, p: &PropertyKey) -> AltCompletion<bool>
+pub fn ordinary_has_property<'a, T>(agent: &mut Agent, o: T, p: &PropertyKey) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -700,7 +700,7 @@ where
 //  6. Let getter be desc.[[Get]].
 //  7. If getter is undefined, return undefined.
 //  8. Return ? Call(getter, Receiver).
-pub fn ordinary_get<'a, T>(agent: &mut Agent, o: T, p: &PropertyKey, receiver: &ECMAScriptValue) -> Completion
+pub fn ordinary_get<'a, T>(agent: &mut Agent, o: T, p: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -735,7 +735,7 @@ where
 //  1. Assert: IsPropertyKey(P) is true.
 //  2. Let ownDesc be ? O.[[GetOwnProperty]](P).
 //  3. Return OrdinarySetWithOwnDescriptor(O, P, V, Receiver, ownDesc).
-pub fn ordinary_set<'a, T>(agent: &mut Agent, o: T, p: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> AltCompletion<bool>
+pub fn ordinary_set<'a, T>(agent: &mut Agent, o: T, p: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -781,7 +781,7 @@ pub fn ordinary_set_with_own_descriptor<'a, T>(
     v: ECMAScriptValue,
     receiver: &ECMAScriptValue,
     pot_own_desc: Option<PropertyDescriptor>,
-) -> AltCompletion<bool>
+) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -848,7 +848,7 @@ where
 //      a. Remove the own property with name P from O.
 //      b. Return true.
 //  5. Return false.
-pub fn ordinary_delete<'a, T>(agent: &mut Agent, o: T, p: &PropertyKey) -> AltCompletion<bool>
+pub fn ordinary_delete<'a, T>(agent: &mut Agent, o: T, p: &PropertyKey) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -981,17 +981,17 @@ pub trait ObjectInterface: Debug {
         false
     }
 
-    fn get_prototype_of(&self, agent: &mut Agent) -> AltCompletion<Option<Object>>;
-    fn set_prototype_of(&self, agent: &mut Agent, obj: Option<Object>) -> AltCompletion<bool>;
-    fn is_extensible(&self, agent: &mut Agent) -> AltCompletion<bool>;
-    fn prevent_extensions(&self, agent: &mut Agent) -> AltCompletion<bool>;
-    fn get_own_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>>;
-    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> AltCompletion<bool>;
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool>;
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion;
-    fn set(&self, agent: &mut Agent, key: PropertyKey, value: ECMAScriptValue, receiver: &ECMAScriptValue) -> AltCompletion<bool>;
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool>;
-    fn own_property_keys(&self, agent: &mut Agent) -> AltCompletion<Vec<PropertyKey>>;
+    fn get_prototype_of(&self, agent: &mut Agent) -> Completion<Option<Object>>;
+    fn set_prototype_of(&self, agent: &mut Agent, obj: Option<Object>) -> Completion<bool>;
+    fn is_extensible(&self, agent: &mut Agent) -> Completion<bool>;
+    fn prevent_extensions(&self, agent: &mut Agent) -> Completion<bool>;
+    fn get_own_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>>;
+    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool>;
+    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool>;
+    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue>;
+    fn set(&self, agent: &mut Agent, key: PropertyKey, value: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool>;
+    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool>;
+    fn own_property_keys(&self, agent: &mut Agent) -> Completion<Vec<PropertyKey>>;
 }
 
 pub trait FunctionInterface: CallableObject {
@@ -1133,7 +1133,7 @@ impl ObjectInterface for OrdinaryObject {
     // steps when called:
     //
     //  1. Return ! OrdinaryGetPrototypeOf(O).
-    fn get_prototype_of(&self, _agent: &mut Agent) -> AltCompletion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &mut Agent) -> Completion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
 
@@ -1143,7 +1143,7 @@ impl ObjectInterface for OrdinaryObject {
     // the following steps when called:
     //
     //  1. Return ! OrdinarySetPrototypeOf(O, V).
-    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<Object>) -> AltCompletion<bool> {
+    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<Object>) -> Completion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
 
@@ -1153,7 +1153,7 @@ impl ObjectInterface for OrdinaryObject {
     // when called:
     //
     //  1. Return ! OrdinaryIsExtensible(O).
-    fn is_extensible(&self, _agent: &mut Agent) -> AltCompletion<bool> {
+    fn is_extensible(&self, _agent: &mut Agent) -> Completion<bool> {
         Ok(ordinary_is_extensible(self))
     }
 
@@ -1163,7 +1163,7 @@ impl ObjectInterface for OrdinaryObject {
     // steps when called:
     //
     //  1. Return ! OrdinaryPreventExtensions(O).
-    fn prevent_extensions(&self, _agent: &mut Agent) -> AltCompletion<bool> {
+    fn prevent_extensions(&self, _agent: &mut Agent) -> Completion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
 
@@ -1173,7 +1173,7 @@ impl ObjectInterface for OrdinaryObject {
     // following steps when called:
     //
     //  1. Return ! OrdinaryGetOwnProperty(O, P).
-    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(self, key))
     }
 
@@ -1183,7 +1183,7 @@ impl ObjectInterface for OrdinaryObject {
     // Property Descriptor). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
-    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> AltCompletion<bool> {
+    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool> {
         ordinary_define_own_property(agent, self, key, desc)
     }
 
@@ -1193,7 +1193,7 @@ impl ObjectInterface for OrdinaryObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryHasProperty(O, P).
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_has_property(agent, self, key)
     }
 
@@ -1203,7 +1203,7 @@ impl ObjectInterface for OrdinaryObject {
     // ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryGet(O, P, Receiver).
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion {
+    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         ordinary_get(agent, self, key, receiver)
     }
 
@@ -1213,7 +1213,7 @@ impl ObjectInterface for OrdinaryObject {
     // value), and Receiver (an ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinarySet(O, P, V, Receiver).
-    fn set(&self, agent: &mut Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> AltCompletion<bool> {
+    fn set(&self, agent: &mut Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
         ordinary_set(agent, self, key, v, receiver)
     }
 
@@ -1223,7 +1223,7 @@ impl ObjectInterface for OrdinaryObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryDelete(O, P).
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_delete(agent, self, key)
     }
 
@@ -1233,7 +1233,7 @@ impl ObjectInterface for OrdinaryObject {
     // steps when called:
     //
     // 1. Return ! OrdinaryOwnPropertyKeys(O).
-    fn own_property_keys(&self, agent: &mut Agent) -> AltCompletion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(agent, self))
     }
 }
@@ -1296,7 +1296,7 @@ impl Object {
     //      b. Let target be argument.[[ProxyTarget]].
     //      c. Return ? IsArray(target).
     //  4. Return false.
-    pub fn is_array(&self, _agent: &mut Agent) -> AltCompletion<bool> {
+    pub fn is_array(&self, _agent: &mut Agent) -> Completion<bool> {
         if self.o.is_array_object() {
             Ok(true)
         } else if self.o.is_proxy_object() {
@@ -1387,7 +1387,7 @@ pub fn make_basic_object(agent: &mut Agent, internal_slots_list: &[InternalSlotN
 //  1. Assert: Type(O) is Object.
 //  2. Assert: IsPropertyKey(P) is true.
 //  3. Return ? O.[[Get]](P, O).
-pub fn get(agent: &mut Agent, obj: &Object, key: &PropertyKey) -> Completion {
+pub fn get(agent: &mut Agent, obj: &Object, key: &PropertyKey) -> Completion<ECMAScriptValue> {
     let val = ECMAScriptValue::Object(obj.clone());
     obj.o.get(agent, key, &val)
 }
@@ -1402,7 +1402,7 @@ pub fn get(agent: &mut Agent, obj: &Object, key: &PropertyKey) -> Completion {
 //  1. Assert: IsPropertyKey(P) is true.
 //  2. Let O be ? ToObject(V).
 //  3. Return ? O.[[Get]](P, V).
-pub fn getv(agent: &mut Agent, v: &ECMAScriptValue, p: &PropertyKey) -> Completion {
+pub fn getv(agent: &mut Agent, v: &ECMAScriptValue, p: &PropertyKey) -> Completion<ECMAScriptValue> {
     let o = to_object(agent, v.clone())?;
     o.o.get(agent, p, v)
 }
@@ -1419,7 +1419,7 @@ pub fn getv(agent: &mut Agent, v: &ECMAScriptValue, p: &PropertyKey) -> Completi
 //  4. Let success be ? O.[[Set]](P, V, O).
 //  5. If success is false and Throw is true, throw a TypeError exception.
 //  6. Return success.
-pub fn set(agent: &mut Agent, obj: &Object, propkey: PropertyKey, value: ECMAScriptValue, throw: bool) -> AltCompletion<bool> {
+pub fn set(agent: &mut Agent, obj: &Object, propkey: PropertyKey, value: ECMAScriptValue, throw: bool) -> Completion<bool> {
     let objval = ECMAScriptValue::Object(obj.clone());
     let success = obj.o.set(agent, propkey, value, &objval)?;
     if !success && throw {
@@ -1442,7 +1442,7 @@ pub fn set(agent: &mut Agent, obj: &Object, propkey: PropertyKey, value: ECMAScr
 // NOTE     This abstract operation creates a property whose attributes are set to the same defaults used for properties
 //          created by the ECMAScript language assignment operator. Normally, the property will not already exist. If it
 //          does exist and is not configurable or if O is not extensible, [[DefineOwnProperty]] will return false.
-pub fn create_data_property(agent: &mut Agent, obj: &Object, p: PropertyKey, v: ECMAScriptValue) -> AltCompletion<bool> {
+pub fn create_data_property(agent: &mut Agent, obj: &Object, p: PropertyKey, v: ECMAScriptValue) -> Completion<bool> {
     let new_desc = PotentialPropertyDescriptor::new().value(v).writable(true).enumerable(true).configurable(true);
     obj.o.define_own_property(agent, p, new_desc)
 }
@@ -1461,7 +1461,7 @@ pub fn create_data_property(agent: &mut Agent, obj: &Object, p: PropertyKey, v: 
 //          | properties created by the ECMAScript language assignment operator. Normally, the property will not
 //          | already exist. If it does exist and is not configurable or if O is not extensible, [[DefineOwnProperty]]
 //          | will return false causing this operation to throw a TypeError exception.
-pub fn create_data_property_or_throw(agent: &mut Agent, obj: &Object, p: impl Into<PropertyKey>, v: impl Into<ECMAScriptValue>) -> AltCompletion<()> {
+pub fn create_data_property_or_throw(agent: &mut Agent, obj: &Object, p: impl Into<PropertyKey>, v: impl Into<ECMAScriptValue>) -> Completion<()> {
     let success = create_data_property(agent, obj, p.into(), v.into())?;
     if !success {
         Err(create_type_error(agent, "Unable to create data property"))
@@ -1482,7 +1482,7 @@ pub fn create_data_property_or_throw(agent: &mut Agent, obj: &Object, p: impl In
 //  3. Let success be ? O.[[DefineOwnProperty]](P, desc).
 //  4. If success is false, throw a TypeError exception.
 //  5. Return success.
-pub fn define_property_or_throw(agent: &mut Agent, obj: &Object, p: impl Into<PropertyKey>, desc: PotentialPropertyDescriptor) -> AltCompletion<()> {
+pub fn define_property_or_throw(agent: &mut Agent, obj: &Object, p: impl Into<PropertyKey>, desc: PotentialPropertyDescriptor) -> Completion<()> {
     let success = obj.o.define_own_property(agent, p.into(), desc)?;
     if !success {
         Err(create_type_error(agent, "Property cannot be assigned to"))
@@ -1502,7 +1502,7 @@ pub fn define_property_or_throw(agent: &mut Agent, obj: &Object, p: impl Into<Pr
 //  3. If func is either undefined or null, return undefined.
 //  4. If IsCallable(func) is false, throw a TypeError exception.
 //  5. Return func.
-pub fn get_method(agent: &mut Agent, val: &ECMAScriptValue, key: &PropertyKey) -> Completion {
+pub fn get_method(agent: &mut Agent, val: &ECMAScriptValue, key: &PropertyKey) -> Completion<ECMAScriptValue> {
     let func = getv(agent, val, key)?;
     if func.is_undefined() || func.is_null() {
         Ok(ECMAScriptValue::Undefined)
@@ -1523,7 +1523,7 @@ pub fn get_method(agent: &mut Agent, val: &ECMAScriptValue, key: &PropertyKey) -
 //  1. Assert: Type(O) is Object.
 //  2. Assert: IsPropertyKey(P) is true.
 //  3. Return ? O.[[HasProperty]](P).
-pub fn has_property(agent: &mut Agent, obj: &Object, p: &PropertyKey) -> AltCompletion<bool> {
+pub fn has_property(agent: &mut Agent, obj: &Object, p: &PropertyKey) -> Completion<bool> {
     obj.o.has_property(agent, p)
 }
 
@@ -1538,7 +1538,7 @@ pub fn has_property(agent: &mut Agent, obj: &Object, p: &PropertyKey) -> AltComp
 //  3. Let desc be ? O.[[GetOwnProperty]](P).
 //  4. If desc is undefined, return false.
 //  5. Return true.
-pub fn has_own_property(agent: &mut Agent, obj: &Object, p: &PropertyKey) -> AltCompletion<bool> {
+pub fn has_own_property(agent: &mut Agent, obj: &Object, p: &PropertyKey) -> Completion<bool> {
     Ok(obj.o.get_own_property(agent, p)?.is_some())
 }
 
@@ -1560,7 +1560,7 @@ pub fn to_callable(val: &ECMAScriptValue) -> Option<&dyn CallableObject> {
     }
 }
 
-pub fn call(agent: &mut Agent, func: &ECMAScriptValue, this_value: &ECMAScriptValue, args: &[ECMAScriptValue]) -> Completion {
+pub fn call(agent: &mut Agent, func: &ECMAScriptValue, this_value: &ECMAScriptValue, args: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let maybe_callable = to_callable(func);
     match maybe_callable {
         None => Err(create_type_error(agent, "Value not callable")),
@@ -1586,7 +1586,7 @@ pub fn call(agent: &mut Agent, func: &ECMAScriptValue, this_value: &ECMAScriptVa
 //    5. Return ? F.[[Construct]](argumentsList, newTarget).
 //
 // NOTE     If newTarget is not present, this operation is equivalent to: new F(...argumentsList)
-pub fn construct(agent: &mut Agent, func: &Object, args: &[ECMAScriptValue], new_target: Option<&Object>) -> Completion {
+pub fn construct(agent: &mut Agent, func: &Object, args: &[ECMAScriptValue], new_target: Option<&Object>) -> Completion<ECMAScriptValue> {
     let nt = new_target.unwrap_or(func);
     let cstr = func.o.to_constructable().unwrap();
     cstr.construct(agent, func, args, nt)
@@ -1628,7 +1628,7 @@ pub enum IntegrityLevel {
     Sealed,
     Frozen,
 }
-pub fn set_integrity_level(agent: &mut Agent, o: &Object, level: IntegrityLevel) -> AltCompletion<bool> {
+pub fn set_integrity_level(agent: &mut Agent, o: &Object, level: IntegrityLevel) -> Completion<bool> {
     let status = o.o.prevent_extensions(agent)?;
     if !status {
         return Ok(false);
@@ -1685,7 +1685,7 @@ pub fn create_array_from_list(agent: &mut Agent, elements: &[ECMAScriptValue]) -
 //  2. If argumentsList is not present, set argumentsList to a new empty List.
 //  3. Let func be ? GetV(V, P).
 //  4. Return ? Call(func, V, argumentsList).
-pub fn invoke(agent: &mut Agent, v: ECMAScriptValue, p: &PropertyKey, arguments_list: &[ECMAScriptValue]) -> Completion {
+pub fn invoke(agent: &mut Agent, v: ECMAScriptValue, p: &PropertyKey, arguments_list: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let func = getv(agent, &v, p)?;
     call(agent, &func, &v, arguments_list)
 }
@@ -1718,7 +1718,7 @@ pub enum EnumerationStyle {
     Value,
     KeyPlusValue,
 }
-pub fn enumerable_own_property_names(agent: &mut Agent, obj: &Object, kind: EnumerationStyle) -> AltCompletion<Vec<ECMAScriptValue>> {
+pub fn enumerable_own_property_names(agent: &mut Agent, obj: &Object, kind: EnumerationStyle) -> Completion<Vec<ECMAScriptValue>> {
     let own_keys = obj.o.own_property_keys(agent)?;
     let mut properties: Vec<ECMAScriptValue> = vec![];
     for key in own_keys.into_iter() {
@@ -1781,7 +1781,7 @@ pub fn ordinary_object_create(agent: &mut Agent, proto: Option<Object>, addition
 //     corresponding object must be an intrinsic that is intended to be used as the [[Prototype]] value of an object.
 //  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
 //  3. Return ! OrdinaryObjectCreate(proto, internalSlotsList).
-pub fn ordinary_create_from_constructor(agent: &mut Agent, constructor: &Object, intrinsic_default_proto: IntrinsicId, internal_slots_list: &[InternalSlotName]) -> AltCompletion<Object> {
+pub fn ordinary_create_from_constructor(agent: &mut Agent, constructor: &Object, intrinsic_default_proto: IntrinsicId, internal_slots_list: &[InternalSlotName]) -> Completion<Object> {
     let proto = get_prototype_from_constructor(agent, constructor, intrinsic_default_proto)?;
     Ok(ordinary_object_create(agent, Some(proto), internal_slots_list))
 }
@@ -1804,7 +1804,7 @@ pub fn ordinary_create_from_constructor(agent: &mut Agent, constructor: &Object,
 //
 // NOTE     If constructor does not supply a [[Prototype]] value, the default value that is used is obtained from the
 //          realm of the constructor function rather than from the running execution context.
-fn get_prototype_from_constructor(agent: &mut Agent, constructor: &Object, intrinsic_default_proto: IntrinsicId) -> AltCompletion<Object> {
+fn get_prototype_from_constructor(agent: &mut Agent, constructor: &Object, intrinsic_default_proto: IntrinsicId) -> Completion<Object> {
     let proto = get(agent, constructor, &PropertyKey::from("prototype"))?;
     match proto {
         ECMAScriptValue::Object(obj) => Ok(obj),
@@ -1831,37 +1831,37 @@ impl ObjectInterface for DeadObject {
         self.objid
     }
 
-    fn get_prototype_of(&self, agent: &mut Agent) -> AltCompletion<Option<Object>> {
+    fn get_prototype_of(&self, agent: &mut Agent) -> Completion<Option<Object>> {
         Err(create_type_error(agent, "get_prototype_of called on DeadObject"))
     }
-    fn set_prototype_of(&self, agent: &mut Agent, _obj: Option<Object>) -> AltCompletion<bool> {
+    fn set_prototype_of(&self, agent: &mut Agent, _obj: Option<Object>) -> Completion<bool> {
         Err(create_type_error(agent, "set_prototype_of called on DeadObject"))
     }
-    fn is_extensible(&self, agent: &mut Agent) -> AltCompletion<bool> {
+    fn is_extensible(&self, agent: &mut Agent) -> Completion<bool> {
         Err(create_type_error(agent, "is_extensible called on DeadObject"))
     }
-    fn prevent_extensions(&self, agent: &mut Agent) -> AltCompletion<bool> {
+    fn prevent_extensions(&self, agent: &mut Agent) -> Completion<bool> {
         Err(create_type_error(agent, "prevent_extensions called on DeadObject"))
     }
-    fn get_own_property(&self, agent: &mut Agent, _key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, agent: &mut Agent, _key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         Err(create_type_error(agent, "get_own_property called on DeadObject"))
     }
-    fn define_own_property(&self, agent: &mut Agent, _key: PropertyKey, _desc: PotentialPropertyDescriptor) -> AltCompletion<bool> {
+    fn define_own_property(&self, agent: &mut Agent, _key: PropertyKey, _desc: PotentialPropertyDescriptor) -> Completion<bool> {
         Err(create_type_error(agent, "define_own_property called on DeadObject"))
     }
-    fn has_property(&self, agent: &mut Agent, _key: &PropertyKey) -> AltCompletion<bool> {
+    fn has_property(&self, agent: &mut Agent, _key: &PropertyKey) -> Completion<bool> {
         Err(create_type_error(agent, "has_property called on DeadObject"))
     }
-    fn get(&self, agent: &mut Agent, _key: &PropertyKey, _receiver: &ECMAScriptValue) -> Completion {
+    fn get(&self, agent: &mut Agent, _key: &PropertyKey, _receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         Err(create_type_error(agent, "get called on DeadObject"))
     }
-    fn set(&self, agent: &mut Agent, _key: PropertyKey, _value: ECMAScriptValue, _receiver: &ECMAScriptValue) -> AltCompletion<bool> {
+    fn set(&self, agent: &mut Agent, _key: PropertyKey, _value: ECMAScriptValue, _receiver: &ECMAScriptValue) -> Completion<bool> {
         Err(create_type_error(agent, "set called on DeadObject"))
     }
-    fn delete(&self, agent: &mut Agent, _key: &PropertyKey) -> AltCompletion<bool> {
+    fn delete(&self, agent: &mut Agent, _key: &PropertyKey) -> Completion<bool> {
         Err(create_type_error(agent, "delete called on DeadObject"))
     }
-    fn own_property_keys(&self, agent: &mut Agent) -> AltCompletion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
         Err(create_type_error(agent, "own_property_keys called on DeadObject"))
     }
 }
@@ -1881,7 +1881,7 @@ impl DeadObject {
 //  2. Let current be ? O.[[GetPrototypeOf]]().
 //  3. If SameValue(V, current) is true, return true.
 //  4. Return false.
-pub fn set_immutable_prototype<'a, T>(agent: &mut Agent, o: T, val: Option<Object>) -> AltCompletion<bool>
+pub fn set_immutable_prototype<'a, T>(agent: &mut Agent, o: T, val: Option<Object>) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -1918,7 +1918,7 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // steps when called:
     //
     //  1. Return ! OrdinaryGetPrototypeOf(O).
-    fn get_prototype_of(&self, _agent: &mut Agent) -> AltCompletion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &mut Agent) -> Completion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
 
@@ -1928,7 +1928,7 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // null). It performs the following steps when called:
     //
     //  1. Return ? SetImmutablePrototype(O, V).
-    fn set_prototype_of(&self, agent: &mut Agent, obj: Option<Object>) -> AltCompletion<bool> {
+    fn set_prototype_of(&self, agent: &mut Agent, obj: Option<Object>) -> Completion<bool> {
         set_immutable_prototype(agent, self, obj)
     }
 
@@ -1938,7 +1938,7 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // when called:
     //
     //  1. Return ! OrdinaryIsExtensible(O).
-    fn is_extensible(&self, _agent: &mut Agent) -> AltCompletion<bool> {
+    fn is_extensible(&self, _agent: &mut Agent) -> Completion<bool> {
         Ok(ordinary_is_extensible(self))
     }
 
@@ -1948,7 +1948,7 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // steps when called:
     //
     //  1. Return ! OrdinaryPreventExtensions(O).
-    fn prevent_extensions(&self, _agent: &mut Agent) -> AltCompletion<bool> {
+    fn prevent_extensions(&self, _agent: &mut Agent) -> Completion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
 
@@ -1958,7 +1958,7 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // following steps when called:
     //
     //  1. Return ! OrdinaryGetOwnProperty(O, P).
-    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(self, key))
     }
 
@@ -1968,7 +1968,7 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // Property Descriptor). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
-    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> AltCompletion<bool> {
+    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool> {
         ordinary_define_own_property(agent, self, key, desc)
     }
 
@@ -1978,7 +1978,7 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryHasProperty(O, P).
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_has_property(agent, self, key)
     }
 
@@ -1988,7 +1988,7 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryGet(O, P, Receiver).
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion {
+    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         ordinary_get(agent, self, key, receiver)
     }
 
@@ -1998,7 +1998,7 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // value), and Receiver (an ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinarySet(O, P, V, Receiver).
-    fn set(&self, agent: &mut Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> AltCompletion<bool> {
+    fn set(&self, agent: &mut Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
         ordinary_set(agent, self, key, v, receiver)
     }
 
@@ -2008,7 +2008,7 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryDelete(O, P).
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_delete(agent, self, key)
     }
 
@@ -2018,7 +2018,7 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // steps when called:
     //
     // 1. Return ! OrdinaryOwnPropertyKeys(O).
-    fn own_property_keys(&self, agent: &mut Agent) -> AltCompletion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(agent, self))
     }
 }
@@ -2045,7 +2045,7 @@ pub fn immutable_prototype_exotic_object_create(agent: &mut Agent, proto: Option
 //
 // NOTE     Step 5 will only be reached if obj is a non-standard function exotic object that does not have a [[Realm]]
 //          internal slot.
-pub fn get_function_realm(agent: &mut Agent, obj: &Object) -> AltCompletion<Rc<RefCell<Realm>>> {
+pub fn get_function_realm(agent: &mut Agent, obj: &Object) -> Completion<Rc<RefCell<Realm>>> {
     if let Some(f) = obj.o.to_function_obj() {
         Ok(f.function_data().borrow().realm.clone())
     } else if let Some(b) = obj.o.to_builtin_function_obj() {
@@ -2086,7 +2086,7 @@ pub fn private_element_find(o: &Object, p: &PrivateName) -> Option<Rc<PrivateEle
 //  1. Let entry be ! PrivateElementFind(O, P).
 //  2. If entry is not empty, throw a TypeError exception.
 //  3. Append PrivateElement { [[Key]]: P, [[Kind]]: field, [[Value]]: value } to O.[[PrivateElements]].
-pub fn private_field_add(agent: &mut Agent, obj: &Object, p: PrivateName, value: ECMAScriptValue) -> AltCompletion<()> {
+pub fn private_field_add(agent: &mut Agent, obj: &Object, p: PrivateName, value: ECMAScriptValue) -> Completion<()> {
     let entry = private_element_find(obj, &p);
     match entry {
         Some(_) => Err(create_type_error(agent, "PrivateName already defined")),
@@ -2110,7 +2110,7 @@ pub fn private_field_add(agent: &mut Agent, obj: &Object, p: PrivateName, value:
 //
 // NOTE: The values for private methods and accessors are shared across instances. This step does not create a new copy
 // of the method or accessor.
-pub fn private_method_or_accessor_add(agent: &mut Agent, obj: &Object, method: Rc<PrivateElement>) -> AltCompletion<()> {
+pub fn private_method_or_accessor_add(agent: &mut Agent, obj: &Object, method: Rc<PrivateElement>) -> Completion<()> {
     if private_element_find(obj, &method.key).is_some() {
         Err(create_type_error(agent, "PrivateName already defined"))
     } else {
@@ -2132,7 +2132,7 @@ pub fn private_method_or_accessor_add(agent: &mut Agent, obj: &Object, method: R
 //  5. If entry.[[Get]] is undefined, throw a TypeError exception.
 //  6. Let getter be entry.[[Get]].
 //  7. Return ? Call(getter, O).
-pub fn private_get(agent: &mut Agent, obj: &Object, pn: &PrivateName) -> Completion {
+pub fn private_get(agent: &mut Agent, obj: &Object, pn: &PrivateName) -> Completion<ECMAScriptValue> {
     match private_element_find(obj, pn) {
         None => Err(create_type_error(agent, "PrivateName not defined")),
         Some(pe) => match &pe.kind {
@@ -2160,7 +2160,7 @@ pub fn private_get(agent: &mut Agent, obj: &Object, pn: &PrivateName) -> Complet
 //      b. If entry.[[Set]] is undefined, throw a TypeError exception.
 //      c. Let setter be entry.[[Set]].
 //      d. Perform ? Call(setter, O, « value »).
-pub fn private_set(agent: &mut Agent, obj: &Object, pn: &PrivateName, v: ECMAScriptValue) -> AltCompletion<()> {
+pub fn private_set(agent: &mut Agent, obj: &Object, pn: &PrivateName, v: ECMAScriptValue) -> Completion<()> {
     match private_element_find(obj, pn) {
         None => Err(create_type_error(agent, "PrivateName not defined")),
         Some(pe) => match &pe.kind {

--- a/src/object/tests.rs
+++ b/src/object/tests.rs
@@ -1075,7 +1075,7 @@ fn ordinary_get_04() {
     let result = ordinary_get(&mut agent, &obj, &key, &ECMAScriptValue::Undefined).unwrap();
     assert_eq!(result, ECMAScriptValue::from(0));
 }
-fn test_getter(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn test_getter(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     // This is a getter; it is essentially:
     // function() { return this.result; }
     let obj = to_object(agent, this_value)?;
@@ -1293,7 +1293,7 @@ fn ordinary_set_with_own_descriptor_09() {
     let item = get(&mut agent, &obj, &key).unwrap();
     assert_eq!(item, value);
 }
-fn test_setter(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn test_setter(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion <ECMAScriptValue>{
     // This is a setter; it is essentially:
     // function(val) { this.value = val; }
     let obj = to_object(agent, this_value)?;
@@ -2291,7 +2291,7 @@ mod to_property_descriptor {
         ECMAScriptValue::from(obj)
     }
 
-    fn faux_errors(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+    fn faux_errors(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
         Err(create_type_error(agent, "Test Sentinel"))
     }
 
@@ -2443,7 +2443,7 @@ mod enumerable_own_property_names {
         .unwrap();
         obj
     }
-    fn gop_override(agent: &mut Agent, this: &AdaptableObject, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+    fn gop_override(agent: &mut Agent, this: &AdaptableObject, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         if this.something.get() == 0 {
             this.something.set(1);
             Ok(ordinary_get_own_property(this, key))
@@ -2461,7 +2461,7 @@ mod enumerable_own_property_names {
         create_data_property_or_throw(agent, &obj, "one", 1.0).unwrap();
         obj
     }
-    fn lying_ownprops(_: &mut Agent, _: &AdaptableObject) -> AltCompletion<Vec<PropertyKey>> {
+    fn lying_ownprops(_: &mut Agent, _: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
         Ok(vec!["one".into(), "two".into(), "three".into()])
     }
     fn lyingkeys(agent: &mut Agent) -> Object {
@@ -2545,7 +2545,7 @@ mod set_integrity_level {
         create_data_property_or_throw(agent, &obj, "property", 99.0).unwrap();
         obj
     }
-    fn gop_override(agent: &mut Agent, this: &AdaptableObject, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+    fn gop_override(agent: &mut Agent, this: &AdaptableObject, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         if this.something.get() == 0 {
             this.something.set(1);
             Ok(ordinary_get_own_property(this, key))
@@ -2558,7 +2558,7 @@ mod set_integrity_level {
         create_data_property_or_throw(agent, &obj, "one", 1.0).unwrap();
         obj
     }
-    fn lying_ownprops(_: &mut Agent, _: &AdaptableObject) -> AltCompletion<Vec<PropertyKey>> {
+    fn lying_ownprops(_: &mut Agent, _: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
         Ok(vec!["one".into(), "two".into(), "three".into()])
     }
     fn lyingkeys(agent: &mut Agent) -> Object {

--- a/src/object/tests.rs
+++ b/src/object/tests.rs
@@ -1293,7 +1293,7 @@ fn ordinary_set_with_own_descriptor_09() {
     let item = get(&mut agent, &obj, &key).unwrap();
     assert_eq!(item, value);
 }
-fn test_setter(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion <ECMAScriptValue>{
+fn test_setter(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     // This is a setter; it is essentially:
     // function(val) { this.value = val; }
     let obj = to_object(agent, this_value)?;

--- a/src/object_object/mod.rs
+++ b/src/object_object/mod.rs
@@ -17,7 +17,7 @@ use std::rc::Rc;
 // When the valueOf method is called, the following steps are taken:
 //
 //      1. Return ? ToObject(this value).
-fn object_prototype_value_of(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_prototype_value_of(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     to_object(agent, this_value).map(ECMAScriptValue::from)
 }
 
@@ -49,7 +49,7 @@ fn object_prototype_value_of(agent: &mut Agent, this_value: ECMAScriptValue, _ne
 //            test for those specific kinds of built-in objects. It does not provide a reliable type testing mechanism
 //            for other kinds of built-in or program defined objects. In addition, programs can use @@toStringTag in
 //            ways that will invalidate the reliability of such legacy type tests.
-fn object_prototype_to_string(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_prototype_to_string(agent: &mut Agent, this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     if this_value.is_undefined() {
         return Ok(ECMAScriptValue::from("[object Undefined]"));
     }
@@ -204,7 +204,7 @@ pub fn provision_object_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>)
 //  2. If value is undefined or null, return ! OrdinaryObjectCreate(%Object.prototype%).
 //  3. Return ! ToObject(value).
 // The "length" property of the Object function is 1𝔽.
-fn object_constructor_function(agent: &mut Agent, _this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn object_constructor_function(agent: &mut Agent, _this_value: ECMAScriptValue, new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     if let Some(nt) = new_target {
         if let Some(afo) = agent.active_function_object() {
             if *nt != afo {
@@ -238,7 +238,7 @@ fn object_constructor_function(agent: &mut Agent, _this_value: ECMAScriptValue, 
 //  4. Return to.
 //
 // The "length" property of the assign function is 2𝔽.
-fn object_assign(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn object_assign(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let target = args.next_arg();
     let to = to_object(agent, target)?;
@@ -270,7 +270,7 @@ fn object_assign(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: O
 //  3. If Properties is not undefined, then
 //      a. Return ? ObjectDefineProperties(obj, Properties).
 //  4. Return obj.
-fn object_create(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn object_create(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let o_arg = args.next_arg();
     let o = match o_arg {
@@ -308,7 +308,7 @@ fn object_create(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: O
 //      b. Let desc be the second element of pair.
 //      c. Perform ? DefinePropertyOrThrow(O, P, desc).
 //  6. Return O.
-fn object_define_properties_helper(agent: &mut Agent, o: Object, properties: ECMAScriptValue) -> Completion {
+fn object_define_properties_helper(agent: &mut Agent, o: Object, properties: ECMAScriptValue) -> Completion<ECMAScriptValue> {
     let props = to_object(agent, properties)?;
     let keys = props.o.own_property_keys(agent)?;
     let mut descriptors = Vec::new();
@@ -336,7 +336,7 @@ fn object_define_properties_helper(agent: &mut Agent, o: Object, properties: ECM
 //
 //  1. If Type(O) is not Object, throw a TypeError exception.
 //  2. Return ? ObjectDefineProperties(O, Properties).
-fn object_define_properties(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn object_define_properties(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let o_arg = args.next_arg();
     match o_arg {
@@ -358,7 +358,7 @@ fn object_define_properties(agent: &mut Agent, _this_value: ECMAScriptValue, _ne
 //  3. Let desc be ? ToPropertyDescriptor(Attributes).
 //  4. Perform ? DefinePropertyOrThrow(O, key, desc).
 //  5. Return O.
-fn object_define_property(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn object_define_property(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let o_arg = args.next_arg();
     match o_arg {
@@ -386,7 +386,7 @@ fn object_define_property(agent: &mut Agent, _this_value: ECMAScriptValue, _new_
 //  3. Return CreateArrayFromList(nameList).
 //
 // https://tc39.es/ecma262/#sec-object.entries
-fn object_entries(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn object_entries(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let o_arg = args.next_arg();
     let obj = to_object(agent, o_arg)?;
@@ -404,7 +404,7 @@ fn object_entries(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: 
 //  4. Return O.
 //
 // https://tc39.es/ecma262/#sec-object.freeze
-fn object_freeze(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn object_freeze(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let mut args = Arguments::from(arguments);
     let o_arg = args.next_arg();
     match o_arg {
@@ -420,64 +420,64 @@ fn object_freeze(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: O
     }
 }
 
-fn object_from_entries(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_from_entries(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_get_own_property_descriptor(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_get_own_property_descriptor(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_get_own_property_descriptors(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_get_own_property_descriptors(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_get_own_property_names(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_get_own_property_names(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_get_own_property_symbols(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_get_own_property_symbols(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_get_prototype_of(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_get_prototype_of(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_has_own(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_has_own(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_is(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_is(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_is_extensible(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_is_extensible(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_is_frozen(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_is_frozen(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_is_sealed(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_is_sealed(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_keys(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_keys(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_prevent_extensions(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_prevent_extensions(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_seal(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_seal(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_set_prototype_of(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_set_prototype_of(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_values(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_values(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_prototype_has_own_property(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_prototype_has_own_property(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_prototype_is_prototype_of(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_prototype_is_prototype_of(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_prototype_property_is_enumerable(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_prototype_property_is_enumerable(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
-fn object_prototype_to_locale_string(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn object_prototype_to_locale_string(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     todo!()
 }
 

--- a/src/object_object/tests.rs
+++ b/src/object_object/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::cr::AltCompletion;
+use crate::cr::Completion;
 use crate::errors::{create_type_error, create_type_error_object};
 use crate::execution_context::ExecutionContext;
 use crate::object::{
@@ -117,7 +117,7 @@ mod constructor {
         use super::*;
         use test_case::test_case;
 
-        fn fake_keys(_agent: &mut Agent, _this: &AdaptableObject) -> AltCompletion<Vec<PropertyKey>> {
+        fn fake_keys(_agent: &mut Agent, _this: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
             Ok(vec![PropertyKey::from("once"), PropertyKey::from("twice")])
         }
 
@@ -179,10 +179,10 @@ mod constructor {
         fn own_property_keys_throws(agent: &mut Agent) -> ECMAScriptValue {
             ECMAScriptValue::from(TestObject::object(agent, &[FunctionId::OwnPropertyKeys]))
         }
-        fn own_prop_keys(_: &mut Agent, _: &AdaptableObject) -> AltCompletion<Vec<PropertyKey>> {
+        fn own_prop_keys(_: &mut Agent, _: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
             Ok(vec![PropertyKey::from("prop")])
         }
-        fn get_own_prop_err(agent: &mut Agent, _: &AdaptableObject, _: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+        fn get_own_prop_err(agent: &mut Agent, _: &AdaptableObject, _: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
             Err(create_type_error(agent, "Test Sentinel"))
         }
         fn get_own_property_throws(agent: &mut Agent) -> ECMAScriptValue {
@@ -199,7 +199,7 @@ mod constructor {
             create_data_property_or_throw(agent, &obj, "something", 782).unwrap();
             ECMAScriptValue::from(obj)
         }
-        fn get_own_prop_ok(_: &mut Agent, _: &AdaptableObject, _: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+        fn get_own_prop_ok(_: &mut Agent, _: &AdaptableObject, _: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
             Ok(Some(PropertyDescriptor {
                 property: PropertyKind::Data(DataProperty { value: ECMAScriptValue::from(22), writable: true }),
                 enumerable: true,
@@ -207,7 +207,7 @@ mod constructor {
                 ..Default::default()
             }))
         }
-        fn get_err(agent: &mut Agent, _: &AdaptableObject, _: &PropertyKey, _: &ECMAScriptValue) -> Completion {
+        fn get_err(agent: &mut Agent, _: &AdaptableObject, _: &PropertyKey, _: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
             Err(create_type_error(agent, "[[Get]] throws from AdaptableObject"))
         }
         fn get_throws(agent: &mut Agent) -> ECMAScriptValue {
@@ -405,7 +405,7 @@ mod constructor {
         fn plain_obj(agent: &mut Agent) -> ECMAScriptValue {
             ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]).into()
         }
-        fn faux_errors(agent: &mut Agent, _: ECMAScriptValue, _: Option<&Object>, _: &[ECMAScriptValue]) -> Completion {
+        fn faux_errors(agent: &mut Agent, _: ECMAScriptValue, _: Option<&Object>, _: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
             Err(create_type_error(agent, "Test Sentinel"))
         }
         fn make_bad_property_key(agent: &mut Agent) -> ECMAScriptValue {

--- a/src/realm/mod.rs
+++ b/src/realm/mod.rs
@@ -387,7 +387,7 @@ pub fn add_restricted_function_properties(agent: &mut Agent, f: &Object, realm: 
 //
 // The "name" property of a %ThrowTypeError% function has the attributes { [[Writable]]: false, [[Enumerable]]: false,
 // [[Configurable]]: false }.
-fn throw_type_error(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn throw_type_error(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     Err(create_type_error(agent, "Generic TypeError"))
 }
 

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -56,7 +56,7 @@ impl PartialEq for Base {
                 let left = &**left as *const dyn EnvironmentRecord as *const u8;
                 let right = &**right as *const dyn EnvironmentRecord as *const u8;
                 std::ptr::eq(left, right)
-            },
+            }
             (Self::Value(left), Self::Value(right)) => left == right,
             (Self::Unresolvable, Self::Unresolvable) => true,
             _ => false,

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -51,7 +51,12 @@ pub enum Base {
 impl PartialEq for Base {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::Environment(left), Self::Environment(right)) => Rc::ptr_eq(left, right),
+            (Self::Environment(left), Self::Environment(right)) => {
+                //Rc::ptr_eq(left, right) <<-- Can't do this because fat pointers aren't comparable. Convert to thin pointers to the allocated memory instead.
+                let left = &**left as *const dyn EnvironmentRecord as *const u8;
+                let right = &**right as *const dyn EnvironmentRecord as *const u8;
+                std::ptr::eq(left, right)
+            },
             (Self::Value(left), Self::Value(right)) => left == right,
             (Self::Unresolvable, Self::Unresolvable) => true,
             _ => false,

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -204,21 +204,6 @@ impl Reference {
 // NOTE     The object that may be created in step 4.a is not accessible outside of the above abstract operation and the
 //          ordinary object [[Get]] internal method. An implementation might choose to avoid the actual creation of the
 //          object.
-#[derive(Debug)]
-pub enum SuperValue {
-    Value(ECMAScriptValue),
-    Reference(Reference),
-}
-impl From<ECMAScriptValue> for SuperValue {
-    fn from(src: ECMAScriptValue) -> Self {
-        Self::Value(src)
-    }
-}
-impl From<Reference> for SuperValue {
-    fn from(src: Reference) -> Self {
-        Self::Reference(src)
-    }
-}
 pub fn get_value(agent: &mut Agent, v_completion: FullCompletion) -> Completion<ECMAScriptValue> {
     let v = v_completion?;
     match v {

--- a/src/reference/tests.rs
+++ b/src/reference/tests.rs
@@ -307,7 +307,7 @@ mod get_value {
     fn simple_value() {
         let mut agent = test_agent();
         let val = ECMAScriptValue::from("a value");
-        let result = get_value(&mut agent, Ok(SuperValue::from(val))).unwrap();
+        let result = get_value(&mut agent, Ok(NormalCompletion::from(val))).unwrap();
         assert_eq!(result, ECMAScriptValue::from("a value"));
     }
 
@@ -315,7 +315,7 @@ mod get_value {
     fn unresolvable() {
         let mut agent = test_agent();
         let badref = Reference::new(Base::Unresolvable, "no_ref", true, None);
-        let result = get_value(&mut agent, Ok(SuperValue::from(badref))).unwrap_err();
+        let result = get_value(&mut agent, Ok(NormalCompletion::from(badref))).unwrap_err();
         assert_eq!(unwind_reference_error(&mut agent, result), "Unresolvable Reference");
     }
     #[test]
@@ -328,14 +328,14 @@ mod get_value {
         define_property_or_throw(&mut agent, &normal_object, PropertyKey::from("test_value"), descriptor).unwrap();
         let reference = Reference::new(Base::Value(ECMAScriptValue::from(normal_object)), "test_value", true, None);
 
-        let result = get_value(&mut agent, Ok(SuperValue::from(reference))).unwrap();
+        let result = get_value(&mut agent, Ok(NormalCompletion::from(reference))).unwrap();
         assert_eq!(result, value);
     }
     #[test]
     fn to_object_err() {
         let mut agent = test_agent();
         let reference = Reference::new(Base::Value(ECMAScriptValue::Undefined), "test_value", true, None);
-        let result = get_value(&mut agent, Ok(SuperValue::from(reference))).unwrap_err();
+        let result = get_value(&mut agent, Ok(NormalCompletion::from(reference))).unwrap_err();
         assert_eq!(unwind_type_error(&mut agent, result), "Undefined and null cannot be converted to objects");
     }
     #[test]
@@ -347,7 +347,7 @@ mod get_value {
         let value = ECMAScriptValue::from("test value for private identifier");
         private_field_add(&mut agent, &normal_object, pn.clone(), value.clone()).unwrap();
         let reference = Reference::new(Base::Value(ECMAScriptValue::from(normal_object)), pn, true, None);
-        let result = get_value(&mut agent, Ok(SuperValue::from(reference))).unwrap();
+        let result = get_value(&mut agent, Ok(NormalCompletion::from(reference))).unwrap();
         assert_eq!(result, value);
     }
     #[test]
@@ -362,7 +362,7 @@ mod get_value {
         env.initialize_binding(&mut agent, &JSString::from("test_var"), value.clone()).unwrap();
         let reference = Reference::new(Base::Environment(Rc::new(env)), "test_var", true, None);
 
-        let result = get_value(&mut agent, Ok(SuperValue::from(reference))).unwrap();
+        let result = get_value(&mut agent, Ok(NormalCompletion::from(reference))).unwrap();
         assert_eq!(result, value);
     }
 }
@@ -385,14 +385,14 @@ mod put_value {
         let mut agent = test_agent();
         let v = ECMAScriptValue::Undefined;
         let w = create_type_error(&mut agent, "Error in W");
-        let result = put_value(&mut agent, Ok(SuperValue::from(v)), Err(w)).unwrap_err();
+        let result = put_value(&mut agent, Ok(NormalCompletion::from(v)), Err(w)).unwrap_err();
 
         assert_eq!(unwind_type_error(&mut agent, result), "Error in W");
     }
     #[test]
     fn bad_lhs() {
         let mut agent = test_agent();
-        let result = put_value(&mut agent, Ok(SuperValue::from(ECMAScriptValue::Undefined)), Ok(ECMAScriptValue::Undefined)).unwrap_err();
+        let result = put_value(&mut agent, Ok(NormalCompletion::from(ECMAScriptValue::Undefined)), Ok(ECMAScriptValue::Undefined)).unwrap_err();
 
         assert_eq!(unwind_reference_error(&mut agent, result), "Invalid Reference");
     }
@@ -400,7 +400,7 @@ mod put_value {
     fn unresolvable_strict() {
         let mut agent = test_agent();
         let reference = Reference::new(Base::Unresolvable, "blue", true, None);
-        let result = put_value(&mut agent, Ok(SuperValue::from(reference)), Ok(ECMAScriptValue::Undefined)).unwrap_err();
+        let result = put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(ECMAScriptValue::Undefined)).unwrap_err();
         assert_eq!(unwind_reference_error(&mut agent, result), "Unknown reference");
     }
     #[test]
@@ -408,7 +408,7 @@ mod put_value {
         let mut agent = test_agent();
         let value = ECMAScriptValue::from("Test Value for Unresolvable, non-strict writes");
         let reference = Reference::new(Base::Unresolvable, "blue", false, None);
-        put_value(&mut agent, Ok(SuperValue::from(reference)), Ok(value.clone())).unwrap();
+        put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
         let global = get_global_object(&agent).unwrap();
         let from_global = get(&mut agent, &global, &PropertyKey::from("blue")).unwrap();
         assert_eq!(from_global, value);
@@ -428,7 +428,7 @@ mod put_value {
         )
         .unwrap();
 
-        let result = put_value(&mut agent, Ok(SuperValue::from(reference)), Ok(value)).unwrap_err();
+        let result = put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value)).unwrap_err();
         assert_eq!(unwind_type_error(&mut agent, result), "Generic TypeError");
     }
     #[test]
@@ -441,7 +441,7 @@ mod put_value {
         private_field_add(&mut agent, &normal_object, pn.clone(), ECMAScriptValue::Undefined).unwrap();
         let reference = Reference::new(Base::Value(ECMAScriptValue::from(normal_object.clone())), pn.clone(), true, None);
 
-        put_value(&mut agent, Ok(SuperValue::from(reference)), Ok(value.clone())).unwrap();
+        put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
 
         let from_private = private_get(&mut agent, &normal_object, &pn).unwrap();
         assert_eq!(from_private, value);
@@ -451,7 +451,7 @@ mod put_value {
     fn bad_value() {
         let mut agent = test_agent();
         let reference = Reference::new(Base::Value(ECMAScriptValue::Undefined), "test", true, None);
-        let result = put_value(&mut agent, Ok(SuperValue::from(reference)), Ok(ECMAScriptValue::Null)).unwrap_err();
+        let result = put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(ECMAScriptValue::Null)).unwrap_err();
         assert_eq!(unwind_type_error(&mut agent, result), "Undefined and null cannot be converted to objects");
     }
     #[test]
@@ -463,7 +463,7 @@ mod put_value {
         let key = PropertyKey::from("phrase");
         let reference = Reference::new(Base::Value(ECMAScriptValue::from(normal_object.clone())), key.clone(), true, None);
 
-        put_value(&mut agent, Ok(SuperValue::from(reference)), Ok(value.clone())).unwrap();
+        put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
 
         let from_object = get(&mut agent, &normal_object, &key).unwrap();
         assert_eq!(from_object, value);
@@ -485,7 +485,7 @@ mod put_value {
         )
         .unwrap();
 
-        let result = put_value(&mut agent, Ok(SuperValue::from(reference)), Ok(value)).unwrap_err();
+        let result = put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value)).unwrap_err();
         assert_eq!(unwind_type_error(&mut agent, result), "Generic TypeError");
     }
     #[test_case(false => Ok(()); "non-strict")]
@@ -505,7 +505,7 @@ mod put_value {
         .unwrap();
         let reference = Reference::new(Base::Value(ECMAScriptValue::from(normal_object.clone())), key.clone(), strict, None);
 
-        let r = put_value(&mut agent, Ok(SuperValue::from(reference)), Ok(value)).map_err(|ac| unwind_type_error(&mut agent, ac));
+        let r = put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value)).map_err(|ac| unwind_type_error(&mut agent, ac));
 
         let from_obj = get(&mut agent, &normal_object, &key).unwrap();
         assert_eq!(from_obj, ECMAScriptValue::Undefined);
@@ -522,7 +522,7 @@ mod put_value {
         der.initialize_binding(&mut agent, &key, ECMAScriptValue::Undefined).unwrap();
         let reference = Reference::new(Base::Environment(der.clone()), key.clone(), true, None);
 
-        put_value(&mut agent, Ok(SuperValue::from(reference)), Ok(value.clone())).unwrap();
+        put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
 
         let from_env = der.get_binding_value(&mut agent, &key, true).unwrap();
         assert_eq!(from_env, value);
@@ -546,7 +546,7 @@ mod initialize_referenced_binding {
         let mut agent = test_agent();
         let v = ECMAScriptValue::Undefined;
         let w = create_type_error(&mut agent, "Error in W");
-        let result = initialize_referenced_binding(&mut agent, Ok(SuperValue::from(v)), Err(w)).unwrap_err();
+        let result = initialize_referenced_binding(&mut agent, Ok(NormalCompletion::from(v)), Err(w)).unwrap_err();
 
         assert_eq!(unwind_type_error(&mut agent, result), "Error in W");
     }
@@ -559,7 +559,7 @@ mod initialize_referenced_binding {
         let reference = Reference::new(Base::Environment(env.clone()), key.clone(), true, None);
         let value = ECMAScriptValue::from("There was so much to read, for one thing,");
 
-        initialize_referenced_binding(&mut agent, Ok(SuperValue::from(reference)), Ok(value.clone())).unwrap();
+        initialize_referenced_binding(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
 
         let from_env = env.get_binding_value(&mut agent, &key, true).unwrap();
         assert_eq!(from_env, value);
@@ -569,19 +569,19 @@ mod initialize_referenced_binding {
     fn value_ref() {
         let mut agent = test_agent();
         let reference = Reference::new(Base::Value(ECMAScriptValue::Undefined), "phrase", true, None);
-        initialize_referenced_binding(&mut agent, Ok(SuperValue::from(reference)), Ok(ECMAScriptValue::Undefined)).unwrap();
+        initialize_referenced_binding(&mut agent, Ok(NormalCompletion::from(reference)), Ok(ECMAScriptValue::Undefined)).unwrap();
     }
     #[test]
     #[should_panic(expected = "unreachable code")]
     fn unresolveable_ref() {
         let mut agent = test_agent();
         let reference = Reference::new(Base::Unresolvable, "phrase", true, None);
-        initialize_referenced_binding(&mut agent, Ok(SuperValue::from(reference)), Ok(ECMAScriptValue::Undefined)).unwrap();
+        initialize_referenced_binding(&mut agent, Ok(NormalCompletion::from(reference)), Ok(ECMAScriptValue::Undefined)).unwrap();
     }
     #[test]
     #[should_panic(expected = "unreachable code")]
     fn value() {
         let mut agent = test_agent();
-        initialize_referenced_binding(&mut agent, Ok(SuperValue::from(ECMAScriptValue::Undefined)), Ok(ECMAScriptValue::Undefined)).unwrap();
+        initialize_referenced_binding(&mut agent, Ok(NormalCompletion::from(ECMAScriptValue::Undefined)), Ok(ECMAScriptValue::Undefined)).unwrap();
     }
 }

--- a/src/reference/tests.rs
+++ b/src/reference/tests.rs
@@ -17,13 +17,14 @@ mod base {
     #[test_case(Base::Unresolvable => Base::Unresolvable; "unresolvable")]
     #[test_case(Base::Value(ECMAScriptValue::from("regurgitate")) => Base::Value(ECMAScriptValue::from("regurgitate")); "value")]
     fn clone(b: Base) -> Base {
+        #[allow(clippy::redundant_clone)]
         b.clone()
     }
 
     #[test]
     fn clone_with_environment() {
         let env = Rc::new(DeclarativeEnvironmentRecord::new(None));
-        let base = Base::Environment(env.clone());
+        let base = Base::Environment(env);
         let duplicate = base.clone();
         assert_eq!(&base, &duplicate);
     }
@@ -33,8 +34,8 @@ mod base {
         let env = Rc::new(DeclarativeEnvironmentRecord::new(None));
         let other_env = Rc::new(DeclarativeEnvironmentRecord::new(None));
         let base = Base::Environment(env.clone());
-        let should_be_equal = Base::Environment(env.clone());
-        let shouldnt_be_equal = Base::Environment(other_env.clone());
+        let should_be_equal = Base::Environment(env);
+        let shouldnt_be_equal = Base::Environment(other_env);
         assert!(base == should_be_equal);
         assert!(base != shouldnt_be_equal);
     }
@@ -60,6 +61,7 @@ mod referenced_name {
 
     #[test_case(ReferencedName::from("popsicle") => ReferencedName::from("popsicle"); "string")]
     fn clone(rn: ReferencedName) -> ReferencedName {
+        #[allow(clippy::redundant_clone)]
         rn.clone()
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,5 @@
 use super::agent::Agent;
-use super::cr::{AbruptCompletion, AltCompletion, Completion, CompletionInfo};
+use super::cr::{AbruptCompletion, Completion};
 use super::errors::create_type_error;
 use super::object::{
     get, ordinary_define_own_property, ordinary_delete, ordinary_get, ordinary_get_own_property, ordinary_get_prototype_of, ordinary_has_property, ordinary_is_extensible,
@@ -87,8 +87,8 @@ pub fn unwind_any_error_value(agent: &mut Agent, err: ECMAScriptValue) -> String
 }
 
 pub fn unwind_error(agent: &mut Agent, kind: &str, completion: AbruptCompletion) -> String {
-    assert!(matches!(completion, AbruptCompletion::Throw(CompletionInfo { value: Some(ECMAScriptValue::Object(_)), target: None })));
-    if let AbruptCompletion::Throw(CompletionInfo { value: Some(ECMAScriptValue::Object(err)), target: None }) = completion {
+    assert!(matches!(completion, AbruptCompletion::Throw { value: ECMAScriptValue::Object(_) }));
+    if let AbruptCompletion::Throw { value: ECMAScriptValue::Object(err) } = completion {
         unwind_error_object(agent, kind, err)
     } else {
         unreachable!()
@@ -97,7 +97,7 @@ pub fn unwind_error(agent: &mut Agent, kind: &str, completion: AbruptCompletion)
 
 pub fn unwind_any_error(agent: &mut Agent, completion: AbruptCompletion) -> String {
     match completion {
-        AbruptCompletion::Throw(CompletionInfo { value: Some(err), target: None }) => unwind_any_error_value(agent, err),
+        AbruptCompletion::Throw { value: err } => unwind_any_error_value(agent, err),
         _ => panic!("Improper completion for error: {:?}", completion),
     }
 }
@@ -175,77 +175,77 @@ impl ObjectInterface for TestObject {
         self.common.borrow().objid
     }
 
-    fn get_prototype_of(&self, agent: &mut Agent) -> AltCompletion<Option<Object>> {
+    fn get_prototype_of(&self, agent: &mut Agent) -> Completion<Option<Object>> {
         if self.get_prototype_of_throws {
             Err(create_type_error(agent, "[[GetPrototypeOf]] called on TestObject"))
         } else {
             Ok(ordinary_get_prototype_of(self))
         }
     }
-    fn set_prototype_of(&self, agent: &mut Agent, obj: Option<Object>) -> AltCompletion<bool> {
+    fn set_prototype_of(&self, agent: &mut Agent, obj: Option<Object>) -> Completion<bool> {
         if self.set_prototype_of_throws {
             Err(create_type_error(agent, "[[SetPrototypeOf]] called on TestObject"))
         } else {
             Ok(ordinary_set_prototype_of(self, obj))
         }
     }
-    fn is_extensible(&self, agent: &mut Agent) -> AltCompletion<bool> {
+    fn is_extensible(&self, agent: &mut Agent) -> Completion<bool> {
         if self.is_extensible_throws {
             Err(create_type_error(agent, "[[IsExtensible]] called on TestObject"))
         } else {
             Ok(ordinary_is_extensible(self))
         }
     }
-    fn prevent_extensions(&self, agent: &mut Agent) -> AltCompletion<bool> {
+    fn prevent_extensions(&self, agent: &mut Agent) -> Completion<bool> {
         if self.prevent_extensions_throws {
             Err(create_type_error(agent, "[[PreventExtensions]] called on TestObject"))
         } else {
             Ok(ordinary_prevent_extensions(self))
         }
     }
-    fn get_own_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         if self.get_own_property_throws.0 && self.get_own_property_throws.1.as_ref().map_or(true, |k| *k == *key) {
             Err(create_type_error(agent, "[[GetOwnProperty]] called on TestObject"))
         } else {
             Ok(ordinary_get_own_property(self, key))
         }
     }
-    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> AltCompletion<bool> {
+    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool> {
         if self.define_own_property_throws.0 && self.define_own_property_throws.1.as_ref().map_or(true, |k| *k == key) {
             Err(create_type_error(agent, "[[DefineOwnProperty]] called on TestObject"))
         } else {
             ordinary_define_own_property(agent, self, key, desc)
         }
     }
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         if self.has_property_throws.0 && self.has_property_throws.1.as_ref().map_or(true, |k| *k == *key) {
             Err(create_type_error(agent, "[[HasProperty]] called on TestObject"))
         } else {
             ordinary_has_property(agent, self, key)
         }
     }
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion {
+    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         if self.get_throws.0 && self.get_throws.1.as_ref().map_or(true, |k| *k == *key) {
             Err(create_type_error(agent, "[[Get]] called on TestObject"))
         } else {
             ordinary_get(agent, self, key, receiver)
         }
     }
-    fn set(&self, agent: &mut Agent, key: PropertyKey, value: ECMAScriptValue, receiver: &ECMAScriptValue) -> AltCompletion<bool> {
+    fn set(&self, agent: &mut Agent, key: PropertyKey, value: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
         if self.set_throws.0 && self.set_throws.1.as_ref().map_or(true, |k| *k == key) {
             Err(create_type_error(agent, "[[Set]] called on TestObject"))
         } else {
             ordinary_set(agent, self, key, value, receiver)
         }
     }
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         if self.delete_throws.0 && self.delete_throws.1.as_ref().map_or(true, |k| *k == *key) {
             Err(create_type_error(agent, "[[Delete]] called on TestObject"))
         } else {
             ordinary_delete(agent, self, key)
         }
     }
-    fn own_property_keys(&self, agent: &mut Agent) -> AltCompletion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
         if self.own_property_keys_throws {
             Err(create_type_error(agent, "[[OwnPropertyKeys]] called on TestObject"))
         } else {
@@ -318,17 +318,17 @@ impl TestObject {
     }
 }
 
-type GetPrototypeOfFunction = fn(agent: &mut Agent, this: &AdaptableObject) -> AltCompletion<Option<Object>>;
-type SetPrototypeOfFunction = fn(agent: &mut Agent, this: &AdaptableObject, obj: Option<Object>) -> AltCompletion<bool>;
-type IsExtensibleFunction = fn(agent: &mut Agent, this: &AdaptableObject) -> AltCompletion<bool>;
-type PreventExtensionsFunction = fn(agent: &mut Agent, this: &AdaptableObject) -> AltCompletion<bool>;
-type GetOwnPropertyFunction = fn(agent: &mut Agent, this: &AdaptableObject, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>>;
-type DefineOwnPropertyFunction = fn(agent: &mut Agent, this: &AdaptableObject, key: PropertyKey, desc: PotentialPropertyDescriptor) -> AltCompletion<bool>;
-type HasPropertyFunction = fn(agent: &mut Agent, this: &AdaptableObject, key: &PropertyKey) -> AltCompletion<bool>;
-type GetFunction = fn(agent: &mut Agent, this: &AdaptableObject, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion;
-type SetFunction = fn(agent: &mut Agent, this: &AdaptableObject, key: PropertyKey, value: ECMAScriptValue, receiver: &ECMAScriptValue) -> AltCompletion<bool>;
-type DeleteFunction = fn(agent: &mut Agent, this: &AdaptableObject, key: &PropertyKey) -> AltCompletion<bool>;
-type OwnPropertyKeysFunction = fn(agent: &mut Agent, this: &AdaptableObject) -> AltCompletion<Vec<PropertyKey>>;
+type GetPrototypeOfFunction = fn(agent: &mut Agent, this: &AdaptableObject) -> Completion<Option<Object>>;
+type SetPrototypeOfFunction = fn(agent: &mut Agent, this: &AdaptableObject, obj: Option<Object>) -> Completion<bool>;
+type IsExtensibleFunction = fn(agent: &mut Agent, this: &AdaptableObject) -> Completion<bool>;
+type PreventExtensionsFunction = fn(agent: &mut Agent, this: &AdaptableObject) -> Completion<bool>;
+type GetOwnPropertyFunction = fn(agent: &mut Agent, this: &AdaptableObject, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>>;
+type DefineOwnPropertyFunction = fn(agent: &mut Agent, this: &AdaptableObject, key: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool>;
+type HasPropertyFunction = fn(agent: &mut Agent, this: &AdaptableObject, key: &PropertyKey) -> Completion<bool>;
+type GetFunction = fn(agent: &mut Agent, this: &AdaptableObject, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue>;
+type SetFunction = fn(agent: &mut Agent, this: &AdaptableObject, key: PropertyKey, value: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool>;
+type DeleteFunction = fn(agent: &mut Agent, this: &AdaptableObject, key: &PropertyKey) -> Completion<bool>;
+type OwnPropertyKeysFunction = fn(agent: &mut Agent, this: &AdaptableObject) -> Completion<Vec<PropertyKey>>;
 
 pub struct AdaptableObject {
     common: RefCell<CommonObjectData>,
@@ -382,68 +382,68 @@ impl ObjectInterface for AdaptableObject {
         self.common.borrow().objid
     }
 
-    fn get_prototype_of(&self, agent: &mut Agent) -> AltCompletion<Option<Object>> {
+    fn get_prototype_of(&self, agent: &mut Agent) -> Completion<Option<Object>> {
         match &self.get_prototype_of_override {
             Some(func) => func(agent, self),
             None => Ok(ordinary_get_prototype_of(self)),
         }
     }
 
-    fn set_prototype_of(&self, agent: &mut Agent, obj: Option<Object>) -> AltCompletion<bool> {
+    fn set_prototype_of(&self, agent: &mut Agent, obj: Option<Object>) -> Completion<bool> {
         match &self.set_prototype_of_override {
             Some(func) => func(agent, self, obj),
             None => Ok(ordinary_set_prototype_of(self, obj)),
         }
     }
-    fn is_extensible(&self, agent: &mut Agent) -> AltCompletion<bool> {
+    fn is_extensible(&self, agent: &mut Agent) -> Completion<bool> {
         match &self.is_extensible_override {
             Some(func) => func(agent, self),
             None => Ok(ordinary_is_extensible(self)),
         }
     }
-    fn prevent_extensions(&self, agent: &mut Agent) -> AltCompletion<bool> {
+    fn prevent_extensions(&self, agent: &mut Agent) -> Completion<bool> {
         match &self.prevent_extensions_override {
             Some(func) => func(agent, self),
             None => Ok(ordinary_prevent_extensions(self)),
         }
     }
-    fn get_own_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         match &self.get_own_property_override {
             Some(func) => func(agent, self, key),
             None => Ok(ordinary_get_own_property(self, key)),
         }
     }
-    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> AltCompletion<bool> {
+    fn define_own_property(&self, agent: &mut Agent, key: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool> {
         match &self.define_own_property_override {
             Some(func) => func(agent, self, key, desc),
             None => ordinary_define_own_property(agent, self, key, desc),
         }
     }
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         match &self.has_property_override {
             Some(func) => func(agent, self, key),
             None => ordinary_has_property(agent, self, key),
         }
     }
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion {
+    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         match &self.get_override {
             Some(func) => func(agent, self, key, receiver),
             None => ordinary_get(agent, self, key, receiver),
         }
     }
-    fn set(&self, agent: &mut Agent, key: PropertyKey, value: ECMAScriptValue, receiver: &ECMAScriptValue) -> AltCompletion<bool> {
+    fn set(&self, agent: &mut Agent, key: PropertyKey, value: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
         match &self.set_override {
             Some(func) => func(agent, self, key, value, receiver),
             None => ordinary_set(agent, self, key, value, receiver),
         }
     }
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> AltCompletion<bool> {
+    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
         match &self.delete_override {
             Some(func) => func(agent, self, key),
             None => ordinary_delete(agent, self, key),
         }
     }
-    fn own_property_keys(&self, agent: &mut Agent) -> AltCompletion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
         match &self.own_property_keys_override {
             Some(func) => func(agent, self),
             None => Ok(ordinary_own_property_keys(agent, self)),
@@ -490,7 +490,7 @@ impl AdaptableObject {
 }
 
 // error
-pub fn faux_errors(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+pub fn faux_errors(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     Err(create_type_error(agent, "Test Sentinel"))
 }
 

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -1,7 +1,7 @@
 use super::agent::{Agent, WksId};
 use super::bigint_object::create_bigint_object;
 use super::boolean_object::create_boolean_object;
-use super::cr::{AltCompletion, Completion};
+use super::cr::Completion;
 use super::dtoa_r::dtoa;
 use super::errors::{create_range_error, create_type_error};
 use super::number_object::create_number_object;
@@ -72,7 +72,7 @@ impl ECMAScriptValue {
     //      b. Let target be argument.[[ProxyTarget]].
     //      c. Return ? IsArray(target).
     //  4. Return false.
-    pub fn is_array(&self, agent: &mut Agent) -> AltCompletion<bool> {
+    pub fn is_array(&self, agent: &mut Agent) -> Completion<bool> {
         match self {
             ECMAScriptValue::Object(obj) => obj.is_array(agent),
             _ => Ok(false),
@@ -514,7 +514,7 @@ pub enum ConversionHint {
     String,
     Number,
 }
-pub fn ordinary_to_primitive(agent: &mut Agent, obj: &Object, hint: ConversionHint) -> Completion {
+pub fn ordinary_to_primitive(agent: &mut Agent, obj: &Object, hint: ConversionHint) -> Completion<ECMAScriptValue> {
     let method_names = match hint {
         ConversionHint::String => vec![PropertyKey::from("toString"), PropertyKey::from("valueOf")],
         ConversionHint::Number => vec![PropertyKey::from("valueOf"), PropertyKey::from("toString")],
@@ -557,7 +557,7 @@ pub fn ordinary_to_primitive(agent: &mut Agent, obj: &Object, hint: ConversionHi
 //          objects may over-ride this behaviour by defining a @@toPrimitive method. Of the objects defined in this
 //          specification only Date objects (see 21.4.4.45) and Symbol objects (see 20.4.3.5) over-ride the default
 //          ToPrimitive behaviour. Date objects treat no hint as if the hint were string.
-pub fn to_primitive(agent: &mut Agent, input: ECMAScriptValue, preferred_type: Option<ConversionHint>) -> Completion {
+pub fn to_primitive(agent: &mut Agent, input: ECMAScriptValue, preferred_type: Option<ConversionHint>) -> Completion<ECMAScriptValue> {
     if let ECMAScriptValue::Object(obj) = &input {
         let exotic_to_prim = get_method(agent, &input, &PropertyKey::from(agent.wks(WksId::ToPrimitive)))?;
         if !exotic_to_prim.is_undefined() {
@@ -629,7 +629,7 @@ pub enum Numeric {
     Number(f64),
     BigInt(Rc<BigInt>),
 }
-pub fn to_numeric(agent: &mut Agent, value: ECMAScriptValue) -> AltCompletion<Numeric> {
+pub fn to_numeric(agent: &mut Agent, value: ECMAScriptValue) -> Completion<Numeric> {
     let prim_value = to_primitive(agent, value, Some(ConversionHint::Number))?;
     if let ECMAScriptValue::BigInt(bi) = prim_value {
         Ok(Numeric::BigInt(bi))
@@ -665,7 +665,7 @@ pub fn to_numeric(agent: &mut Agent, value: ECMAScriptValue) -> AltCompletion<Nu
 // |               |     1. Let primValue be ? ToPrimitive(argument, number).          |
 // |               |     2. Return ? ToNumber(primValue).                              |
 // +---------------+-------------------------------------------------------------------+
-pub fn to_number(agent: &mut Agent, value: impl Into<ECMAScriptValue>) -> AltCompletion<f64> {
+pub fn to_number(agent: &mut Agent, value: impl Into<ECMAScriptValue>) -> Completion<f64> {
     match value.into() {
         ECMAScriptValue::Undefined => Ok(f64::NAN),
         ECMAScriptValue::Null => Ok(0_f64),
@@ -731,7 +731,7 @@ fn string_to_number(string: JSString) -> f64 {
 //  5. Let integer be floor(abs(ℝ(number))).
 //  6. If number < +0𝔽, set integer to -integer.
 //  7. Return integer.
-pub fn to_integer_or_infinity(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> AltCompletion<f64> {
+pub fn to_integer_or_infinity(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> Completion<f64> {
     let number = to_number(agent, argument)?;
     if number.is_nan() || number == 0.0 {
         Ok(0.0)
@@ -765,7 +765,7 @@ pub fn to_integer_or_infinity(agent: &mut Agent, argument: impl Into<ECMAScriptV
 //      | * ToInt32(ToUint32(x)) is the same value as ToInt32(x) for all values of x. (It is to preserve this latter
 //      |   property that +∞𝔽 and -∞𝔽 are mapped to +0𝔽.)
 //      | * ToInt32 maps -0𝔽 to +0𝔽.
-fn to_core_int(agent: &mut Agent, modulo: f64, argument: impl Into<ECMAScriptValue>) -> AltCompletion<f64> {
+fn to_core_int(agent: &mut Agent, modulo: f64, argument: impl Into<ECMAScriptValue>) -> Completion<f64> {
     Ok({
         let number = to_number(agent, argument)?;
         if !number.is_finite() || number == 0.0 {
@@ -776,7 +776,7 @@ fn to_core_int(agent: &mut Agent, modulo: f64, argument: impl Into<ECMAScriptVal
         }
     })
 }
-fn to_core_signed(agent: &mut Agent, modulo: f64, argument: impl Into<ECMAScriptValue>) -> AltCompletion<f64> {
+fn to_core_signed(agent: &mut Agent, modulo: f64, argument: impl Into<ECMAScriptValue>) -> Completion<f64> {
     Ok({
         let intval = to_core_int(agent, modulo, argument)?;
         if intval >= modulo / 2.0 {
@@ -786,7 +786,7 @@ fn to_core_signed(agent: &mut Agent, modulo: f64, argument: impl Into<ECMAScript
         }
     })
 }
-pub fn to_int32(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> AltCompletion<i32> {
+pub fn to_int32(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> Completion<i32> {
     Ok(to_core_signed(agent, 4294967296.0, argument)? as i32)
 }
 
@@ -809,7 +809,7 @@ pub fn to_int32(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> AltC
 //      | * ToUint32(ToInt32(x)) is the same value as ToUint32(x) for all values of x. (It is to preserve this latter
 //      |   property that +∞𝔽 and -∞𝔽 are mapped to +0𝔽.)
 //      | * ToUint32 maps -0𝔽 to +0𝔽.
-pub fn to_uint32(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> AltCompletion<u32> {
+pub fn to_uint32(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> Completion<u32> {
     Ok(to_core_int(agent, 4294967296.0, argument)? as u32)
 }
 
@@ -823,7 +823,7 @@ pub fn to_uint32(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> Alt
 //  3. Let int be the mathematical value whose sign is the sign of number and whose magnitude is floor(abs(ℝ(number))).
 //  4. Let int16bit be int modulo 2**16.
 //  5. If int16bit ≥ 2**15, return 𝔽(int16bit - 2**16); otherwise return 𝔽(int16bit).
-pub fn to_int16(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> AltCompletion<i16> {
+pub fn to_int16(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> Completion<i16> {
     Ok(to_core_signed(agent, 65536.0, argument)? as i16)
 }
 
@@ -842,7 +842,7 @@ pub fn to_int16(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> AltC
 //      |
 //      | * The substitution of 2**16 for 2**32 in step 4 is the only difference between ToUint32 and ToUint16.
 //      | * ToUint16 maps -0𝔽 to +0𝔽.
-pub fn to_uint16(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> AltCompletion<u16> {
+pub fn to_uint16(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> Completion<u16> {
     Ok(to_core_int(agent, 65536.0, argument)? as u16)
 }
 
@@ -856,7 +856,7 @@ pub fn to_uint16(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> Alt
 //  3. Let int be the mathematical value whose sign is the sign of number and whose magnitude is floor(abs(ℝ(number))).
 //  4. Let int8bit be int modulo 2**8.
 //  5. If int8bit ≥ 2**7, return 𝔽(int8bit - 2**8); otherwise return 𝔽(int8bit).
-pub fn to_int8(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> AltCompletion<i8> {
+pub fn to_int8(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> Completion<i8> {
     Ok(to_core_signed(agent, 256.0, argument)? as i8)
 }
 
@@ -870,7 +870,7 @@ pub fn to_int8(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> AltCo
 //  3. Let int be the mathematical value whose sign is the sign of number and whose magnitude is floor(abs(ℝ(number))).
 //  4. Let int8bit be int modulo 2**8.
 //  5. Return 𝔽(int8bit).
-pub fn to_uint8(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> AltCompletion<u8> {
+pub fn to_uint8(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> Completion<u8> {
     Ok(to_core_int(agent, 256.0, argument)? as u8)
 }
 
@@ -902,7 +902,7 @@ pub fn to_uint8(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> AltC
 // |               |      1. Let primValue be ? ToPrimitive(argument, string). |
 // |               |      2. Return ? ToString(primValue).                     |
 // +---------------+-----------------------------------------------------------+
-pub fn to_string(agent: &mut Agent, val: impl Into<ECMAScriptValue>) -> AltCompletion<JSString> {
+pub fn to_string(agent: &mut Agent, val: impl Into<ECMAScriptValue>) -> Completion<JSString> {
     match val.into() {
         ECMAScriptValue::Undefined => Ok(JSString::from("undefined")),
         ECMAScriptValue::Null => Ok(JSString::from("null")),
@@ -940,7 +940,7 @@ pub fn to_string(agent: &mut Agent, val: impl Into<ECMAScriptValue>) -> AltCompl
 // | BigInt        | Return a new BigInt object whose [[BigIntData]] internal slot is set to argument.   |
 // | Object        | Return argument.                                                                    |
 // +---------------+-------------------------------------------------------------------------------------+
-pub fn to_object(agent: &mut Agent, val: impl Into<ECMAScriptValue>) -> AltCompletion<Object> {
+pub fn to_object(agent: &mut Agent, val: impl Into<ECMAScriptValue>) -> Completion<Object> {
     match val.into() {
         ECMAScriptValue::Null | ECMAScriptValue::Undefined => Err(create_type_error(agent, "Undefined and null cannot be converted to objects")),
         ECMAScriptValue::Boolean(b) => Ok(create_boolean_object(agent, b)),
@@ -961,7 +961,7 @@ pub fn to_object(agent: &mut Agent, val: impl Into<ECMAScriptValue>) -> AltCompl
 //  2. If Type(key) is Symbol, then
 //      a. Return key.
 //  3. Return ! ToString(key).
-pub fn to_property_key(agent: &mut Agent, argument: ECMAScriptValue) -> AltCompletion<PropertyKey> {
+pub fn to_property_key(agent: &mut Agent, argument: ECMAScriptValue) -> Completion<PropertyKey> {
     let key = to_primitive(agent, argument, Some(ConversionHint::String))?;
     match key {
         ECMAScriptValue::Symbol(sym) => Ok(PropertyKey::from(sym)),
@@ -977,7 +977,7 @@ pub fn to_property_key(agent: &mut Agent, argument: ECMAScriptValue) -> AltCompl
 //  1. Let len be ? ToIntegerOrInfinity(argument).
 //  2. If len ≤ 0, return +0𝔽.
 //  3. Return 𝔽(min(len, 2**53 - 1)).
-pub fn to_length(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> AltCompletion<i64> {
+pub fn to_length(agent: &mut Agent, argument: impl Into<ECMAScriptValue>) -> Completion<i64> {
     let len = to_integer_or_infinity(agent, argument)?;
     Ok(len.clamp(0.0, 2_i64.pow(53) as f64 - 1.0) as i64)
 }
@@ -1022,7 +1022,7 @@ pub fn canonical_numeric_index_string(agent: &mut Agent, argument: JSString) -> 
 //      c. If ! SameValue(𝔽(integer), clamped) is false, throw a RangeError exception.
 //      d. Assert: 0 ≤ integer ≤ 2**53 - 1.
 //      e. Return integer.
-pub fn to_index(agent: &mut Agent, value: impl Into<ECMAScriptValue>) -> AltCompletion<i64> {
+pub fn to_index(agent: &mut Agent, value: impl Into<ECMAScriptValue>) -> Completion<i64> {
     let value = value.into();
     if value == ECMAScriptValue::Undefined {
         Ok(0)

--- a/src/values/tests.rs
+++ b/src/values/tests.rs
@@ -727,7 +727,7 @@ fn to_string_09() {
     let result = to_string(&mut agent, ECMAScriptValue::from(obj)).unwrap_err();
     assert_eq!(unwind_type_error(&mut agent, result), "Cannot convert object to primitive value");
 }
-fn tostring_symbol(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn tostring_symbol(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let sym = Symbol::new(agent, None);
     Ok(ECMAScriptValue::from(sym))
 }
@@ -818,21 +818,21 @@ fn to_object_08() {
 // * object value & object string -> type error
 
 // non-object number
-fn faux_makes_number(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn faux_makes_number(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     Ok(ECMAScriptValue::from(123456))
 }
 // non-object string
-fn faux_makes_string(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn faux_makes_string(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     Ok(ECMAScriptValue::from("test result"))
 }
 // object value
-fn faux_makes_obj(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn faux_makes_obj(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(agent, Some(object_prototype), &[]);
     Ok(ECMAScriptValue::from(obj))
 }
 // error
-fn faux_errors(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn faux_errors(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     Err(create_type_error(agent, "Test Sentinel"))
 }
 enum FauxKind {
@@ -1037,7 +1037,7 @@ fn to_primitive_prefer_number() {
     let result = to_primitive(&mut agent, test_value, Some(ConversionHint::String)).unwrap();
     assert_eq!(result, ECMAScriptValue::from("test result"));
 }
-fn exotic_to_prim(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion {
+fn exotic_to_prim(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     if arguments.len() == 1 {
         if let ECMAScriptValue::String(s) = &arguments[0] {
             Ok(ECMAScriptValue::from(format!("Saw {}", s)))
@@ -1048,7 +1048,7 @@ fn exotic_to_prim(_agent: &mut Agent, _this_value: ECMAScriptValue, _new_target:
         Ok(ECMAScriptValue::from(format!("Incorrect arg count: there were {} elements, should have been 1", arguments.len())))
     }
 }
-fn make_toprimitive_obj(agent: &mut Agent, steps: fn(&mut Agent, ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion) -> Object {
+fn make_toprimitive_obj(agent: &mut Agent, steps: fn(&mut Agent, ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion<ECMAScriptValue>) -> Object {
     let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
@@ -1077,7 +1077,7 @@ fn to_primitive_uses_exotics() {
     let result = to_primitive(&mut agent, test_value, Some(ConversionHint::String)).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Saw string"));
 }
-fn exotic_returns_object(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn exotic_returns_object(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let target = ordinary_object_create(agent, Some(object_prototype), &[]);
@@ -1092,7 +1092,7 @@ fn to_primitive_exotic_returns_object() {
     let result = to_primitive(&mut agent, test_value, None).unwrap_err();
     assert_eq!(unwind_type_error(&mut agent, result), "Cannot convert object to primitive value");
 }
-fn exotic_throws(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion {
+fn exotic_throws(agent: &mut Agent, _this_value: ECMAScriptValue, _new_target: Option<&Object>, _arguments: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
     Err(create_type_error(agent, "Test Sentinel"))
 }
 #[test]


### PR DESCRIPTION
Refactor completion records so that it's not possible to construct invalid combinations.

Ultimately, I wanted to be able to write `update_empty` without having lots of `unreachable!()` code.