### PR TITLE
Finish off IsIdentifierRef

### DIFF
--- a/src/parser/left_hand_side_expressions/mod.rs
+++ b/src/parser/left_hand_side_expressions/mod.rs
@@ -372,6 +372,22 @@ impl MemberExpression {
             MemberExpressionKind::NewArguments(..) => ATTKind::Invalid,
         }
     }
+
+    /// True if this production winds up being an IdentifierRef
+    ///
+    /// See [IsIdentifierRef](https://tc39.es/ecma262/#sec-static-semantics-isidentifierref) from ECMA-262.
+    pub fn is_identifier_ref(&self) -> bool {
+        match &self.kind {
+            MemberExpressionKind::PrimaryExpression(x) => x.is_identifier_ref(),
+            MemberExpressionKind::Expression(..)
+            | MemberExpressionKind::IdentifierName(..)
+            | MemberExpressionKind::TemplateLiteral(..)
+            | MemberExpressionKind::SuperProperty(..)
+            | MemberExpressionKind::MetaProperty(..)
+            | MemberExpressionKind::NewArguments(..)
+            | MemberExpressionKind::PrivateId(..) => false,
+        }
+    }
 }
 
 // SuperProperty[Yield, Await] :
@@ -1085,6 +1101,16 @@ impl NewExpression {
             NewExpressionKind::NewExpression(_) => ATTKind::Invalid,
         }
     }
+
+    /// True if this production winds up being an IdentifierRef
+    ///
+    /// See [IsIdentifierRef](https://tc39.es/ecma262/#sec-static-semantics-isidentifierref) from ECMA-262.
+    pub fn is_identifier_ref(&self) -> bool {
+        match &self.kind {
+            NewExpressionKind::NewExpression(_) => false,
+            NewExpressionKind::MemberExpression(x) => x.is_identifier_ref(),
+        }
+    }
 }
 
 // CallMemberExpression[Yield, Await] :
@@ -1736,6 +1762,16 @@ impl LeftHandSideExpression {
             LeftHandSideExpression::New(boxed) => boxed.assignment_target_type(strict),
             LeftHandSideExpression::Call(boxed) => boxed.assignment_target_type(),
             LeftHandSideExpression::Optional(_) => ATTKind::Invalid,
+        }
+    }
+
+    /// True if this production winds up being an IdentifierRef
+    ///
+    /// See [IsIdentifierRef](https://tc39.es/ecma262/#sec-static-semantics-isidentifierref) from ECMA-262.
+    pub fn is_identifier_ref(&self) -> bool {
+        match self {
+            LeftHandSideExpression::Call(_) | LeftHandSideExpression::Optional(_) => false,
+            LeftHandSideExpression::New(x) => x.is_identifier_ref(),
         }
     }
 }

--- a/src/parser/left_hand_side_expressions/tests.rs
+++ b/src/parser/left_hand_side_expressions/tests.rs
@@ -2408,4 +2408,30 @@ mod left_hand_side_expression {
     fn assignment_target_type(src: &str, strict: bool) -> ATTKind {
         Maker::new(src).left_hand_side_expression().assignment_target_type(strict)
     }
+
+    #[test_case("idref" => true; "Id Ref")]
+    #[test_case("this" => false; "this kwd")]
+    #[test_case("10" => false; "literal")]
+    #[test_case("[10, 11, 12]" => false; "array literal")]
+    #[test_case("{ a: 12 }" => false; "object literal")]
+    #[test_case("function a(){}" => false; "function expression")]
+    #[test_case("function *a(){}" => false; "generator expression")]
+    #[test_case("async function () {}" => false; "async func expr")]
+    #[test_case("async function *(){}" => false; "async gen expr")]
+    #[test_case("/abcd/" => false; "regex literal")]
+    #[test_case("`template`" => false; "template literal")]
+    #[test_case("(id)" => false; "parentheszied expr")]
+    #[test_case("a[0]" => false; "expression member access")]
+    #[test_case("a.a" => false; "name member access")]
+    #[test_case("a`${b}`" => false; "tagged template")]
+    #[test_case("super.a" => false; "super prop")]
+    #[test_case("new.target" => false; "meta prop")]
+    #[test_case("new a()" => false; "new expr")]
+    #[test_case("a.#b" => false; "private member access")]
+    #[test_case("new a" => false; "other new expr")]
+    #[test_case("a()" => false; "call")]
+    #[test_case("a?.b" => false; "optional")]
+    fn is_identifier_ref(src: &str) -> bool {
+        Maker::new(src).left_hand_side_expression().is_identifier_ref()
+    }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -521,10 +521,6 @@ pub trait IsFunctionDefinition {
     fn is_function_definition(&self) -> bool;
 }
 
-pub trait IsIdentifierReference {
-    fn is_identifier_reference(&self) -> bool;
-}
-
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum ATTKind {
     Invalid,

--- a/src/parser/primary_expressions/mod.rs
+++ b/src/parser/primary_expressions/mod.rs
@@ -130,18 +130,6 @@ impl IsFunctionDefinition for PrimaryExpression {
         }
     }
 }
-
-impl IsIdentifierReference for PrimaryExpression {
-    fn is_identifier_reference(&self) -> bool {
-        use PrimaryExpression::*;
-        match self {
-            This | Literal(_) | ArrayLiteral(_) | ObjectLiteral(_) | Parenthesized(_) | TemplateLiteral(_) | RegularExpression(_) | Function(_) | Class(_) | Generator(_)
-            | AsyncFunction(_) | AsyncGenerator(_) => false,
-            IdentifierReference(_) => true,
-        }
-    }
-}
-
 pub trait ToPrimaryExpression {
     fn to_primary_expression(node: Rc<Self>) -> PrimaryExpression;
     fn to_primary_expression_result(node: Rc<Self>, scanner: Scanner) -> ParseResult<PrimaryExpression> {
@@ -424,6 +412,13 @@ impl PrimaryExpression {
             IdentifierReference(id) => id.assignment_target_type(strict),
             Parenthesized(expr) => expr.assignment_target_type(strict),
         }
+    }
+
+    /// True if this production winds up being an IdentifierRef
+    ///
+    /// See [IsIdentifierRef](https://tc39.es/ecma262/#sec-static-semantics-isidentifierref) from ECMA-262.
+    pub fn is_identifier_ref(&self) -> bool {
+        matches!(self, PrimaryExpression::IdentifierReference(_))
     }
 }
 

--- a/src/parser/primary_expressions/tests.rs
+++ b/src/parser/primary_expressions/tests.rs
@@ -46,7 +46,6 @@ fn primary_expression_test_idref() {
     chk_scan(&scanner, 4);
     assert!(matches!(*boxed_pe, PrimaryExpression::IdentifierReference(_)));
     assert_eq!(boxed_pe.is_function_definition(), false);
-    assert_eq!(boxed_pe.is_identifier_reference(), true);
 }
 #[test]
 fn primary_expression_test_literal() {
@@ -54,7 +53,6 @@ fn primary_expression_test_literal() {
     chk_scan(&scanner, 3);
     assert!(matches!(*node, PrimaryExpression::Literal(_)));
     assert_eq!(node.is_function_definition(), false);
-    assert_eq!(node.is_identifier_reference(), false);
 }
 #[test]
 fn primary_expression_test_this() {
@@ -62,7 +60,6 @@ fn primary_expression_test_this() {
     chk_scan(&scanner, 4);
     assert!(matches!(*node, PrimaryExpression::This));
     assert_eq!(node.is_function_definition(), false);
-    assert_eq!(node.is_identifier_reference(), false);
 }
 #[test]
 fn primary_expression_test_arraylit() {
@@ -70,7 +67,6 @@ fn primary_expression_test_arraylit() {
     chk_scan(&scanner, 2);
     assert!(matches!(*node, PrimaryExpression::ArrayLiteral(_)));
     assert_eq!(node.is_function_definition(), false);
-    assert_eq!(node.is_identifier_reference(), false);
 }
 #[test]
 fn primary_expression_test_objlit() {
@@ -78,7 +74,6 @@ fn primary_expression_test_objlit() {
     chk_scan(&scanner, 2);
     assert!(matches!(*node, PrimaryExpression::ObjectLiteral(_)));
     assert_eq!(node.is_function_definition(), false);
-    assert_eq!(node.is_identifier_reference(), false);
 }
 #[test]
 fn primary_expression_test_group() {
@@ -86,7 +81,6 @@ fn primary_expression_test_group() {
     chk_scan(&scanner, 3);
     assert!(matches!(*node, PrimaryExpression::Parenthesized(_)));
     assert_eq!(node.is_function_definition(), false);
-    assert_eq!(node.is_identifier_reference(), false);
 }
 #[test]
 fn primary_expression_test_func() {
@@ -94,7 +88,6 @@ fn primary_expression_test_func() {
     chk_scan(&scanner, 14);
     assert!(matches!(*node, PrimaryExpression::Function(..)));
     assert_eq!(node.is_function_definition(), true);
-    assert_eq!(node.is_identifier_reference(), false);
     pretty_check(&*node, "PrimaryExpression: function a (  ) {  }", vec!["FunctionExpression: function a (  ) {  }"]);
     concise_check(&*node, "FunctionExpression: function a (  ) {  }", vec!["Keyword: function", "IdentifierName: a", "Punctuator: (", "Punctuator: )", "Punctuator: {", "Punctuator: }"]);
 }
@@ -104,7 +97,6 @@ fn primary_expression_test_generator() {
     chk_scan(&scanner, 18);
     assert!(matches!(*node, PrimaryExpression::Generator(..)));
     assert_eq!(node.is_function_definition(), true);
-    assert_eq!(node.is_identifier_reference(), false);
     pretty_check(&*node, "PrimaryExpression: function * a ( b ) { c ; }", vec!["GeneratorExpression: function * a ( b ) { c ; }"]);
     concise_check(
         &*node,
@@ -118,7 +110,6 @@ fn primary_expression_test_async_generator() {
     chk_scan(&scanner, 24);
     assert!(matches!(*node, PrimaryExpression::AsyncGenerator(..)));
     assert_eq!(node.is_function_definition(), true);
-    assert_eq!(node.is_identifier_reference(), false);
     pretty_check(&*node, "PrimaryExpression: async function * a ( b ) { c ; }", vec!["AsyncGeneratorExpression: async function * a ( b ) { c ; }"]);
     concise_check(
         &*node,
@@ -143,7 +134,6 @@ fn primary_expression_test_async_function() {
     chk_scan(&scanner, 23);
     assert!(matches!(*node, PrimaryExpression::AsyncFunction(..)));
     assert_eq!(node.is_function_definition(), true);
-    assert_eq!(node.is_identifier_reference(), false);
     pretty_check(&*node, "PrimaryExpression: async function a ( b ) { c ; }", vec!["AsyncFunctionExpression: async function a ( b ) { c ; }"]);
     concise_check(
         &*node,
@@ -157,7 +147,6 @@ fn primary_expression_test_regexp() {
     chk_scan(&scanner, 6);
     assert!(matches!(*node, PrimaryExpression::RegularExpression(..)));
     assert_eq!(node.is_function_definition(), false);
-    assert_eq!(node.is_identifier_reference(), false);
 }
 #[test]
 fn primary_expression_test_class_expression() {
@@ -165,7 +154,6 @@ fn primary_expression_test_class_expression() {
     chk_scan(&scanner, 7);
     assert!(matches!(*node, PrimaryExpression::Class(..)));
     assert_eq!(node.is_function_definition(), true);
-    assert_eq!(node.is_identifier_reference(), false);
     pretty_check(&*node, "PrimaryExpression: class { }", vec!["ClassExpression: class { }"]);
     concise_check(&*node, "ClassExpression: class { }", vec!["Keyword: class", "ClassTail: { }"]);
 }


### PR DESCRIPTION
(Remove it as a trait, doing impls just as normal methods.)