### PR TITLE
Touch up the env record tests so they don't require nightly

### DIFF
--- a/src/environment_record/mod.rs
+++ b/src/environment_record/mod.rs
@@ -124,6 +124,7 @@ pub trait EnvironmentRecord: Debug {
     fn get_this_binding(&self, _agent: &mut Agent) -> Completion<ECMAScriptValue> {
         unreachable!()
     }
+    fn name(&self) -> String;
 }
 
 // Declarative Environment Records
@@ -401,6 +402,10 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
     fn get_outer_env(&self) -> Option<Rc<dyn EnvironmentRecord>> {
         self.outer_env.as_ref().cloned()
     }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
 }
 
 impl DeclarativeEnvironmentRecord {
@@ -662,6 +667,10 @@ impl EnvironmentRecord for ObjectEnvironmentRecord {
     fn get_outer_env(&self) -> Option<Rc<dyn EnvironmentRecord>> {
         self.outer_env.as_ref().cloned()
     }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
 }
 
 impl ObjectEnvironmentRecord {
@@ -823,6 +832,10 @@ impl EnvironmentRecord for FunctionEnvironmentRecord {
         } else {
             Ok(self.this_value.clone())
         }
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
     }
 }
 
@@ -1241,6 +1254,10 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     //  1. Return envRec.[[GlobalThisValue]].
     fn get_this_binding(&self, _: &mut Agent) -> Completion<ECMAScriptValue> {
         Ok(ECMAScriptValue::from(self.global_this_value.clone()))
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
     }
 }
 

--- a/src/environment_record/tests.rs
+++ b/src/environment_record/tests.rs
@@ -1891,12 +1891,10 @@ mod get_identifier_reference {
         parent.create_immutable_binding(&mut agent, JSString::from("parent"), true).unwrap();
         parent.initialize_binding(&mut agent, &JSString::from("parent"), ECMAScriptValue::from("testing")).unwrap();
         let rcparent: Rc<dyn EnvironmentRecord> = Rc::new(parent);
-        let (rcparent_ptr, _) = Rc::as_ptr(&rcparent).to_raw_parts(); // Remove vtable for comparison
         let env = DeclarativeEnvironmentRecord::new(Some(Rc::clone(&rcparent)), "inner");
         env.create_immutable_binding(&mut agent, JSString::from("present"), true).unwrap();
         env.initialize_binding(&mut agent, &JSString::from("present"), ECMAScriptValue::from("testing")).unwrap();
         let rcenv: Rc<dyn EnvironmentRecord> = Rc::new(env);
-        let (rcenv_ptr, _) = Rc::as_ptr(&rcenv).to_raw_parts(); // Remove vtable for comparison
 
         let result =
             get_identifier_reference(&mut agent, Some(Rc::clone(&rcenv)), JSString::from(name), strict).unwrap();
@@ -1904,10 +1902,9 @@ mod get_identifier_reference {
             match &result.base {
                 Base::Unresolvable => EnvResult::Unresolvable,
                 Base::Environment(e) => {
-                    let (e_ptr, _) = Rc::as_ptr(e).to_raw_parts(); // Remove vtable for comparison
-                    if std::ptr::eq(e_ptr, rcenv_ptr) {
+                    if e.name() == "inner" {
                         EnvResult::SelfEnv
-                    } else if std::ptr::eq(e_ptr, rcparent_ptr) {
+                    } else if e.name() == "test" {
                         EnvResult::ParentEnv
                     } else {
                         panic!("Strange environment came back")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(ptr_metadata)]
 #![allow(dead_code)]
 #![allow(clippy::bool_assert_comparison)]
 #![allow(clippy::enum_variant_names)]


### PR DESCRIPTION
The "name" field got added after these tests were written; we can use
that to do the same things pointer matching was doing. This means I can
run on stable.

Which is nice, because nightly is giving me unrelated issues today.