### PR TITLE
Add a `bound_name` api for the productions with only one name

### DIFF
--- a/src/parser/async_function_definitions/mod.rs
+++ b/src/parser/async_function_definitions/mod.rs
@@ -101,9 +101,13 @@ impl AsyncFunctionDeclaration {
     }
 
     pub fn bound_names(&self) -> Vec<JSString> {
+        vec![self.bound_name()]
+    }
+
+    pub fn bound_name(&self) -> JSString {
         match &self.ident {
-            None => vec![JSString::from("*default*")],
-            Some(node) => node.bound_names(),
+            None => JSString::from("*default*"),
+            Some(node) => node.bound_name(),
         }
     }
 

--- a/src/parser/async_function_definitions/tests.rs
+++ b/src/parser/async_function_definitions/tests.rs
@@ -277,6 +277,12 @@ mod async_function_declaration {
     fn location(src: &str) -> Location {
         Maker::new(src).async_function_declaration().location()
     }
+
+    #[test_case("async function named() {}" => "named"; "named")]
+    #[test_case("async function (){}" => "*default*"; "unnamed")]
+    fn bound_name(src: &str) -> String {
+        Maker::new(src).async_function_declaration().bound_name().into()
+    }
 }
 
 // ASYNC FUNCTION EXPRESSION

--- a/src/parser/async_generator_function_definitions/mod.rs
+++ b/src/parser/async_generator_function_definitions/mod.rs
@@ -238,9 +238,13 @@ impl AsyncGeneratorDeclaration {
     }
 
     pub fn bound_names(&self) -> Vec<JSString> {
+        vec![self.bound_name()]
+    }
+
+    pub fn bound_name(&self) -> JSString {
         match &self.ident {
-            None => vec![JSString::from("*default*")],
-            Some(node) => node.bound_names(),
+            None => JSString::from("*default*"),
+            Some(node) => node.bound_name(),
         }
     }
 

--- a/src/parser/async_generator_function_definitions/tests.rs
+++ b/src/parser/async_generator_function_definitions/tests.rs
@@ -530,6 +530,12 @@ mod async_generator_declaration {
     fn location(src: &str) -> Location {
         Maker::new(src).async_generator_declaration().location()
     }
+
+    #[test_case("async function *named() {}" => "named"; "named")]
+    #[test_case("async function *(){}" => "*default*"; "unnamed")]
+    fn bound_name(src: &str) -> String {
+        Maker::new(src).async_generator_declaration().bound_name().into()
+    }
 }
 
 // ASYNC GENERATOR EXPRESSION

--- a/src/parser/class_definitions/mod.rs
+++ b/src/parser/class_definitions/mod.rs
@@ -92,9 +92,13 @@ impl ClassDeclaration {
     }
 
     pub fn bound_names(&self) -> Vec<JSString> {
+        vec![self.bound_name()]
+    }
+
+    pub fn bound_name(&self) -> JSString {
         match self {
-            ClassDeclaration::Named { ident, .. } => ident.bound_names(),
-            ClassDeclaration::Unnamed { .. } => vec![JSString::from("*default*")],
+            ClassDeclaration::Named { ident, .. } => ident.bound_name(),
+            ClassDeclaration::Unnamed { .. } => JSString::from("*default*"),
         }
     }
 

--- a/src/parser/class_definitions/tests.rs
+++ b/src/parser/class_definitions/tests.rs
@@ -155,6 +155,12 @@ mod class_declaration {
     fn location(src: &str) -> Location {
         Maker::new(src).class_declaration().location()
     }
+
+    #[test_case("class named {}" => "named"; "named")]
+    #[test_case("class {}" => "*default*"; "unnamed")]
+    fn bound_name(src: &str) -> String {
+        Maker::new(src).class_declaration().bound_name().into()
+    }
 }
 
 // CLASS EXPRESSION

--- a/src/parser/function_definitions/mod.rs
+++ b/src/parser/function_definitions/mod.rs
@@ -112,9 +112,13 @@ impl FunctionDeclaration {
     }
 
     pub fn bound_names(&self) -> Vec<JSString> {
+        vec![self.bound_name()]
+    }
+
+    pub fn bound_name(&self) -> JSString {
         match &self.ident {
-            None => vec![JSString::from("*default*")],
-            Some(node) => node.bound_names(),
+            None => JSString::from("*default*"),
+            Some(node) => node.bound_name(),
         }
     }
 

--- a/src/parser/function_definitions/tests.rs
+++ b/src/parser/function_definitions/tests.rs
@@ -236,6 +236,12 @@ mod function_declaration {
     fn location(src: &str) -> Location {
         Maker::new(src).function_declaration().location()
     }
+
+    #[test_case("function named() {}" => "named"; "named")]
+    #[test_case("function (){}" => "*default*"; "unnamed")]
+    fn bound_name(src: &str) -> String {
+        Maker::new(src).function_declaration().bound_name().into()
+    }
 }
 
 // FUNCTION EXPRESSION

--- a/src/parser/generator_function_definitions/mod.rs
+++ b/src/parser/generator_function_definitions/mod.rs
@@ -276,9 +276,13 @@ impl GeneratorDeclaration {
     }
 
     pub fn bound_names(&self) -> Vec<JSString> {
+        vec![self.bound_name()]
+    }
+
+    pub fn bound_name(&self) -> JSString {
         match &self.ident {
-            None => vec![JSString::from("*default*")],
-            Some(node) => node.bound_names(),
+            None => JSString::from("*default*"),
+            Some(node) => node.bound_name(),
         }
     }
 

--- a/src/parser/generator_function_definitions/tests.rs
+++ b/src/parser/generator_function_definitions/tests.rs
@@ -403,6 +403,12 @@ mod generator_declaration {
     fn location(src: &str) -> Location {
         Maker::new(src).generator_declaration().location()
     }
+
+    #[test_case("function *named() {}" => "named"; "named")]
+    #[test_case("function *(){}" => "*default*"; "unnamed")]
+    fn bound_name(src: &str) -> String {
+        Maker::new(src).generator_declaration().bound_name().into()
+    }
 }
 
 // GENERATOR EXPRESSION

--- a/src/parser/identifiers/mod.rs
+++ b/src/parser/identifiers/mod.rs
@@ -540,11 +540,15 @@ impl BindingIdentifier {
     }
 
     pub fn bound_names(&self) -> Vec<JSString> {
+        vec![self.bound_name()]
+    }
+
+    pub fn bound_name(&self) -> JSString {
         use BindingIdentifier::*;
         match self {
-            Identifier { identifier, .. } => vec![identifier.string_value()],
-            Yield { .. } => vec![JSString::from("yield")],
-            Await { .. } => vec![JSString::from("await")],
+            Identifier { identifier, .. } => identifier.string_value(),
+            Yield { .. } => JSString::from("yield"),
+            Await { .. } => JSString::from("await"),
         }
     }
 

--- a/src/parser/identifiers/tests.rs
+++ b/src/parser/identifiers/tests.rs
@@ -853,6 +853,13 @@ mod binding_identifier {
     fn location(src: &str) -> Location {
         Maker::new(src).yield_ok(false).await_ok(false).binding_identifier().location()
     }
+
+    #[test_case("named" => "named"; "named")]
+    #[test_case("yield" => "yield"; "yield kwd")]
+    #[test_case("await" => "await"; "await kwd")]
+    fn bound_name(src: &str) -> String {
+        Maker::new(src).yield_ok(false).await_ok(false).binding_identifier().bound_name().into()
+    }
 }
 
 // LABEL IDENTIFIER


### PR DESCRIPTION
Realized that in a number of places were were taking "the sole element
of `bound_names`". This was a bit silly. Why make a vector of names
only to immediately throw the vector part away? That's a wasted
allocation. So this change lets consumers of the one-name productions
actually just get that one name.