### PR TITLE
Force tests to run in a single thread, for coverage

### DIFF
--- a/funcs.sh
+++ b/funcs.sh
@@ -16,7 +16,7 @@ function tst() {
   rm -f res-*.profraw
   local quiet=
   if [ $# -eq 0 ]; then quiet=-q; fi
-  RUST_BACKTRACE=1 LLVM_PROFILE_FILE="res-%m.profraw" cargo test --profile coverage $quiet "$@"
+  RUST_BACKTRACE=1 LLVM_PROFILE_FILE="res-%m.profraw" cargo test --profile coverage $quiet -- --test-threads=1 "$@"
   cargo profdata -- merge res-*.profraw --output=res.profdata
   cd $here
 }


### PR DESCRIPTION
I think I've finally figured out my workaround. Turns out `-j` and `-- --test-threads` aren't the same thing.