### PR TITLE
Rename "Arguments" iterator to "FuncArgs"

### DIFF
--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -1,6 +1,6 @@
 use super::agent::*;
 use super::cr::{AbruptCompletion, Completion};
-use super::function_object::{create_builtin_function, Arguments};
+use super::function_object::{create_builtin_function, FuncArgs};
 use super::object::{
     define_property_or_throw, get, get_agentless, ordinary_create_from_constructor, ordinary_define_own_property,
     ordinary_delete, ordinary_get, ordinary_get_own_property, ordinary_get_prototype_of, ordinary_has_property,
@@ -521,7 +521,7 @@ fn native_error_constructor_function(
     arguments: &[ECMAScriptValue],
     intrinsic_id: IntrinsicId,
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let message = args.next_arg();
     let afo: Object;
 

--- a/src/function_object/mod.rs
+++ b/src/function_object/mod.rs
@@ -266,22 +266,22 @@ pub fn set_function_length(agent: &mut Agent, func: &Object, length: f64) {
 // When you have
 // fn builtin_function(..., arguments: &[ECMAScriptValue]) -> ...
 // Then in your code you can say:
-//      let mut args = Arguments::from(arguments);
+//      let mut args = FuncArgs::from(arguments);
 //      let first_arg = args.next_arg();
 //      let second_arg = args.next_arg();
 // etc. If the args are there, you get them, if the arguments array is short, then you get undefined.
 // args.remaining() returns an iterator over the "rest" of the args (since "next_arg" won't tell if you've "gotten to the end")
-pub struct Arguments<'a> {
+pub struct FuncArgs<'a> {
     iterator: std::slice::Iter<'a, ECMAScriptValue>,
     count: usize,
 }
-impl<'a> From<&'a [ECMAScriptValue]> for Arguments<'a> {
+impl<'a> From<&'a [ECMAScriptValue]> for FuncArgs<'a> {
     fn from(source: &'a [ECMAScriptValue]) -> Self {
         let count = source.len();
         Self { iterator: source.iter(), count }
     }
 }
-impl<'a> Arguments<'a> {
+impl<'a> FuncArgs<'a> {
     pub fn next_arg(&mut self) -> ECMAScriptValue {
         self.iterator.next().cloned().unwrap_or(ECMAScriptValue::Undefined)
     }

--- a/src/function_object/tests.rs
+++ b/src/function_object/tests.rs
@@ -8,7 +8,7 @@ mod arguments {
     #[test]
     fn empty() {
         let arguments: &[ECMAScriptValue] = &[];
-        let mut args = Arguments::from(arguments);
+        let mut args = FuncArgs::from(arguments);
 
         assert_eq!(args.count(), 0);
         assert_eq!(args.next_arg(), ECMAScriptValue::Undefined);
@@ -17,7 +17,7 @@ mod arguments {
     #[test]
     fn list_of_two() {
         let arguments: &[ECMAScriptValue] = &[ECMAScriptValue::from(10), ECMAScriptValue::from(20)];
-        let mut args = Arguments::from(arguments);
+        let mut args = FuncArgs::from(arguments);
 
         assert_eq!(args.count(), 2);
         assert_eq!(args.next_arg(), ECMAScriptValue::from(10));
@@ -35,7 +35,7 @@ mod arguments {
             ECMAScriptValue::from(2),
             ECMAScriptValue::from(3),
         ];
-        let mut args = Arguments::from(arguments);
+        let mut args = FuncArgs::from(arguments);
 
         let first = args.next_arg();
         assert_eq!(first, ECMAScriptValue::from("first"));

--- a/src/number_object/mod.rs
+++ b/src/number_object/mod.rs
@@ -3,7 +3,7 @@ use super::comparison::is_integral_number;
 use super::cr::Completion;
 use super::dtoa_r::{dtoa, dtoa_fixed, dtoa_precise};
 use super::errors::{create_range_error, create_type_error};
-use super::function_object::{create_builtin_function, Arguments};
+use super::function_object::{create_builtin_function, FuncArgs};
 use super::object::{
     define_property_or_throw, ordinary_create_from_constructor, ordinary_define_own_property, ordinary_delete,
     ordinary_get, ordinary_get_own_property, ordinary_get_prototype_of, ordinary_has_property, ordinary_is_extensible,
@@ -444,7 +444,7 @@ fn number_constructor_function(
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let n = if args.count() >= 1 {
         let value = args.next_arg();
         let prim = to_numeric(agent, value)?;
@@ -484,7 +484,7 @@ fn number_is_finite(
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let number = args.next_arg();
     Ok(ECMAScriptValue::from(match number {
         ECMAScriptValue::Number(n) => n.is_finite(),
@@ -503,7 +503,7 @@ fn number_is_integer(
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let number = args.next_arg();
     Ok(ECMAScriptValue::from(is_integral_number(&number)))
 }
@@ -524,7 +524,7 @@ fn number_is_nan(
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let number = args.next_arg();
     Ok(ECMAScriptValue::from(match number {
         ECMAScriptValue::Number(n) => n.is_nan(),
@@ -545,7 +545,7 @@ fn number_is_safe_integer(
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let number = args.next_arg();
     Ok(ECMAScriptValue::from(match number {
         ECMAScriptValue::Number(n) => is_integral_number(&number) && n.abs() <= 9007199254740991.0,
@@ -640,7 +640,7 @@ fn number_prototype_to_exponential(
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let fraction_digits = args.next_arg();
 
     let value = this_number_value(agent, this_value)?;
@@ -750,7 +750,7 @@ fn number_prototype_to_fixed(
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let fraction_digits = args.next_arg();
     let value = this_number_value(agent, this_value)?;
     let fraction = to_integer_or_infinity(agent, fraction_digits)?;
@@ -883,7 +883,7 @@ fn number_prototype_to_precision(
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let precision = args.next_arg();
     let value = this_number_value(agent, this_value)?;
     if precision.is_undefined() {
@@ -1127,7 +1127,7 @@ fn number_prototype_to_string(
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let radix = args.next_arg();
     let x = this_number_value(agent, this_value)?;
     let radix_mv = if radix.is_undefined() { 10.0 } else { to_integer_or_infinity(agent, radix)? };

--- a/src/object_object/mod.rs
+++ b/src/object_object/mod.rs
@@ -1,7 +1,7 @@
 use crate::agent::{Agent, WksId};
 use crate::cr::Completion;
 use crate::errors::create_type_error;
-use crate::function_object::{create_builtin_function, Arguments};
+use crate::function_object::{create_builtin_function, FuncArgs};
 use crate::object::{
     create_array_from_list, define_property_or_throw, enumerable_own_property_names, get,
     ordinary_create_from_constructor, ordinary_object_create, set, set_integrity_level, to_property_descriptor,
@@ -277,7 +277,7 @@ fn object_constructor_function(
             }
         }
     }
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let value = args.next_arg();
     let obj = if value.is_null() || value.is_undefined() {
         ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[])
@@ -312,7 +312,7 @@ fn object_assign(
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let target = args.next_arg();
     let to = to_object(agent, target)?;
     for next_source in args.remaining() {
@@ -349,7 +349,7 @@ fn object_create(
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let o_arg = args.next_arg();
     let o = match o_arg {
         ECMAScriptValue::Object(o) => Some(o),
@@ -424,7 +424,7 @@ fn object_define_properties(
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let o_arg = args.next_arg();
     match o_arg {
         ECMAScriptValue::Object(o) => {
@@ -451,7 +451,7 @@ fn object_define_property(
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let o_arg = args.next_arg();
     match o_arg {
         ECMAScriptValue::Object(o) => {
@@ -484,7 +484,7 @@ fn object_entries(
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let o_arg = args.next_arg();
     let obj = to_object(agent, o_arg)?;
     let name_list = enumerable_own_property_names(agent, &obj, EnumerationStyle::KeyPlusValue)?;
@@ -507,7 +507,7 @@ fn object_freeze(
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let o_arg = args.next_arg();
     match o_arg {
         ECMAScriptValue::Object(o) => {

--- a/src/symbol_object/mod.rs
+++ b/src/symbol_object/mod.rs
@@ -426,7 +426,7 @@ fn symbol_constructor_function(
     if new_target.is_some() {
         Err(create_type_error(agent, "Symbol is not a constructor"))
     } else {
-        let mut args = Arguments::from(arguments);
+        let mut args = FuncArgs::from(arguments);
         let description = args.next_arg();
         let desc_string = match description {
             ECMAScriptValue::Undefined => None,
@@ -472,7 +472,7 @@ fn symbol_for(
     // +------------+----------+--------------------------------------------------+
     // | [[Symbol]] | a Symbol | A symbol that can be retrieved from any realm.   |
     // +------------+----------+--------------------------------------------------+
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let key = args.next_arg();
     let string_key = to_string(agent, key)?;
     let gsm = agent.global_symbol_registry();
@@ -507,7 +507,7 @@ fn symbol_key_for(
     //      a. If SameValue(e.[[Symbol]], sym) is true, return e.[[Key]].
     //  3. Assert: GlobalSymbolRegistry does not currently contain an entry for sym.
     //  4. Return undefined.
-    let mut args = Arguments::from(arguments);
+    let mut args = FuncArgs::from(arguments);
     let sym = args.next_arg();
     if let ECMAScriptValue::Symbol(sym) = sym {
         let gsm = agent.global_symbol_registry();


### PR DESCRIPTION
so that it doesn't name clash with the parse node structure of the same
name.