### PR TITLE
Put agents into Rc<RefCell<>> (effectively)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -3,7 +3,7 @@ use anyhow::anyhow;
 use itertools::Itertools;
 use num::pow::Pow;
 use num::{BigInt, BigUint, ToPrimitive, Zero};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::error;
@@ -28,19 +28,22 @@ use std::rc::Rc;
 // running execution context, the execution context stack, and the Agent Record's fields.
 
 #[derive(Debug)]
-pub struct Agent {
-    execution_context_stack: Vec<ExecutionContext>,
-    pub symbols: WellKnownSymbols,
-    obj_id: usize,
-    pub symbol_id: usize,
+struct AgentInternals {
+    execution_context_stack: RefCell<Vec<ExecutionContext>>,
+    symbols: WellKnownSymbols,
+    obj_id: Cell<usize>,
+    symbol_id: Cell<usize>,
     gsr: Rc<RefCell<SymbolRegistry>>,
 }
 
+#[derive(Debug)]
+pub struct Agent(Rc<AgentInternals>);
+
 impl Agent {
     pub fn new(gsr: Rc<RefCell<SymbolRegistry>>) -> Self {
-        Agent {
-            obj_id: 1,
-            execution_context_stack: vec![],
+        Agent(Rc::new(AgentInternals {
+            obj_id: Cell::new(1),
+            execution_context_stack: RefCell::new(vec![]),
             symbols: WellKnownSymbols {
                 async_iterator_: Symbol(Rc::new(SymbolInternals {
                     id: 1,
@@ -86,15 +89,16 @@ impl Agent {
                     description: Some(JSString::from("Symbol.unscopables")),
                 })),
             },
-            symbol_id: 14,
+            symbol_id: Cell::new(14),
             gsr,
-        }
+        }))
     }
 
     pub fn active_function_object(&self) -> Option<Object> {
-        match self.execution_context_stack.len() {
+        let stack = self.0.execution_context_stack.borrow();
+        match stack.len() {
             0 => None,
-            n => self.execution_context_stack[n - 1].function.clone(),
+            n => stack[n - 1].function.clone(),
         }
     }
 
@@ -111,7 +115,8 @@ impl Agent {
         //  1. If the execution context stack is empty, return null.
         //  2. Let ec be the topmost execution context on the execution context stack whose ScriptOrModule component is not null.
         //  3. If no such execution context exists, return null. Otherwise, return ec's ScriptOrModule.
-        for ec in self.execution_context_stack.iter() {
+        let stack = self.0.execution_context_stack.borrow();
+        for ec in stack.iter() {
             if let Some(script_or_module) = &ec.script_or_module {
                 return Some(script_or_module.clone());
             }
@@ -119,52 +124,56 @@ impl Agent {
         None
     }
 
-    pub fn next_object_id(&mut self) -> usize {
-        let result = self.obj_id;
+    pub fn next_object_id(&self) -> usize {
+        // Note: single threaded, so no worries about read-then-write trouble.
+        let result = self.0.obj_id.get();
         assert!(result < usize::MAX);
-        self.obj_id = result + 1;
+        self.0.obj_id.set(result + 1);
         result
     }
 
-    pub fn next_symbol_id(&mut self) -> usize {
-        assert!(self.symbol_id < usize::MAX);
-        let result = self.symbol_id;
-        self.symbol_id += 1;
+    pub fn next_symbol_id(&self) -> usize {
+        let result = self.0.symbol_id.get();
+        assert!(result < usize::MAX);
+        self.0.symbol_id.set(result + 1);
         result
     }
 
-    pub fn push_execution_context(&mut self, context: ExecutionContext) {
-        self.execution_context_stack.push(context)
+    pub fn push_execution_context(&self, context: ExecutionContext) {
+        self.0.execution_context_stack.borrow_mut().push(context)
     }
 
-    pub fn pop_execution_context(&mut self) {
-        self.execution_context_stack.pop();
+    pub fn pop_execution_context(&self) {
+        self.0.execution_context_stack.borrow_mut().pop();
     }
 
-    pub fn ec_push(&mut self, val: FullCompletion) {
-        let len = self.execution_context_stack.len();
+    pub fn ec_push(&self, val: FullCompletion) {
+        let mut ec_stack = self.0.execution_context_stack.borrow_mut();
+        let len = ec_stack.len();
         assert!(len > 0, "EC Push called with no active EC");
-        let ec = &mut self.execution_context_stack[len - 1];
+        let ec = &mut ec_stack[len - 1];
         ec.stack.push(val);
     }
 
-    pub fn ec_pop(&mut self) -> Option<FullCompletion> {
-        let len = self.execution_context_stack.len();
+    pub fn ec_pop(&self) -> Option<FullCompletion> {
+        let mut execution_context_stack = self.0.execution_context_stack.borrow_mut();
+        let len = execution_context_stack.len();
         match len {
             0 => None,
             _ => {
-                let ec = &mut self.execution_context_stack[len - 1];
+                let ec = &mut execution_context_stack[len - 1];
                 ec.stack.pop()
             }
         }
     }
 
     pub fn ec_stack_len(&self) -> usize {
-        let len = self.execution_context_stack.len();
+        let execution_context_stack = self.0.execution_context_stack.borrow();
+        let len = execution_context_stack.len();
         match len {
             0 => 0,
             _ => {
-                let ec = &self.execution_context_stack[len - 1];
+                let ec = &execution_context_stack[len - 1];
                 ec.stack.len()
             }
         }
@@ -172,65 +181,71 @@ impl Agent {
 
     pub fn wks(&self, sym_id: WksId) -> Symbol {
         match sym_id {
-            WksId::AsyncIterator => &self.symbols.async_iterator_,
-            WksId::HasInstance => &self.symbols.has_instance_,
-            WksId::IsConcatSpreadable => &self.symbols.is_concat_spreadable_,
-            WksId::Iterator => &self.symbols.iterator_,
-            WksId::Match => &self.symbols.match_,
-            WksId::MatchAll => &self.symbols.match_all_,
-            WksId::Replace => &self.symbols.replace_,
-            WksId::Search => &self.symbols.search_,
-            WksId::Species => &self.symbols.species_,
-            WksId::Split => &self.symbols.split_,
-            WksId::ToPrimitive => &self.symbols.to_primitive_,
-            WksId::ToStringTag => &self.symbols.to_string_tag_,
-            WksId::Unscopables => &self.symbols.unscopables_,
+            WksId::AsyncIterator => &self.0.symbols.async_iterator_,
+            WksId::HasInstance => &self.0.symbols.has_instance_,
+            WksId::IsConcatSpreadable => &self.0.symbols.is_concat_spreadable_,
+            WksId::Iterator => &self.0.symbols.iterator_,
+            WksId::Match => &self.0.symbols.match_,
+            WksId::MatchAll => &self.0.symbols.match_all_,
+            WksId::Replace => &self.0.symbols.replace_,
+            WksId::Search => &self.0.symbols.search_,
+            WksId::Species => &self.0.symbols.species_,
+            WksId::Split => &self.0.symbols.split_,
+            WksId::ToPrimitive => &self.0.symbols.to_primitive_,
+            WksId::ToStringTag => &self.0.symbols.to_string_tag_,
+            WksId::Unscopables => &self.0.symbols.unscopables_,
         }
         .clone()
     }
 
     pub fn current_realm_record(&self) -> Option<Rc<RefCell<Realm>>> {
-        match self.execution_context_stack.len() {
+        let execution_context_stack = self.0.execution_context_stack.borrow();
+        match execution_context_stack.len() {
             0 => None,
-            n => Some(self.execution_context_stack[n - 1].realm.clone()),
+            n => Some(execution_context_stack[n - 1].realm.clone()),
         }
     }
 
     pub fn current_lexical_environment(&self) -> Option<Rc<dyn EnvironmentRecord>> {
-        match self.execution_context_stack.len() {
+        let execution_context_stack = self.0.execution_context_stack.borrow();
+        match execution_context_stack.len() {
             0 => None,
-            n => self.execution_context_stack[n - 1].lexical_environment.clone(),
+            n => execution_context_stack[n - 1].lexical_environment.clone(),
         }
     }
 
     pub fn current_variable_environment(&self) -> Option<Rc<dyn EnvironmentRecord>> {
-        match self.execution_context_stack.len() {
+        let execution_context_stack = self.0.execution_context_stack.borrow();
+        match execution_context_stack.len() {
             0 => None,
-            n => self.execution_context_stack[n - 1].variable_environment.clone(),
+            n => execution_context_stack[n - 1].variable_environment.clone(),
         }
     }
 
     pub fn current_private_environment(&self) -> Option<Rc<RefCell<PrivateEnvironmentRecord>>> {
-        match self.execution_context_stack.len() {
+        let execution_context_stack = self.0.execution_context_stack.borrow();
+        match execution_context_stack.len() {
             0 => None,
-            n => self.execution_context_stack[n - 1].private_environment.clone(),
+            n => execution_context_stack[n - 1].private_environment.clone(),
         }
     }
 
-    pub fn set_lexical_environment(&mut self, env: Option<Rc<dyn EnvironmentRecord>>) {
-        match self.execution_context_stack.len() {
+    pub fn set_lexical_environment(&self, env: Option<Rc<dyn EnvironmentRecord>>) {
+        let mut execution_context_stack = self.0.execution_context_stack.borrow_mut();
+        match execution_context_stack.len() {
             0 => (),
             n => {
-                self.execution_context_stack[n - 1].lexical_environment = env;
+                execution_context_stack[n - 1].lexical_environment = env;
             }
         }
     }
 
-    pub fn set_variable_environment(&mut self, env: Option<Rc<dyn EnvironmentRecord>>) {
-        match self.execution_context_stack.len() {
+    pub fn set_variable_environment(&self, env: Option<Rc<dyn EnvironmentRecord>>) {
+        let mut execution_context_stack = self.0.execution_context_stack.borrow_mut();
+        match execution_context_stack.len() {
             0 => (),
             n => {
-                self.execution_context_stack[n - 1].variable_environment = env;
+                execution_context_stack[n - 1].variable_environment = env;
             }
         }
     }
@@ -255,7 +270,7 @@ impl Agent {
     //  5. Let newGlobalEnv be NewGlobalEnvironment(globalObj, thisValue).
     //  6. Set realmRec.[[GlobalEnv]] to newGlobalEnv.
     //  7. Return realmRec.
-    pub fn set_realm_global_object(&mut self, global_obj: Option<Object>, this_value: Option<Object>) {
+    pub fn set_realm_global_object(&self, global_obj: Option<Object>, this_value: Option<Object>) {
         let go = global_obj.unwrap_or_else(|| {
             let object_proto = self.intrinsic(IntrinsicId::ObjectPrototype);
             ordinary_object_create(self, Some(object_proto), &[])
@@ -282,7 +297,7 @@ impl Agent {
     //         attribute is the corresponding intrinsic object from realmRec.
     //      c. Perform ? DefinePropertyOrThrow(global, name, desc).
     //  3. Return global.
-    pub fn set_default_global_bindings(&mut self) {
+    pub fn set_default_global_bindings(&self) {
         let global = get_global_object(self).unwrap();
 
         //////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -438,7 +453,7 @@ impl Agent {
     //  10. Let globalObj be ? SetDefaultGlobalBindings(realm).
     //  11. Create any host-defined global object properties on globalObj.
     //  12. Return NormalCompletion(empty).
-    pub fn initialize_host_defined_realm(&mut self, install_test_hooks: bool) {
+    pub fn initialize_host_defined_realm(&self, install_test_hooks: bool) {
         let realm = create_realm(self);
         let new_context = ExecutionContext::new(None, realm, None);
         self.push_execution_context(new_context);
@@ -466,44 +481,48 @@ impl Agent {
     }
 
     pub fn global_symbol_registry(&self) -> Rc<RefCell<SymbolRegistry>> {
-        self.gsr.clone()
+        self.0.gsr.clone()
     }
 
-    pub fn evaluate(&mut self, chunk: Rc<Chunk>, text: &str) -> Completion<ECMAScriptValue> {
-        if self.execution_context_stack.is_empty() {
+    pub fn evaluate(&self, chunk: Rc<Chunk>, text: &str) -> Completion<ECMAScriptValue> {
+        if self.0.execution_context_stack.borrow().is_empty() {
             return Err(create_type_error(self, "No active execution context"));
         }
 
         self.prepare_running_ec_for_execution(chunk);
         let result = self.execute(text);
 
-        let ec_idx = self.execution_context_stack.len() - 1;
-        assert!(self.execution_context_stack[ec_idx].stack.is_empty());
+        {
+            let execution_context_stack = self.0.execution_context_stack.borrow();
+            let ec_idx = execution_context_stack.len() - 1;
+            assert!(execution_context_stack[ec_idx].stack.is_empty());
+        }
 
         result
     }
 
-    pub fn prepare_running_ec_for_execution(&mut self, chunk: Rc<Chunk>) {
-        assert!(!self.execution_context_stack.is_empty());
-        let index = self.execution_context_stack.len() - 1;
+    pub fn prepare_running_ec_for_execution(&self, chunk: Rc<Chunk>) {
+        assert!(!self.0.execution_context_stack.borrow().is_empty());
+        let index = self.0.execution_context_stack.borrow().len() - 1;
         self.prepare_for_execution(index, chunk);
     }
 
-    pub fn prepare_for_execution(&mut self, index: usize, chunk: Rc<Chunk>) {
-        self.execution_context_stack[index].chunk = Some(chunk);
-        self.execution_context_stack[index].pc = 0;
+    pub fn prepare_for_execution(&self, index: usize, chunk: Rc<Chunk>) {
+        let mut execution_context_stack = self.0.execution_context_stack.borrow_mut();
+        execution_context_stack[index].chunk = Some(chunk);
+        execution_context_stack[index].pc = 0;
     }
 
-    pub fn execute(&mut self, text: &str) -> Completion<ECMAScriptValue> {
+    pub fn execute(&self, text: &str) -> Completion<ECMAScriptValue> {
         // If our ec index drops below this, we exit.
-        let initial_context_index = self.execution_context_stack.len() - 1;
+        let initial_context_index = self.0.execution_context_stack.borrow().len() - 1;
         loop {
-            let index = self.execution_context_stack.len() - 1;
+            let index = self.0.execution_context_stack.borrow().len() - 1;
             /* Diagnostics */
             print!("Stack: [ ");
             print!(
                 "{}",
-                self.execution_context_stack[index]
+                self.0.execution_context_stack.borrow()[index]
                     .stack
                     .iter()
                     .rev()
@@ -519,21 +538,21 @@ impl Agent {
                 break;
             }
 
-            let chunk = match self.execution_context_stack[index].chunk.clone() {
+            let chunk = match self.0.execution_context_stack.borrow()[index].chunk.clone() {
                 Some(r) => Ok(r),
                 None => Err(create_type_error(self, "No compiled units!")),
             }?;
 
-            if self.execution_context_stack[index].pc >= chunk.opcodes.len() {
+            if self.0.execution_context_stack.borrow()[index].pc >= chunk.opcodes.len() {
                 break;
             }
-            let (_, repr) = chunk.insn_repr_at(self.execution_context_stack[index].pc as usize);
-            println!("{:04}{}", self.execution_context_stack[index].pc, repr);
+            let (_, repr) = chunk.insn_repr_at(self.0.execution_context_stack.borrow()[index].pc as usize);
+            println!("{:04}{}", self.0.execution_context_stack.borrow()[index].pc, repr);
 
             /* Real work */
-            let icode = chunk.opcodes[self.execution_context_stack[index].pc as usize]; // in range due to while condition
+            let icode = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize]; // in range due to while condition
             let instruction = Insn::try_from(icode).unwrap(); // failure is a coding error (the compiler broke)
-            self.execution_context_stack[index].pc += 1;
+            self.0.execution_context_stack.borrow_mut()[index].pc += 1;
             match instruction {
                 Insn::Nop => {
                     // Do nothing
@@ -543,92 +562,97 @@ impl Agent {
                     todo!()
                 }
                 Insn::String => {
-                    let string_index = chunk.opcodes[self.execution_context_stack[index].pc as usize]; // failure is a coding error (the compiler broke)
-                    self.execution_context_stack[index].pc += 1;
+                    let string_index = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize]; // failure is a coding error (the compiler broke)
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let string = &chunk.strings[string_index as usize];
-                    self.execution_context_stack[index].stack.push(Ok(string.into()));
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(string.into()));
                 }
-                Insn::Null => self.execution_context_stack[index].stack.push(Ok(ECMAScriptValue::Null.into())),
-                Insn::True => self.execution_context_stack[index].stack.push(Ok(true.into())),
-                Insn::False => self.execution_context_stack[index].stack.push(Ok(false.into())),
-                Insn::Empty => self.execution_context_stack[index].stack.push(Ok(NormalCompletion::Empty)),
+                Insn::Null => {
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(ECMAScriptValue::Null.into()))
+                }
+                Insn::True => self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(true.into())),
+                Insn::False => self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(false.into())),
+                Insn::Empty => {
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(NormalCompletion::Empty))
+                }
                 Insn::Undefined => {
-                    self.execution_context_stack[index].stack.push(Ok(ECMAScriptValue::Undefined.into()))
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(ECMAScriptValue::Undefined.into()))
                 }
                 Insn::This => {
                     let this_resolved = self.resolve_this_binding().map(NormalCompletion::from);
-                    self.execution_context_stack[index].stack.push(this_resolved);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(this_resolved);
                 }
                 Insn::Resolve => {
-                    let name = match self.execution_context_stack[index].stack.pop().unwrap().unwrap() {
+                    let name = match self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap() {
                         NormalCompletion::Value(ECMAScriptValue::String(s)) => s,
                         _ => unreachable!(),
                     };
                     let resolved = self.resolve_binding(&name, None, false);
-                    self.execution_context_stack[index].stack.push(resolved);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(resolved);
                 }
                 Insn::StrictResolve => {
-                    let name = match self.execution_context_stack[index].stack.pop().unwrap().unwrap() {
+                    let name = match self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap() {
                         NormalCompletion::Value(ECMAScriptValue::String(s)) => s,
                         _ => unreachable!(),
                     };
                     let resolved = self.resolve_binding(&name, None, true);
-                    self.execution_context_stack[index].stack.push(resolved);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(resolved);
                 }
                 Insn::Float => {
-                    let float_index = chunk.opcodes[self.execution_context_stack[index].pc as usize];
-                    self.execution_context_stack[index].pc += 1;
+                    let float_index = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize];
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let number = chunk.floats[float_index as usize];
-                    self.execution_context_stack[index].stack.push(Ok(number.into()));
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(number.into()));
                 }
                 Insn::Bigint => {
-                    let bigint_index = chunk.opcodes[self.execution_context_stack[index].pc as usize];
-                    self.execution_context_stack[index].pc += 1;
+                    let bigint_index = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize];
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let number = Rc::clone(&chunk.bigints[bigint_index as usize]);
-                    self.execution_context_stack[index].stack.push(Ok(number.into()));
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(number.into()));
                 }
                 Insn::GetValue => {
-                    let reference = self.execution_context_stack[index].stack.pop().unwrap();
+                    let reference = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap();
                     let value = get_value(self, reference);
-                    self.execution_context_stack[index].stack.push(value.map(NormalCompletion::from));
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(value.map(NormalCompletion::from));
                 }
                 Insn::PutValue => {
-                    let w = self.execution_context_stack[index].stack.pop().unwrap();
-                    let v = self.execution_context_stack[index].stack.pop().unwrap();
+                    let w = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap();
+                    let v = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap();
                     let result = put_value(self, v, w.map(|v| v.try_into().unwrap()));
-                    self.execution_context_stack[index].stack.push(result.map(NormalCompletion::from));
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result.map(NormalCompletion::from));
                 }
                 Insn::JumpIfAbrupt => {
-                    let jump = chunk.opcodes[self.execution_context_stack[index].pc as usize] as i16;
-                    self.execution_context_stack[index].pc += 1;
-                    let stack_idx = self.execution_context_stack[index].stack.len() - 1;
-                    if self.execution_context_stack[index].stack[stack_idx].is_err() {
+                    let jump = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize] as i16;
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
+                    let stack_idx = self.0.execution_context_stack.borrow()[index].stack.len() - 1;
+                    if self.0.execution_context_stack.borrow()[index].stack[stack_idx].is_err() {
                         if jump >= 0 {
-                            self.execution_context_stack[index].pc += jump as usize;
+                            self.0.execution_context_stack.borrow_mut()[index].pc += jump as usize;
                         } else {
-                            self.execution_context_stack[index].pc -= (-jump) as usize;
+                            self.0.execution_context_stack.borrow_mut()[index].pc -= (-jump) as usize;
                         }
                     }
                 }
                 Insn::JumpIfNormal => {
-                    let jump = chunk.opcodes[self.execution_context_stack[index].pc as usize] as i16;
-                    self.execution_context_stack[index].pc += 1;
-                    let stack_idx = self.execution_context_stack[index].stack.len() - 1;
-                    if self.execution_context_stack[index].stack[stack_idx].is_ok() {
+                    let jump = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize] as i16;
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
+                    let stack_idx = self.0.execution_context_stack.borrow()[index].stack.len() - 1;
+                    if self.0.execution_context_stack.borrow()[index].stack[stack_idx].is_ok() {
                         if jump >= 0 {
-                            self.execution_context_stack[index].pc += jump as usize;
+                            self.0.execution_context_stack.borrow_mut()[index].pc += jump as usize;
                         } else {
-                            self.execution_context_stack[index].pc -= (-jump) as usize;
+                            self.0.execution_context_stack.borrow_mut()[index].pc -= (-jump) as usize;
                         }
                     }
                 }
                 Insn::JumpIfFalse | Insn::JumpIfTrue => {
-                    let jump = chunk.opcodes[self.execution_context_stack[index].pc as usize] as i16;
-                    self.execution_context_stack[index].pc += 1;
-                    let stack_idx = self.execution_context_stack[index].stack.len() - 1;
+                    let mut execution_context = &mut self.0.execution_context_stack.borrow_mut()[index];
+                    let jump = chunk.opcodes[execution_context.pc as usize] as i16;
+                    execution_context.pc += 1;
+                    let stack_idx = execution_context.stack.len() - 1;
                     let bool_val = bool::from(
                         ECMAScriptValue::try_from(
-                            self.execution_context_stack[index].stack[stack_idx]
+                            execution_context.stack[stack_idx]
                                 .clone()
                                 .expect("Boolean Jumps may only be used with Normal completions"),
                         )
@@ -637,19 +661,19 @@ impl Agent {
                     if (instruction == Insn::JumpIfFalse && !bool_val) || (instruction == Insn::JumpIfTrue && bool_val)
                     {
                         if jump >= 0 {
-                            self.execution_context_stack[index].pc += jump as usize;
+                            execution_context.pc += jump as usize;
                         } else {
-                            self.execution_context_stack[index].pc -= (-jump) as usize;
+                            execution_context.pc -= (-jump) as usize;
                         }
                     }
                 }
                 Insn::JumpPopIfFalse | Insn::JumpPopIfTrue => {
-                    let jump = chunk.opcodes[self.execution_context_stack[index].pc as usize] as i16;
-                    self.execution_context_stack[index].pc += 1;
+                    let mut ec = &mut self.0.execution_context_stack.borrow_mut()[index];
+                    let jump = chunk.opcodes[ec.pc as usize] as i16;
+                    ec.pc += 1;
                     let bool_val = bool::from(
                         ECMAScriptValue::try_from(
-                            self.execution_context_stack[index]
-                                .stack
+                            ec.stack
                                 .pop()
                                 .expect("JumpPop must have an argument")
                                 .expect("Boolean Jumps may only be used with Normal completions"),
@@ -660,139 +684,145 @@ impl Agent {
                         || (instruction == Insn::JumpPopIfTrue && bool_val)
                     {
                         if jump >= 0 {
-                            self.execution_context_stack[index].pc += jump as usize;
+                            ec.pc += jump as usize;
                         } else {
-                            self.execution_context_stack[index].pc -= (-jump) as usize;
+                            ec.pc -= (-jump) as usize;
                         }
                     }
                 }
                 Insn::JumpIfNotNullish => {
-                    let jump = chunk.opcodes[self.execution_context_stack[index].pc as usize] as i16;
-                    self.execution_context_stack[index].pc += 1;
-                    let stack_idx = self.execution_context_stack[index].stack.len() - 1;
+                    let mut ec = &mut self.0.execution_context_stack.borrow_mut()[index];
+                    let jump = chunk.opcodes[ec.pc as usize] as i16;
+                    ec.pc += 1;
+                    let stack_idx = ec.stack.len() - 1;
                     let val = ECMAScriptValue::try_from(
-                        self.execution_context_stack[index].stack[stack_idx]
-                            .clone()
-                            .expect("Nullish Jumps may only be used with Normal completions"),
+                        ec.stack[stack_idx].clone().expect("Nullish Jumps may only be used with Normal completions"),
                     )
                     .expect("Nullish Jumps may only be used with Values");
                     if val != ECMAScriptValue::Undefined && val != ECMAScriptValue::Null {
                         if jump >= 0 {
-                            self.execution_context_stack[index].pc += jump as usize;
+                            ec.pc += jump as usize;
                         } else {
-                            self.execution_context_stack[index].pc -= (-jump) as usize;
+                            ec.pc -= (-jump) as usize;
                         }
                     }
                 }
                 Insn::JumpIfNotUndef => {
-                    let jump = chunk.opcodes[self.execution_context_stack[index].pc as usize] as i16;
-                    self.execution_context_stack[index].pc += 1;
-                    let stack_idx = self.execution_context_stack[index].stack.len() - 1;
+                    let mut ec = &mut self.0.execution_context_stack.borrow_mut()[index];
+                    let jump = chunk.opcodes[ec.pc as usize] as i16;
+                    ec.pc += 1;
+                    let stack_idx = ec.stack.len() - 1;
                     let val = ECMAScriptValue::try_from(
-                        self.execution_context_stack[index].stack[stack_idx]
-                            .clone()
-                            .expect("Undef Jumps may only be used with Normal completions"),
+                        ec.stack[stack_idx].clone().expect("Undef Jumps may only be used with Normal completions"),
                     )
                     .expect("Undef Jumps may only be used with Values");
                     if val != ECMAScriptValue::Undefined {
                         if jump >= 0 {
-                            self.execution_context_stack[index].pc += jump as usize;
+                            ec.pc += jump as usize;
                         } else {
-                            self.execution_context_stack[index].pc -= (-jump) as usize;
+                            ec.pc -= (-jump) as usize;
                         }
                     }
                 }
                 Insn::JumpNotThrow => {
-                    let jump = chunk.opcodes[self.execution_context_stack[index].pc as usize] as i16;
-                    self.execution_context_stack[index].pc += 1;
-                    let stack_idx = self.execution_context_stack[index].stack.len() - 1;
-                    let completion = &self.execution_context_stack[index].stack[stack_idx];
+                    let mut ec = &mut self.0.execution_context_stack.borrow_mut()[index];
+                    let jump = chunk.opcodes[ec.pc as usize] as i16;
+                    ec.pc += 1;
+                    let stack_idx = ec.stack.len() - 1;
+                    let completion = &ec.stack[stack_idx];
 
                     if !matches!(completion, Err(AbruptCompletion::Throw { .. })) {
                         if jump >= 0 {
-                            self.execution_context_stack[index].pc += jump as usize;
+                            ec.pc += jump as usize;
                         } else {
-                            self.execution_context_stack[index].pc -= (-jump) as usize;
+                            ec.pc -= (-jump) as usize;
                         }
                     }
                 }
                 Insn::Jump => {
-                    let jump = chunk.opcodes[self.execution_context_stack[index].pc as usize] as i16;
-                    self.execution_context_stack[index].pc += 1;
+                    let mut ec = &mut self.0.execution_context_stack.borrow_mut()[index];
+                    let jump = chunk.opcodes[ec.pc as usize] as i16;
+                    ec.pc += 1;
                     if jump >= 0 {
-                        self.execution_context_stack[index].pc += jump as usize;
+                        ec.pc += jump as usize;
                     } else {
-                        self.execution_context_stack[index].pc -= (-jump) as usize;
+                        ec.pc -= (-jump) as usize;
                     }
                 }
                 Insn::UpdateEmpty => {
-                    let newer = self.execution_context_stack[index].stack.pop().unwrap();
-                    let older = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
-                    self.execution_context_stack[index].stack.push(update_empty(newer, older));
+                    let ec = &mut self.0.execution_context_stack.borrow_mut()[index];
+                    let newer = ec.stack.pop().unwrap();
+                    let older = ec.stack.pop().unwrap().unwrap();
+                    ec.stack.push(update_empty(newer, older));
                 }
                 Insn::Pop2Push3 => {
+                    let ec = &mut self.0.execution_context_stack.borrow_mut()[index];
                     // Stack: top lower ====> top lower top
-                    let top = self.execution_context_stack[index].stack.pop().unwrap();
-                    let lower = self.execution_context_stack[index].stack.pop().unwrap();
+                    let top = ec.stack.pop().unwrap();
+                    let lower = ec.stack.pop().unwrap();
                     let bottom = top.clone();
-                    self.execution_context_stack[index].stack.push(bottom);
-                    self.execution_context_stack[index].stack.push(lower);
-                    self.execution_context_stack[index].stack.push(top);
+                    ec.stack.push(bottom);
+                    ec.stack.push(lower);
+                    ec.stack.push(top);
                 }
                 Insn::Ref | Insn::StrictRef => {
+                    let ec = &mut self.0.execution_context_stack.borrow_mut()[index];
                     let strict = instruction == Insn::StrictRef;
                     // Stack: name base ...
                     let name = {
-                        let result: Result<ECMAScriptValue, _> =
-                            self.execution_context_stack[index].stack.pop().unwrap().unwrap().try_into();
+                        let result: Result<ECMAScriptValue, _> = ec.stack.pop().unwrap().unwrap().try_into();
                         let value: Result<PropertyKey, _> = result.unwrap().try_into();
                         value.unwrap()
                     };
                     // Stack: base ...
                     let base = {
-                        let result: Result<ECMAScriptValue, _> =
-                            self.execution_context_stack[index].stack.pop().unwrap().unwrap().try_into();
+                        let result: Result<ECMAScriptValue, _> = ec.stack.pop().unwrap().unwrap().try_into();
                         result.unwrap()
                     };
                     // Stack: ...
                     let reference = Reference::new(Base::Value(base), name, strict, None);
                     let result = Ok(NormalCompletion::from(reference));
-                    self.execution_context_stack[index].stack.push(result);
+                    ec.stack.push(result);
                     // Stack: ref ...
                 }
                 Insn::Pop => {
-                    let stack_size = self.execution_context_stack[index].stack.len();
+                    let ec = &mut self.0.execution_context_stack.borrow_mut()[index];
+                    let stack_size = ec.stack.len();
                     assert!(stack_size > 0);
-                    self.execution_context_stack[index].stack.truncate(stack_size - 1);
+                    ec.stack.truncate(stack_size - 1);
                 }
                 Insn::Swap => {
-                    let stack_size = self.execution_context_stack[index].stack.len();
+                    let ec = &mut self.0.execution_context_stack.borrow_mut()[index];
+                    let stack_size = ec.stack.len();
                     assert!(stack_size >= 2);
-                    self.execution_context_stack[index].stack.swap(stack_size - 1, stack_size - 2);
+                    ec.stack.swap(stack_size - 1, stack_size - 2);
                 }
                 Insn::SwapList => {
-                    let stack_size = self.execution_context_stack[index].stack.len();
+                    let ec = &mut self.0.execution_context_stack.borrow_mut()[index];
+                    let stack_size = ec.stack.len();
                     assert!(stack_size >= 2);
                     let list_len = f64::try_from(
                         ECMAScriptValue::try_from(
-                            self.execution_context_stack[index].stack[stack_size - 1]
-                                .clone()
-                                .expect("Top of stack must contain a list"),
+                            ec.stack[stack_size - 1].clone().expect("Top of stack must contain a list"),
                         )
                         .expect("Top of stack must contain a list"),
                     )
                     .expect("Top of stack must contain a list") as usize;
-                    let item = self.execution_context_stack[index].stack.remove(stack_size - list_len - 2);
-                    self.execution_context_stack[index].stack.push(item);
+                    let item = ec.stack.remove(stack_size - list_len - 2);
+                    ec.stack.push(item);
                 }
                 Insn::InitializeReferencedBinding => {
-                    let stack_size = self.execution_context_stack[index].stack.len();
-                    assert!(stack_size >= 2);
-                    let value = self.execution_context_stack[index].stack.pop().unwrap();
-                    let lhs = self.execution_context_stack[index].stack.pop().unwrap();
+                    let (value, lhs) = {
+                        let ec = &mut self.0.execution_context_stack.borrow_mut()[index];
+                        let stack_size = ec.stack.len();
+                        assert!(stack_size >= 2);
+                        let value = ec.stack.pop().unwrap();
+                        let lhs = ec.stack.pop().unwrap();
+                        (value, lhs)
+                    };
                     let result = initialize_referenced_binding(self, lhs, value.map(|nc| nc.try_into().unwrap()))
                         .map(NormalCompletion::from);
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::PushNewLexEnv => {
                     let current_env = self.current_lexical_environment();
@@ -821,8 +851,8 @@ impl Agent {
 
                 Insn::CreateStrictImmutableLexBinding | Insn::CreateNonStrictImmutableLexBinding => {
                     let env = self.current_lexical_environment().expect("lex environment must exist");
-                    let string_idx = chunk.opcodes[self.execution_context_stack[index].pc as usize] as usize;
-                    self.execution_context_stack[index].pc += 1;
+                    let string_idx = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize] as usize;
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let name = chunk.strings[string_idx].clone();
 
                     env.create_immutable_binding(self, name, instruction == Insn::CreateStrictImmutableLexBinding)
@@ -834,8 +864,8 @@ impl Agent {
                     } else {
                         self.current_variable_environment().expect("var environment must exist")
                     };
-                    let string_idx = chunk.opcodes[self.execution_context_stack[index].pc as usize] as usize;
-                    self.execution_context_stack[index].pc += 1;
+                    let string_idx = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize] as usize;
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let name = chunk.strings[string_idx].clone();
 
                     env.create_mutable_binding(self, name, false).expect("binding should not already exist");
@@ -845,8 +875,8 @@ impl Agent {
                     //  2. If alreadyDeclared is false, then
                     //        a. Perform ! env.CreateMutableBinding(paramName, false).
                     let env = self.current_lexical_environment().expect("lex environment must exist");
-                    let string_idx = chunk.opcodes[self.execution_context_stack[index].pc as usize] as usize;
-                    self.execution_context_stack[index].pc += 1;
+                    let string_idx = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize] as usize;
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let name = &chunk.strings[string_idx];
 
                     let already_declared = env.has_binding(self, name).expect("basic environments can't fail this");
@@ -860,8 +890,8 @@ impl Agent {
                     //      a. Perform ! env.CreateMutableBinding(paramName, false).
                     //      b. Perform ! env.InitializeBinding(paramName, undefined).
                     let env = self.current_lexical_environment().expect("lex environment must exist");
-                    let string_idx = chunk.opcodes[self.execution_context_stack[index].pc as usize] as usize;
-                    self.execution_context_stack[index].pc += 1;
+                    let string_idx = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize] as usize;
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let name = &chunk.strings[string_idx];
 
                     let already_declared = env.has_binding(self, name).expect("basic environments can't fail this");
@@ -877,12 +907,12 @@ impl Agent {
                     } else {
                         self.current_variable_environment().expect("var environment must exist")
                     };
-                    let string_idx = chunk.opcodes[self.execution_context_stack[index].pc as usize] as usize;
-                    self.execution_context_stack[index].pc += 1;
+                    let string_idx = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize] as usize;
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let name = &chunk.strings[string_idx];
 
                     let value = ECMAScriptValue::try_from(
-                        self.execution_context_stack[index]
+                        self.0.execution_context_stack.borrow_mut()[index]
                             .stack
                             .pop()
                             .expect("InitializeLexBinding must have a stack arg")
@@ -893,19 +923,19 @@ impl Agent {
                 }
                 Insn::GetLexBinding => {
                     let env = self.current_lexical_environment().expect("lex environment must exist");
-                    let string_idx = chunk.opcodes[self.execution_context_stack[index].pc as usize] as usize;
-                    self.execution_context_stack[index].pc += 1;
+                    let string_idx = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize] as usize;
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let name = &chunk.strings[string_idx];
                     let value = env.get_binding_value(self, name, false).expect("Binding will be there");
-                    self.execution_context_stack[index].stack.push(Ok(NormalCompletion::from(value)));
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(NormalCompletion::from(value)));
                 }
                 Insn::SetMutableVarBinding => {
                     let env = self.current_variable_environment().expect("var environment must exist");
-                    let string_idx = chunk.opcodes[self.execution_context_stack[index].pc as usize] as usize;
-                    self.execution_context_stack[index].pc += 1;
+                    let string_idx = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize] as usize;
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let name = &chunk.strings[string_idx];
                     let value = ECMAScriptValue::try_from(
-                        self.execution_context_stack[index]
+                        self.0.execution_context_stack.borrow_mut()[index]
                             .stack
                             .pop()
                             .expect("SetMutableVarBinding must have a stack arg")
@@ -915,53 +945,50 @@ impl Agent {
                     env.set_mutable_binding(self, name.clone(), value, false).expect("error free execution");
                 }
                 Insn::ExtractThrownValue => {
-                    let stack_idx = self.execution_context_stack[index].stack.len() - 1;
-                    let completion = &self.execution_context_stack[index].stack[stack_idx];
+                    let stack_idx = self.0.execution_context_stack.borrow()[index].stack.len() - 1;
+                    let completion = &self.0.execution_context_stack.borrow()[index].stack[stack_idx];
                     match completion.as_ref().unwrap_err() {
                         AbruptCompletion::Throw { value } => {
-                            self.execution_context_stack[index].stack[stack_idx] = Ok(value.clone().into())
+                            self.0.execution_context_stack.borrow_mut()[index].stack[stack_idx] =
+                                Ok(value.clone().into())
                         }
                         _ => panic!("Bad error type for ExtractThrownValue"),
                     }
                 }
                 Insn::ExtractArg => {
+                    let ec = &mut self.0.execution_context_stack.borrow_mut()[index];
                     // Stack: N arg[N-1] arg[N-2] ... arg[1] arg[0] (when N >= 1)
                     // Out: arg[0] N-1 arg[N-1] arg[N-2] ... arg[1]
                     //   --or, if N == 0 --
                     // Stack: 0
                     // Out: Undefined 0
-                    let stack_len = self.execution_context_stack[index].stack.len();
+                    let stack_len = ec.stack.len();
                     assert!(stack_len > 0, "ExtractArg must have an argument list on the stack");
                     let arg_count = f64::try_from(
                         ECMAScriptValue::try_from(
-                            self.execution_context_stack[index].stack[stack_len - 1]
-                                .clone()
-                                .expect("ExtractArg must have a 'count' argument"),
+                            ec.stack[stack_len - 1].clone().expect("ExtractArg must have a 'count' argument"),
                         )
                         .expect("ExtractArg must have a 'count' argument"),
                     )
                     .expect("ExtractArg 'count' arg must be a number");
                     if arg_count < 0.5 {
-                        self.execution_context_stack[index]
-                            .stack
-                            .push(Ok(NormalCompletion::from(ECMAScriptValue::Undefined)));
+                        ec.stack.push(Ok(NormalCompletion::from(ECMAScriptValue::Undefined)));
                     } else {
                         let arg_count = arg_count as usize;
                         assert!(stack_len > arg_count, "Stack must contain an argument list");
-                        let arg0 = self.execution_context_stack[index].stack.remove(stack_len - arg_count - 1);
-                        self.execution_context_stack[index].stack[stack_len - 2] =
-                            Ok(NormalCompletion::from((arg_count - 1) as u32));
-                        self.execution_context_stack[index].stack.push(arg0);
+                        let arg0 = ec.stack.remove(stack_len - arg_count - 1);
+                        ec.stack[stack_len - 2] = Ok(NormalCompletion::from((arg_count - 1) as u32));
+                        ec.stack.push(arg0);
                     }
                 }
                 Insn::FinishArgs => {
+                    let ec = &mut self.0.execution_context_stack.borrow_mut()[index];
                     // Stack: N arg[N-1] ... arg[0]
                     // Out:
                     // Remove any remaining arguments from the stack (we're at zero, or the caller gave us too much)
                     let arg_count = f64::try_from(
                         ECMAScriptValue::try_from(
-                            self.execution_context_stack[index]
-                                .stack
+                            ec.stack
                                 .pop()
                                 .expect("FinishArgs must have a 'count' argument")
                                 .expect("FinishArgs must have a 'count' argument"),
@@ -969,45 +996,45 @@ impl Agent {
                         .expect("FinishArgs must have a 'count' argument"),
                     )
                     .expect("FinishArgs 'count' arg must be a number");
-                    let to_retain = self.execution_context_stack[index].stack.len() - arg_count as usize;
-                    self.execution_context_stack[index].stack.truncate(to_retain);
+                    let to_retain = ec.stack.len() - arg_count as usize;
+                    ec.stack.truncate(to_retain);
                 }
                 Insn::Object => {
                     let obj_proto = self.intrinsic(IntrinsicId::ObjectPrototype);
                     let o = ordinary_object_create(self, Some(obj_proto), &[]);
-                    self.execution_context_stack[index].stack.push(Ok(ECMAScriptValue::from(o).into()));
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(ECMAScriptValue::from(o).into()));
                 }
                 Insn::CreateDataProperty => {
-                    let nc_value = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
-                    let nc_name = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
-                    let nc_obj = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
+                    let nc_value = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
+                    let nc_name = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
+                    let nc_obj = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
                     let obj = Object::try_from(nc_obj).unwrap();
                     let name = PropertyKey::try_from(nc_name).unwrap();
                     let value = ECMAScriptValue::try_from(nc_value).unwrap();
                     create_data_property_or_throw(self, &obj, name, value).unwrap();
-                    self.execution_context_stack[index].stack.push(Ok(NormalCompletion::from(obj)));
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(NormalCompletion::from(obj)));
                 }
                 Insn::SetPrototype => {
-                    let nc_value = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
-                    let nc_obj = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
+                    let nc_value = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
+                    let nc_obj = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
                     let obj = Object::try_from(nc_obj).unwrap();
                     let value = ECMAScriptValue::try_from(nc_value).unwrap();
                     let val_obj_res: anyhow::Result<Option<Object>> = value.try_into();
                     if let Ok(new_proto) = val_obj_res {
                         obj.o.set_prototype_of(self, new_proto).unwrap();
                     }
-                    self.execution_context_stack[index].stack.push(Ok(NormalCompletion::from(obj)));
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(NormalCompletion::from(obj)));
                 }
                 Insn::ToPropertyKey => {
-                    let nc_name = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
+                    let nc_name = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
                     let value_name = ECMAScriptValue::try_from(nc_name).unwrap();
                     let key = to_property_key(self, value_name);
                     let fc = key.map(|pk| NormalCompletion::from(ECMAScriptValue::from(pk)));
-                    self.execution_context_stack[index].stack.push(fc);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(fc);
                 }
                 Insn::CopyDataProps => {
-                    let nc_value = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
-                    let nc_obj = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
+                    let nc_value = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
+                    let nc_obj = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
                     let obj = Object::try_from(nc_obj).unwrap();
                     let value = ECMAScriptValue::try_from(nc_value).unwrap();
                     let result = copy_data_properties(self, &obj, value, &[]);
@@ -1015,81 +1042,86 @@ impl Agent {
                         Ok(_) => Ok(NormalCompletion::from(obj)),
                         Err(e) => Err(e),
                     };
-                    self.execution_context_stack[index].stack.push(fc);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(fc);
                 }
                 Insn::Dup => {
-                    let idx = self.execution_context_stack[index].stack.len() - 1;
-                    let fc = self.execution_context_stack[index].stack[idx].clone();
-                    self.execution_context_stack[index].stack.push(fc);
+                    let idx = self.0.execution_context_stack.borrow()[index].stack.len() - 1;
+                    let fc = self.0.execution_context_stack.borrow()[index].stack[idx].clone();
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(fc);
                 }
                 Insn::ToNumeric => {
-                    let nc_val = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
+                    let nc_val = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
                     let val: ECMAScriptValue = nc_val.try_into().unwrap();
                     let result = to_numeric(self, val).map(NormalCompletion::from);
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::Increment => {
-                    let nc_val = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
+                    let nc_val = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
                     let num: Numeric = nc_val.try_into().unwrap();
                     let result_val: ECMAScriptValue = match num {
                         Numeric::Number(n) => (n + 1.0).into(),
                         Numeric::BigInt(bi) => ECMAScriptValue::BigInt(Rc::new(&*bi + 1)),
                     };
                     let fc = Ok(NormalCompletion::from(result_val));
-                    self.execution_context_stack[index].stack.push(fc);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(fc);
                 }
                 Insn::Decrement => {
-                    let nc_val = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
+                    let nc_val = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
                     let num: Numeric = nc_val.try_into().unwrap();
                     let result_val: ECMAScriptValue = match num {
                         Numeric::Number(n) => (n - 1.0).into(),
                         Numeric::BigInt(bi) => ECMAScriptValue::BigInt(Rc::new(&*bi - 1)),
                     };
                     let fc = Ok(NormalCompletion::from(result_val));
-                    self.execution_context_stack[index].stack.push(fc);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(fc);
                 }
                 Insn::PreIncrement => {
-                    let fc = self.execution_context_stack[index].stack.pop().unwrap();
+                    let fc = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap();
                     let result = self.prefix_increment(fc);
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::PreDecrement => {
-                    let fc = self.execution_context_stack[index].stack.pop().unwrap();
+                    let fc = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap();
                     let result = self.prefix_decrement(fc);
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::Delete => {
-                    let fc = self.execution_context_stack[index].stack.pop().unwrap();
+                    let fc = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap();
                     let result = self.delete_ref(fc);
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::Void => {
-                    let fc = self.execution_context_stack[index].stack.pop().unwrap();
+                    let fc = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap();
                     let result = self.void_operator(fc);
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::TypeOf => {
-                    let fc = self.execution_context_stack[index].stack.pop().unwrap();
+                    let fc = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap();
                     let result = self.typeof_operator(fc);
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::Unwind => {
-                    let vals_to_remove = chunk.opcodes[self.execution_context_stack[index].pc as usize] as usize;
-                    self.execution_context_stack[index].pc += 1;
-                    assert!(vals_to_remove < self.execution_context_stack[index].stack.len());
+                    let vals_to_remove =
+                        chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize] as usize;
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
+                    assert!(vals_to_remove < self.0.execution_context_stack.borrow()[index].stack.len());
                     if vals_to_remove > 0 {
-                        let old_index_of_err = self.execution_context_stack[index].stack.len() - 1;
+                        let old_index_of_err = self.0.execution_context_stack.borrow()[index].stack.len() - 1;
                         let new_index_of_err = old_index_of_err - vals_to_remove;
-                        self.execution_context_stack[index].stack.swap(new_index_of_err, old_index_of_err);
-                        self.execution_context_stack[index].stack.truncate(new_index_of_err + 1);
+                        self.0.execution_context_stack.borrow_mut()[index]
+                            .stack
+                            .swap(new_index_of_err, old_index_of_err);
+                        self.0.execution_context_stack.borrow_mut()[index].stack.truncate(new_index_of_err + 1);
                     }
                 }
                 Insn::UnwindList => {
-                    let err_to_keep =
-                        self.execution_context_stack[index].stack.pop().expect("UnwindList has two stack args");
+                    let err_to_keep = self.0.execution_context_stack.borrow_mut()[index]
+                        .stack
+                        .pop()
+                        .expect("UnwindList has two stack args");
                     let vals_to_remove = f64::try_from(
                         ECMAScriptValue::try_from(
-                            self.execution_context_stack[index]
+                            self.0.execution_context_stack.borrow_mut()[index]
                                 .stack
                                 .pop()
                                 .expect("UnwindList has a stack argument")
@@ -1099,39 +1131,42 @@ impl Agent {
                     )
                     .expect("UnwindList expects a number") as usize;
                     if vals_to_remove > 0 {
-                        let old_stack_size = self.execution_context_stack[index].stack.len();
+                        let old_stack_size = self.0.execution_context_stack.borrow()[index].stack.len();
                         assert!(vals_to_remove <= old_stack_size);
                         let new_stack_size = old_stack_size - vals_to_remove;
-                        self.execution_context_stack[index].stack.truncate(new_stack_size);
+                        self.0.execution_context_stack.borrow_mut()[index].stack.truncate(new_stack_size);
                     }
-                    self.execution_context_stack[index].stack.push(err_to_keep);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(err_to_keep);
                 }
                 Insn::Call => {
-                    let arg_count_nc = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
+                    let arg_count_nc = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
                     let arg_count_val = ECMAScriptValue::try_from(arg_count_nc).unwrap();
                     let arg_count: usize = (f64::try_from(arg_count_val).unwrap().round() as i64).try_into().unwrap();
                     let mut arguments = Vec::with_capacity(arg_count);
                     for _ in 1..=arg_count {
                         let nc = ECMAScriptValue::try_from(
-                            self.execution_context_stack[index].stack.pop().unwrap().unwrap(),
+                            self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap(),
                         )
                         .unwrap();
                         arguments.push(nc);
                     }
                     arguments.reverse();
-                    let func_nc = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
+                    let func_nc = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
                     let func_val = ECMAScriptValue::try_from(func_nc).unwrap();
-                    let ref_nc = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
+                    let ref_nc = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
 
                     self.begin_call_evaluation(func_val, ref_nc, &arguments);
                 }
                 Insn::EndFunction => {
-                    let stack_len = self.execution_context_stack[index].stack.len();
+                    let stack_len = self.0.execution_context_stack.borrow()[index].stack.len();
                     assert!(stack_len >= 2);
-                    let result = self.execution_context_stack[index].stack.pop().expect("Stack is at least 2 elements");
+                    let result = self.0.execution_context_stack.borrow_mut()[index]
+                        .stack
+                        .pop()
+                        .expect("Stack is at least 2 elements");
                     let f_obj = Object::try_from(
                         ECMAScriptValue::try_from(
-                            self.execution_context_stack[index]
+                            self.0.execution_context_stack.borrow_mut()[index]
                                 .stack
                                 .pop()
                                 .expect("Stack is at least 2 elements")
@@ -1145,22 +1180,23 @@ impl Agent {
                 }
                 Insn::Construct => {
                     // Stack: N arg[n-1] arg[n-2] ... arg[0] newtgt cstr
-                    let arg_count_nc = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
+                    let arg_count_nc = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
                     let arg_count_val = ECMAScriptValue::try_from(arg_count_nc).unwrap();
                     let arg_count: usize = (f64::try_from(arg_count_val).unwrap().round() as i64).try_into().unwrap();
                     let mut arguments = Vec::with_capacity(arg_count);
                     for _ in 1..=arg_count {
                         let nc = ECMAScriptValue::try_from(
-                            self.execution_context_stack[index].stack.pop().unwrap().unwrap(),
+                            self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap(),
                         )
                         .unwrap();
                         arguments.push(nc);
                     }
                     arguments.reverse();
-                    let newtgt =
-                        ECMAScriptValue::try_from(self.execution_context_stack[index].stack.pop().unwrap().unwrap())
-                            .expect("new target must be value");
-                    let cstr_nc = self.execution_context_stack[index].stack.pop().unwrap().unwrap();
+                    let newtgt = ECMAScriptValue::try_from(
+                        self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap(),
+                    )
+                    .expect("new target must be value");
+                    let cstr_nc = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap();
                     let cstr_val = ECMAScriptValue::try_from(cstr_nc).unwrap();
 
                     self.begin_constructor_evaluation(cstr_val, newtgt, &arguments);
@@ -1184,16 +1220,16 @@ impl Agent {
                     self.ec_push(Err(AbruptCompletion::Return { value }));
                 }
                 Insn::UnaryPlus => {
-                    let exp = self.execution_context_stack[index].stack.pop().unwrap();
+                    let exp = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap();
                     let val = get_value(self, exp);
                     let result = match val {
                         Ok(ev) => to_number(self, ev).map(NormalCompletion::from),
                         Err(ac) => Err(ac),
                     };
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::UnaryMinus => {
-                    let exp = self.execution_context_stack[index].stack.pop().unwrap();
+                    let exp = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap();
                     let val = get_value(self, exp);
                     let old_val = match val {
                         Ok(val) => to_numeric(self, val),
@@ -1204,10 +1240,10 @@ impl Agent {
                         Ok(Numeric::Number(n)) => Ok(NormalCompletion::from(-n)),
                         Ok(Numeric::BigInt(bi)) => Ok(NormalCompletion::from(Rc::new(-&*bi))),
                     };
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::UnaryComplement => {
-                    let exp = self.execution_context_stack[index].stack.pop().unwrap();
+                    let exp = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap();
                     let val = get_value(self, exp);
                     let old_val = match val {
                         Ok(val) => to_numeric(self, val),
@@ -1218,16 +1254,16 @@ impl Agent {
                         Ok(Numeric::Number(n)) => Ok(NormalCompletion::from(!to_int32(self, n).unwrap())),
                         Ok(Numeric::BigInt(bi)) => Ok(NormalCompletion::from(Rc::new(!&*bi))),
                     };
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::UnaryNot => {
-                    let exp = self.execution_context_stack[index].stack.pop().unwrap();
+                    let exp = self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap();
                     let val = get_value(self, exp);
                     let result = match val {
                         Ok(val) => Ok(NormalCompletion::from(!to_boolean(val))),
                         Err(ac) => Err(ac),
                     };
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::Exponentiate => self.binary_operation(index, BinOp::Exponentiate),
                 Insn::Multiply => self.binary_operation(index, BinOp::Multiply),
@@ -1237,30 +1273,30 @@ impl Agent {
                 Insn::Subtract => self.binary_operation(index, BinOp::Subtract),
 
                 Insn::InstantiateIdFreeFunctionExpression => {
-                    let id = chunk.opcodes[self.execution_context_stack[index].pc as usize]; // failure is a coding error (the compiler broke)
-                    self.execution_context_stack[index].pc += 1;
+                    let id = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize]; // failure is a coding error (the compiler broke)
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let info = &chunk.function_object_data[id as usize];
                     self.instantiate_ordinary_function_expression_without_binding_id(index, text, info)
                 }
                 Insn::InstantiateOrdinaryFunctionExpression => {
-                    let id = chunk.opcodes[self.execution_context_stack[index].pc as usize]; // failure is a coding error (the compiler broke)
-                    self.execution_context_stack[index].pc += 1;
+                    let id = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize]; // failure is a coding error (the compiler broke)
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let info = &chunk.function_object_data[id as usize];
                     self.instantiate_ordinary_function_expression_with_binding_id(index, text, info)
                 }
 
                 Insn::InstantiateArrowFunctionExpression => {
-                    let id = chunk.opcodes[self.execution_context_stack[index].pc as usize]; // failure is a coding error (the compiler broke)
-                    self.execution_context_stack[index].pc += 1;
+                    let id = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize]; // failure is a coding error (the compiler broke)
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let info = &chunk.function_object_data[id as usize];
                     self.instantiate_arrow_function_expression(Some(index), text, info)
                 }
                 Insn::InstantiateOrdinaryFunctionObject => {
-                    let string_index = chunk.opcodes[self.execution_context_stack[index].pc as usize]; // failure is a coding error (the compiler broke)
-                    self.execution_context_stack[index].pc += 1;
+                    let string_index = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize]; // failure is a coding error (the compiler broke)
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let string = &chunk.strings[string_index as usize];
-                    let func_index = chunk.opcodes[self.execution_context_stack[index].pc as usize] as usize;
-                    self.execution_context_stack[index].pc += 1;
+                    let func_index = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize] as usize;
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let info = &chunk.function_object_data[func_index as usize];
                     self.instantiate_ordinary_function_object(Some(index), text, string, info)
                 }
@@ -1269,43 +1305,45 @@ impl Agent {
                 Insn::UnsignedRightShift => self.binary_operation(index, BinOp::UnsignedRightShift),
                 Insn::Throw => {
                     // Convert the NormalCompletion::Value on top of the stack into a ThrowCompletion with a matching value
-                    let exp: ECMAScriptValue = self.execution_context_stack[index]
+                    let exp: ECMAScriptValue = self.0.execution_context_stack.borrow_mut()[index]
                         .stack
                         .pop()
                         .expect("Throw requires an argument")
                         .expect("Throw requires a NormalCompletion")
                         .try_into()
                         .expect("Throw requires a value");
-                    self.execution_context_stack[index].stack.push(Err(AbruptCompletion::Throw { value: exp }));
+                    self.0.execution_context_stack.borrow_mut()[index]
+                        .stack
+                        .push(Err(AbruptCompletion::Throw { value: exp }));
                 }
                 Insn::Less => {
                     let (lval, rval) = self.two_values(index);
                     let result =
                         self.is_less_than(lval, rval, true).map(|optb| NormalCompletion::from(optb.unwrap_or(false)));
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::Greater => {
                     let (lval, rval) = self.two_values(index);
                     let result =
                         self.is_less_than(rval, lval, false).map(|optb| NormalCompletion::from(optb.unwrap_or(false)));
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::LessEqual => {
                     let (lval, rval) = self.two_values(index);
                     let result =
                         self.is_less_than(rval, lval, false).map(|optb| NormalCompletion::from(!optb.unwrap_or(true)));
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::GreaterEqual => {
                     let (lval, rval) = self.two_values(index);
                     let result =
                         self.is_less_than(lval, rval, true).map(|optb| NormalCompletion::from(!optb.unwrap_or(true)));
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::InstanceOf => {
                     let (lval, rval) = self.two_values(index);
                     let result = self.instanceof_operator(lval, rval);
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::In => {
                     let (lval, rval) = self.two_values(index);
@@ -1316,27 +1354,27 @@ impl Agent {
                         }
                         _ => Err(create_type_error(self, "Right-hand side of 'in' must be an object")),
                     };
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::Equal => {
                     let (lval, rval) = self.two_values(index);
                     let result = self.is_loosely_equal(&lval, &rval).map(NormalCompletion::from);
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::NotEqual => {
                     let (lval, rval) = self.two_values(index);
                     let result = self.is_loosely_equal(&lval, &rval).map(|val| NormalCompletion::from(!val));
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::StrictEqual => {
                     let (lval, rval) = self.two_values(index);
                     let result = Ok(NormalCompletion::from(lval.is_strictly_equal(&rval)));
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::StrictNotEqual => {
                     let (lval, rval) = self.two_values(index);
                     let result = Ok(NormalCompletion::from(!lval.is_strictly_equal(&rval)));
-                    self.execution_context_stack[index].stack.push(result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
                 }
                 Insn::BitwiseAnd => self.binary_operation(index, BinOp::BitwiseAnd),
                 Insn::BitwiseOr => self.binary_operation(index, BinOp::BitwiseOr),
@@ -1344,16 +1382,19 @@ impl Agent {
                 Insn::CreateUnmappedArguments => self.create_unmapped_arguments_object(index),
                 Insn::CreateMappedArguments => self.create_mapped_arguments_object(index),
                 Insn::AddMappedArgument => {
-                    let string_index = chunk.opcodes[self.execution_context_stack[index].pc as usize]; // failure is a coding error (the compiler broke)
-                    self.execution_context_stack[index].pc += 1;
+                    let string_index = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize]; // failure is a coding error (the compiler broke)
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let string = &chunk.strings[string_index as usize];
-                    let argument_index = chunk.opcodes[self.execution_context_stack[index].pc as usize] as usize;
-                    self.execution_context_stack[index].pc += 1;
+                    let argument_index =
+                        chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize] as usize;
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     self.attach_mapped_arg(index, string, argument_index);
                 }
                 Insn::HandleEmptyBreak => {
-                    let prior_result =
-                        self.execution_context_stack[index].stack.pop().expect("HandleEmptyBreak requires an argument");
+                    let prior_result = self.0.execution_context_stack.borrow_mut()[index]
+                        .stack
+                        .pop()
+                        .expect("HandleEmptyBreak requires an argument");
                     let new_result = if let Err(AbruptCompletion::Break { value, target: None }) = prior_result {
                         match value {
                             NormalCompletion::Empty => Ok(NormalCompletion::from(ECMAScriptValue::Undefined)),
@@ -1362,13 +1403,13 @@ impl Agent {
                     } else {
                         prior_result
                     };
-                    self.execution_context_stack[index].stack.push(new_result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(new_result);
                 }
                 Insn::HandleTargetedBreak => {
-                    let str_idx = chunk.opcodes[self.execution_context_stack[index].pc as usize] as usize;
-                    self.execution_context_stack[index].pc += 1;
+                    let str_idx = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize] as usize;
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let label = &chunk.strings[str_idx];
-                    let prior_result = self.execution_context_stack[index]
+                    let prior_result = self.0.execution_context_stack.borrow_mut()[index]
                         .stack
                         .pop()
                         .expect("HandleTargetedBreak requires an argument");
@@ -1376,22 +1417,24 @@ impl Agent {
                         Err(AbruptCompletion::Break { value, target: Some(target) }) if &target == label => Ok(value),
                         _ => prior_result,
                     };
-                    self.execution_context_stack[index].stack.push(new_result);
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(new_result);
                 }
                 Insn::CoalesceValue => {
                     // Stack: stmtResult V ...
                     // If stmtResult.[[Value]] is not empty, set V to stmtResult.[[Value]].
-                    let stmt_result =
-                        self.execution_context_stack[index].stack.pop().expect("CoalesceValue requires two arguments");
+                    let stmt_result = self.0.execution_context_stack.borrow_mut()[index]
+                        .stack
+                        .pop()
+                        .expect("CoalesceValue requires two arguments");
                     let v = ECMAScriptValue::try_from(
-                        self.execution_context_stack[index]
+                        self.0.execution_context_stack.borrow_mut()[index]
                             .stack
                             .pop()
                             .expect("CoalesceValue requires two arguments")
                             .expect("argument V must be  normal completion"),
                     )
                     .expect("argument V must be a value");
-                    self.execution_context_stack[index].stack.push(Ok(match stmt_result {
+                    self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(match stmt_result {
                         Ok(NormalCompletion::Value(value))
                         | Err(AbruptCompletion::Throw { value })
                         | Err(AbruptCompletion::Return { value })
@@ -1403,54 +1446,55 @@ impl Agent {
                     }));
                 }
                 Insn::LoopContinues => {
-                    let set_idx = chunk.opcodes[self.execution_context_stack[index].pc as usize] as usize;
-                    self.execution_context_stack[index].pc += 1;
+                    let ec = &mut self.0.execution_context_stack.borrow_mut()[index];
+                    let set_idx = chunk.opcodes[ec.pc as usize] as usize;
+                    ec.pc += 1;
                     let label_set = &chunk.label_sets[set_idx];
                     // 1. If completion.[[Type]] is normal, return true.
                     // 2. If completion.[[Type]] is not continue, return false.
                     // 3. If completion.[[Target]] is empty, return true.
                     // 4. If completion.[[Target]] is an element of labelSet, return true.
                     // 5. Return false.
-                    let idx = self.execution_context_stack[index].stack.len() - 1;
-                    let completion = &self.execution_context_stack[index].stack[idx];
+                    let idx = ec.stack.len() - 1;
+                    let completion = &ec.stack[idx];
                     let result = match completion {
                         Ok(_) => true,
                         Err(AbruptCompletion::Continue { value: _, target: None }) => true,
                         Err(AbruptCompletion::Continue { value: _, target: Some(label) }) => label_set.contains(label),
                         _ => false,
                     };
-                    self.execution_context_stack[index].stack.push(Ok(NormalCompletion::from(result)));
+                    ec.stack.push(Ok(NormalCompletion::from(result)));
                 }
                 Insn::Continue => {
-                    self.execution_context_stack[index]
+                    self.0.execution_context_stack.borrow_mut()[index]
                         .stack
                         .push(Err(AbruptCompletion::Continue { value: NormalCompletion::Empty, target: None }));
                 }
                 Insn::TargetedContinue => {
-                    let str_idx = chunk.opcodes[self.execution_context_stack[index].pc as usize] as usize;
-                    self.execution_context_stack[index].pc += 1;
+                    let str_idx = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize] as usize;
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let label = chunk.strings[str_idx].clone();
-                    self.execution_context_stack[index]
+                    self.0.execution_context_stack.borrow_mut()[index]
                         .stack
                         .push(Err(AbruptCompletion::Continue { value: NormalCompletion::Empty, target: Some(label) }));
                 }
                 Insn::Break => {
-                    self.execution_context_stack[index]
+                    self.0.execution_context_stack.borrow_mut()[index]
                         .stack
                         .push(Err(AbruptCompletion::Break { value: NormalCompletion::Empty, target: None }));
                 }
                 Insn::TargetedBreak => {
-                    let str_idx = chunk.opcodes[self.execution_context_stack[index].pc as usize] as usize;
-                    self.execution_context_stack[index].pc += 1;
+                    let str_idx = chunk.opcodes[self.0.execution_context_stack.borrow()[index].pc as usize] as usize;
+                    self.0.execution_context_stack.borrow_mut()[index].pc += 1;
                     let label = chunk.strings[str_idx].clone();
-                    self.execution_context_stack[index]
+                    self.0.execution_context_stack.borrow_mut()[index]
                         .stack
                         .push(Err(AbruptCompletion::Break { value: NormalCompletion::Empty, target: Some(label) }));
                 }
             }
         }
-        let index = self.execution_context_stack.len() - 1;
-        self.execution_context_stack[index]
+        let index = self.0.execution_context_stack.borrow().len() - 1;
+        self.0.execution_context_stack.borrow_mut()[index]
             .stack
             .pop()
             .map(|svr| {
@@ -1463,12 +1507,7 @@ impl Agent {
             .unwrap_or(Ok(ECMAScriptValue::Undefined))
     }
 
-    fn begin_call_evaluation(
-        &mut self,
-        func: ECMAScriptValue,
-        reference: NormalCompletion,
-        arguments: &[ECMAScriptValue],
-    ) {
+    fn begin_call_evaluation(&self, func: ECMAScriptValue, reference: NormalCompletion, arguments: &[ECMAScriptValue]) {
         let this_value = match &reference {
             NormalCompletion::Empty | NormalCompletion::Environment(..) => unreachable!(),
             NormalCompletion::Value(_) => ECMAScriptValue::Undefined,
@@ -1493,19 +1532,14 @@ impl Agent {
         initiate_call(self, &func, &this_value, arguments);
     }
 
-    fn begin_constructor_evaluation(
-        &mut self,
-        cstr: ECMAScriptValue,
-        newtgt: ECMAScriptValue,
-        args: &[ECMAScriptValue],
-    ) {
+    fn begin_constructor_evaluation(&self, cstr: ECMAScriptValue, newtgt: ECMAScriptValue, args: &[ECMAScriptValue]) {
         assert!(is_constructor(&cstr));
         let cstr = Object::try_from(cstr).expect("Must be a constructor");
         let newtgt = Object::try_from(newtgt).expect("Must be an object");
         initiate_construct(self, &cstr, args, Some(&newtgt));
     }
 
-    fn prefix_increment(&mut self, expr: FullCompletion) -> FullCompletion {
+    fn prefix_increment(&self, expr: FullCompletion) -> FullCompletion {
         let value = get_value(self, expr.clone())?;
         let old_value = to_numeric(self, value)?;
         let new_value: ECMAScriptValue = match old_value {
@@ -1516,7 +1550,7 @@ impl Agent {
         Ok(NormalCompletion::from(new_value))
     }
 
-    fn prefix_decrement(&mut self, expr: FullCompletion) -> FullCompletion {
+    fn prefix_decrement(&self, expr: FullCompletion) -> FullCompletion {
         let value = get_value(self, expr.clone())?;
         let old_value = to_numeric(self, value)?;
         let new_value: ECMAScriptValue = match old_value {
@@ -1527,7 +1561,7 @@ impl Agent {
         Ok(NormalCompletion::from(new_value))
     }
 
-    fn delete_ref(&mut self, expr: FullCompletion) -> FullCompletion {
+    fn delete_ref(&self, expr: FullCompletion) -> FullCompletion {
         let reference = expr?;
         match reference {
             NormalCompletion::Environment(..) => unreachable!(),
@@ -1559,12 +1593,12 @@ impl Agent {
         }
     }
 
-    fn void_operator(&mut self, expr: FullCompletion) -> FullCompletion {
+    fn void_operator(&self, expr: FullCompletion) -> FullCompletion {
         get_value(self, expr)?;
         Ok(ECMAScriptValue::Undefined.into())
     }
 
-    fn typeof_operator(&mut self, expr: FullCompletion) -> FullCompletion {
+    fn typeof_operator(&self, expr: FullCompletion) -> FullCompletion {
         if let Ok(NormalCompletion::Reference(r)) = &expr {
             if r.is_unresolvable_reference() {
                 return Ok(NormalCompletion::from("undefined"));
@@ -1591,9 +1625,9 @@ impl Agent {
         Ok(NormalCompletion::from(type_string))
     }
 
-    fn two_values(&mut self, index: usize) -> (ECMAScriptValue, ECMAScriptValue) {
+    fn two_values(&self, index: usize) -> (ECMAScriptValue, ECMAScriptValue) {
         let (right, left) = {
-            let stack = &mut self.execution_context_stack[index].stack;
+            let stack = &mut self.0.execution_context_stack.borrow_mut()[index].stack;
             (stack.pop(), stack.pop())
         };
         let rval: ECMAScriptValue = right
@@ -1609,14 +1643,14 @@ impl Agent {
         (lval, rval)
     }
 
-    fn binary_operation(&mut self, index: usize, op: BinOp) {
+    fn binary_operation(&self, index: usize, op: BinOp) {
         let (lval, rval) = self.two_values(index);
         let result = self.apply_string_or_numeric_binary_operator(lval, rval, op);
-        self.execution_context_stack[index].stack.push(result);
+        self.0.execution_context_stack.borrow_mut()[index].stack.push(result);
     }
 
     fn apply_string_or_numeric_binary_operator(
-        &mut self,
+        &self,
         lval: ECMAScriptValue,
         rval: ECMAScriptValue,
         op: BinOp,
@@ -1735,7 +1769,7 @@ impl Agent {
     }
 
     fn instantiate_ordinary_function_expression_without_binding_id(
-        &mut self,
+        &self,
         index: usize,
         text: &str,
         info: &StashedFunctionData,
@@ -1761,8 +1795,9 @@ impl Agent {
         let compilation_status = to_compile.body.compile_body(&mut compiled, text, info);
         if let Err(err) = compilation_status {
             let typeerror = create_type_error(self, err.to_string());
-            let l = self.execution_context_stack[index].stack.len();
-            self.execution_context_stack[index].stack[l - 1] = Err(typeerror); // pop then push
+            let stack = &mut self.0.execution_context_stack.borrow_mut()[index].stack;
+            let l = stack.len();
+            stack[l - 1] = Err(typeerror); // pop then push
             return;
         }
         for line in compiled.disassemble() {
@@ -1779,7 +1814,7 @@ impl Agent {
 
         let name = PropertyKey::try_from(
             ECMAScriptValue::try_from(
-                self.execution_context_stack[index]
+                self.0.execution_context_stack.borrow_mut()[index]
                     .stack
                     .pop()
                     .expect("Insn only used with argument on stack")
@@ -1807,11 +1842,11 @@ impl Agent {
         set_function_name(self, &closure, name.into(), None);
         make_constructor(self, &closure, None);
 
-        self.execution_context_stack[index].stack.push(Ok(closure.into()));
+        self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(closure.into()));
     }
 
     fn instantiate_ordinary_function_expression_with_binding_id(
-        &mut self,
+        &self,
         index: usize,
         text: &str,
         info: &StashedFunctionData,
@@ -1848,8 +1883,10 @@ impl Agent {
         let compilation_status = to_compile.body.compile_body(&mut compiled, text, info);
         if let Err(err) = compilation_status {
             let typeerror = create_type_error(self, err.to_string());
-            let l = self.execution_context_stack[index].stack.len();
-            self.execution_context_stack[index].stack[l - 1] = Err(typeerror); // pop then push
+            let mut execution_context_stack = self.0.execution_context_stack.borrow_mut();
+            let stack = &mut execution_context_stack[index].stack;
+            let l = stack.len();
+            stack[l - 1] = Err(typeerror); // pop then push
             return;
         }
         for line in compiled.disassemble() {
@@ -1858,7 +1895,7 @@ impl Agent {
 
         let name = JSString::try_from(
             ECMAScriptValue::try_from(
-                self.execution_context_stack[index]
+                self.0.execution_context_stack.borrow_mut()[index]
                     .stack
                     .pop()
                     .expect("Insn only used with argument on stack")
@@ -1892,21 +1929,17 @@ impl Agent {
         make_constructor(self, &closure, None);
         func_env.initialize_binding(self, &name, closure.clone().into()).expect("binding has been created");
 
-        self.execution_context_stack[index].stack.push(Ok(closure.into()));
+        self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(closure.into()));
     }
 
-    pub fn instantiate_arrow_function_expression(
-        &mut self,
-        index: Option<usize>,
-        text: &str,
-        info: &StashedFunctionData,
-    ) {
-        let index = index.unwrap_or(self.execution_context_stack.len() - 1);
+    pub fn instantiate_arrow_function_expression(&self, index: Option<usize>, text: &str, info: &StashedFunctionData) {
+        let index = index.unwrap_or(self.0.execution_context_stack.borrow().len() - 1);
         let env = self.current_lexical_environment().unwrap();
         let priv_env = self.current_private_environment();
 
         let name = JSString::try_from(
-            ECMAScriptValue::try_from(self.execution_context_stack[index].stack.pop().unwrap().unwrap()).unwrap(),
+            ECMAScriptValue::try_from(self.0.execution_context_stack.borrow_mut()[index].stack.pop().unwrap().unwrap())
+                .unwrap(),
         )
         .unwrap();
 
@@ -1917,8 +1950,9 @@ impl Agent {
         let compilation_status = to_compile.body.compile_body(&mut compiled, text, info);
         if let Err(err) = compilation_status {
             let typeerror = create_type_error(self, err.to_string());
-            let l = self.execution_context_stack[index].stack.len();
-            self.execution_context_stack[index].stack[l - 1] = Err(typeerror); // pop then push
+            let mut execution_context_stack = self.0.execution_context_stack.borrow_mut();
+            let l = execution_context_stack[index].stack.len();
+            execution_context_stack[index].stack[l - 1] = Err(typeerror); // pop then push
             return;
         }
         for line in compiled.disassemble() {
@@ -1941,17 +1975,17 @@ impl Agent {
         );
         set_function_name(self, &closure, name.into(), None);
 
-        self.execution_context_stack[index].stack.push(Ok(closure.into()));
+        self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(closure.into()));
     }
 
     pub fn instantiate_ordinary_function_object(
-        &mut self,
+        &self,
         index: Option<usize>,
         text: &str,
         name: &JSString,
         info: &StashedFunctionData,
     ) {
-        let index = index.unwrap_or(self.execution_context_stack.len() - 1);
+        let index = index.unwrap_or(self.0.execution_context_stack.borrow().len() - 1);
         let to_compile: Rc<FunctionDeclaration> =
             info.to_compile.clone().try_into().expect("This routine only used with Function Declarations");
         let chunk_name = nameify(&info.source_text, 50);
@@ -1959,8 +1993,9 @@ impl Agent {
         let compilation_status = to_compile.body.compile_body(&mut compiled, text, info);
         if let Err(err) = compilation_status {
             let typeerror = create_type_error(self, err.to_string());
-            let l = self.execution_context_stack[index].stack.len();
-            self.execution_context_stack[index].stack[l - 1] = Err(typeerror); // pop then push
+            let mut execution_context_stack = self.0.execution_context_stack.borrow_mut();
+            let l = execution_context_stack[index].stack.len();
+            execution_context_stack[index].stack[l - 1] = Err(typeerror); // pop then push
             return;
         }
         for line in compiled.disassemble() {
@@ -1986,10 +2021,10 @@ impl Agent {
         set_function_name(self, &closure, name.clone().into(), None);
         make_constructor(self, &closure, None);
 
-        self.execution_context_stack[index].stack.push(Ok(closure.into()));
+        self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(closure.into()));
     }
 
-    fn is_less_than(&mut self, x: ECMAScriptValue, y: ECMAScriptValue, left_first: bool) -> Completion<Option<bool>> {
+    fn is_less_than(&self, x: ECMAScriptValue, y: ECMAScriptValue, left_first: bool) -> Completion<Option<bool>> {
         let (px, py) = if left_first {
             let px = to_primitive(self, x, None)?;
             let py = to_primitive(self, y, None)?;
@@ -2058,7 +2093,7 @@ impl Agent {
         }
     }
 
-    fn instanceof_operator(&mut self, v: ECMAScriptValue, target: ECMAScriptValue) -> FullCompletion {
+    fn instanceof_operator(&self, v: ECMAScriptValue, target: ECMAScriptValue) -> FullCompletion {
         // InstanceofOperator ( V, target )
         //
         // The abstract operation InstanceofOperator takes arguments V (an ECMAScript language value) and target (an
@@ -2100,15 +2135,17 @@ impl Agent {
         }
     }
 
-    pub fn create_unmapped_arguments_object(&mut self, index: usize) {
+    pub fn create_unmapped_arguments_object(&self, index: usize) {
         // Stack should have n arg[n-1] arg[n-2] ... arg[0] ...
         // Those values are NOT consumed; this function assumes they'll be used again.
 
-        let stack_len = self.execution_context_stack[index].stack.len();
+        let stack_len = self.0.execution_context_stack.borrow()[index].stack.len();
         assert!(stack_len > 0, "Stack must not be empty");
         let length = f64::try_from(
             ECMAScriptValue::try_from(
-                self.execution_context_stack[index].stack[stack_len - 1].clone().expect("Non-error arguments needed"),
+                self.0.execution_context_stack.borrow()[index].stack[stack_len - 1]
+                    .clone()
+                    .expect("Non-error arguments needed"),
             )
             .expect("Value arguments needed"),
         )
@@ -2125,8 +2162,9 @@ impl Agent {
         .expect("Normal Object");
 
         let first_arg_index = stack_len - length as usize - 1;
-        let arguments =
-            self.execution_context_stack[index].stack[first_arg_index..first_arg_index + length as usize].to_vec();
+        let arguments = self.0.execution_context_stack.borrow()[index].stack
+            [first_arg_index..first_arg_index + length as usize]
+            .to_vec();
 
         for (arg_number, item) in arguments.into_iter().enumerate() {
             let value =
@@ -2156,18 +2194,20 @@ impl Agent {
         )
         .expect("Normal Object");
 
-        self.execution_context_stack[index].stack.push(Ok(NormalCompletion::from(obj)));
+        self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(NormalCompletion::from(obj)));
         // Stack at exit: AObj N arg[N-1] ... arg[0] ...
     }
 
-    pub fn create_mapped_arguments_object(&mut self, index: usize) {
+    pub fn create_mapped_arguments_object(&self, index: usize) {
         // Stack should have n arg[n-1] arg[n-2] ... arg[0] func ...
 
-        let stack_len = self.execution_context_stack[index].stack.len();
+        let stack_len = self.0.execution_context_stack.borrow()[index].stack.len();
         assert!(stack_len > 0, "Stack must not be empty");
         let length = f64::try_from(
             ECMAScriptValue::try_from(
-                self.execution_context_stack[index].stack[stack_len - 1].clone().expect("Non-error arguments needed"),
+                self.0.execution_context_stack.borrow()[index].stack[stack_len - 1]
+                    .clone()
+                    .expect("Non-error arguments needed"),
             )
             .expect("Value arguments needed"),
         )
@@ -2175,8 +2215,9 @@ impl Agent {
         assert!(stack_len > length as usize + 1, "Stack too short to fit all the arguments plus the function obj");
 
         let first_arg_index = stack_len - length as usize - 1;
-        let arguments =
-            self.execution_context_stack[index].stack[first_arg_index..first_arg_index + length as usize].to_vec();
+        let arguments = self.0.execution_context_stack.borrow()[index].stack
+            [first_arg_index..first_arg_index + length as usize]
+            .to_vec();
 
         let env = self.current_lexical_environment().expect("A lex env must exist");
         let map = ParameterMap::new(env);
@@ -2205,7 +2246,9 @@ impl Agent {
         )
         .expect("ArgumentObject won't throw");
         let func = ECMAScriptValue::try_from(
-            self.execution_context_stack[index].stack[first_arg_index - 1].clone().expect("Function object type error"),
+            self.0.execution_context_stack.borrow()[index].stack[first_arg_index - 1]
+                .clone()
+                .expect("Function object type error"),
         )
         .expect("Function object type error");
         define_property_or_throw(
@@ -2216,17 +2259,19 @@ impl Agent {
         )
         .expect("ArgumentObject won't throw");
 
-        self.execution_context_stack[index].stack.push(Ok(NormalCompletion::from(ao)));
+        self.0.execution_context_stack.borrow_mut()[index].stack.push(Ok(NormalCompletion::from(ao)));
         // Stack at exit: AObj N arg[N-1] ... arg[0] func ...
     }
 
-    pub fn attach_mapped_arg(&mut self, index: usize, name: &JSString, idx: usize) {
+    pub fn attach_mapped_arg(&self, index: usize, name: &JSString, idx: usize) {
         // Stack: AObj ...
-        let top = self.execution_context_stack[index].stack.len();
+        let top = self.0.execution_context_stack.borrow()[index].stack.len();
         assert!(top > 0, "stack must not be empty");
         let obj = Object::try_from(
             ECMAScriptValue::try_from(
-                self.execution_context_stack[index].stack[top - 1].clone().expect("arguments must be values"),
+                self.0.execution_context_stack.borrow()[index].stack[top - 1]
+                    .clone()
+                    .expect("arguments must be values"),
             )
             .expect("arguments must be values"),
         )
@@ -2289,11 +2334,7 @@ pub struct WellKnownSymbols {
     pub unscopables_: Symbol,
 }
 
-pub fn parse_script(
-    agent: &mut Agent,
-    source_text: &str,
-    realm: Rc<RefCell<Realm>>,
-) -> Result<ScriptRecord, Vec<Object>> {
+pub fn parse_script(agent: &Agent, source_text: &str, realm: Rc<RefCell<Realm>>) -> Result<ScriptRecord, Vec<Object>> {
     let script = parse_text(agent, source_text, ParseGoal::Script);
     match script {
         ParsedText::Errors(errs) => Err(errs),
@@ -2365,7 +2406,7 @@ impl FcnDef {
     }
     pub fn instantiate_function_object(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         env: Rc<dyn EnvironmentRecord>,
         private_env: Option<Rc<RefCell<PrivateEnvironmentRecord>>>,
         strict: bool,
@@ -2407,7 +2448,7 @@ impl TryFrom<VarScopeDecl> for TopLevelVarDecl {
 }
 
 pub fn global_declaration_instantiation(
-    agent: &mut Agent,
+    agent: &Agent,
     script: Rc<Script>,
     env: Rc<GlobalEnvironmentRecord>,
     strict: bool,
@@ -2503,7 +2544,7 @@ pub fn global_declaration_instantiation(
     Ok(())
 }
 
-pub fn script_evaluation(agent: &mut Agent, sr: ScriptRecord) -> Completion<ECMAScriptValue> {
+pub fn script_evaluation(agent: &Agent, sr: ScriptRecord) -> Completion<ECMAScriptValue> {
     let global_env = sr.realm.borrow().global_env.clone();
     let mut script_context =
         ExecutionContext::new(None, Rc::clone(&sr.realm), Some(ScriptOrModule::Script(Rc::new(sr.clone()))));
@@ -2556,7 +2597,7 @@ impl fmt::Display for ProcessError {
     }
 }
 
-pub fn process_ecmascript(agent: &mut Agent, source_text: &str) -> Result<ECMAScriptValue, ProcessError> {
+pub fn process_ecmascript(agent: &Agent, source_text: &str) -> Result<ECMAScriptValue, ProcessError> {
     let realm = agent.current_realm_record().unwrap();
     let x = parse_script(agent, source_text, realm).map_err(|errs| ProcessError::CompileErrors { values: errs })?;
 

--- a/src/arguments_object/mod.rs
+++ b/src/arguments_object/mod.rs
@@ -35,12 +35,12 @@ impl ParameterMap {
         self.properties[idx] = None;
     }
 
-    pub fn get(&self, agent: &mut Agent, idx: usize) -> Completion<ECMAScriptValue> {
+    pub fn get(&self, agent: &Agent, idx: usize) -> Completion<ECMAScriptValue> {
         let name = self.properties[idx].as_ref().expect("Get only used on existing values");
         self.env.get_binding_value(agent, name, false)
     }
 
-    pub fn set(&self, agent: &mut Agent, idx: usize, value: ECMAScriptValue) -> Completion<()> {
+    pub fn set(&self, agent: &Agent, idx: usize, value: ECMAScriptValue) -> Completion<()> {
         let name = self.properties[idx].as_ref().expect("Set only used on existing values").clone();
         self.env.set_mutable_binding(agent, name, value, false)
     }
@@ -75,7 +75,7 @@ impl ObjectInterface for ArgumentsObject {
         Some(self)
     }
 
-    fn get_prototype_of(&self, _agent: &mut Agent) -> Completion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &Agent) -> Completion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
 
@@ -85,7 +85,7 @@ impl ObjectInterface for ArgumentsObject {
     // the following steps when called:
     //
     //  1. Return ! OrdinarySetPrototypeOf(O, V).
-    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<Object>) -> Completion<bool> {
+    fn set_prototype_of(&self, _agent: &Agent, obj: Option<Object>) -> Completion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
 
@@ -95,7 +95,7 @@ impl ObjectInterface for ArgumentsObject {
     // when called:
     //
     //  1. Return ! OrdinaryIsExtensible(O).
-    fn is_extensible(&self, _agent: &mut Agent) -> Completion<bool> {
+    fn is_extensible(&self, _agent: &Agent) -> Completion<bool> {
         Ok(ordinary_is_extensible(self))
     }
 
@@ -105,14 +105,14 @@ impl ObjectInterface for ArgumentsObject {
     // steps when called:
     //
     //  1. Return ! OrdinaryPreventExtensions(O).
-    fn prevent_extensions(&self, _agent: &mut Agent) -> Completion<bool> {
+    fn prevent_extensions(&self, _agent: &Agent) -> Completion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
 
     /// Returns the property descriptor corresponding to the given key, or None if the key does not exist.
     ///
     /// See [GetOwnProperty](https://tc39.es/ecma262/#sec-arguments-exotic-objects-getownproperty-p) from ECMA-262.
-    fn get_own_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         // [[GetOwnProperty]] ( P )
         //
         // The [[GetOwnProperty]] internal method of an arguments exotic object args takes argument P (a property key)
@@ -174,7 +174,7 @@ impl ObjectInterface for ArgumentsObject {
     //  8. Return true.
     fn define_own_property(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         key: PropertyKey,
         desc: PotentialPropertyDescriptor,
     ) -> Completion<bool> {
@@ -216,14 +216,14 @@ impl ObjectInterface for ArgumentsObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryHasProperty(O, P).
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
+    fn has_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_has_property(agent, self, key)
     }
 
     /// Retrieves the value of a property from an object, following the prototype chain
     ///
     /// See [Get](https://tc39.es/ecma262/#sec-arguments-exotic-objects-get-p-receiver) in ECMA-262.
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+    fn get(&self, agent: &Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         // [[Get]] ( P, Receiver )
         //
         // The [[Get]] internal method of an arguments exotic object args takes arguments P (a property key) and
@@ -255,13 +255,7 @@ impl ObjectInterface for ArgumentsObject {
     // value), and Receiver (an ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinarySet(O, P, V, Receiver).
-    fn set(
-        &self,
-        agent: &mut Agent,
-        key: PropertyKey,
-        v: ECMAScriptValue,
-        receiver: &ECMAScriptValue,
-    ) -> Completion<bool> {
+    fn set(&self, agent: &Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
         // [[Set]] ( P, V, Receiver )
         //
         // The [[Set]] internal method of an arguments exotic object args takes arguments P (a property key), V (an
@@ -304,7 +298,7 @@ impl ObjectInterface for ArgumentsObject {
     //  4. If result is true and isMapped is true, then
     //      a. Perform ! map.[[Delete]](P).
     //  5. Return result.
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
+    fn delete(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
         // Note: ordinary_delete only fails if its call to o.[[GetOwnProperty]]
         // fails. And the ArgumentsObject::GetOwnProperty routine, just above,
         // cannot fail. Thus: we don't need to pass back an error from
@@ -325,13 +319,13 @@ impl ObjectInterface for ArgumentsObject {
     // steps when called:
     //
     // 1. Return ! OrdinaryOwnPropertyKeys(O).
-    fn own_property_keys(&self, _agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, _agent: &Agent) -> Completion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(self))
     }
 }
 
 impl ArgumentsObject {
-    pub fn object(agent: &mut Agent, parameter_map: Option<ParameterMap>) -> Object {
+    pub fn object(agent: &Agent, parameter_map: Option<ParameterMap>) -> Object {
         let prototype = Some(agent.intrinsic(IntrinsicId::ObjectPrototype));
         Object {
             o: Rc::new(Self {

--- a/src/arguments_object/tests.rs
+++ b/src/arguments_object/tests.rs
@@ -32,9 +32,9 @@ mod parameter_map {
     #[test_case(|_| PropertyKey::from("-9932") => None; "negative numbers")]
     #[test_case(|_| PropertyKey::from("83828") => Some(83828); "valid nonzero")]
     #[test_case(|a| PropertyKey::from(a.wks(WksId::Iterator)) => None; "symbol key")]
-    fn idx_from_key(make_key: impl FnOnce(&mut Agent) -> PropertyKey) -> Option<usize> {
-        let mut agent = test_agent();
-        let actual_key = make_key(&mut agent);
+    fn idx_from_key(make_key: impl FnOnce(&Agent) -> PropertyKey) -> Option<usize> {
+        let agent = test_agent();
+        let actual_key = make_key(&agent);
         ParameterMap::idx_from_key(&actual_key)
     }
 
@@ -84,7 +84,7 @@ mod parameter_map {
     #[test_case(&[Some("first"), Some("second"), Some("third")], 0 => ECMAScriptValue::from("first+0"); "typical")]
     #[test_case(&[Some("first"), None, Some("third")], 1 => panics "Get only used on existing values"; "get a deleted item")]
     fn get(before: &[Option<&str>], loc: usize) -> ECMAScriptValue {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let pmap =
             ParameterMap { env: env.clone(), properties: before.iter().map(|os| os.map(JSString::from)).collect() };
@@ -92,17 +92,17 @@ mod parameter_map {
             before.iter().enumerate().filter_map(|(idx, os)| os.as_ref().map(|&s| (idx, JSString::from(s))))
         {
             let value = ECMAScriptValue::from(format!("{}+{}", name, idx));
-            env.create_mutable_binding(&mut agent, name.clone(), false).unwrap();
-            env.initialize_binding(&mut agent, &name, value).unwrap();
+            env.create_mutable_binding(&agent, name.clone(), false).unwrap();
+            env.initialize_binding(&agent, &name, value).unwrap();
         }
 
-        pmap.get(&mut agent, loc).unwrap()
+        pmap.get(&agent, loc).unwrap()
     }
 
     #[test_case(&[Some("first"), Some("second"), Some("third")], 0, ECMAScriptValue::from("sentinel") => ECMAScriptValue::from("sentinel"); "typical")]
     #[test_case(&[Some("first"), None, Some("third")], 1, ECMAScriptValue::from("sentinel") => panics "Set only used on existing values"; "set a deleted item")]
     fn set(before: &[Option<&str>], loc: usize, val: ECMAScriptValue) -> ECMAScriptValue {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let pmap =
             ParameterMap { env: env.clone(), properties: before.iter().map(|os| os.map(JSString::from)).collect() };
@@ -110,13 +110,13 @@ mod parameter_map {
             before.iter().enumerate().filter_map(|(idx, os)| os.as_ref().map(|&s| (idx, JSString::from(s))))
         {
             let value = ECMAScriptValue::from(format!("{}+{}", name, idx));
-            env.create_mutable_binding(&mut agent, name.clone(), false).unwrap();
-            env.initialize_binding(&mut agent, &name, value).unwrap();
+            env.create_mutable_binding(&agent, name.clone(), false).unwrap();
+            env.initialize_binding(&agent, &name, value).unwrap();
         }
 
-        pmap.set(&mut agent, loc, val).unwrap();
+        pmap.set(&agent, loc, val).unwrap();
 
-        env.get_binding_value(&mut agent, pmap.properties[loc].as_ref().unwrap(), true).unwrap()
+        env.get_binding_value(&agent, pmap.properties[loc].as_ref().unwrap(), true).unwrap()
     }
 }
 
@@ -127,14 +127,14 @@ mod arguments_object {
 
     #[test]
     fn object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let pmap = ParameterMap {
             env: env.clone(),
             properties: vec![Some("from".into()), Some("the".into()), Some("test".into())],
         };
 
-        let result = ArgumentsObject::object(&mut agent, Some(pmap));
+        let result = ArgumentsObject::object(&agent, Some(pmap));
 
         let d = result.o.common_object_data().borrow();
 
@@ -151,7 +151,7 @@ mod arguments_object {
         assert_eq!(pmap.properties, vec![Some("from".into()), Some("the".into()), Some("test".into())]);
     }
 
-    fn test_ao(agent: &mut Agent) -> Object {
+    fn test_ao(agent: &Agent) -> Object {
         let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let lexenv = Rc::new(DeclarativeEnvironmentRecord::new(Some(env), "test_ao"));
         agent.set_lexical_environment(Some(lexenv.clone() as Rc<dyn EnvironmentRecord>));
@@ -177,7 +177,7 @@ mod arguments_object {
         obj
     }
 
-    fn test_unmapped(agent: &mut Agent) -> Object {
+    fn test_unmapped(agent: &Agent) -> Object {
         let obj = ArgumentsObject::object(agent, None);
 
         super::set(agent, &obj, "0".into(), "value of 'from'".into(), false).unwrap();
@@ -201,77 +201,77 @@ mod arguments_object {
     #[test_case(|ao| ao.o.is_ordinary() => true; "is_ordinary")]
     #[test_case(|ao| ao.o.is_arguments_object() => true; "is_arguments_object")]
     fn bool_stub(op: impl FnOnce(&Object) -> bool) -> bool {
-        let mut agent = test_agent();
-        let ao = test_ao(&mut agent);
+        let agent = test_agent();
+        let ao = test_ao(&agent);
         op(&ao)
     }
 
     #[test]
     fn to_array_object() {
-        let mut agent = test_agent();
-        let ao = test_ao(&mut agent);
+        let agent = test_agent();
+        let ao = test_ao(&agent);
         assert!(ao.o.to_array_object().is_none());
     }
 
     #[test]
     fn to_boolean_obj() {
-        let mut agent = test_agent();
-        let ao = test_ao(&mut agent);
+        let agent = test_agent();
+        let ao = test_ao(&agent);
         assert!(ao.o.to_boolean_obj().is_none());
     }
 
     #[test]
     fn to_error_obj() {
-        let mut agent = test_agent();
-        let ao = test_ao(&mut agent);
+        let agent = test_agent();
+        let ao = test_ao(&agent);
         assert!(ao.o.to_error_obj().is_none());
     }
     #[test]
     fn to_symbol_obj() {
-        let mut agent = test_agent();
-        let ao = test_ao(&mut agent);
+        let agent = test_agent();
+        let ao = test_ao(&agent);
         assert!(ao.o.to_symbol_obj().is_none());
     }
 
     #[test]
     fn to_number_obj() {
-        let mut agent = test_agent();
-        let ao = test_ao(&mut agent);
+        let agent = test_agent();
+        let ao = test_ao(&agent);
         assert!(ao.o.to_number_obj().is_none());
     }
 
     #[test]
     fn to_callable_obj() {
-        let mut agent = test_agent();
-        let ao = test_ao(&mut agent);
+        let agent = test_agent();
+        let ao = test_ao(&agent);
         assert!(ao.o.to_callable_obj().is_none());
     }
 
     #[test]
     fn to_constructable() {
-        let mut agent = test_agent();
-        let ao = test_ao(&mut agent);
+        let agent = test_agent();
+        let ao = test_ao(&agent);
         assert!(ao.o.to_constructable().is_none());
     }
 
     #[test]
     fn to_function_obj() {
-        let mut agent = test_agent();
-        let ao = test_ao(&mut agent);
+        let agent = test_agent();
+        let ao = test_ao(&agent);
         assert!(ao.o.to_function_obj().is_none());
     }
 
     #[test]
     fn to_builtin_function_obj() {
-        let mut agent = test_agent();
-        let ao = test_ao(&mut agent);
+        let agent = test_agent();
+        let ao = test_ao(&agent);
         assert!(ao.o.to_builtin_function_obj().is_none());
     }
 
     #[test]
     fn debug() {
-        let mut agent = test_agent();
-        let obj = test_ao(&mut agent);
+        let agent = test_agent();
+        let obj = test_ao(&agent);
         let ao = obj.o.to_arguments_object().unwrap();
         assert_ne!(format!("{:?}", ao), "");
     }
@@ -280,12 +280,12 @@ mod arguments_object {
     #[test_case(test_ao, "not" => Ok(ECMAScriptValue::Undefined); "prop wasn't there")]
     #[test_case(|a| { let ao = test_ao(a); ao.o.delete(a, &"1".into()).unwrap(); ao }, "1" => Ok(ECMAScriptValue::Undefined); "tried to get a deleted one")]
     #[test_case(|a| ArgumentsObject::object(a, None), "10" => Ok(ECMAScriptValue::Undefined); "unmapped")]
-    fn get(make_object: impl FnOnce(&mut Agent) -> Object, propname: &str) -> Result<ECMAScriptValue, String> {
-        let mut agent = test_agent();
-        let obj = make_object(&mut agent);
+    fn get(make_object: impl FnOnce(&Agent) -> Object, propname: &str) -> Result<ECMAScriptValue, String> {
+        let agent = test_agent();
+        let obj = make_object(&agent);
         let receiver = ECMAScriptValue::from(obj.clone());
 
-        obj.o.get(&mut agent, &propname.into(), &receiver).map_err(|err| unwind_any_error(&mut agent, err))
+        obj.o.get(&agent, &propname.into(), &receiver).map_err(|err| unwind_any_error(&agent, err))
     }
 
     #[test_case(test_ao, "0", ECMAScriptValue::from(99), &["0", "1", "2", "from", "the", "test"] => Ok((true, vec![
@@ -309,28 +309,27 @@ mod arguments_object {
         (ECMAScriptValue::from("sentinel"), ECMAScriptValue::Undefined),
     ])); "unmapped")]
     fn set(
-        make_object: impl FnOnce(&mut Agent) -> Object,
+        make_object: impl FnOnce(&Agent) -> Object,
         propname: &str,
         val: ECMAScriptValue,
         to_check: &[&str],
     ) -> Result<(bool, Vec<(ECMAScriptValue, ECMAScriptValue)>), String> {
-        let mut agent = test_agent();
-        let obj = make_object(&mut agent);
+        let agent = test_agent();
+        let obj = make_object(&agent);
         let env = agent
             .current_lexical_environment()
             .unwrap_or_else(|| agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap());
         let receiver = ECMAScriptValue::from(obj.clone());
 
-        let result =
-            obj.o.set(&mut agent, propname.into(), val, &receiver).map_err(|err| unwind_any_error(&mut agent, err))?;
+        let result = obj.o.set(&agent, propname.into(), val, &receiver).map_err(|err| unwind_any_error(&agent, err))?;
 
         let values = to_check
             .iter()
             .map(|&probe| {
                 (
-                    obj.o.get(&mut agent, &probe.into(), &receiver).unwrap(),
-                    if env.has_binding(&mut agent, &probe.into()).unwrap() {
-                        env.get_binding_value(&mut agent, &probe.into(), false).unwrap()
+                    obj.o.get(&agent, &probe.into(), &receiver).unwrap(),
+                    if env.has_binding(&agent, &probe.into()).unwrap() {
+                        env.get_binding_value(&agent, &probe.into(), false).unwrap()
                     } else {
                         ECMAScriptValue::Undefined
                     },
@@ -382,15 +381,15 @@ mod arguments_object {
         define_property_or_throw(a, &obj, "key", PotentialPropertyDescriptor::new().value(39).configurable(false)).unwrap();
         obj
     }, "key", &["key"] => Ok((false, test_hm(&[("key", ECMAScriptValue::from(39), ECMAScriptValue::Undefined)]), None)); "undeletable")]
-    fn delete(make_object: impl FnOnce(&mut Agent) -> Object, name: &str, to_check: &[&str]) -> TestResult {
-        let mut agent = test_agent();
-        let obj = make_object(&mut agent);
+    fn delete(make_object: impl FnOnce(&Agent) -> Object, name: &str, to_check: &[&str]) -> TestResult {
+        let agent = test_agent();
+        let obj = make_object(&agent);
         let env = agent
             .current_lexical_environment()
             .unwrap_or_else(|| agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap());
         let receiver = ECMAScriptValue::from(obj.clone());
 
-        let result = obj.o.delete(&mut agent, &name.into()).map_err(|err| unwind_any_error(&mut agent, err))?;
+        let result = obj.o.delete(&agent, &name.into()).map_err(|err| unwind_any_error(&agent, err))?;
 
         let values = to_check
             .iter()
@@ -398,9 +397,9 @@ mod arguments_object {
                 (
                     probe.to_string(),
                     (
-                        obj.o.get(&mut agent, &probe.into(), &receiver).unwrap(),
-                        if env.has_binding(&mut agent, &probe.into()).unwrap() {
-                            env.get_binding_value(&mut agent, &probe.into(), false).unwrap()
+                        obj.o.get(&agent, &probe.into(), &receiver).unwrap(),
+                        if env.has_binding(&agent, &probe.into()).unwrap() {
+                            env.get_binding_value(&agent, &probe.into(), false).unwrap()
                         } else {
                             ECMAScriptValue::Undefined
                         },
@@ -455,11 +454,11 @@ mod arguments_object {
     #[test_case(test_ao, "100" => using prop_checker(PotentialPropertyDescriptor::new().value("not in index").writable(true).enumerable(true).configurable(true)); "unmapped value")]
     #[test_case(test_unmapped, "2" => using prop_checker(PotentialPropertyDescriptor::new().value("value of 'test'").writable(true).enumerable(true).configurable(true)); "unmapped obj")]
     #[test_case(test_unmapped, "200" => None; "property not present")]
-    fn get_own_property(make_object: impl FnOnce(&mut Agent) -> Object, name: &str) -> Option<PropertyDescriptor> {
-        let mut agent = test_agent();
-        let obj = make_object(&mut agent);
+    fn get_own_property(make_object: impl FnOnce(&Agent) -> Object, name: &str) -> Option<PropertyDescriptor> {
+        let agent = test_agent();
+        let obj = make_object(&agent);
 
-        obj.o.get_own_property(&mut agent, &name.into()).unwrap()
+        obj.o.get_own_property(&agent, &name.into()).unwrap()
     }
 
     type DefineOwnPropertyTestResult =
@@ -536,27 +535,26 @@ mod arguments_object {
         ("2", "value of 'test'".into()),
     ]), hm(&[]))); "unmapped")]
     fn define_own_property(
-        make_object: impl FnOnce(&mut Agent) -> Object,
+        make_object: impl FnOnce(&Agent) -> Object,
         name: &str,
         desc: PotentialPropertyDescriptor,
     ) -> DefineOwnPropertyTestResult {
-        let mut agent = test_agent();
-        let obj = make_object(&mut agent);
+        let agent = test_agent();
+        let obj = make_object(&agent);
         let env = agent.current_lexical_environment().unwrap();
 
-        let result =
-            obj.o.define_own_property(&mut agent, name.into(), desc).map_err(|e| unwind_any_error(&mut agent, e))?;
+        let result = obj.o.define_own_property(&agent, name.into(), desc).map_err(|e| unwind_any_error(&agent, e))?;
 
-        let object_keys = obj.o.own_property_keys(&mut agent).unwrap();
+        let object_keys = obj.o.own_property_keys(&agent).unwrap();
         let items = object_keys
             .iter()
-            .map(|key| (key.to_string(), super::get(&mut agent, &obj, key).unwrap()))
+            .map(|key| (key.to_string(), super::get(&agent, &obj, key).unwrap()))
             .collect::<AHashMap<_, _>>();
 
         let env_items = env
             .binding_names()
             .iter()
-            .map(|key| (key.to_string(), env.get_binding_value(&mut agent, key, false).unwrap()))
+            .map(|key| (key.to_string(), env.get_binding_value(&agent, key, false).unwrap()))
             .collect::<AHashMap<_, _>>();
 
         Ok((result, items, env_items))
@@ -564,26 +562,26 @@ mod arguments_object {
 
     #[test_case(test_ao, "0" => true; "exists")]
     #[test_case(test_ao, "from" => false; "not in ao")]
-    fn has_property(make_object: impl FnOnce(&mut Agent) -> Object, name: &str) -> bool {
-        let mut agent = test_agent();
-        let obj = make_object(&mut agent);
+    fn has_property(make_object: impl FnOnce(&Agent) -> Object, name: &str) -> bool {
+        let agent = test_agent();
+        let obj = make_object(&agent);
 
-        obj.o.has_property(&mut agent, &name.into()).unwrap()
+        obj.o.has_property(&agent, &name.into()).unwrap()
     }
 
     #[test_case(test_ao => true; "typical")]
-    fn set_prototype_of(make_object: impl FnOnce(&mut Agent) -> Object) -> bool {
-        let mut agent = test_agent();
-        let obj = make_object(&mut agent);
+    fn set_prototype_of(make_object: impl FnOnce(&Agent) -> Object) -> bool {
+        let agent = test_agent();
+        let obj = make_object(&agent);
 
-        obj.o.set_prototype_of(&mut agent, None).unwrap()
+        obj.o.set_prototype_of(&agent, None).unwrap()
     }
 
     #[test_case(test_ao => true; "typical")]
-    fn prevent_extensions(make_object: impl FnOnce(&mut Agent) -> Object) -> bool {
-        let mut agent = test_agent();
-        let obj = make_object(&mut agent);
+    fn prevent_extensions(make_object: impl FnOnce(&Agent) -> Object) -> bool {
+        let agent = test_agent();
+        let obj = make_object(&agent);
 
-        obj.o.prevent_extensions(&mut agent).unwrap()
+        obj.o.prevent_extensions(&agent).unwrap()
     }
 }

--- a/src/arrays/tests.rs
+++ b/src/arrays/tests.rs
@@ -17,15 +17,15 @@ mod array_object {
         ]); "hundred length")]
         #[test_case(7294967295 => Err("RangeError: Array lengths greater than 4294967295 are not allowed".to_string()); "over limit")]
         fn normal(length: u64) -> Result<Vec<PropertyInfo>, String> {
-            let mut agent = test_agent();
+            let agent = test_agent();
 
-            let result = ArrayObject::create(&mut agent, length, None);
+            let result = ArrayObject::create(&agent, length, None);
             match result {
-                Err(err) => Err(unwind_any_error(&mut agent, err)),
+                Err(err) => Err(unwind_any_error(&agent, err)),
                 Ok(obj) => {
-                    assert!(obj.is_array(&mut agent).unwrap());
+                    assert!(obj.is_array(&agent).unwrap());
                     assert_eq!(
-                        obj.o.get_prototype_of(&mut agent).unwrap(),
+                        obj.o.get_prototype_of(&agent).unwrap(),
                         Some(agent.intrinsic(IntrinsicId::ArrayPrototype))
                     );
                     Ok(obj.o.common_object_data().borrow().propdump())
@@ -35,66 +35,65 @@ mod array_object {
 
         #[test]
         fn proto_specified() {
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
 
-            let obj = ArrayObject::create(&mut agent, 600, Some(object_proto.clone())).unwrap();
-            assert!(obj.is_array(&mut agent).unwrap());
-            assert_eq!(obj.o.get_prototype_of(&mut agent).unwrap(), Some(object_proto));
+            let obj = ArrayObject::create(&agent, 600, Some(object_proto.clone())).unwrap();
+            assert!(obj.is_array(&agent).unwrap());
+            assert_eq!(obj.o.get_prototype_of(&agent).unwrap(), Some(object_proto));
         }
     }
 
     #[test]
     fn debug() {
-        let mut agent = test_agent();
-        let a = ArrayObject::create(&mut agent, 0, None).unwrap();
+        let agent = test_agent();
+        let a = ArrayObject::create(&agent, 0, None).unwrap();
         assert_ne!(format!("{:?}", a), "");
     }
 
     #[test]
     fn is_ordinary() {
-        let mut agent = test_agent();
-        let a = ArrayObject::create(&mut agent, 0, None).unwrap();
+        let agent = test_agent();
+        let a = ArrayObject::create(&agent, 0, None).unwrap();
         assert_eq!(a.o.is_ordinary(), true);
     }
 
     #[test]
     fn get_prototype_of() {
-        let mut agent = test_agent();
-        let a = ArrayObject::create(&mut agent, 0, None).unwrap();
-        let a_proto = a.o.get_prototype_of(&mut agent).unwrap().unwrap();
+        let agent = test_agent();
+        let a = ArrayObject::create(&agent, 0, None).unwrap();
+        let a_proto = a.o.get_prototype_of(&agent).unwrap().unwrap();
         assert_eq!(a_proto, agent.intrinsic(IntrinsicId::ArrayPrototype));
     }
 
     #[test]
     fn set_prototype_of() {
-        let mut agent = test_agent();
-        let a = ArrayObject::create(&mut agent, 0, None).unwrap();
+        let agent = test_agent();
+        let a = ArrayObject::create(&agent, 0, None).unwrap();
         let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let success = a.o.set_prototype_of(&mut agent, Some(obj_proto.clone())).unwrap();
+        let success = a.o.set_prototype_of(&agent, Some(obj_proto.clone())).unwrap();
         assert!(success);
-        assert_eq!(obj_proto, a.o.get_prototype_of(&mut agent).unwrap().unwrap());
+        assert_eq!(obj_proto, a.o.get_prototype_of(&agent).unwrap().unwrap());
     }
 
     #[test]
     fn is_extensible() {
-        let mut agent = test_agent();
-        let a = ArrayObject::create(&mut agent, 0, None).unwrap();
-        assert!(a.o.is_extensible(&mut agent).unwrap());
+        let agent = test_agent();
+        let a = ArrayObject::create(&agent, 0, None).unwrap();
+        assert!(a.o.is_extensible(&agent).unwrap());
     }
     #[test]
     fn prevent_extensions() {
-        let mut agent = test_agent();
-        let a = ArrayObject::create(&mut agent, 0, None).unwrap();
-        assert!(a.o.prevent_extensions(&mut agent).unwrap());
-        assert!(!a.o.is_extensible(&mut agent).unwrap());
+        let agent = test_agent();
+        let a = ArrayObject::create(&agent, 0, None).unwrap();
+        assert!(a.o.prevent_extensions(&agent).unwrap());
+        assert!(!a.o.is_extensible(&agent).unwrap());
     }
     #[test]
     fn get_own_property() {
-        let mut agent = test_agent();
-        let a = ArrayObject::create(&mut agent, 0, None).unwrap();
-        let desc: DataDescriptor =
-            a.o.get_own_property(&mut agent, &"length".into()).unwrap().unwrap().try_into().unwrap();
+        let agent = test_agent();
+        let a = ArrayObject::create(&agent, 0, None).unwrap();
+        let desc: DataDescriptor = a.o.get_own_property(&agent, &"length".into()).unwrap().unwrap().try_into().unwrap();
 
         assert_eq!(desc.configurable, false);
         assert_eq!(desc.enumerable, false);
@@ -128,10 +127,10 @@ mod array_object {
             enumerable: bool,
             configurable: bool,
         ) -> Result<(bool, Vec<PropertyInfo>), String> {
-            let mut agent = test_agent();
-            let a = ArrayObject::create(&mut agent, 0, None).unwrap();
+            let agent = test_agent();
+            let a = ArrayObject::create(&agent, 0, None).unwrap();
             let result = a.o.define_own_property(
-                &mut agent,
+                &agent,
                 key.into(),
                 PotentialPropertyDescriptor {
                     value: Some(val.into()),
@@ -142,7 +141,7 @@ mod array_object {
                 },
             );
             match result {
-                Err(err) => Err(unwind_any_error(&mut agent, err)),
+                Err(err) => Err(unwind_any_error(&agent, err)),
                 Ok(success) => Ok((success, a.o.common_object_data().borrow().propdump())),
             }
         }
@@ -161,18 +160,18 @@ mod array_object {
             enumerable: bool,
             configurable: bool,
         ) -> Result<(bool, Vec<PropertyInfo>), String> {
-            let mut agent = test_agent();
-            let a = ArrayObject::create(&mut agent, 100, None).unwrap();
+            let agent = test_agent();
+            let a = ArrayObject::create(&agent, 100, None).unwrap();
             // Make the length property read-only
             a.o.define_own_property(
-                &mut agent,
+                &agent,
                 "length".into(),
                 PotentialPropertyDescriptor { writable: Some(false), ..Default::default() },
             )
             .unwrap();
             // Exercise function under test
             let result = a.o.define_own_property(
-                &mut agent,
+                &agent,
                 key.into(),
                 PotentialPropertyDescriptor {
                     value: Some(val.into()),
@@ -183,18 +182,18 @@ mod array_object {
                 },
             );
             match result {
-                Err(err) => Err(unwind_any_error(&mut agent, err)),
+                Err(err) => Err(unwind_any_error(&agent, err)),
                 Ok(success) => Ok((success, a.o.common_object_data().borrow().propdump())),
             }
         }
 
         #[test]
         fn read_only_elem() {
-            let mut agent = test_agent();
-            let a = ArrayObject::create(&mut agent, 100, None).unwrap();
+            let agent = test_agent();
+            let a = ArrayObject::create(&agent, 100, None).unwrap();
             // Make a read-only property with an array index
             a.o.define_own_property(
-                &mut agent,
+                &agent,
                 "30".into(),
                 PotentialPropertyDescriptor {
                     value: Some("blue".into()),
@@ -208,7 +207,7 @@ mod array_object {
             // Now exercise: try to overwrite that property
             let result =
                 a.o.define_own_property(
-                    &mut agent,
+                    &agent,
                     "30".into(),
                     PotentialPropertyDescriptor {
                         value: Some("green".into()),
@@ -243,45 +242,45 @@ mod array_object {
 
     #[test]
     fn has_property() {
-        let mut agent = test_agent();
-        let a = ArrayObject::create(&mut agent, 0, None).unwrap();
-        assert!(a.o.has_property(&mut agent, &"length".into()).unwrap());
+        let agent = test_agent();
+        let a = ArrayObject::create(&agent, 0, None).unwrap();
+        assert!(a.o.has_property(&agent, &"length".into()).unwrap());
     }
     #[test]
     fn get() {
-        let mut agent = test_agent();
-        let a = ArrayObject::create(&mut agent, 0, None).unwrap();
+        let agent = test_agent();
+        let a = ArrayObject::create(&agent, 0, None).unwrap();
         let receiver: ECMAScriptValue = a.clone().into();
-        let val = a.o.get(&mut agent, &"length".into(), &receiver).unwrap();
+        let val = a.o.get(&agent, &"length".into(), &receiver).unwrap();
         assert_eq!(val, 0.into());
     }
     #[test]
     fn set_() {
-        let mut agent = test_agent();
-        let a = ArrayObject::create(&mut agent, 0, None).unwrap();
+        let agent = test_agent();
+        let a = ArrayObject::create(&agent, 0, None).unwrap();
         let receiver: ECMAScriptValue = a.clone().into();
-        let success = a.o.set(&mut agent, "length".into(), 100.into(), &receiver).unwrap();
+        let success = a.o.set(&agent, "length".into(), 100.into(), &receiver).unwrap();
         assert!(success);
-        assert_eq!(a.o.get(&mut agent, &"length".into(), &receiver).unwrap(), 100.into());
+        assert_eq!(a.o.get(&agent, &"length".into(), &receiver).unwrap(), 100.into());
     }
     #[test]
     fn delete() {
-        let mut agent = test_agent();
-        let a = ArrayObject::create(&mut agent, 0, None).unwrap();
-        let success = a.o.delete(&mut agent, &"length".into()).unwrap();
+        let agent = test_agent();
+        let a = ArrayObject::create(&agent, 0, None).unwrap();
+        let success = a.o.delete(&agent, &"length".into()).unwrap();
         assert!(!success);
     }
     #[test]
     fn own_property_keys() {
-        let mut agent = test_agent();
-        let a = ArrayObject::create(&mut agent, 0, None).unwrap();
-        let list = a.o.own_property_keys(&mut agent).unwrap();
+        let agent = test_agent();
+        let a = ArrayObject::create(&agent, 0, None).unwrap();
+        let list = a.o.own_property_keys(&agent).unwrap();
         assert_eq!(list, vec!["length".into()]);
     }
     #[test]
     fn is_array_object() {
-        let mut agent = test_agent();
-        let a = ArrayObject::create(&mut agent, 0, None).unwrap();
+        let agent = test_agent();
+        let a = ArrayObject::create(&agent, 0, None).unwrap();
         assert!(a.o.is_array_object());
     }
 
@@ -290,7 +289,7 @@ mod array_object {
         use test_case::test_case;
 
         fn value_just_once(
-            agent: &mut Agent,
+            agent: &Agent,
             this_value: ECMAScriptValue,
             _: Option<&Object>,
             _: &[ECMAScriptValue],
@@ -306,7 +305,7 @@ mod array_object {
                 _ => Err(create_type_error(agent, "valueOf called too many times")),
             }
         }
-        fn screwy_get_value(agent: &mut Agent) -> PotentialPropertyDescriptor {
+        fn screwy_get_value(agent: &Agent) -> PotentialPropertyDescriptor {
             let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let function_proto = agent.intrinsic(IntrinsicId::FunctionPrototype);
             let obj = ordinary_object_create(agent, Some(object_proto), &[]);
@@ -336,29 +335,29 @@ mod array_object {
             .unwrap();
             PotentialPropertyDescriptor { value: Some(obj.into()), ..Default::default() }
         }
-        fn readonly(_: &mut Agent) -> PotentialPropertyDescriptor {
+        fn readonly(_: &Agent) -> PotentialPropertyDescriptor {
             PotentialPropertyDescriptor { writable: Some(false), ..Default::default() }
         }
-        fn fraction(_: &mut Agent) -> PotentialPropertyDescriptor {
+        fn fraction(_: &Agent) -> PotentialPropertyDescriptor {
             PotentialPropertyDescriptor { value: Some(1.5.into()), ..Default::default() }
         }
-        fn symbol(a: &mut Agent) -> PotentialPropertyDescriptor {
+        fn symbol(a: &Agent) -> PotentialPropertyDescriptor {
             let sym = a.wks(WksId::Species);
             PotentialPropertyDescriptor { value: Some(sym.into()), ..Default::default() }
         }
-        fn bigger(_: &mut Agent) -> PotentialPropertyDescriptor {
+        fn bigger(_: &Agent) -> PotentialPropertyDescriptor {
             PotentialPropertyDescriptor { value: Some(7000.into()), ..Default::default() }
         }
-        fn configurable_400(_: &mut Agent) -> PotentialPropertyDescriptor {
+        fn configurable_400(_: &Agent) -> PotentialPropertyDescriptor {
             PotentialPropertyDescriptor { value: Some(400.into()), configurable: Some(true), ..Default::default() }
         }
-        fn writable_700(_: &mut Agent) -> PotentialPropertyDescriptor {
+        fn writable_700(_: &Agent) -> PotentialPropertyDescriptor {
             PotentialPropertyDescriptor { value: Some(700.0.into()), writable: Some(true), ..Default::default() }
         }
-        fn readonly_0(_: &mut Agent) -> PotentialPropertyDescriptor {
+        fn readonly_0(_: &Agent) -> PotentialPropertyDescriptor {
             PotentialPropertyDescriptor { value: Some(0.into()), writable: Some(false), ..Default::default() }
         }
-        fn fifty(_: &mut Agent) -> PotentialPropertyDescriptor {
+        fn fifty(_: &Agent) -> PotentialPropertyDescriptor {
             PotentialPropertyDescriptor { value: Some(50.0.into()), ..Default::default() }
         }
 
@@ -384,24 +383,24 @@ mod array_object {
                 }
             ])); "length increase")]
         fn zero_elements(
-            make_desc: fn(&mut Agent) -> PotentialPropertyDescriptor,
+            make_desc: fn(&Agent) -> PotentialPropertyDescriptor,
         ) -> Result<(bool, Vec<PropertyInfo>), String> {
-            let mut agent = test_agent();
-            let aobj = ArrayObject::create(&mut agent, 0, None).unwrap();
+            let agent = test_agent();
+            let aobj = ArrayObject::create(&agent, 0, None).unwrap();
             let a = aobj.o.to_array_object().unwrap();
-            let desc = make_desc(&mut agent);
+            let desc = make_desc(&agent);
 
-            a.set_length(&mut agent, desc)
+            a.set_length(&agent, desc)
                 .map(|success| (success, a.common.borrow().propdump()))
-                .map_err(|err| unwind_any_error(&mut agent, err))
+                .map_err(|err| unwind_any_error(&agent, err))
         }
 
         #[test]
         fn readonly_length() {
-            let mut agent = test_agent();
-            let aobj = ArrayObject::create(&mut agent, 9000, None).unwrap();
+            let agent = test_agent();
+            let aobj = ArrayObject::create(&agent, 9000, None).unwrap();
             define_property_or_throw(
-                &mut agent,
+                &agent,
                 &aobj,
                 "length",
                 PotentialPropertyDescriptor { writable: Some(false), ..Default::default() },
@@ -410,12 +409,9 @@ mod array_object {
             let a = aobj.o.to_array_object().unwrap();
 
             let result = a
-                .set_length(
-                    &mut agent,
-                    PotentialPropertyDescriptor { value: Some(1000.0.into()), ..Default::default() },
-                )
+                .set_length(&agent, PotentialPropertyDescriptor { value: Some(1000.0.into()), ..Default::default() })
                 .map(|success| (success, a.common.borrow().propdump()))
-                .map_err(|err| unwind_any_error(&mut agent, err));
+                .map_err(|err| unwind_any_error(&agent, err));
             assert_eq!(
                 result,
                 Ok((
@@ -491,19 +487,19 @@ mod array_object {
             },
         ])); "delete them all and lock")]
         fn three_elements(
-            make_desc: fn(&mut Agent) -> PotentialPropertyDescriptor,
+            make_desc: fn(&Agent) -> PotentialPropertyDescriptor,
         ) -> Result<(bool, Vec<PropertyInfo>), String> {
-            let mut agent = test_agent();
-            let aobj = ArrayObject::create(&mut agent, 9000, None).unwrap();
-            set(&mut agent, &aobj, "0".into(), "blue".into(), true).unwrap();
-            set(&mut agent, &aobj, "100".into(), "green".into(), true).unwrap();
-            set(&mut agent, &aobj, "500".into(), "red".into(), true).unwrap();
+            let agent = test_agent();
+            let aobj = ArrayObject::create(&agent, 9000, None).unwrap();
+            set(&agent, &aobj, "0".into(), "blue".into(), true).unwrap();
+            set(&agent, &aobj, "100".into(), "green".into(), true).unwrap();
+            set(&agent, &aobj, "500".into(), "red".into(), true).unwrap();
             let a = aobj.o.to_array_object().unwrap();
-            let desc = make_desc(&mut agent);
+            let desc = make_desc(&agent);
 
-            a.set_length(&mut agent, desc)
+            a.set_length(&agent, desc)
                 .map(|success| (success, a.common.borrow().propdump()))
-                .map_err(|err| unwind_any_error(&mut agent, err))
+                .map_err(|err| unwind_any_error(&agent, err))
         }
 
         #[test_case(fifty => Ok((false, vec![
@@ -547,13 +543,13 @@ mod array_object {
             },
         ])); "abort then freeze")]
         fn frozen_middle(
-            make_desc: fn(&mut Agent) -> PotentialPropertyDescriptor,
+            make_desc: fn(&Agent) -> PotentialPropertyDescriptor,
         ) -> Result<(bool, Vec<PropertyInfo>), String> {
-            let mut agent = test_agent();
-            let aobj = ArrayObject::create(&mut agent, 9000, None).unwrap();
-            set(&mut agent, &aobj, "0".into(), "blue".into(), true).unwrap();
+            let agent = test_agent();
+            let aobj = ArrayObject::create(&agent, 9000, None).unwrap();
+            set(&agent, &aobj, "0".into(), "blue".into(), true).unwrap();
             define_property_or_throw(
-                &mut agent,
+                &agent,
                 &aobj,
                 "100",
                 PotentialPropertyDescriptor {
@@ -565,33 +561,33 @@ mod array_object {
                 },
             )
             .unwrap();
-            set(&mut agent, &aobj, "500".into(), "red".into(), true).unwrap();
+            set(&agent, &aobj, "500".into(), "red".into(), true).unwrap();
             let a = aobj.o.to_array_object().unwrap();
-            let desc = make_desc(&mut agent);
+            let desc = make_desc(&agent);
 
-            a.set_length(&mut agent, desc)
+            a.set_length(&agent, desc)
                 .map(|success| (success, a.common.borrow().propdump()))
-                .map_err(|err| unwind_any_error(&mut agent, err))
+                .map_err(|err| unwind_any_error(&agent, err))
         }
     }
 }
 
 #[test]
 fn array_create() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let array_proto = agent.intrinsic(IntrinsicId::ArrayPrototype);
-    let custom_proto = ordinary_object_create(&mut agent, Some(array_proto), &[]);
-    let aobj = super::array_create(&mut agent, 231, Some(custom_proto.clone())).unwrap();
-    assert_eq!(aobj.o.get_prototype_of(&mut agent).unwrap(), Some(custom_proto));
-    assert_eq!(get(&mut agent, &aobj, &"length".into()).unwrap(), ECMAScriptValue::from(231.0));
-    assert!(aobj.is_array(&mut agent).unwrap())
+    let custom_proto = ordinary_object_create(&agent, Some(array_proto), &[]);
+    let aobj = super::array_create(&agent, 231, Some(custom_proto.clone())).unwrap();
+    assert_eq!(aobj.o.get_prototype_of(&agent).unwrap(), Some(custom_proto));
+    assert_eq!(get(&agent, &aobj, &"length".into()).unwrap(), ECMAScriptValue::from(231.0));
+    assert!(aobj.is_array(&agent).unwrap())
 }
 
-fn make_ordinary_object(agent: &mut Agent) -> ECMAScriptValue {
+fn make_ordinary_object(agent: &Agent) -> ECMAScriptValue {
     let proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     ordinary_object_create(agent, Some(proto), &[]).into()
 }
-fn make_array_object(agent: &mut Agent) -> ECMAScriptValue {
+fn make_array_object(agent: &Agent) -> ECMAScriptValue {
     super::array_create(agent, 10, None).unwrap().into()
 }
 #[test_case(make_ordinary_object => Ok(false); "ordinary object")]
@@ -600,23 +596,23 @@ fn make_array_object(agent: &mut Agent) -> ECMAScriptValue {
 #[test_case(|_| ECMAScriptValue::Null => Ok(false); "null")]
 #[test_case(|_| ECMAScriptValue::from(true) => Ok(false); "boolean")]
 #[test_case(|_| ECMAScriptValue::from(33.2) => Ok(false); "number")]
-fn is_array(make_arg: fn(&mut Agent) -> ECMAScriptValue) -> Result<bool, String> {
-    let mut agent = test_agent();
-    let arg = make_arg(&mut agent);
+fn is_array(make_arg: fn(&Agent) -> ECMAScriptValue) -> Result<bool, String> {
+    let agent = test_agent();
+    let arg = make_arg(&agent);
 
-    super::is_array(&mut agent, &arg).map_err(|err| unwind_any_error(&mut agent, err))
+    super::is_array(&agent, &arg).map_err(|err| unwind_any_error(&agent, err))
 }
 
 mod array_species_create {
     use super::*;
     use test_case::test_case;
 
-    fn make_ordinary(agent: &mut Agent) -> Object {
+    fn make_ordinary(agent: &Agent) -> Object {
         let proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         ordinary_object_create(agent, Some(proto), &[])
     }
 
-    fn make_throwing_constructor_prop(agent: &mut Agent) -> Object {
+    fn make_throwing_constructor_prop(agent: &Agent) -> Object {
         let proto = agent.intrinsic(IntrinsicId::ArrayPrototype);
         let function_proto = agent.intrinsic(IntrinsicId::FunctionPrototype);
         let obj = super::super::array_create(agent, 0, Some(proto)).unwrap();
@@ -646,7 +642,7 @@ mod array_species_create {
         .unwrap();
         obj
     }
-    fn make_undefined_constructor_prop(agent: &mut Agent) -> Object {
+    fn make_undefined_constructor_prop(agent: &Agent) -> Object {
         let proto = agent.intrinsic(IntrinsicId::ArrayPrototype);
         let obj = super::super::array_create(agent, 0, Some(proto)).unwrap();
         define_property_or_throw(
@@ -664,11 +660,11 @@ mod array_species_create {
         .unwrap();
         obj
     }
-    fn make_plain_array(agent: &mut Agent) -> Object {
+    fn make_plain_array(agent: &Agent) -> Object {
         let proto = agent.intrinsic(IntrinsicId::ArrayPrototype);
         super::super::array_create(agent, 5, Some(proto)).unwrap()
     }
-    fn make_primitive_constructor_prop(agent: &mut Agent) -> Object {
+    fn make_primitive_constructor_prop(agent: &Agent) -> Object {
         let proto = agent.intrinsic(IntrinsicId::ArrayPrototype);
         let obj = super::super::array_create(agent, 0, Some(proto)).unwrap();
         define_property_or_throw(
@@ -715,12 +711,12 @@ mod array_species_create {
         },
     ]); "plain array")]
     #[test_case(make_primitive_constructor_prop, 10 => Err("TypeError: Array species constructor invalid".to_string()); "primitive in constructor")]
-    fn f(make_original: fn(&mut Agent) -> Object, length: u64) -> Result<Vec<PropertyInfo>, String> {
-        let mut agent = test_agent();
-        let original = make_original(&mut agent);
-        array_species_create(&mut agent, &original, length)
+    fn f(make_original: fn(&Agent) -> Object, length: u64) -> Result<Vec<PropertyInfo>, String> {
+        let agent = test_agent();
+        let original = make_original(&agent);
+        array_species_create(&agent, &original, length)
             .map(|val| Object::try_from(val).unwrap().o.common_object_data().borrow().propdump())
-            .map_err(|err| unwind_any_error(&mut agent, err))
+            .map_err(|err| unwind_any_error(&agent, err))
     }
 
     // todo!(): More tests want to be here to cover other code paths, but those code paths require:
@@ -734,8 +730,8 @@ mod array_species_create {
 fn defaults() {
     // These don't really test anything except the default implementations, but it does clear a fair few instantiations
     // out of the "uncovered" set.
-    let mut agent = test_agent();
-    let a = super::array_create(&mut agent, 10, None).unwrap();
+    let agent = test_agent();
+    let a = super::array_create(&agent, 10, None).unwrap();
     assert_eq!(a.o.is_date_object(), false);
     assert!(a.o.to_function_obj().is_none());
     assert!(a.o.to_error_obj().is_none());
@@ -790,7 +786,7 @@ fn defaults() {
 #[test_case(super::array_prototype_to_string => panics; "array_prototype_to_string")]
 #[test_case(super::array_prototype_unshift => panics; "array_prototype_unshift")]
 #[test_case(super::array_prototype_values => panics; "array_prototype_values")]
-fn todo(f: fn(&mut Agent, ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion<ECMAScriptValue>) {
-    let mut agent = test_agent();
-    f(&mut agent, ECMAScriptValue::Undefined, None, &[]).unwrap();
+fn todo(f: fn(&Agent, ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion<ECMAScriptValue>) {
+    let agent = test_agent();
+    f(&agent, ECMAScriptValue::Undefined, None, &[]).unwrap();
 }

--- a/src/bigint_object/mod.rs
+++ b/src/bigint_object/mod.rs
@@ -2,6 +2,6 @@ use super::*;
 use num::BigInt;
 use std::rc::Rc;
 
-pub fn create_bigint_object(_agent: &mut Agent, _b: Rc<BigInt>) -> Object {
+pub fn create_bigint_object(_agent: &Agent, _b: Rc<BigInt>) -> Object {
     todo!()
 }

--- a/src/boolean_object/mod.rs
+++ b/src/boolean_object/mod.rs
@@ -35,7 +35,7 @@ impl ObjectInterface for BooleanObject {
         true
     }
 
-    fn get_prototype_of(&self, _agent: &mut Agent) -> Completion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &Agent) -> Completion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
 
@@ -45,7 +45,7 @@ impl ObjectInterface for BooleanObject {
     // the following steps when called:
     //
     //  1. Return ! OrdinarySetPrototypeOf(O, V).
-    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<Object>) -> Completion<bool> {
+    fn set_prototype_of(&self, _agent: &Agent, obj: Option<Object>) -> Completion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
 
@@ -55,7 +55,7 @@ impl ObjectInterface for BooleanObject {
     // when called:
     //
     //  1. Return ! OrdinaryIsExtensible(O).
-    fn is_extensible(&self, _agent: &mut Agent) -> Completion<bool> {
+    fn is_extensible(&self, _agent: &Agent) -> Completion<bool> {
         Ok(ordinary_is_extensible(self))
     }
 
@@ -65,7 +65,7 @@ impl ObjectInterface for BooleanObject {
     // steps when called:
     //
     //  1. Return ! OrdinaryPreventExtensions(O).
-    fn prevent_extensions(&self, _agent: &mut Agent) -> Completion<bool> {
+    fn prevent_extensions(&self, _agent: &Agent) -> Completion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
 
@@ -75,7 +75,7 @@ impl ObjectInterface for BooleanObject {
     // following steps when called:
     //
     //  1. Return ! OrdinaryGetOwnProperty(O, P).
-    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _agent: &Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(self, key))
     }
 
@@ -87,7 +87,7 @@ impl ObjectInterface for BooleanObject {
     //  1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
     fn define_own_property(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         key: PropertyKey,
         desc: PotentialPropertyDescriptor,
     ) -> Completion<bool> {
@@ -100,7 +100,7 @@ impl ObjectInterface for BooleanObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryHasProperty(O, P).
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
+    fn has_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_has_property(agent, self, key)
     }
 
@@ -110,7 +110,7 @@ impl ObjectInterface for BooleanObject {
     // ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryGet(O, P, Receiver).
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+    fn get(&self, agent: &Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         ordinary_get(agent, self, key, receiver)
     }
 
@@ -120,13 +120,7 @@ impl ObjectInterface for BooleanObject {
     // value), and Receiver (an ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinarySet(O, P, V, Receiver).
-    fn set(
-        &self,
-        agent: &mut Agent,
-        key: PropertyKey,
-        v: ECMAScriptValue,
-        receiver: &ECMAScriptValue,
-    ) -> Completion<bool> {
+    fn set(&self, agent: &Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
         ordinary_set(agent, self, key, v, receiver)
     }
 
@@ -136,7 +130,7 @@ impl ObjectInterface for BooleanObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryDelete(O, P).
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
+    fn delete(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_delete(agent, self, key)
     }
 
@@ -146,7 +140,7 @@ impl ObjectInterface for BooleanObject {
     // steps when called:
     //
     // 1. Return ! OrdinaryOwnPropertyKeys(O).
-    fn own_property_keys(&self, _agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, _agent: &Agent) -> Completion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(self))
     }
 }
@@ -158,7 +152,7 @@ impl BooleanObjectInterface for BooleanObject {
 }
 
 impl BooleanObject {
-    pub fn object(agent: &mut Agent, prototype: Option<Object>) -> Object {
+    pub fn object(agent: &Agent, prototype: Option<Object>) -> Object {
         Object {
             o: Rc::new(Self {
                 common: RefCell::new(CommonObjectData::new(agent, prototype, true, BOOLEAN_OBJECT_SLOTS)),
@@ -175,7 +169,7 @@ impl BooleanObject {
 //  3. Let O be ? OrdinaryCreateFromConstructor(%Boolean%, "%Boolean.prototype%", « [[BooleanData]] »).
 //  4. Set O.[[BooleanData]] to b.
 //  5. Return O.
-pub fn create_boolean_object(agent: &mut Agent, b: bool) -> Object {
+pub fn create_boolean_object(agent: &Agent, b: bool) -> Object {
     let constructor = agent.intrinsic(IntrinsicId::Boolean);
     let o = ordinary_create_from_constructor(
         agent,
@@ -196,7 +190,7 @@ pub fn create_boolean_object(agent: &mut Agent, b: bool) -> Object {
 //      b. Assert: Type(b) is Boolean.
 //      c. Return b.
 //  3. Throw a TypeError exception.
-pub fn this_boolean_value(agent: &mut Agent, value: &ECMAScriptValue) -> Completion<bool> {
+pub fn this_boolean_value(agent: &Agent, value: &ECMAScriptValue) -> Completion<bool> {
     match value {
         ECMAScriptValue::Boolean(b) => Ok(*b),
         ECMAScriptValue::Object(o) => {

--- a/src/boolean_object/tests.rs
+++ b/src/boolean_object/tests.rs
@@ -3,8 +3,8 @@ use crate::tests::*;
 
 #[test]
 fn create_boolean_object_01() {
-    let mut agent = test_agent();
-    let result = create_boolean_object(&mut agent, true);
+    let agent = test_agent();
+    let result = create_boolean_object(&agent, true);
 
     let maybe_native = result.o.to_boolean_obj();
     assert!(maybe_native.is_some());
@@ -15,8 +15,8 @@ fn create_boolean_object_01() {
 
 #[test]
 fn create_boolean_object_02() {
-    let mut agent = test_agent();
-    let result = create_boolean_object(&mut agent, false);
+    let agent = test_agent();
+    let result = create_boolean_object(&agent, false);
 
     let maybe_native = result.o.to_boolean_obj();
     assert!(maybe_native.is_some());
@@ -27,102 +27,102 @@ fn create_boolean_object_02() {
 
 #[test]
 fn this_boolean_value_01() {
-    let mut agent = test_agent();
-    let result = this_boolean_value(&mut agent, &ECMAScriptValue::Boolean(true));
+    let agent = test_agent();
+    let result = this_boolean_value(&agent, &ECMAScriptValue::Boolean(true));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), true);
 }
 #[test]
 fn this_boolean_value_02() {
-    let mut agent = test_agent();
-    let result = this_boolean_value(&mut agent, &ECMAScriptValue::Boolean(false));
+    let agent = test_agent();
+    let result = this_boolean_value(&agent, &ECMAScriptValue::Boolean(false));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), false);
 }
 #[test]
 fn this_boolean_value_03() {
-    let mut agent = test_agent();
-    let result = this_boolean_value(&mut agent, &ECMAScriptValue::Null);
+    let agent = test_agent();
+    let result = this_boolean_value(&agent, &ECMAScriptValue::Null);
     assert!(result.is_err());
-    let msg = unwind_type_error(&mut agent, result.unwrap_err());
+    let msg = unwind_type_error(&agent, result.unwrap_err());
     assert_eq!(msg, "Value is not boolean");
 }
 #[test]
 fn this_boolean_value_04() {
-    let mut agent = test_agent();
-    let bool_obj = create_boolean_object(&mut agent, true);
-    let result = this_boolean_value(&mut agent, &ECMAScriptValue::Object(bool_obj));
+    let agent = test_agent();
+    let bool_obj = create_boolean_object(&agent, true);
+    let result = this_boolean_value(&agent, &ECMAScriptValue::Object(bool_obj));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), true);
 }
 #[test]
 fn this_boolean_value_05() {
-    let mut agent = test_agent();
-    let bool_obj = create_boolean_object(&mut agent, false);
-    let result = this_boolean_value(&mut agent, &ECMAScriptValue::Object(bool_obj));
+    let agent = test_agent();
+    let bool_obj = create_boolean_object(&agent, false);
+    let result = this_boolean_value(&agent, &ECMAScriptValue::Object(bool_obj));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), false);
 }
 
 #[test]
 fn this_boolean_value_06() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let other_obj = ordinary_object_create(&mut agent, Some(proto), &[]);
-    let result = this_boolean_value(&mut agent, &ECMAScriptValue::Object(other_obj));
+    let other_obj = ordinary_object_create(&agent, Some(proto), &[]);
+    let result = this_boolean_value(&agent, &ECMAScriptValue::Object(other_obj));
     assert!(result.is_err());
-    let msg = unwind_type_error(&mut agent, result.unwrap_err());
+    let msg = unwind_type_error(&agent, result.unwrap_err());
     assert_eq!(msg, "Object has no boolean value");
 }
 
 #[test]
 fn get_prototype_of_01() {
-    let mut agent = test_agent();
-    let bool_obj = create_boolean_object(&mut agent, true);
-    let proto = bool_obj.o.get_prototype_of(&mut agent).unwrap().unwrap();
+    let agent = test_agent();
+    let bool_obj = create_boolean_object(&agent, true);
+    let proto = bool_obj.o.get_prototype_of(&agent).unwrap().unwrap();
     assert_eq!(proto, agent.intrinsic(IntrinsicId::BooleanPrototype));
 }
 
 #[test]
 fn set_prototype_of_01() {
-    let mut agent = test_agent();
-    let bool_obj = create_boolean_object(&mut agent, true);
-    let res = bool_obj.o.set_prototype_of(&mut agent, None).unwrap();
+    let agent = test_agent();
+    let bool_obj = create_boolean_object(&agent, true);
+    let res = bool_obj.o.set_prototype_of(&agent, None).unwrap();
     assert!(res);
-    assert!(bool_obj.o.get_prototype_of(&mut agent).unwrap().is_none());
+    assert!(bool_obj.o.get_prototype_of(&agent).unwrap().is_none());
 }
 
 #[test]
 fn is_extensible_01() {
-    let mut agent = test_agent();
-    let bool_obj = create_boolean_object(&mut agent, true);
-    let res = bool_obj.o.is_extensible(&mut agent).unwrap();
+    let agent = test_agent();
+    let bool_obj = create_boolean_object(&agent, true);
+    let res = bool_obj.o.is_extensible(&agent).unwrap();
     assert!(res);
 }
 
 #[test]
 fn prevent_extensions_01() {
-    let mut agent = test_agent();
-    let bool_obj = create_boolean_object(&mut agent, true);
-    let res = bool_obj.o.prevent_extensions(&mut agent).unwrap();
+    let agent = test_agent();
+    let bool_obj = create_boolean_object(&agent, true);
+    let res = bool_obj.o.prevent_extensions(&agent).unwrap();
     assert!(res);
-    assert!(!bool_obj.o.is_extensible(&mut agent).unwrap());
+    assert!(!bool_obj.o.is_extensible(&agent).unwrap());
 }
 
 #[test]
 fn define_and_get_own_property_01() {
-    let mut agent = test_agent();
-    let bool_obj = create_boolean_object(&mut agent, true);
+    let agent = test_agent();
+    let bool_obj = create_boolean_object(&agent, true);
     let res = bool_obj
         .o
         .define_own_property(
-            &mut agent,
+            &agent,
             PropertyKey::from("rust"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from("is awesome")), ..Default::default() },
         )
         .unwrap();
     assert!(res);
-    let val = bool_obj.o.get_own_property(&mut agent, &PropertyKey::from("rust")).unwrap().unwrap();
+    let val = bool_obj.o.get_own_property(&agent, &PropertyKey::from("rust")).unwrap().unwrap();
     assert_eq!(val.enumerable, false);
     assert_eq!(val.configurable, false);
     assert!(matches!(val.property, PropertyKind::Data(..)));
@@ -134,21 +134,21 @@ fn define_and_get_own_property_01() {
 
 #[test]
 fn has_property_01() {
-    let mut agent = test_agent();
-    let bool_obj = create_boolean_object(&mut agent, true);
-    let res = bool_obj.o.has_property(&mut agent, &PropertyKey::from("rust")).unwrap();
+    let agent = test_agent();
+    let bool_obj = create_boolean_object(&agent, true);
+    let res = bool_obj.o.has_property(&agent, &PropertyKey::from("rust")).unwrap();
     assert_eq!(res, false);
-    let res2 = bool_obj.o.has_property(&mut agent, &PropertyKey::from("constructor")).unwrap();
+    let res2 = bool_obj.o.has_property(&agent, &PropertyKey::from("constructor")).unwrap();
     assert_eq!(res2, true);
 }
 
 #[test]
 fn get_01() {
-    let mut agent = test_agent();
-    let bool_obj = create_boolean_object(&mut agent, true);
-    let res = bool_obj.o.get(&mut agent, &PropertyKey::from("rust"), &ECMAScriptValue::Undefined).unwrap();
+    let agent = test_agent();
+    let bool_obj = create_boolean_object(&agent, true);
+    let res = bool_obj.o.get(&agent, &PropertyKey::from("rust"), &ECMAScriptValue::Undefined).unwrap();
     assert_eq!(res, ECMAScriptValue::Undefined);
-    let res2 = bool_obj.o.get(&mut agent, &PropertyKey::from("constructor"), &ECMAScriptValue::Undefined).unwrap();
+    let res2 = bool_obj.o.get(&agent, &PropertyKey::from("constructor"), &ECMAScriptValue::Undefined).unwrap();
     assert!(matches!(res2, ECMAScriptValue::Object(..)));
     if let ECMAScriptValue::Object(obj) = res2 {
         assert_eq!(obj, agent.intrinsic(IntrinsicId::Boolean));
@@ -157,40 +157,40 @@ fn get_01() {
 
 #[test]
 fn set_01() {
-    let mut agent = test_agent();
-    let bool_obj = create_boolean_object(&mut agent, true);
+    let agent = test_agent();
+    let bool_obj = create_boolean_object(&agent, true);
     let receiver = ECMAScriptValue::Object(bool_obj.clone());
-    let res = bool_obj.o.set(&mut agent, PropertyKey::from("rust"), ECMAScriptValue::Null, &receiver).unwrap();
+    let res = bool_obj.o.set(&agent, PropertyKey::from("rust"), ECMAScriptValue::Null, &receiver).unwrap();
     assert_eq!(res, true);
 }
 
 #[test]
 fn delete_01() {
-    let mut agent = test_agent();
-    let bool_obj = create_boolean_object(&mut agent, true);
-    let res = bool_obj.o.delete(&mut agent, &PropertyKey::from("rust")).unwrap();
+    let agent = test_agent();
+    let bool_obj = create_boolean_object(&agent, true);
+    let res = bool_obj.o.delete(&agent, &PropertyKey::from("rust")).unwrap();
     assert_eq!(res, true);
 }
 
 #[test]
 fn own_keys_01() {
-    let mut agent = test_agent();
-    let bool_obj = create_boolean_object(&mut agent, true);
-    let res = bool_obj.o.own_property_keys(&mut agent).unwrap();
+    let agent = test_agent();
+    let bool_obj = create_boolean_object(&agent, true);
+    let res = bool_obj.o.own_property_keys(&agent).unwrap();
     assert!(res.is_empty())
 }
 
 #[test]
 fn is_ordinary_01() {
-    let mut agent = test_agent();
-    let bool_obj = create_boolean_object(&mut agent, true);
+    let agent = test_agent();
+    let bool_obj = create_boolean_object(&agent, true);
     assert_eq!(bool_obj.o.is_ordinary(), true);
 }
 
 #[test]
 fn bool_object_checks() {
-    let mut agent = test_agent();
-    let bool_obj = create_boolean_object(&mut agent, true);
+    let agent = test_agent();
+    let bool_obj = create_boolean_object(&agent, true);
     assert_eq!(bool_obj.o.is_boolean_object(), true);
     assert_eq!(bool_obj.o.is_callable_obj(), false);
     assert_eq!(bool_obj.o.is_string_object(), false);
@@ -206,7 +206,7 @@ fn bool_object_checks() {
 }
 #[test]
 fn bool_object_debug() {
-    let mut agent = test_agent();
-    let bool_obj = create_boolean_object(&mut agent, true);
+    let agent = test_agent();
+    let bool_obj = create_boolean_object(&agent, true);
     assert_ne!(format!("{:?}", bool_obj), "");
 }

--- a/src/comparison/mod.rs
+++ b/src/comparison/mod.rs
@@ -26,7 +26,7 @@ use super::*;
 // +---------------+------------------------------+
 //
 // https://tc39.es/ecma262/#sec-requireobjectcoercible
-pub fn require_object_coercible(agent: &mut Agent, argument: &ECMAScriptValue) -> Completion<()> {
+pub fn require_object_coercible(agent: &Agent, argument: &ECMAScriptValue) -> Completion<()> {
     match argument {
         ECMAScriptValue::Undefined | ECMAScriptValue::Null => {
             Err(create_type_error(agent, "Undefined and null are not allowed in this context"))
@@ -43,7 +43,7 @@ pub fn require_object_coercible(agent: &mut Agent, argument: &ECMAScriptValue) -
 //
 //  1. Assert: Type(O) is Object.
 //  2. Return ? O.[[IsExtensible]]().
-pub fn is_extensible<'a, T>(agent: &mut Agent, obj: T) -> Completion<bool>
+pub fn is_extensible<'a, T>(agent: &Agent, obj: T) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {

--- a/src/comparison/tests.rs
+++ b/src/comparison/tests.rs
@@ -22,10 +22,10 @@ mod require_object_coercible {
     #[test_case(|a| a.wks(WksId::Species).into() => Ok(()); "symbol")]
     #[test_case(|_| BigInt::from(10).into() => Ok(()); "bigint")]
     #[test_case(|a| ordinary_object_create(a, None, &[]).into() => Ok(()); "object")]
-    fn roc(make_arg: fn(&mut Agent) -> ECMAScriptValue) -> Result<(), String> {
-        let mut agent = test_agent();
-        let arg = make_arg(&mut agent);
+    fn roc(make_arg: fn(&Agent) -> ECMAScriptValue) -> Result<(), String> {
+        let agent = test_agent();
+        let arg = make_arg(&agent);
 
-        require_object_coercible(&mut agent, &arg).map_err(|err| unwind_any_error(&mut agent, err))
+        require_object_coercible(&agent, &arg).map_err(|err| unwind_any_error(&agent, err))
     }
 }

--- a/src/control_abstraction/mod.rs
+++ b/src/control_abstraction/mod.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use std::fmt;
 
 impl Agent {
-    pub fn provision_iterator_prototype(&mut self, realm: &Rc<RefCell<Realm>>) {
+    pub fn provision_iterator_prototype(&self, realm: &Rc<RefCell<Realm>>) {
         let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
         let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -59,7 +59,7 @@ impl Agent {
         realm.borrow_mut().intrinsics.iterator_prototype = iterator_prototype;
     }
 
-    pub fn provision_generator_function_intrinsics(&mut self, realm: &Rc<RefCell<Realm>>) {
+    pub fn provision_generator_function_intrinsics(&self, realm: &Rc<RefCell<Realm>>) {
         let function = realm.borrow().intrinsics.function.clone();
         let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
         let iterator_prototype = realm.borrow().intrinsics.iterator_prototype.clone();
@@ -215,7 +215,7 @@ impl Agent {
 }
 
 fn iterator_prototype_iterator(
-    _agent: &mut Agent,
+    _agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -229,7 +229,7 @@ fn iterator_prototype_iterator(
 }
 
 fn generator_function(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -238,7 +238,7 @@ fn generator_function(
 }
 
 fn generator_prototype_next(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -247,7 +247,7 @@ fn generator_prototype_next(
 }
 
 fn generator_prototype_return(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -256,7 +256,7 @@ fn generator_prototype_return(
 }
 
 fn generator_prototype_throw(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -265,7 +265,7 @@ fn generator_prototype_throw(
 }
 
 impl Agent {
-    fn create_iter_result_object(&mut self, value: ECMAScriptValue, done: bool) -> Object {
+    fn create_iter_result_object(&self, value: ECMAScriptValue, done: bool) -> Object {
         // CreateIterResultObject ( value, done )
         //
         // The abstract operation CreateIterResultObject takes arguments value (an ECMAScript language value)
@@ -327,7 +327,7 @@ impl ObjectInterface for GeneratorObject {
     fn to_generator_object(&self) -> Option<&GeneratorObject> {
         Some(self)
     }
-    fn get_prototype_of(&self, _agent: &mut Agent) -> Completion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &Agent) -> Completion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
 
@@ -337,7 +337,7 @@ impl ObjectInterface for GeneratorObject {
     // the following steps when called:
     //
     //  1. Return ! OrdinarySetPrototypeOf(O, V).
-    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<Object>) -> Completion<bool> {
+    fn set_prototype_of(&self, _agent: &Agent, obj: Option<Object>) -> Completion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
 
@@ -347,7 +347,7 @@ impl ObjectInterface for GeneratorObject {
     // when called:
     //
     //  1. Return ! OrdinaryIsExtensible(O).
-    fn is_extensible(&self, _agent: &mut Agent) -> Completion<bool> {
+    fn is_extensible(&self, _agent: &Agent) -> Completion<bool> {
         Ok(ordinary_is_extensible(self))
     }
 
@@ -357,7 +357,7 @@ impl ObjectInterface for GeneratorObject {
     // steps when called:
     //
     //  1. Return ! OrdinaryPreventExtensions(O).
-    fn prevent_extensions(&self, _agent: &mut Agent) -> Completion<bool> {
+    fn prevent_extensions(&self, _agent: &Agent) -> Completion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
 
@@ -367,7 +367,7 @@ impl ObjectInterface for GeneratorObject {
     // following steps when called:
     //
     //  1. Return ! OrdinaryGetOwnProperty(O, P).
-    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _agent: &Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(self, key))
     }
 
@@ -379,7 +379,7 @@ impl ObjectInterface for GeneratorObject {
     //  1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
     fn define_own_property(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         key: PropertyKey,
         desc: PotentialPropertyDescriptor,
     ) -> Completion<bool> {
@@ -392,7 +392,7 @@ impl ObjectInterface for GeneratorObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryHasProperty(O, P).
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
+    fn has_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_has_property(agent, self, key)
     }
 
@@ -402,7 +402,7 @@ impl ObjectInterface for GeneratorObject {
     // ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryGet(O, P, Receiver).
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+    fn get(&self, agent: &Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         ordinary_get(agent, self, key, receiver)
     }
 
@@ -412,13 +412,7 @@ impl ObjectInterface for GeneratorObject {
     // value), and Receiver (an ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinarySet(O, P, V, Receiver).
-    fn set(
-        &self,
-        agent: &mut Agent,
-        key: PropertyKey,
-        v: ECMAScriptValue,
-        receiver: &ECMAScriptValue,
-    ) -> Completion<bool> {
+    fn set(&self, agent: &Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
         ordinary_set(agent, self, key, v, receiver)
     }
 
@@ -428,7 +422,7 @@ impl ObjectInterface for GeneratorObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryDelete(O, P).
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
+    fn delete(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_delete(agent, self, key)
     }
 
@@ -438,7 +432,7 @@ impl ObjectInterface for GeneratorObject {
     // steps when called:
     //
     // 1. Return ! OrdinaryOwnPropertyKeys(O).
-    fn own_property_keys(&self, _agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, _agent: &Agent) -> Completion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(self))
     }
 }
@@ -463,7 +457,7 @@ impl fmt::Display for GeneratorError {
 impl Error for GeneratorError {}
 
 impl GeneratorObject {
-    pub fn object(agent: &mut Agent, prototype: Option<Object>, state: GeneratorState, brand: &str) -> Object {
+    pub fn object(agent: &Agent, prototype: Option<Object>, state: GeneratorState, brand: &str) -> Object {
         Object {
             o: Rc::new(Self {
                 common: RefCell::new(CommonObjectData::new(agent, prototype, true, GENERATOR_OBJECT_SLOTS)),
@@ -505,11 +499,7 @@ impl GeneratorObject {
 }
 
 impl Agent {
-    pub fn generator_validate(
-        &mut self,
-        generator: ECMAScriptValue,
-        generator_brand: &str,
-    ) -> Completion<GeneratorState> {
+    pub fn generator_validate(&self, generator: ECMAScriptValue, generator_brand: &str) -> Completion<GeneratorState> {
         // GeneratorValidate ( generator, generatorBrand )
         // The abstract operation GeneratorValidate takes arguments generator and generatorBrand and returns
         // either a normal completion containing either suspendedStart, suspendedYield, or completed, or a

--- a/src/cr/tests.rs
+++ b/src/cr/tests.rs
@@ -52,8 +52,8 @@ mod normal_completion {
 
         #[test]
         fn object() {
-            let mut agent = test_agent();
-            let obj = ordinary_object_create(&mut agent, None, &[]);
+            let agent = test_agent();
+            let obj = ordinary_object_create(&agent, None, &[]);
             let nc = NormalCompletion::from(obj.clone());
 
             if let NormalCompletion::Value(ECMAScriptValue::Object(result)) = nc {
@@ -113,8 +113,8 @@ mod normal_completion {
 
             #[test]
             fn actual() {
-                let mut agent = test_agent();
-                let obj = ordinary_object_create(&mut agent, None, &[]);
+                let agent = test_agent();
+                let obj = ordinary_object_create(&agent, None, &[]);
                 let val = ECMAScriptValue::from(obj.clone());
                 let nc = NormalCompletion::from(val);
                 let extracted: Object = nc.try_into().unwrap();

--- a/src/environment_record/tests.rs
+++ b/src/environment_record/tests.rs
@@ -173,21 +173,21 @@ mod declarative_environment_record {
 
     #[test]
     fn has_binding() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_mutable_binding(&mut agent, JSString::from("a"), true).unwrap();
+        der.create_mutable_binding(&agent, JSString::from("a"), true).unwrap();
 
-        assert_eq!(der.has_binding(&mut agent, &JSString::from("a")).unwrap(), true);
-        assert_eq!(der.has_binding(&mut agent, &JSString::from("b")).unwrap(), false);
+        assert_eq!(der.has_binding(&agent, &JSString::from("a")).unwrap(), true);
+        assert_eq!(der.has_binding(&agent, &JSString::from("b")).unwrap(), false);
     }
 
     #[test]
     fn create_mutable_binding() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
 
-        der.create_mutable_binding(&mut agent, JSString::from("a"), true).unwrap();
-        der.create_mutable_binding(&mut agent, JSString::from("b"), false).unwrap();
+        der.create_mutable_binding(&agent, JSString::from("a"), true).unwrap();
+        der.create_mutable_binding(&agent, JSString::from("b"), false).unwrap();
 
         // Poke in the internals
         let bindings = der.bindings.borrow();
@@ -200,11 +200,11 @@ mod declarative_environment_record {
     }
     #[test]
     fn create_immmutable_binding() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
 
-        der.create_immutable_binding(&mut agent, JSString::from("a"), true).unwrap();
-        der.create_immutable_binding(&mut agent, JSString::from("b"), false).unwrap();
+        der.create_immutable_binding(&agent, JSString::from("a"), true).unwrap();
+        der.create_immutable_binding(&agent, JSString::from("b"), false).unwrap();
 
         // Poke in the internals
         let bindings = der.bindings.borrow();
@@ -218,13 +218,13 @@ mod declarative_environment_record {
 
     #[test]
     fn initialize_binding() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_immutable_binding(&mut agent, JSString::from("a"), true).unwrap();
-        der.create_mutable_binding(&mut agent, JSString::from("b"), true).unwrap();
+        der.create_immutable_binding(&agent, JSString::from("a"), true).unwrap();
+        der.create_mutable_binding(&agent, JSString::from("b"), true).unwrap();
 
-        der.initialize_binding(&mut agent, &JSString::from("a"), ECMAScriptValue::from("value")).unwrap();
-        der.initialize_binding(&mut agent, &JSString::from("b"), ECMAScriptValue::from("other")).unwrap();
+        der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from("value")).unwrap();
+        der.initialize_binding(&agent, &JSString::from("b"), ECMAScriptValue::from("other")).unwrap();
 
         let bindings = der.bindings.borrow();
         let binding = bindings.get(&JSString::from("a")).unwrap();
@@ -234,20 +234,19 @@ mod declarative_environment_record {
     }
     #[test]
     fn set_mutable_binding_01() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
 
-        let err =
-            der.set_mutable_binding(&mut agent, JSString::from("a"), ECMAScriptValue::from(10), true).unwrap_err();
-        let msg = unwind_reference_error(&mut agent, err);
+        let err = der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), true).unwrap_err();
+        let msg = unwind_reference_error(&agent, err);
         assert_eq!(msg, "Identifier not defined");
     }
     #[test]
     fn set_mutable_binding_02() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
 
-        der.set_mutable_binding(&mut agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap();
+        der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap();
 
         let bindings = der.bindings.borrow();
         let binding = bindings.get(&JSString::from("a")).unwrap();
@@ -256,47 +255,44 @@ mod declarative_environment_record {
     }
     #[test]
     fn set_mutable_binding_03() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_immutable_binding(&mut agent, JSString::from("a"), true).unwrap();
+        der.create_immutable_binding(&agent, JSString::from("a"), true).unwrap();
 
-        let err =
-            der.set_mutable_binding(&mut agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap_err();
-        let msg = unwind_reference_error(&mut agent, err);
+        let err = der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap_err();
+        let msg = unwind_reference_error(&agent, err);
         assert_eq!(msg, "Binding not initialized");
     }
     #[test]
     fn set_mutable_binding_04() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_immutable_binding(&mut agent, JSString::from("a"), true).unwrap();
-        der.initialize_binding(&mut agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
+        der.create_immutable_binding(&agent, JSString::from("a"), true).unwrap();
+        der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
 
-        let err =
-            der.set_mutable_binding(&mut agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap_err();
-        let msg = unwind_type_error(&mut agent, err);
+        let err = der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap_err();
+        let msg = unwind_type_error(&agent, err);
         assert_eq!(msg, "Cannot change read-only value");
     }
     #[test]
     fn set_mutable_binding_05() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_immutable_binding(&mut agent, JSString::from("a"), false).unwrap();
-        der.initialize_binding(&mut agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
+        der.create_immutable_binding(&agent, JSString::from("a"), false).unwrap();
+        der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
 
-        let err =
-            der.set_mutable_binding(&mut agent, JSString::from("a"), ECMAScriptValue::from(10), true).unwrap_err();
-        let msg = unwind_type_error(&mut agent, err);
+        let err = der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), true).unwrap_err();
+        let msg = unwind_type_error(&agent, err);
         assert_eq!(msg, "Cannot change read-only value");
     }
     #[test]
     fn set_mutable_binding_06() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_immutable_binding(&mut agent, JSString::from("a"), false).unwrap();
-        der.initialize_binding(&mut agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
+        der.create_immutable_binding(&agent, JSString::from("a"), false).unwrap();
+        der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
 
-        der.set_mutable_binding(&mut agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap();
+        der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap();
 
         let bindings = der.bindings.borrow();
         let binding = bindings.get(&JSString::from("a")).unwrap();
@@ -304,12 +300,12 @@ mod declarative_environment_record {
     }
     #[test]
     fn set_mutable_binding_07() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_mutable_binding(&mut agent, JSString::from("a"), false).unwrap();
-        der.initialize_binding(&mut agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
+        der.create_mutable_binding(&agent, JSString::from("a"), false).unwrap();
+        der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
 
-        der.set_mutable_binding(&mut agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap();
+        der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap();
 
         let bindings = der.bindings.borrow();
         let binding = bindings.get(&JSString::from("a")).unwrap();
@@ -317,58 +313,58 @@ mod declarative_environment_record {
     }
     #[test]
     fn get_binding_value_01() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_mutable_binding(&mut agent, JSString::from("a"), false).unwrap();
-        der.initialize_binding(&mut agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
+        der.create_mutable_binding(&agent, JSString::from("a"), false).unwrap();
+        der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
 
-        let result = der.get_binding_value(&mut agent, &JSString::from("a"), false).unwrap();
+        let result = der.get_binding_value(&agent, &JSString::from("a"), false).unwrap();
 
         assert_eq!(result, ECMAScriptValue::from(1));
     }
     #[test]
     fn get_binding_value_02() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_mutable_binding(&mut agent, JSString::from("a"), false).unwrap();
+        der.create_mutable_binding(&agent, JSString::from("a"), false).unwrap();
 
-        let result = der.get_binding_value(&mut agent, &JSString::from("a"), false).unwrap_err();
-        let msg = unwind_reference_error(&mut agent, result);
+        let result = der.get_binding_value(&agent, &JSString::from("a"), false).unwrap_err();
+        let msg = unwind_reference_error(&agent, result);
 
         assert_eq!(msg, "Binding not initialized");
     }
     #[test]
     fn delete_binding_01() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_mutable_binding(&mut agent, JSString::from("permanent"), false).unwrap();
+        der.create_mutable_binding(&agent, JSString::from("permanent"), false).unwrap();
 
-        let result = der.delete_binding(&mut agent, &JSString::from("permanent")).unwrap();
+        let result = der.delete_binding(&agent, &JSString::from("permanent")).unwrap();
 
         assert_eq!(result, false);
-        assert!(der.has_binding(&mut agent, &JSString::from("permanent")).unwrap());
+        assert!(der.has_binding(&agent, &JSString::from("permanent")).unwrap());
     }
     #[test]
     fn delete_binding_02() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_mutable_binding(&mut agent, JSString::from("deletable"), true).unwrap();
+        der.create_mutable_binding(&agent, JSString::from("deletable"), true).unwrap();
 
-        let result = der.delete_binding(&mut agent, &JSString::from("deletable")).unwrap();
+        let result = der.delete_binding(&agent, &JSString::from("deletable")).unwrap();
 
         assert_eq!(result, true);
-        assert!(!der.has_binding(&mut agent, &JSString::from("deletable")).unwrap());
+        assert!(!der.has_binding(&agent, &JSString::from("deletable")).unwrap());
     }
     #[test]
     fn delete_binding_03() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_immutable_binding(&mut agent, JSString::from("immutable"), true).unwrap();
+        der.create_immutable_binding(&agent, JSString::from("immutable"), true).unwrap();
 
-        let result = der.delete_binding(&mut agent, &JSString::from("immutable")).unwrap();
+        let result = der.delete_binding(&agent, &JSString::from("immutable")).unwrap();
 
         assert_eq!(result, false);
-        assert!(der.has_binding(&mut agent, &JSString::from("immutable")).unwrap());
+        assert!(der.has_binding(&agent, &JSString::from("immutable")).unwrap());
     }
     #[test]
     fn has_this_binding() {
@@ -390,41 +386,41 @@ mod declarative_environment_record {
     }
     #[test]
     fn get_outer_env() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = Rc::new(DeclarativeEnvironmentRecord::new(None, "test"));
-        der.create_immutable_binding(&mut agent, JSString::from("sentinel"), true).unwrap();
-        der.initialize_binding(&mut agent, &JSString::from("sentinel"), ECMAScriptValue::from("very unique string"))
+        der.create_immutable_binding(&agent, JSString::from("sentinel"), true).unwrap();
+        der.initialize_binding(&agent, &JSString::from("sentinel"), ECMAScriptValue::from("very unique string"))
             .unwrap();
         let der2 = DeclarativeEnvironmentRecord::new(Some(der), "inner");
 
         let outer = der2.get_outer_env().unwrap();
 
-        let val_from_outer = outer.get_binding_value(&mut agent, &JSString::from("sentinel"), true).unwrap();
+        let val_from_outer = outer.get_binding_value(&agent, &JSString::from("sentinel"), true).unwrap();
         assert_eq!(val_from_outer, ECMAScriptValue::from("very unique string"));
     }
 
     #[test]
     #[should_panic(expected = "unreachable")]
     fn get_this_binding() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.get_this_binding(&mut agent).unwrap();
+        der.get_this_binding(&agent).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "unreachable")]
     fn bind_this_value() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.bind_this_value(&mut agent, ECMAScriptValue::Undefined).unwrap();
+        der.bind_this_value(&agent, ECMAScriptValue::Undefined).unwrap();
     }
 
     #[test]
     fn binding_names() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_mutable_binding(&mut agent, JSString::from("a"), true).unwrap();
-        der.create_mutable_binding(&mut agent, JSString::from("greasy"), true).unwrap();
+        der.create_mutable_binding(&agent, JSString::from("a"), true).unwrap();
+        der.create_mutable_binding(&agent, JSString::from("greasy"), true).unwrap();
 
         let mut names = der.binding_names();
         names.sort();
@@ -436,9 +432,9 @@ mod object_environment_record {
     use super::*;
     #[test]
     fn debug() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, false, None, "test");
 
         assert_ne!(format!("{:#?}", oer), "");
@@ -446,21 +442,21 @@ mod object_environment_record {
     }
     #[test]
     fn has_binding_01() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, false, None, "test");
 
-        let result = oer.has_binding(&mut agent, &JSString::from("not_here")).unwrap();
+        let result = oer.has_binding(&agent, &JSString::from("not_here")).unwrap();
         assert_eq!(result, false);
     }
     #[test]
     fn has_binding_02() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &binding_object,
             "exists",
             PotentialPropertyDescriptor {
@@ -474,16 +470,16 @@ mod object_environment_record {
         .unwrap();
         let oer = ObjectEnvironmentRecord::new(binding_object, false, None, "test");
 
-        let result = oer.has_binding(&mut agent, &JSString::from("exists")).unwrap();
+        let result = oer.has_binding(&agent, &JSString::from("exists")).unwrap();
         assert_eq!(result, true);
     }
     #[test]
     fn has_binding_03() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &binding_object,
             "exists",
             PotentialPropertyDescriptor {
@@ -497,21 +493,21 @@ mod object_environment_record {
         .unwrap();
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
-        let result = oer.has_binding(&mut agent, &JSString::from("exists")).unwrap();
+        let result = oer.has_binding(&agent, &JSString::from("exists")).unwrap();
 
         assert_eq!(result, true);
     }
     #[test]
     fn has_binding_04() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         // unscopables_obj = {
         //    hidden: 10,
         //    visible: false
         // }
-        let unscopables_obj = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
+        let unscopables_obj = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &unscopables_obj,
             "hidden",
             PotentialPropertyDescriptor {
@@ -524,7 +520,7 @@ mod object_environment_record {
         )
         .unwrap();
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &unscopables_obj,
             "visible",
             PotentialPropertyDescriptor {
@@ -542,9 +538,9 @@ mod object_environment_record {
         //    hidden: "This name is not in the environment"
         //    also: "This one also visible"
         // }
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &binding_object,
             "visible",
             PotentialPropertyDescriptor {
@@ -557,7 +553,7 @@ mod object_environment_record {
         )
         .unwrap();
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &binding_object,
             "hidden",
             PotentialPropertyDescriptor {
@@ -570,7 +566,7 @@ mod object_environment_record {
         )
         .unwrap();
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &binding_object,
             "also",
             PotentialPropertyDescriptor {
@@ -584,7 +580,7 @@ mod object_environment_record {
         .unwrap();
         let unscopables_sym = agent.wks(WksId::Unscopables);
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &binding_object,
             unscopables_sym,
             PotentialPropertyDescriptor {
@@ -598,27 +594,27 @@ mod object_environment_record {
         .unwrap();
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
-        assert!(oer.has_binding(&mut agent, &JSString::from("visible")).unwrap());
-        assert!(!oer.has_binding(&mut agent, &JSString::from("hidden")).unwrap());
-        assert!(oer.has_binding(&mut agent, &JSString::from("also")).unwrap());
+        assert!(oer.has_binding(&agent, &JSString::from("visible")).unwrap());
+        assert!(!oer.has_binding(&agent, &JSString::from("hidden")).unwrap());
+        assert!(oer.has_binding(&agent, &JSString::from("also")).unwrap());
     }
     #[test]
     fn has_binding_05() {
         // has_property returns an error
-        let mut agent = test_agent();
-        let binding_object = DeadObject::object(&mut agent);
+        let agent = test_agent();
+        let binding_object = DeadObject::object(&agent);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
-        let err = oer.has_binding(&mut agent, &JSString::from("random")).unwrap_err();
-        let msg = unwind_type_error(&mut agent, err);
+        let err = oer.has_binding(&agent, &JSString::from("random")).unwrap_err();
+        let msg = unwind_type_error(&agent, err);
         assert_eq!(msg, "has_property called on DeadObject");
     }
     #[test]
     fn has_binding_06() {
         // binding_object.get(@@unscopables) fails
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         // binding_object = {
         //    get [Symbol.unscopables] = %ThrowTypeError%
         //    field: true
@@ -631,7 +627,7 @@ mod object_environment_record {
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(&mut agent, &binding_object, pk, property).unwrap();
+        define_property_or_throw(&agent, &binding_object, pk, property).unwrap();
         let pk = PropertyKey::from("field");
         let property = PotentialPropertyDescriptor {
             value: Some(ECMAScriptValue::from(true)),
@@ -640,27 +636,27 @@ mod object_environment_record {
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(&mut agent, &binding_object, pk, property).unwrap();
+        define_property_or_throw(&agent, &binding_object, pk, property).unwrap();
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
-        let err = oer.has_binding(&mut agent, &JSString::from("field")).unwrap_err();
+        let err = oer.has_binding(&agent, &JSString::from("field")).unwrap_err();
 
-        let msg = unwind_type_error(&mut agent, err);
+        let msg = unwind_type_error(&agent, err);
         assert_eq!(msg, "Generic TypeError");
     }
     #[test]
     fn has_binding_07() {
         // binding_object.@@unscopables.get(field) fails
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
         // binding_object = {
         //    [Symbol.unscopables] = {
         //        get field = %ThrowTypeError%
         //    }
         //    field: true
         // }
-        let unscopables_obj = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let unscopables_obj = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let tte = agent.intrinsic(IntrinsicId::ThrowTypeError);
         let pk = PropertyKey::from("field");
         let property = PotentialPropertyDescriptor {
@@ -669,7 +665,7 @@ mod object_environment_record {
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(&mut agent, &unscopables_obj, pk.clone(), property).unwrap();
+        define_property_or_throw(&agent, &unscopables_obj, pk.clone(), property).unwrap();
         let property = PotentialPropertyDescriptor {
             value: Some(ECMAScriptValue::from(true)),
             writable: Some(true),
@@ -677,7 +673,7 @@ mod object_environment_record {
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(&mut agent, &binding_object, pk, property).unwrap();
+        define_property_or_throw(&agent, &binding_object, pk, property).unwrap();
         let pk = PropertyKey::from(agent.wks(WksId::Unscopables));
         let property = PotentialPropertyDescriptor {
             value: Some(ECMAScriptValue::from(unscopables_obj)),
@@ -686,27 +682,27 @@ mod object_environment_record {
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(&mut agent, &binding_object, pk, property).unwrap();
+        define_property_or_throw(&agent, &binding_object, pk, property).unwrap();
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
-        let err = oer.has_binding(&mut agent, &JSString::from("field")).unwrap_err();
+        let err = oer.has_binding(&agent, &JSString::from("field")).unwrap_err();
 
-        let msg = unwind_type_error(&mut agent, err);
+        let msg = unwind_type_error(&agent, err);
         assert_eq!(msg, "Generic TypeError");
     }
 
     #[test]
     fn create_mutable_binding() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object.clone(), true, None, "test");
 
-        oer.create_mutable_binding(&mut agent, JSString::from("can_delete"), true).unwrap();
-        oer.create_mutable_binding(&mut agent, JSString::from("permanent"), false).unwrap();
+        oer.create_mutable_binding(&agent, JSString::from("can_delete"), true).unwrap();
+        oer.create_mutable_binding(&agent, JSString::from("permanent"), false).unwrap();
 
         let can_delete_key = PropertyKey::from("can_delete");
-        let cd_desc = binding_object.o.get_own_property(&mut agent, &can_delete_key).unwrap().unwrap();
+        let cd_desc = binding_object.o.get_own_property(&agent, &can_delete_key).unwrap().unwrap();
         assert_eq!(cd_desc.enumerable, true);
         assert_eq!(cd_desc.configurable, true);
         assert!(cd_desc.is_data_descriptor());
@@ -716,7 +712,7 @@ mod object_environment_record {
         }
 
         let permanent_key = PropertyKey::from("permanent");
-        let perm_desc = binding_object.o.get_own_property(&mut agent, &permanent_key).unwrap().unwrap();
+        let perm_desc = binding_object.o.get_own_property(&agent, &permanent_key).unwrap().unwrap();
         assert_eq!(perm_desc.enumerable, true);
         assert_eq!(perm_desc.configurable, false);
         assert!(perm_desc.is_data_descriptor());
@@ -729,27 +725,27 @@ mod object_environment_record {
     #[test]
     #[should_panic(expected = "unreachable code")]
     fn create_immutable_binding() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
-        oer.create_immutable_binding(&mut agent, JSString::from("nothing"), true).unwrap();
+        oer.create_immutable_binding(&agent, JSString::from("nothing"), true).unwrap();
     }
 
     #[test]
     fn initialize_binding() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object.clone(), true, None, "test");
         let name = JSString::from("colorado");
-        oer.create_mutable_binding(&mut agent, name.clone(), true).unwrap();
+        oer.create_mutable_binding(&agent, name.clone(), true).unwrap();
 
-        oer.initialize_binding(&mut agent, &name, ECMAScriptValue::from(76)).unwrap();
+        oer.initialize_binding(&agent, &name, ECMAScriptValue::from(76)).unwrap();
 
         let key = PropertyKey::from(name);
-        let desc = binding_object.o.get_own_property(&mut agent, &key).unwrap().unwrap();
+        let desc = binding_object.o.get_own_property(&agent, &key).unwrap().unwrap();
         assert_eq!(desc.enumerable, true);
         assert_eq!(desc.configurable, true);
         assert!(desc.is_data_descriptor());
@@ -761,18 +757,18 @@ mod object_environment_record {
 
     #[test]
     fn set_mutable_binding_01() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object.clone(), true, None, "test");
         let name = JSString::from("vegetable");
-        oer.create_mutable_binding(&mut agent, name.clone(), true).unwrap();
-        oer.initialize_binding(&mut agent, &name, ECMAScriptValue::from(true)).unwrap();
+        oer.create_mutable_binding(&agent, name.clone(), true).unwrap();
+        oer.initialize_binding(&agent, &name, ECMAScriptValue::from(true)).unwrap();
 
-        oer.set_mutable_binding(&mut agent, name.clone(), ECMAScriptValue::from(false), true).unwrap();
+        oer.set_mutable_binding(&agent, name.clone(), ECMAScriptValue::from(false), true).unwrap();
 
         let key = PropertyKey::from(name);
-        let desc = binding_object.o.get_own_property(&mut agent, &key).unwrap().unwrap();
+        let desc = binding_object.o.get_own_property(&agent, &key).unwrap().unwrap();
         assert_eq!(desc.enumerable, true);
         assert_eq!(desc.configurable, true);
         assert!(desc.is_data_descriptor());
@@ -784,36 +780,36 @@ mod object_environment_record {
     #[test]
     fn set_mutable_binding_02() {
         // binding that's been deleted (or was never there)
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
         let name = JSString::from("vegetable");
 
-        let err = oer.set_mutable_binding(&mut agent, name, ECMAScriptValue::Undefined, true).unwrap_err();
+        let err = oer.set_mutable_binding(&agent, name, ECMAScriptValue::Undefined, true).unwrap_err();
 
-        let msg = unwind_reference_error(&mut agent, err);
+        let msg = unwind_reference_error(&agent, err);
         assert_eq!(msg, "Reference no longer exists");
     }
     #[test]
     fn set_mutable_binding_03() {
         // has_property throws
-        let mut agent = test_agent();
-        let binding_object = DeadObject::object(&mut agent);
+        let agent = test_agent();
+        let binding_object = DeadObject::object(&agent);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
         let name = JSString::from("vegetable");
 
-        let err = oer.set_mutable_binding(&mut agent, name, ECMAScriptValue::Undefined, true).unwrap_err();
+        let err = oer.set_mutable_binding(&agent, name, ECMAScriptValue::Undefined, true).unwrap_err();
 
-        let msg = unwind_type_error(&mut agent, err);
+        let msg = unwind_type_error(&agent, err);
         assert_eq!(msg, "has_property called on DeadObject");
     }
     #[test]
     fn set_mutable_binding_04() {
         // set throws
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let name = JSString::from("vegetable");
         let key = PropertyKey::from(name.clone());
         let tte = agent.intrinsic(IntrinsicId::ThrowTypeError);
@@ -823,69 +819,69 @@ mod object_environment_record {
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(&mut agent, &binding_object, key, property).unwrap();
+        define_property_or_throw(&agent, &binding_object, key, property).unwrap();
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
-        let err = oer.set_mutable_binding(&mut agent, name, ECMAScriptValue::Undefined, true).unwrap_err();
+        let err = oer.set_mutable_binding(&agent, name, ECMAScriptValue::Undefined, true).unwrap_err();
 
-        let msg = unwind_type_error(&mut agent, err);
+        let msg = unwind_type_error(&agent, err);
         assert_eq!(msg, "Generic TypeError");
     }
 
     #[test]
     fn get_binding_value_01() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
         let name = JSString::from("vegetable");
-        oer.create_mutable_binding(&mut agent, name.clone(), true).unwrap();
-        oer.initialize_binding(&mut agent, &name, ECMAScriptValue::from(true)).unwrap();
-        oer.set_mutable_binding(&mut agent, name.clone(), ECMAScriptValue::from("squirrel"), true).unwrap();
+        oer.create_mutable_binding(&agent, name.clone(), true).unwrap();
+        oer.initialize_binding(&agent, &name, ECMAScriptValue::from(true)).unwrap();
+        oer.set_mutable_binding(&agent, name.clone(), ECMAScriptValue::from("squirrel"), true).unwrap();
 
-        let result = oer.get_binding_value(&mut agent, &name, false).unwrap();
+        let result = oer.get_binding_value(&agent, &name, false).unwrap();
         assert_eq!(result, ECMAScriptValue::from("squirrel"));
 
-        let result = oer.get_binding_value(&mut agent, &JSString::from("nothere"), false).unwrap();
+        let result = oer.get_binding_value(&agent, &JSString::from("nothere"), false).unwrap();
         assert_eq!(result, ECMAScriptValue::Undefined);
 
-        let result = oer.get_binding_value(&mut agent, &JSString::from("a"), true).unwrap_err();
-        assert_eq!(unwind_reference_error(&mut agent, result), "Unresolvable reference");
+        let result = oer.get_binding_value(&agent, &JSString::from("a"), true).unwrap_err();
+        assert_eq!(unwind_reference_error(&agent, result), "Unresolvable reference");
     }
     #[test]
     fn get_binding_value_02() {
         // has_property throws
-        let mut agent = test_agent();
-        let binding_object = DeadObject::object(&mut agent);
+        let agent = test_agent();
+        let binding_object = DeadObject::object(&agent);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
         let name = JSString::from("vegetable");
 
-        let err = oer.get_binding_value(&mut agent, &name, true).unwrap_err();
+        let err = oer.get_binding_value(&agent, &name, true).unwrap_err();
 
-        let msg = unwind_type_error(&mut agent, err);
+        let msg = unwind_type_error(&agent, err);
         assert_eq!(msg, "has_property called on DeadObject");
     }
 
     #[test]
     fn delete() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
         let name = JSString::from("vegetable");
-        oer.create_mutable_binding(&mut agent, name.clone(), true).unwrap();
-        oer.initialize_binding(&mut agent, &name, ECMAScriptValue::from(true)).unwrap();
-        oer.set_mutable_binding(&mut agent, name.clone(), ECMAScriptValue::from("squirrel"), true).unwrap();
+        oer.create_mutable_binding(&agent, name.clone(), true).unwrap();
+        oer.initialize_binding(&agent, &name, ECMAScriptValue::from(true)).unwrap();
+        oer.set_mutable_binding(&agent, name.clone(), ECMAScriptValue::from("squirrel"), true).unwrap();
 
-        oer.delete_binding(&mut agent, &name).unwrap();
-        assert!(!oer.has_binding(&mut agent, &name).unwrap());
+        oer.delete_binding(&agent, &name).unwrap();
+        assert!(!oer.has_binding(&agent, &name).unwrap());
     }
 
     #[test]
     fn object_environment_record_has_this_binding() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
         assert!(!oer.has_this_binding());
@@ -893,9 +889,9 @@ mod object_environment_record {
 
     #[test]
     fn object_environment_record_has_super_binding() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
         assert!(!oer.has_super_binding());
@@ -903,9 +899,9 @@ mod object_environment_record {
 
     #[test]
     fn object_environment_record_with_base_object_01() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object.clone(), true, None, "test");
 
         assert_eq!(oer.with_base_object(), Some(binding_object));
@@ -913,9 +909,9 @@ mod object_environment_record {
 
     #[test]
     fn object_environment_record_with_base_object_02() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, false, None, "test");
 
         assert!(oer.with_base_object().is_none());
@@ -923,58 +919,58 @@ mod object_environment_record {
 
     #[test]
     fn object_environment_record_get_outer_env() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let der = Rc::new(DeclarativeEnvironmentRecord::new(None, "test"));
-        der.create_immutable_binding(&mut agent, JSString::from("sentinel"), true).unwrap();
-        der.initialize_binding(&mut agent, &JSString::from("sentinel"), ECMAScriptValue::from("very unique string"))
+        der.create_immutable_binding(&agent, JSString::from("sentinel"), true).unwrap();
+        der.initialize_binding(&agent, &JSString::from("sentinel"), ECMAScriptValue::from("very unique string"))
             .unwrap();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, false, Some(der), "test");
 
         let outer = oer.get_outer_env().unwrap();
 
-        let val_from_outer = outer.get_binding_value(&mut agent, &JSString::from("sentinel"), true).unwrap();
+        let val_from_outer = outer.get_binding_value(&agent, &JSString::from("sentinel"), true).unwrap();
         assert_eq!(val_from_outer, ECMAScriptValue::from("very unique string"));
     }
 
     #[test]
     #[should_panic(expected = "unreachable")]
     fn get_this_binding() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
-        oer.get_this_binding(&mut agent).unwrap();
+        oer.get_this_binding(&agent).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "unreachable")]
     fn bind_this_value() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
-        oer.bind_this_value(&mut agent, 29.into()).unwrap();
+        oer.bind_this_value(&agent, 29.into()).unwrap();
     }
 
     #[test]
     fn name() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "sentinel");
         assert_eq!(oer.name(), "sentinel");
     }
 
     #[test]
     fn binding_names() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "sentinel");
-        oer.create_mutable_binding(&mut agent, "bill".into(), true).unwrap();
-        oer.create_mutable_binding(&mut agent, "alice".into(), true).unwrap();
+        oer.create_mutable_binding(&agent, "bill".into(), true).unwrap();
+        oer.create_mutable_binding(&agent, "alice".into(), true).unwrap();
 
         let bindings = oer.binding_names();
         assert_eq!(bindings.len(), 2);
@@ -1016,7 +1012,7 @@ mod function_environment_record {
     use super::*;
     use test_case::test_case;
 
-    fn make_fer(agent: &mut Agent, src: &str, new_target: Option<Object>) -> (Object, FunctionEnvironmentRecord) {
+    fn make_fer(agent: &Agent, src: &str, new_target: Option<Object>) -> (Object, FunctionEnvironmentRecord) {
         let ae = Maker::new(src).assignment_expression();
         let this_mode = if ae.contains(ParseNodeKind::ArrowFunction) || ae.contains(ParseNodeKind::AsyncArrowFunction) {
             ThisLexicality::LexicalThis
@@ -1049,9 +1045,9 @@ mod function_environment_record {
     #[test_case("function foo(left, right) { return left * right; }" => BindingStatus::Uninitialized; "non-lexical")]
     #[test_case("(left, right) => { return left * right; }" => BindingStatus::Lexical; "lexical")]
     fn new(source: &str) -> BindingStatus {
-        let mut agent = test_agent();
+        let agent = test_agent();
 
-        let (closure, fer) = make_fer(&mut agent, source, None);
+        let (closure, fer) = make_fer(&agent, source, None);
 
         assert_eq!(fer.name, "environment_tag");
         assert!(fer.new_target.is_none());
@@ -1064,24 +1060,24 @@ mod function_environment_record {
 
     #[test]
     fn name() {
-        let mut agent = test_agent();
-        let (_, fer) = make_fer(&mut agent, "function a(){}", None);
+        let agent = test_agent();
+        let (_, fer) = make_fer(&agent, "function a(){}", None);
 
         assert_eq!(fer.name(), "environment_tag");
     }
 
     #[test]
     fn create_immutable_binding() {
-        let mut agent = test_agent();
-        let (_, fer) = make_fer(&mut agent, "function a(){}", None);
+        let agent = test_agent();
+        let (_, fer) = make_fer(&agent, "function a(){}", None);
 
-        fer.create_immutable_binding(&mut agent, "bob".into(), false).unwrap();
+        fer.create_immutable_binding(&agent, "bob".into(), false).unwrap();
         assert_eq!(fer.binding_names(), &[JSString::from("bob")]);
 
         // But was it immutable?
-        fer.initialize_binding(&mut agent, &"bob".into(), "initialized".into()).unwrap();
-        fer.set_mutable_binding(&mut agent, "bob".into(), "illegal".into(), true).expect_err("Should be immutable");
-        let val = fer.get_binding_value(&mut agent, &"bob".into(), true).unwrap();
+        fer.initialize_binding(&agent, &"bob".into(), "initialized".into()).unwrap();
+        fer.set_mutable_binding(&agent, "bob".into(), "illegal".into(), true).expect_err("Should be immutable");
+        let val = fer.get_binding_value(&agent, &"bob".into(), true).unwrap();
         assert_eq!(val, ECMAScriptValue::from("initialized"));
     }
 }
@@ -1090,7 +1086,7 @@ mod global_environment_record {
     use super::*;
     use test_case::test_case;
 
-    fn setup(agent: &mut Agent) -> GlobalEnvironmentRecord {
+    fn setup(agent: &Agent) -> GlobalEnvironmentRecord {
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let global_object = ordinary_object_create(agent, Some(object_prototype.clone()), &[]);
         let this_object = ordinary_object_create(agent, Some(object_prototype), &[]);
@@ -1174,10 +1170,10 @@ mod global_environment_record {
 
     #[test]
     fn debug() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
         assert_ne!(format!("{:?}", ger), "");
@@ -1185,10 +1181,10 @@ mod global_environment_record {
 
     #[test]
     fn fancy_debug() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
         assert_ne!(format!("{:#?}", ger), "");
@@ -1198,7 +1194,7 @@ mod global_environment_record {
         use super::*;
         #[test]
         fn happy_path() {
-            let mut agent = test_agent();
+            let agent = test_agent();
 
             let in_object_name = JSString::from("in_object");
             let in_decl_name = JSString::from("in_decl");
@@ -1206,8 +1202,8 @@ mod global_environment_record {
             let in_object_key = PropertyKey::from(in_object_name.clone());
 
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let in_object_property = PotentialPropertyDescriptor {
                 value: Some(ECMAScriptValue::from(0)),
                 writable: Some(true),
@@ -1215,25 +1211,25 @@ mod global_environment_record {
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(&mut agent, &global_object, in_object_key, in_object_property).unwrap();
+            define_property_or_throw(&agent, &global_object, in_object_key, in_object_property).unwrap();
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
-            ger.create_mutable_binding(&mut agent, in_decl_name.clone(), true).unwrap();
-            ger.initialize_binding(&mut agent, &in_decl_name, ECMAScriptValue::from(0)).unwrap();
+            ger.create_mutable_binding(&agent, in_decl_name.clone(), true).unwrap();
+            ger.initialize_binding(&agent, &in_decl_name, ECMAScriptValue::from(0)).unwrap();
 
-            assert!(ger.has_binding(&mut agent, &in_decl_name).unwrap());
-            assert!(ger.has_binding(&mut agent, &in_object_name).unwrap());
-            assert!(!ger.has_binding(&mut agent, &nobody_name).unwrap());
+            assert!(ger.has_binding(&agent, &in_decl_name).unwrap());
+            assert!(ger.has_binding(&agent, &in_object_name).unwrap());
+            assert!(!ger.has_binding(&agent, &nobody_name).unwrap());
         }
         #[test]
         fn error_path() {
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = DeadObject::object(&mut agent);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = DeadObject::object(&agent);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
-            let err = ger.has_binding(&mut agent, &JSString::from("a")).unwrap_err();
-            let msg = unwind_type_error(&mut agent, err);
+            let err = ger.has_binding(&agent, &JSString::from("a")).unwrap_err();
+            let msg = unwind_type_error(&agent, err);
             assert_eq!(msg, "has_property called on DeadObject");
         }
     }
@@ -1246,15 +1242,15 @@ mod global_environment_record {
         #[test_case(false; "Permanent")]
         fn happy(deletable: bool) {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
 
             // Exercise function
-            ger.create_mutable_binding(&mut agent, test_name.clone(), deletable).unwrap();
+            ger.create_mutable_binding(&agent, test_name.clone(), deletable).unwrap();
 
             // Validate results
             let bindings = ger.declarative_record.bindings.borrow();
@@ -1271,20 +1267,20 @@ mod global_environment_record {
         #[test]
         fn error() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.create_mutable_binding(&mut agent, test_name.clone(), true).unwrap();
+            ger.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
 
             // Exercise function
-            let result = ger.create_mutable_binding(&mut agent, test_name, true);
+            let result = ger.create_mutable_binding(&agent, test_name, true);
 
             // Validate result
             let err = result.unwrap_err();
-            let msg = unwind_type_error(&mut agent, err);
+            let msg = unwind_type_error(&agent, err);
             assert_eq!(msg, "Binding already exists");
         }
     }
@@ -1297,15 +1293,15 @@ mod global_environment_record {
         #[test_case(false; "Sloppy")]
         fn happy(strict: bool) {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
 
             // Exercise function
-            ger.create_immutable_binding(&mut agent, test_name.clone(), strict).unwrap();
+            ger.create_immutable_binding(&agent, test_name.clone(), strict).unwrap();
 
             // Validate
             let bindings = ger.declarative_record.bindings.borrow();
@@ -1322,20 +1318,20 @@ mod global_environment_record {
         #[test]
         fn error() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.create_mutable_binding(&mut agent, test_name.clone(), true).unwrap();
+            ger.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
 
             // Exercise function
-            let result = ger.create_immutable_binding(&mut agent, test_name, true);
+            let result = ger.create_immutable_binding(&agent, test_name, true);
 
             // Validate result
             let err = result.unwrap_err();
-            let msg = unwind_type_error(&mut agent, err);
+            let msg = unwind_type_error(&agent, err);
             assert_eq!(msg, "Binding already exists");
         }
     }
@@ -1346,16 +1342,16 @@ mod global_environment_record {
         #[test]
         fn decl() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.create_mutable_binding(&mut agent, test_name.clone(), true).unwrap();
+            ger.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
 
             // Exercise function
-            ger.initialize_binding(&mut agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
 
             let bindings = ger.declarative_record.bindings.borrow();
             // 1. Binding is in declarative record portion
@@ -1366,19 +1362,19 @@ mod global_environment_record {
         #[test]
         fn object() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object.clone(), this_object, "test");
             let test_name = JSString::from("test");
-            ger.object_record.create_mutable_binding(&mut agent, test_name.clone(), true).unwrap();
+            ger.object_record.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
 
             // Excersize function
-            ger.initialize_binding(&mut agent, &test_name, ECMAScriptValue::from(223)).unwrap();
+            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(223)).unwrap();
 
             // Validate
-            let val = get(&mut agent, &global_object, &PropertyKey::from(test_name)).unwrap();
+            let val = get(&agent, &global_object, &PropertyKey::from(test_name)).unwrap();
             assert_eq!(val, ECMAScriptValue::from(223));
         }
     }
@@ -1388,44 +1384,44 @@ mod global_environment_record {
         #[test]
         fn decl() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.create_mutable_binding(&mut agent, test_name.clone(), true).unwrap();
-            ger.initialize_binding(&mut agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
+            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
 
             // Exercise function
-            ger.set_mutable_binding(&mut agent, test_name.clone(), ECMAScriptValue::from(10), false).unwrap();
+            ger.set_mutable_binding(&agent, test_name.clone(), ECMAScriptValue::from(10), false).unwrap();
 
             // Validate
-            let val = ger.get_binding_value(&mut agent, &test_name, false).unwrap();
+            let val = ger.get_binding_value(&agent, &test_name, false).unwrap();
             assert_eq!(val, ECMAScriptValue::from(10));
-            assert!(ger.declarative_record.has_binding(&mut agent, &test_name).unwrap());
-            assert!(!ger.object_record.has_binding(&mut agent, &test_name).unwrap());
+            assert!(ger.declarative_record.has_binding(&agent, &test_name).unwrap());
+            assert!(!ger.object_record.has_binding(&agent, &test_name).unwrap());
         }
         #[test]
         fn object() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.object_record.create_mutable_binding(&mut agent, test_name.clone(), true).unwrap();
-            ger.initialize_binding(&mut agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.object_record.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
+            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
 
             // Exercise function
-            ger.set_mutable_binding(&mut agent, test_name.clone(), ECMAScriptValue::from(9933), false).unwrap();
+            ger.set_mutable_binding(&agent, test_name.clone(), ECMAScriptValue::from(9933), false).unwrap();
 
             // Validate
-            let val = ger.get_binding_value(&mut agent, &test_name, false).unwrap();
+            let val = ger.get_binding_value(&agent, &test_name, false).unwrap();
             assert_eq!(val, ECMAScriptValue::from(9933));
-            assert!(!ger.declarative_record.has_binding(&mut agent, &test_name).unwrap());
-            assert!(ger.object_record.has_binding(&mut agent, &test_name).unwrap());
+            assert!(!ger.declarative_record.has_binding(&agent, &test_name).unwrap());
+            assert!(ger.object_record.has_binding(&agent, &test_name).unwrap());
         }
     }
 
@@ -1435,17 +1431,17 @@ mod global_environment_record {
         #[test]
         fn decl() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.create_mutable_binding(&mut agent, test_name.clone(), true).unwrap();
-            ger.initialize_binding(&mut agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
+            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
 
             // Exercise
-            let result = ger.get_binding_value(&mut agent, &test_name, true).unwrap();
+            let result = ger.get_binding_value(&agent, &test_name, true).unwrap();
 
             // Validate
             assert_eq!(result, ECMAScriptValue::from(527));
@@ -1453,17 +1449,17 @@ mod global_environment_record {
         #[test]
         fn object() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.object_record.create_mutable_binding(&mut agent, test_name.clone(), true).unwrap();
-            ger.initialize_binding(&mut agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.object_record.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
+            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
 
             // Exercise
-            let result = ger.get_binding_value(&mut agent, &test_name, true).unwrap();
+            let result = ger.get_binding_value(&agent, &test_name, true).unwrap();
 
             // Validate
             assert_eq!(result, ECMAScriptValue::from(527));
@@ -1471,15 +1467,15 @@ mod global_environment_record {
         #[test]
         fn missing_sloppy() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
 
             // Exercise
-            let result = ger.get_binding_value(&mut agent, &test_name, false).unwrap();
+            let result = ger.get_binding_value(&agent, &test_name, false).unwrap();
 
             // Validate
             assert_eq!(result, ECMAScriptValue::Undefined);
@@ -1487,19 +1483,19 @@ mod global_environment_record {
         #[test]
         fn missing_strict() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
 
             // Exercise
-            let result = ger.get_binding_value(&mut agent, &test_name, true);
+            let result = ger.get_binding_value(&agent, &test_name, true);
 
             // Validate
             let err = result.unwrap_err();
-            let msg = unwind_reference_error(&mut agent, err);
+            let msg = unwind_reference_error(&agent, err);
             assert_eq!(msg, "Unresolvable reference");
         }
     }
@@ -1510,131 +1506,131 @@ mod global_environment_record {
         #[test]
         fn decl() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.create_mutable_binding(&mut agent, test_name.clone(), true).unwrap();
-            ger.initialize_binding(&mut agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
+            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
 
             // Exercise function
-            let result = ger.delete_binding(&mut agent, &test_name);
+            let result = ger.delete_binding(&agent, &test_name);
 
             // Validate
             assert!(result.unwrap());
-            assert!(!ger.has_binding(&mut agent, &test_name).unwrap());
+            assert!(!ger.has_binding(&agent, &test_name).unwrap());
         }
 
         #[test]
         fn object_binding_in_varnames() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.object_record.create_mutable_binding(&mut agent, test_name.clone(), true).unwrap();
-            ger.initialize_binding(&mut agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.object_record.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
+            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
             ger.var_names.borrow_mut().insert(test_name.clone());
 
             // Exercise
-            let result = ger.delete_binding(&mut agent, &test_name);
+            let result = ger.delete_binding(&agent, &test_name);
 
             // Validate
             assert!(result.unwrap());
-            assert!(!ger.has_binding(&mut agent, &test_name).unwrap());
+            assert!(!ger.has_binding(&agent, &test_name).unwrap());
             assert!(!ger.var_names.borrow().contains(&test_name));
         }
         #[test]
         fn object_binding_not_in_vn() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.object_record.create_mutable_binding(&mut agent, test_name.clone(), true).unwrap();
-            ger.initialize_binding(&mut agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.object_record.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
+            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
 
             // Exercise
-            let result = ger.delete_binding(&mut agent, &test_name);
+            let result = ger.delete_binding(&agent, &test_name);
 
             // Validate
             assert!(result.unwrap());
-            assert!(!ger.has_binding(&mut agent, &test_name).unwrap());
+            assert!(!ger.has_binding(&agent, &test_name).unwrap());
             assert!(!ger.var_names.borrow().contains(&test_name));
         }
         #[test]
         fn object_binding_permanent() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.object_record.create_mutable_binding(&mut agent, test_name.clone(), false).unwrap();
-            ger.initialize_binding(&mut agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.object_record.create_mutable_binding(&agent, test_name.clone(), false).unwrap();
+            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
             ger.var_names.borrow_mut().insert(test_name.clone());
 
             // Exercise
-            let result = ger.delete_binding(&mut agent, &test_name);
+            let result = ger.delete_binding(&agent, &test_name);
 
             // Validate
             assert!(!result.unwrap());
-            assert!(ger.has_binding(&mut agent, &test_name).unwrap());
+            assert!(ger.has_binding(&agent, &test_name).unwrap());
             assert!(ger.var_names.borrow().contains(&test_name));
         }
         #[test]
         fn no_binding() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
 
             // Exercise
-            let result = ger.delete_binding(&mut agent, &test_name);
+            let result = ger.delete_binding(&agent, &test_name);
 
             // Validate
             assert!(result.unwrap());
         }
         #[test]
         fn has_property_error() {
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = DeadObject::object(&mut agent);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = DeadObject::object(&agent);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
-            let err = ger.delete_binding(&mut agent, &JSString::from("a")).unwrap_err();
-            let msg = unwind_type_error(&mut agent, err);
+            let err = ger.delete_binding(&agent, &JSString::from("a")).unwrap_err();
+            let msg = unwind_type_error(&agent, err);
             assert_eq!(msg, "get_own_property called on DeadObject");
         }
         #[test]
         fn delete_error() {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = TestObject::object(&mut agent, &[FunctionId::Delete(None)]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = TestObject::object(&agent, &[FunctionId::Delete(None)]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.object_record.create_mutable_binding(&mut agent, test_name.clone(), true).unwrap();
-            ger.object_record.initialize_binding(&mut agent, &test_name, ECMAScriptValue::from(88)).unwrap();
+            ger.object_record.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
+            ger.object_record.initialize_binding(&agent, &test_name, ECMAScriptValue::from(88)).unwrap();
 
             // Exercise
-            let result = ger.delete_binding(&mut agent, &test_name);
+            let result = ger.delete_binding(&agent, &test_name);
 
             // Validate
             let err = result.unwrap_err();
-            let msg = unwind_type_error(&mut agent, err);
+            let msg = unwind_type_error(&agent, err);
             assert_eq!(msg, "[[Delete]] called on TestObject");
         }
     }
@@ -1642,10 +1638,10 @@ mod global_environment_record {
     #[test]
     fn has_this_binding() {
         // Setup
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
         // Exercise
@@ -1657,10 +1653,10 @@ mod global_environment_record {
     #[test]
     fn has_super_binding() {
         // Setup
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
         // Exercise
@@ -1672,10 +1668,10 @@ mod global_environment_record {
     #[test]
     fn with_base_object() {
         // Setup
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
         // Exercise
@@ -1687,10 +1683,10 @@ mod global_environment_record {
     #[test]
     fn get_outer_env() {
         // Setup
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
         // Exercise
@@ -1703,14 +1699,14 @@ mod global_environment_record {
     #[test]
     fn get_this_binding() {
         // Setup
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object.clone(), "test");
 
         // Exercise function
-        let result = ger.get_this_binding(&mut agent).unwrap();
+        let result = ger.get_this_binding(&agent).unwrap();
 
         // Validate
         assert_eq!(result, ECMAScriptValue::from(this_object));
@@ -1720,16 +1716,16 @@ mod global_environment_record {
     #[test_case("lexical" => false; "lex")]
     fn has_var_declaration(prop_name: &str) -> bool {
         // Setup
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
         let var_name = JSString::from("varstyle");
-        ger.create_global_var_binding(&mut agent, var_name, true).unwrap();
+        ger.create_global_var_binding(&agent, var_name, true).unwrap();
         let lex_name = JSString::from("lexical");
-        ger.create_mutable_binding(&mut agent, lex_name.clone(), true).unwrap();
-        ger.initialize_binding(&mut agent, &lex_name, ECMAScriptValue::Undefined).unwrap();
+        ger.create_mutable_binding(&agent, lex_name.clone(), true).unwrap();
+        ger.initialize_binding(&agent, &lex_name, ECMAScriptValue::Undefined).unwrap();
 
         // Exercise
         ger.has_var_declaration(&JSString::from(prop_name))
@@ -1738,19 +1734,19 @@ mod global_environment_record {
     #[test_case("lexical" => true; "lex")]
     fn has_lexical_declaration(prop_name: &str) -> bool {
         // Setup
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
         let var_name = JSString::from("varstyle");
-        ger.create_global_var_binding(&mut agent, var_name, true).unwrap();
+        ger.create_global_var_binding(&agent, var_name, true).unwrap();
         let lex_name = JSString::from("lexical");
-        ger.create_mutable_binding(&mut agent, lex_name.clone(), true).unwrap();
-        ger.initialize_binding(&mut agent, &lex_name, ECMAScriptValue::Undefined).unwrap();
+        ger.create_mutable_binding(&agent, lex_name.clone(), true).unwrap();
+        ger.initialize_binding(&agent, &lex_name, ECMAScriptValue::Undefined).unwrap();
 
         // Exercise
-        ger.has_lexical_declaration(&mut agent, &JSString::from(prop_name))
+        ger.has_lexical_declaration(&agent, &JSString::from(prop_name))
     }
 
     mod has_restricted_global_property {
@@ -1761,21 +1757,21 @@ mod global_environment_record {
         #[test_case("normal_var" => false; "configurable var property")]
         #[test_case("non_config_var" => true; "non-configurable property on object")]
         fn happy(propname: &str) -> bool {
-            let mut agent = test_agent();
-            let ger = setup(&mut agent);
-            ger.has_restricted_global_property(&mut agent, &JSString::from(propname)).unwrap()
+            let agent = test_agent();
+            let ger = setup(&agent);
+            ger.has_restricted_global_property(&agent, &JSString::from(propname)).unwrap()
         }
 
         #[test]
         fn error() {
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = DeadObject::object(&mut agent);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = DeadObject::object(&agent);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
-            let err = ger.has_restricted_global_property(&mut agent, &JSString::from("test")).unwrap_err();
-            let msg = unwind_type_error(&mut agent, err);
+            let err = ger.has_restricted_global_property(&agent, &JSString::from("test")).unwrap_err();
+            let msg = unwind_type_error(&agent, err);
             assert_eq!(msg, "get_own_property called on DeadObject");
         }
     }
@@ -1789,27 +1785,27 @@ mod global_environment_record {
         #[test_case("normal_var", false => true; "normal, not extensible")]
         #[test_case("not_present", false => false; "not there, not extensible")]
         fn happy(name: &str, global_extensible: bool) -> bool {
-            let mut agent = test_agent();
-            let ger = setup(&mut agent);
+            let agent = test_agent();
+            let ger = setup(&agent);
             if !global_extensible {
-                ger.object_record.binding_object.o.prevent_extensions(&mut agent).unwrap();
+                ger.object_record.binding_object.o.prevent_extensions(&agent).unwrap();
             }
 
-            ger.can_declare_global_var(&mut agent, &JSString::from(name)).unwrap()
+            ger.can_declare_global_var(&agent, &JSString::from(name)).unwrap()
         }
 
         #[test_case(FunctionId::GetOwnProperty(None) => "[[GetOwnProperty]] called on TestObject"; "GetOwnProperty")]
         #[test_case(FunctionId::IsExtensible => "[[IsExtensible]] called on TestObject"; "IsExtensible")]
         fn error(method: FunctionId) -> String {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = TestObject::object(&mut agent, &[method]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = TestObject::object(&agent, &[method]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
-            let err = ger.can_declare_global_var(&mut agent, &JSString::from("anything")).unwrap_err();
-            unwind_type_error(&mut agent, err)
+            let err = ger.can_declare_global_var(&agent, &JSString::from("anything")).unwrap_err();
+            unwind_type_error(&agent, err)
         }
     }
 
@@ -1824,11 +1820,11 @@ mod global_environment_record {
         #[test_case("non_config_unlisted" => false)]
         #[test_case("non_config_accessor" => false)]
         fn happy_extensible(name: &str) -> bool {
-            let mut agent = test_agent();
-            let ger = setup(&mut agent);
+            let agent = test_agent();
+            let ger = setup(&agent);
             let test_name = JSString::from(name);
 
-            ger.can_declare_global_function(&mut agent, &test_name).unwrap()
+            ger.can_declare_global_function(&agent, &test_name).unwrap()
         }
         #[test_case("not_present" => false)]
         #[test_case("normal_var" => true)]
@@ -1837,25 +1833,25 @@ mod global_environment_record {
         #[test_case("non_config_unlisted" => false)]
         #[test_case("non_config_accessor" => false)]
         fn happy_frozen(name: &str) -> bool {
-            let mut agent = test_agent();
-            let ger = setup(&mut agent);
-            ger.object_record.binding_object.o.prevent_extensions(&mut agent).unwrap();
+            let agent = test_agent();
+            let ger = setup(&agent);
+            ger.object_record.binding_object.o.prevent_extensions(&agent).unwrap();
             let test_name = JSString::from(name);
 
-            ger.can_declare_global_function(&mut agent, &test_name).unwrap()
+            ger.can_declare_global_function(&agent, &test_name).unwrap()
         }
         #[test_case(FunctionId::GetOwnProperty(None) => "[[GetOwnProperty]] called on TestObject"; "GetOwnProperty")]
         #[test_case(FunctionId::IsExtensible => "[[IsExtensible]] called on TestObject"; "IsExtensible")]
         fn error(method: FunctionId) -> String {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = TestObject::object(&mut agent, &[method]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = TestObject::object(&agent, &[method]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
-            let err = ger.can_declare_global_function(&mut agent, &JSString::from("anything")).unwrap_err();
-            unwind_type_error(&mut agent, err)
+            let err = ger.can_declare_global_function(&agent, &JSString::from("anything")).unwrap_err();
+            unwind_type_error(&agent, err)
         }
     }
 
@@ -1868,18 +1864,18 @@ mod global_environment_record {
         #[test_case("normal_var", true => (ECMAScriptValue::from("NORMAL VAR"), true); "existing prop; deletable")]
         #[test_case("normal_var", false => (ECMAScriptValue::from("NORMAL VAR"), true); "existing prop; permanent")]
         fn happy_extensible(name: &str, deletable: bool) -> (ECMAScriptValue, bool) {
-            let mut agent = test_agent();
-            let ger = setup(&mut agent);
+            let agent = test_agent();
+            let ger = setup(&agent);
             let test_name = JSString::from(name);
 
-            ger.create_global_var_binding(&mut agent, test_name.clone(), deletable).unwrap();
+            ger.create_global_var_binding(&agent, test_name.clone(), deletable).unwrap();
 
             assert!(ger.var_names.borrow().contains(&test_name));
             let desc = ger
                 .object_record
                 .binding_object
                 .o
-                .get_own_property(&mut agent, &PropertyKey::from(test_name))
+                .get_own_property(&agent, &PropertyKey::from(test_name))
                 .unwrap()
                 .unwrap();
             assert!(matches!(desc.property, PropertyKind::Data(_)));
@@ -1895,16 +1891,16 @@ mod global_environment_record {
         #[test_case("normal_var", true => Some((ECMAScriptValue::from("NORMAL VAR"), true)); "existing prop; deletable")]
         #[test_case("normal_var", false => Some((ECMAScriptValue::from("NORMAL VAR"), true)); "existing prop; permanent")]
         fn happy_frozen(name: &str, deletable: bool) -> Option<(ECMAScriptValue, bool)> {
-            let mut agent = test_agent();
-            let ger = setup(&mut agent);
-            ger.object_record.binding_object.o.prevent_extensions(&mut agent).unwrap();
+            let agent = test_agent();
+            let ger = setup(&agent);
+            ger.object_record.binding_object.o.prevent_extensions(&agent).unwrap();
             let test_name = JSString::from(name);
 
-            ger.create_global_var_binding(&mut agent, test_name.clone(), deletable).unwrap();
+            ger.create_global_var_binding(&agent, test_name.clone(), deletable).unwrap();
 
             assert!(ger.var_names.borrow().contains(&test_name));
             let opt_desc =
-                ger.object_record.binding_object.o.get_own_property(&mut agent, &PropertyKey::from(test_name)).unwrap();
+                ger.object_record.binding_object.o.get_own_property(&agent, &PropertyKey::from(test_name)).unwrap();
             match opt_desc {
                 None => None,
                 Some(desc) => {
@@ -1924,14 +1920,14 @@ mod global_environment_record {
         #[test_case(FunctionId::Set(None) => "[[Set]] called on TestObject"; "Set")]
         fn error(method: FunctionId) -> String {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = TestObject::object(&mut agent, &[method]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = TestObject::object(&agent, &[method]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
-            let err = ger.create_global_var_binding(&mut agent, JSString::from("anything"), true).unwrap_err();
-            unwind_type_error(&mut agent, err)
+            let err = ger.create_global_var_binding(&agent, JSString::from("anything"), true).unwrap_err();
+            unwind_type_error(&agent, err)
         }
     }
 
@@ -1946,21 +1942,16 @@ mod global_environment_record {
         #[test_case("non_config_var", true => Some((ECMAScriptValue::from("unique"), true, true, false)); "not cfgable; deletable")]
         #[test_case("non_config_var", false => Some((ECMAScriptValue::from("unique"), true, true, false)); "not cfgable; permanent")]
         fn happy(name: &str, deletable: bool) -> Option<(ECMAScriptValue, bool, bool, bool)> {
-            let mut agent = test_agent();
-            let ger = setup(&mut agent);
+            let agent = test_agent();
+            let ger = setup(&agent);
             let test_name = JSString::from(name);
 
-            ger.create_global_function_binding(
-                &mut agent,
-                test_name.clone(),
-                ECMAScriptValue::from("unique"),
-                deletable,
-            )
-            .unwrap();
+            ger.create_global_function_binding(&agent, test_name.clone(), ECMAScriptValue::from("unique"), deletable)
+                .unwrap();
 
             assert!(ger.var_names.borrow().contains(&test_name));
             let opt_desc =
-                ger.object_record.binding_object.o.get_own_property(&mut agent, &PropertyKey::from(test_name)).unwrap();
+                ger.object_record.binding_object.o.get_own_property(&agent, &PropertyKey::from(test_name)).unwrap();
             match opt_desc {
                 None => None,
                 Some(desc) => {
@@ -1978,30 +1969,25 @@ mod global_environment_record {
         #[test_case(FunctionId::Set(None) => "[[Set]] called on TestObject"; "Set")]
         fn error(method: FunctionId) -> String {
             // Setup
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = TestObject::object(&mut agent, &[method]);
-            let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+            let global_object = TestObject::object(&agent, &[method]);
+            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
             let err = ger
-                .create_global_function_binding(
-                    &mut agent,
-                    JSString::from("anything"),
-                    ECMAScriptValue::Undefined,
-                    true,
-                )
+                .create_global_function_binding(&agent, JSString::from("anything"), ECMAScriptValue::Undefined, true)
                 .unwrap_err();
-            unwind_type_error(&mut agent, err)
+            unwind_type_error(&agent, err)
         }
     }
 
     #[test]
     fn new() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&mut agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object.clone(), this_object.clone(), "test");
 
         assert_eq!(ger.object_record.binding_object, global_object);
@@ -2012,22 +1998,22 @@ mod global_environment_record {
     #[test]
     #[should_panic(expected = "unreachable")]
     fn bind_this_value() {
-        let mut agent = test_agent();
-        let ger = setup(&mut agent);
-        ger.bind_this_value(&mut agent, ECMAScriptValue::Undefined).unwrap();
+        let agent = test_agent();
+        let ger = setup(&agent);
+        ger.bind_this_value(&agent, ECMAScriptValue::Undefined).unwrap();
     }
 
     #[test]
     fn name() {
-        let mut agent = test_agent();
-        let ger = setup(&mut agent);
+        let agent = test_agent();
+        let ger = setup(&agent);
         assert_eq!(ger.name(), "test");
     }
 
     #[test]
     fn var_decls() {
-        let mut agent = test_agent();
-        let ger = setup(&mut agent);
+        let agent = test_agent();
+        let ger = setup(&agent);
         let vd_list = ger.var_decls();
         assert_eq!(vd_list.len(), 1);
         assert!(vd_list.contains(&JSString::from("normal_var")));
@@ -2035,8 +2021,8 @@ mod global_environment_record {
 
     #[test]
     fn lex_decls() {
-        let mut agent = test_agent();
-        let ger = setup(&mut agent);
+        let agent = test_agent();
+        let ger = setup(&agent);
         let lex_list = ger.lex_decls();
         assert_eq!(lex_list.len(), 4);
         assert!(lex_list.contains(&JSString::from("lexical_sloppy")));
@@ -2047,8 +2033,8 @@ mod global_environment_record {
 
     #[test]
     fn binding_names() {
-        let mut agent = test_agent();
-        let ger = setup(&mut agent);
+        let agent = test_agent();
+        let ger = setup(&agent);
         let bindings = ger.binding_names();
         assert_eq!(bindings.len(), 5);
         assert!(bindings.contains(&JSString::from("lexical_sloppy")));
@@ -2066,8 +2052,8 @@ mod get_identifier_reference {
     #[test_case("bob", true => (true, ReferencedName::from("bob"), true, None); "strict")]
     #[test_case("bob", false => (true, ReferencedName::from("bob"), false, None); "sloppy")]
     fn no_env(name: &str, strict: bool) -> (bool, ReferencedName, bool, Option<ECMAScriptValue>) {
-        let mut agent = test_agent();
-        let reference = get_identifier_reference(&mut agent, None, JSString::from(name), strict).unwrap();
+        let agent = test_agent();
+        let reference = get_identifier_reference(&agent, None, JSString::from(name), strict).unwrap();
         (
             matches!(reference.base, Base::Unresolvable),
             reference.referenced_name,
@@ -2090,18 +2076,17 @@ mod get_identifier_reference {
     #[test_case("parent", true => (EnvResult::ParentEnv, ReferencedName::from("parent"), true, None); "parent; strict")]
     #[test_case("parent", false => (EnvResult::ParentEnv, ReferencedName::from("parent"), false, None); "parent; sloppy")]
     fn some_env(name: &str, strict: bool) -> (EnvResult, ReferencedName, bool, Option<ECMAScriptValue>) {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let parent = DeclarativeEnvironmentRecord::new(None, "test");
-        parent.create_immutable_binding(&mut agent, JSString::from("parent"), true).unwrap();
-        parent.initialize_binding(&mut agent, &JSString::from("parent"), ECMAScriptValue::from("testing")).unwrap();
+        parent.create_immutable_binding(&agent, JSString::from("parent"), true).unwrap();
+        parent.initialize_binding(&agent, &JSString::from("parent"), ECMAScriptValue::from("testing")).unwrap();
         let rcparent: Rc<dyn EnvironmentRecord> = Rc::new(parent);
         let env = DeclarativeEnvironmentRecord::new(Some(Rc::clone(&rcparent)), "inner");
-        env.create_immutable_binding(&mut agent, JSString::from("present"), true).unwrap();
-        env.initialize_binding(&mut agent, &JSString::from("present"), ECMAScriptValue::from("testing")).unwrap();
+        env.create_immutable_binding(&agent, JSString::from("present"), true).unwrap();
+        env.initialize_binding(&agent, &JSString::from("present"), ECMAScriptValue::from("testing")).unwrap();
         let rcenv: Rc<dyn EnvironmentRecord> = Rc::new(env);
 
-        let result =
-            get_identifier_reference(&mut agent, Some(Rc::clone(&rcenv)), JSString::from(name), strict).unwrap();
+        let result = get_identifier_reference(&agent, Some(Rc::clone(&rcenv)), JSString::from(name), strict).unwrap();
         (
             match &result.base {
                 Base::Unresolvable => EnvResult::Unresolvable,
@@ -2124,15 +2109,15 @@ mod get_identifier_reference {
 
     #[test]
     fn error() {
-        let mut agent = test_agent();
-        let binding_object = TestObject::object(&mut agent, &[FunctionId::HasProperty(None)]);
+        let agent = test_agent();
+        let binding_object = TestObject::object(&agent, &[FunctionId::HasProperty(None)]);
         let env = ObjectEnvironmentRecord::new(binding_object, false, None, "test");
         let rcenv: Rc<dyn EnvironmentRecord> = Rc::new(env);
 
-        let result = get_identifier_reference(&mut agent, Some(Rc::clone(&rcenv)), JSString::from("anything"), true);
+        let result = get_identifier_reference(&agent, Some(Rc::clone(&rcenv)), JSString::from("anything"), true);
 
         let err = result.unwrap_err();
-        let msg = unwind_type_error(&mut agent, err);
+        let msg = unwind_type_error(&agent, err);
         assert_eq!(msg, "[[HasProperty]] called on TestObject");
     }
 }

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 fn create_native_error_object(
-    agent: &mut Agent,
+    agent: &Agent,
     message: impl Into<JSString>,
     error_constructor: Object,
     proto_id: IntrinsicId,
@@ -49,65 +49,61 @@ fn create_native_error_object(
     o
 }
 
-pub fn create_type_error_object(agent: &mut Agent, message: impl Into<JSString>) -> Object {
+pub fn create_type_error_object(agent: &Agent, message: impl Into<JSString>) -> Object {
     let error_constructor = agent.intrinsic(IntrinsicId::TypeError);
     create_native_error_object(agent, message, error_constructor, IntrinsicId::TypeErrorPrototype, None)
 }
 
-pub fn create_type_error(agent: &mut Agent, message: impl Into<JSString>) -> AbruptCompletion {
+pub fn create_type_error(agent: &Agent, message: impl Into<JSString>) -> AbruptCompletion {
     AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_type_error_object(agent, message)) }
 }
 
-pub fn create_reference_error_object(agent: &mut Agent, message: impl Into<JSString>) -> Object {
+pub fn create_reference_error_object(agent: &Agent, message: impl Into<JSString>) -> Object {
     let cstr = agent.intrinsic(IntrinsicId::ReferenceError);
     create_native_error_object(agent, message, cstr, IntrinsicId::ReferenceErrorPrototype, None)
 }
 
-pub fn create_reference_error(agent: &mut Agent, message: impl Into<JSString>) -> AbruptCompletion {
+pub fn create_reference_error(agent: &Agent, message: impl Into<JSString>) -> AbruptCompletion {
     AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_reference_error_object(agent, message)) }
 }
 
-pub fn create_syntax_error_object(
-    agent: &mut Agent,
-    message: impl Into<JSString>,
-    location: Option<Location>,
-) -> Object {
+pub fn create_syntax_error_object(agent: &Agent, message: impl Into<JSString>, location: Option<Location>) -> Object {
     let cstr = agent.intrinsic(IntrinsicId::SyntaxError);
     create_native_error_object(agent, message, cstr, IntrinsicId::SyntaxErrorPrototype, location)
 }
 
 pub fn create_syntax_error(
-    agent: &mut Agent,
+    agent: &Agent,
     message: impl Into<JSString>,
     location: Option<Location>,
 ) -> AbruptCompletion {
     AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_syntax_error_object(agent, message, location)) }
 }
 
-pub fn create_range_error_object(agent: &mut Agent, message: impl Into<JSString>) -> Object {
+pub fn create_range_error_object(agent: &Agent, message: impl Into<JSString>) -> Object {
     let cstr = agent.intrinsic(IntrinsicId::RangeError);
     create_native_error_object(agent, message, cstr, IntrinsicId::RangeErrorPrototype, None)
 }
 
-pub fn create_range_error(agent: &mut Agent, message: impl Into<JSString>) -> AbruptCompletion {
+pub fn create_range_error(agent: &Agent, message: impl Into<JSString>) -> AbruptCompletion {
     AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_range_error_object(agent, message)) }
 }
 
-pub fn create_eval_error_object(agent: &mut Agent, message: impl Into<JSString>) -> Object {
+pub fn create_eval_error_object(agent: &Agent, message: impl Into<JSString>) -> Object {
     let cstr = agent.intrinsic(IntrinsicId::EvalError);
     create_native_error_object(agent, message, cstr, IntrinsicId::EvalErrorPrototype, None)
 }
 
-pub fn create_eval_error(agent: &mut Agent, message: impl Into<JSString>) -> AbruptCompletion {
+pub fn create_eval_error(agent: &Agent, message: impl Into<JSString>) -> AbruptCompletion {
     AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_eval_error_object(agent, message)) }
 }
 
-pub fn create_uri_error_object(agent: &mut Agent, message: impl Into<JSString>) -> Object {
+pub fn create_uri_error_object(agent: &Agent, message: impl Into<JSString>) -> Object {
     let cstr = agent.intrinsic(IntrinsicId::URIError);
     create_native_error_object(agent, message, cstr, IntrinsicId::URIErrorPrototype, None)
 }
 
-pub fn create_uri_error(agent: &mut Agent, message: impl Into<JSString>) -> AbruptCompletion {
+pub fn create_uri_error(agent: &Agent, message: impl Into<JSString>) -> AbruptCompletion {
     AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_uri_error_object(agent, message)) }
 }
 
@@ -117,7 +113,7 @@ pub struct ErrorObject {
 }
 
 impl ErrorObject {
-    pub fn object(agent: &mut Agent, prototype: Option<Object>) -> Object {
+    pub fn object(agent: &Agent, prototype: Option<Object>) -> Object {
         Object {
             o: Rc::new(Self {
                 common: RefCell::new(CommonObjectData::new(agent, prototype, true, ERROR_OBJECT_SLOTS)),
@@ -149,53 +145,47 @@ impl ObjectInterface for ErrorObject {
         true
     }
 
-    fn get_prototype_of(&self, _agent: &mut Agent) -> Completion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &Agent) -> Completion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
-    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<Object>) -> Completion<bool> {
+    fn set_prototype_of(&self, _agent: &Agent, obj: Option<Object>) -> Completion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
-    fn is_extensible(&self, _agent: &mut Agent) -> Completion<bool> {
+    fn is_extensible(&self, _agent: &Agent) -> Completion<bool> {
         Ok(ordinary_is_extensible(self))
     }
-    fn prevent_extensions(&self, _agent: &mut Agent) -> Completion<bool> {
+    fn prevent_extensions(&self, _agent: &Agent) -> Completion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
-    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _agent: &Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(self, key))
     }
     fn define_own_property(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         key: PropertyKey,
         desc: PotentialPropertyDescriptor,
     ) -> Completion<bool> {
         ordinary_define_own_property(agent, self, key, desc)
     }
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
+    fn has_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_has_property(agent, self, key)
     }
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+    fn get(&self, agent: &Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         ordinary_get(agent, self, key, receiver)
     }
-    fn set(
-        &self,
-        agent: &mut Agent,
-        key: PropertyKey,
-        v: ECMAScriptValue,
-        receiver: &ECMAScriptValue,
-    ) -> Completion<bool> {
+    fn set(&self, agent: &Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
         ordinary_set(agent, self, key, v, receiver)
     }
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
+    fn delete(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_delete(agent, self, key)
     }
-    fn own_property_keys(&self, _agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, _agent: &Agent) -> Completion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(self))
     }
 }
 
-pub fn provision_error_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_error_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -334,7 +324,7 @@ pub fn provision_error_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>) 
 //          c. Perform ! DefinePropertyOrThrow(O, "message", msgDesc).
 //      4. Return O.
 pub fn error_constructor_function(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -356,7 +346,7 @@ pub fn error_constructor_function(
 //      8. If msg is the empty String, return name.
 //      9. Return the string-concatenation of name, the code unit 0x003A (COLON), the code unit 0x0020 (SPACE), and msg.
 pub fn error_prototype_tostring(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -379,11 +369,11 @@ pub fn error_prototype_tostring(
 }
 
 fn provision_native_error_intrinsics(
-    agent: &mut Agent,
+    agent: &Agent,
     realm: &Rc<RefCell<Realm>>,
     name: &str,
     native_error_constructor_function: fn(
-        &mut Agent,
+        &Agent,
         ECMAScriptValue,
         Option<&Object>,
         &[ECMAScriptValue],
@@ -501,7 +491,7 @@ fn provision_native_error_intrinsics(
 // "%ReferenceError.prototype%", "%SyntaxError.prototype%", "%TypeError.prototype%", or "%URIError.prototype%"
 // corresponding to which NativeError constructor is being defined.
 fn native_error_constructor_function(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -529,7 +519,7 @@ fn native_error_constructor_function(
 }
 
 fn type_error_constructor_function(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -537,7 +527,7 @@ fn type_error_constructor_function(
     native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::TypeErrorPrototype)
 }
 fn eval_error_constructor_function(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -545,7 +535,7 @@ fn eval_error_constructor_function(
     native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::EvalErrorPrototype)
 }
 fn range_error_constructor_function(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -553,7 +543,7 @@ fn range_error_constructor_function(
     native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::RangeErrorPrototype)
 }
 fn reference_error_constructor_function(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -561,7 +551,7 @@ fn reference_error_constructor_function(
     native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::ReferenceErrorPrototype)
 }
 fn syntax_error_constructor_function(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -569,7 +559,7 @@ fn syntax_error_constructor_function(
     native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::SyntaxErrorPrototype)
 }
 fn uri_error_constructor_function(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -577,37 +567,37 @@ fn uri_error_constructor_function(
     native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::URIErrorPrototype)
 }
 
-pub fn provision_type_error_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_type_error_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
         provision_native_error_intrinsics(agent, realm, "TypeError", type_error_constructor_function);
     realm.borrow_mut().intrinsics.type_error = constructor;
     realm.borrow_mut().intrinsics.type_error_prototype = prototype;
 }
-pub fn provision_eval_error_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_eval_error_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
         provision_native_error_intrinsics(agent, realm, "EvalError", eval_error_constructor_function);
     realm.borrow_mut().intrinsics.eval_error = constructor;
     realm.borrow_mut().intrinsics.eval_error_prototype = prototype;
 }
-pub fn provision_range_error_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_range_error_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
         provision_native_error_intrinsics(agent, realm, "RangeError", range_error_constructor_function);
     realm.borrow_mut().intrinsics.range_error = constructor;
     realm.borrow_mut().intrinsics.range_error_prototype = prototype;
 }
-pub fn provision_reference_error_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_reference_error_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
         provision_native_error_intrinsics(agent, realm, "ReferenceError", reference_error_constructor_function);
     realm.borrow_mut().intrinsics.reference_error = constructor;
     realm.borrow_mut().intrinsics.reference_error_prototype = prototype;
 }
-pub fn provision_syntax_error_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_syntax_error_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
         provision_native_error_intrinsics(agent, realm, "SyntaxError", syntax_error_constructor_function);
     realm.borrow_mut().intrinsics.syntax_error = constructor;
     realm.borrow_mut().intrinsics.syntax_error_prototype = prototype;
 }
-pub fn provision_uri_error_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_uri_error_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
         provision_native_error_intrinsics(agent, realm, "URIError", uri_error_constructor_function);
     realm.borrow_mut().intrinsics.uri_error = constructor;
@@ -615,12 +605,12 @@ pub fn provision_uri_error_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm
 }
 
 /// Transform an ECMAScript Error object into a Rust string
-pub fn unwind_any_error_value(agent: &mut Agent, err: ECMAScriptValue) -> String {
+pub fn unwind_any_error_value(agent: &Agent, err: ECMAScriptValue) -> String {
     to_string(agent, err).unwrap().into()
 }
 
 /// Transform an ECMAScript Throw Completion into a Rust string
-pub fn unwind_any_error(agent: &mut Agent, completion: AbruptCompletion) -> String {
+pub fn unwind_any_error(agent: &Agent, completion: AbruptCompletion) -> String {
     match completion {
         AbruptCompletion::Throw { value: err } => unwind_any_error_value(agent, err),
         _ => panic!("Improper completion for error: {:?}", completion),

--- a/src/errors/tests.rs
+++ b/src/errors/tests.rs
@@ -4,220 +4,214 @@ use test_case::test_case;
 
 #[test]
 fn create_native_error_object_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let constructor = agent.intrinsic(IntrinsicId::RangeError);
     let message = "Great Googly Moogly!";
     let proto_id = IntrinsicId::RangeErrorPrototype;
 
-    let result = create_native_error_object(&mut agent, message, constructor, proto_id, None);
+    let result = create_native_error_object(&agent, message, constructor, proto_id, None);
 
     assert!(result.o.is_error_object());
-    let msg_val = get(&mut agent, &result, &PropertyKey::from("message")).unwrap();
+    let msg_val = get(&agent, &result, &PropertyKey::from("message")).unwrap();
     assert_eq!(msg_val, ECMAScriptValue::from(message));
-    let kind = get(&mut agent, &result, &PropertyKey::from("name")).unwrap();
+    let kind = get(&agent, &result, &PropertyKey::from("name")).unwrap();
     assert_eq!(kind, ECMAScriptValue::from("RangeError"));
 }
 
 #[test]
 fn create_type_error_object_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
 
-    let result = create_type_error_object(&mut agent, "Happy Days");
+    let result = create_type_error_object(&agent, "Happy Days");
 
     assert!(result.o.is_error_object());
-    assert_eq!(get(&mut agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("TypeError"));
-    assert_eq!(get(&mut agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
+    assert_eq!(get(&agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("TypeError"));
+    assert_eq!(get(&agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
 }
 
 #[test]
 fn create_type_error_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
 
-    let result = create_type_error(&mut agent, "A");
+    let result = create_type_error(&agent, "A");
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
     if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
-            assert_eq!(get(&mut agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("TypeError"));
-            assert_eq!(get(&mut agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("TypeError"));
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
         }
     }
 }
 
 #[test]
 fn create_eval_error_object_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
 
-    let result = create_eval_error_object(&mut agent, "Happy Days");
+    let result = create_eval_error_object(&agent, "Happy Days");
 
     assert!(result.o.is_error_object());
-    assert_eq!(get(&mut agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("EvalError"));
-    assert_eq!(get(&mut agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
+    assert_eq!(get(&agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("EvalError"));
+    assert_eq!(get(&agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
 }
 
 #[test]
 fn create_eval_error_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
 
-    let result = create_eval_error(&mut agent, "A");
+    let result = create_eval_error(&agent, "A");
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
     if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
-            assert_eq!(get(&mut agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("EvalError"));
-            assert_eq!(get(&mut agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("EvalError"));
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
         }
     }
 }
 
 #[test]
 fn create_reference_error_object_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
 
-    let result = create_reference_error_object(&mut agent, "Happy Days");
+    let result = create_reference_error_object(&agent, "Happy Days");
 
     assert!(result.o.is_error_object());
-    assert_eq!(get(&mut agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("ReferenceError"));
-    assert_eq!(get(&mut agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
+    assert_eq!(get(&agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("ReferenceError"));
+    assert_eq!(get(&agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
 }
 
 #[test]
 fn create_reference_error_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
 
-    let result = create_reference_error(&mut agent, "A");
+    let result = create_reference_error(&agent, "A");
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
     if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
-            assert_eq!(
-                get(&mut agent, &obj, &PropertyKey::from("name")).unwrap(),
-                ECMAScriptValue::from("ReferenceError")
-            );
-            assert_eq!(get(&mut agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("ReferenceError"));
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
         }
     }
 }
 
 #[test]
 fn create_range_error_object_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
 
-    let result = create_range_error_object(&mut agent, "Happy Days");
+    let result = create_range_error_object(&agent, "Happy Days");
 
     assert!(result.o.is_error_object());
-    assert_eq!(get(&mut agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("RangeError"));
-    assert_eq!(get(&mut agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
+    assert_eq!(get(&agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("RangeError"));
+    assert_eq!(get(&agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
 }
 
 #[test]
 fn create_range_error_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
 
-    let result = create_range_error(&mut agent, "A");
+    let result = create_range_error(&agent, "A");
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
     if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
-            assert_eq!(get(&mut agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("RangeError"));
-            assert_eq!(get(&mut agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("RangeError"));
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
         }
     }
 }
 
 #[test]
 fn create_syntax_error_object_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
 
     let result = create_syntax_error_object(
-        &mut agent,
+        &agent,
         "Happy Days",
         Some(Location { starting_line: 10, starting_column: 5, span: Span { starting_index: 232, length: 12 } }),
     );
 
     assert!(result.o.is_error_object());
-    assert_eq!(get(&mut agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("SyntaxError"));
-    assert_eq!(get(&mut agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
-    let loc_obj = Object::try_from(get(&mut agent, &result, &"location".into()).unwrap()).unwrap();
-    assert_eq!(get(&mut agent, &loc_obj, &"line".into()).unwrap(), ECMAScriptValue::from(10));
-    assert_eq!(get(&mut agent, &loc_obj, &"column".into()).unwrap(), ECMAScriptValue::from(5));
-    assert_eq!(get(&mut agent, &loc_obj, &"byte_length".into()).unwrap(), ECMAScriptValue::from(12));
+    assert_eq!(get(&agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("SyntaxError"));
+    assert_eq!(get(&agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
+    let loc_obj = Object::try_from(get(&agent, &result, &"location".into()).unwrap()).unwrap();
+    assert_eq!(get(&agent, &loc_obj, &"line".into()).unwrap(), ECMAScriptValue::from(10));
+    assert_eq!(get(&agent, &loc_obj, &"column".into()).unwrap(), ECMAScriptValue::from(5));
+    assert_eq!(get(&agent, &loc_obj, &"byte_length".into()).unwrap(), ECMAScriptValue::from(12));
 }
 
 #[test]
 fn create_syntax_error_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
 
-    let result = create_syntax_error(&mut agent, "A", None);
+    let result = create_syntax_error(&agent, "A", None);
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
     if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
-            assert_eq!(
-                get(&mut agent, &obj, &PropertyKey::from("name")).unwrap(),
-                ECMAScriptValue::from("SyntaxError")
-            );
-            assert_eq!(get(&mut agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("SyntaxError"));
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
         }
     }
 }
 
 #[test]
 fn create_uri_error_object_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
 
-    let result = create_uri_error_object(&mut agent, "Happy Days");
+    let result = create_uri_error_object(&agent, "Happy Days");
 
     assert!(result.o.is_error_object());
-    assert_eq!(get(&mut agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("URIError"));
-    assert_eq!(get(&mut agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
+    assert_eq!(get(&agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("URIError"));
+    assert_eq!(get(&agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
 }
 
 #[test]
 fn create_uri_error_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
 
-    let result = create_uri_error(&mut agent, "A");
+    let result = create_uri_error(&agent, "A");
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
     if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
-            assert_eq!(get(&mut agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("URIError"));
-            assert_eq!(get(&mut agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("URIError"));
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
         }
     }
 }
 
 #[test]
 fn error_object_debug() {
-    let mut agent = test_agent();
-    let eo = ErrorObject { common: RefCell::new(CommonObjectData::new(&mut agent, None, true, &[])) };
+    let agent = test_agent();
+    let eo = ErrorObject { common: RefCell::new(CommonObjectData::new(&agent, None, true, &[])) };
     assert_ne!(format!("{:?}", eo), "");
 }
 
 #[test]
 fn error_object_object() {
-    let mut agent = test_agent();
-    let eo = ErrorObject::object(&mut agent, None);
+    let agent = test_agent();
+    let eo = ErrorObject::object(&agent, None);
 
     assert!(eo.o.is_error_object());
-    assert!(eo.o.get_prototype_of(&mut agent).unwrap().is_none());
+    assert!(eo.o.get_prototype_of(&agent).unwrap().is_none());
 }
 
-fn create_error_object(agent: &mut Agent) -> Object {
+fn create_error_object(agent: &Agent) -> Object {
     let error_proto = agent.intrinsic(IntrinsicId::ErrorPrototype);
     ErrorObject::object(agent, Some(error_proto))
 }
 #[test]
 fn error_object_common_object_data() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
     let error_prototype = agent.intrinsic(IntrinsicId::ErrorPrototype);
 
     let cod = no.o.common_object_data();
@@ -230,8 +224,8 @@ fn error_object_common_object_data() {
 }
 #[test]
 fn error_object_is_ordinary() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
     let result = no.o.is_ordinary();
 
@@ -239,24 +233,24 @@ fn error_object_is_ordinary() {
 }
 #[test]
 fn error_object_id() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
     // ... essentially, assert that it doesn't panic.
     no.o.id();
 }
 #[test]
 fn error_object_to_error_object() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
     let result = no.o.to_error_obj();
     assert!(result.is_some());
 }
 #[test]
 fn error_object_is_error_object() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
     let result = no.o.is_error_object();
 
@@ -264,52 +258,52 @@ fn error_object_is_error_object() {
 }
 #[test]
 fn error_object_get_prototype_of() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
-    let result = no.o.get_prototype_of(&mut agent).unwrap();
+    let result = no.o.get_prototype_of(&agent).unwrap();
     assert!(result.is_some());
 }
 #[test]
 fn error_object_set_prototype_of() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
-    let result = no.o.set_prototype_of(&mut agent, None).unwrap();
+    let result = no.o.set_prototype_of(&agent, None).unwrap();
     assert!(result);
 }
 #[test]
 fn error_object_is_extensible() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
-    let result = no.o.is_extensible(&mut agent).unwrap();
+    let result = no.o.is_extensible(&agent).unwrap();
     assert!(result);
 }
 #[test]
 fn error_object_prevent_extensions() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
-    let result = no.o.prevent_extensions(&mut agent).unwrap();
+    let result = no.o.prevent_extensions(&agent).unwrap();
     assert!(result);
 }
 #[test]
 fn error_object_get_own_property() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
-    let result = no.o.get_own_property(&mut agent, &PropertyKey::from("a")).unwrap();
+    let result = no.o.get_own_property(&agent, &PropertyKey::from("a")).unwrap();
     assert!(result.is_none());
 }
 #[test]
 fn error_object_define_own_property() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
     let result =
         no.o.define_own_property(
-            &mut agent,
+            &agent,
             PropertyKey::from("a"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::Undefined), ..Default::default() },
         )
@@ -318,50 +312,50 @@ fn error_object_define_own_property() {
 }
 #[test]
 fn error_object_has_property() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
-    let result = no.o.has_property(&mut agent, &PropertyKey::from("a")).unwrap();
+    let result = no.o.has_property(&agent, &PropertyKey::from("a")).unwrap();
     assert!(!result);
 }
 #[test]
 fn error_object_get() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
-    let result = no.o.get(&mut agent, &PropertyKey::from("a"), &ECMAScriptValue::from(no.clone())).unwrap();
+    let result = no.o.get(&agent, &PropertyKey::from("a"), &ECMAScriptValue::from(no.clone())).unwrap();
     assert_eq!(result, ECMAScriptValue::Undefined);
 }
 #[test]
 fn error_object_set() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
     let result =
-        no.o.set(&mut agent, PropertyKey::from("a"), ECMAScriptValue::from(88.0), &ECMAScriptValue::from(no.clone()))
+        no.o.set(&agent, PropertyKey::from("a"), ECMAScriptValue::from(88.0), &ECMAScriptValue::from(no.clone()))
             .unwrap();
     assert!(result);
 }
 #[test]
 fn error_object_delete() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
-    let result = no.o.delete(&mut agent, &PropertyKey::from("a")).unwrap();
+    let result = no.o.delete(&agent, &PropertyKey::from("a")).unwrap();
     assert!(result);
 }
 #[test]
 fn error_object_own_property_keys() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
-    let result = no.o.own_property_keys(&mut agent).unwrap();
+    let result = no.o.own_property_keys(&agent).unwrap();
     assert_eq!(result, &[]);
 }
 #[test]
 fn error_object_other_automatic_functions() {
-    let mut agent = test_agent();
-    let no = create_error_object(&mut agent);
+    let agent = test_agent();
+    let no = create_error_object(&agent);
 
     assert!(!no.o.is_number_object());
     assert!(no.o.to_function_obj().is_none());
@@ -380,10 +374,10 @@ fn error_object_other_automatic_functions() {
 
 #[test]
 fn error_constructor_data_props() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
 
-    let val = get(&mut agent, &error_constructor, &PropertyKey::from("prototype")).unwrap();
+    let val = get(&agent, &error_constructor, &PropertyKey::from("prototype")).unwrap();
     let error_prototype = agent.intrinsic(IntrinsicId::ErrorPrototype);
     assert_eq!(val, ECMAScriptValue::from(error_prototype));
 }
@@ -391,51 +385,50 @@ fn error_constructor_data_props() {
 #[test]
 fn error_constructor_function_01() {
     // Called as function, with argument.
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Error));
 
-    let result =
-        call(&mut agent, &error_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from("A")]).unwrap();
-    let obj = to_object(&mut agent, result).unwrap();
+    let result = call(&agent, &error_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from("A")]).unwrap();
+    let obj = to_object(&agent, result).unwrap();
 
     assert!(obj.o.is_error_object());
-    assert_eq!(get(&mut agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
-    assert_eq!(get(&mut agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("Error"));
+    assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+    assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("Error"));
 }
 
 #[test]
 fn error_constructor_function_02() {
     // Called as function, with no argument.
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Error));
 
-    let result = call(&mut agent, &error_constructor, &ECMAScriptValue::Undefined, &[]).unwrap();
-    let obj = to_object(&mut agent, result).unwrap();
+    let result = call(&agent, &error_constructor, &ECMAScriptValue::Undefined, &[]).unwrap();
+    let obj = to_object(&agent, result).unwrap();
 
     assert!(obj.o.is_error_object());
-    assert!(!has_own_property(&mut agent, &obj, &PropertyKey::from("message")).unwrap());
-    assert_eq!(get(&mut agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("Error"));
+    assert!(!has_own_property(&agent, &obj, &PropertyKey::from("message")).unwrap());
+    assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("Error"));
 }
 
 #[test]
 fn error_constructor_function_03() {
     // Called as constructor
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
 
-    let result = construct(&mut agent, &error_constructor, &[ECMAScriptValue::from("A")], None).unwrap();
-    let obj = to_object(&mut agent, result).unwrap();
+    let result = construct(&agent, &error_constructor, &[ECMAScriptValue::from("A")], None).unwrap();
+    let obj = to_object(&agent, result).unwrap();
 
     assert!(obj.o.is_error_object());
-    assert_eq!(get(&mut agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
-    assert_eq!(get(&mut agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("Error"));
+    assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+    assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("Error"));
 }
 
 #[test]
 fn error_constructor_throws() {
     // ordinary_create_from_contructor throws.
     // This looks to be difficult to make happen, but I can imagine some class shenanigans that could do it.
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
 
     // This hack is to get around the "not configurable" characteristic of Error.prototype.
@@ -450,179 +443,178 @@ fn error_constructor_throws() {
         prop.property = new_prop;
     }
 
-    let result = construct(&mut agent, &error_constructor, &[], None).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Generic TypeError");
+    let result = construct(&agent, &error_constructor, &[], None).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Generic TypeError");
 }
 #[test]
 fn error_constructor_to_string_throws() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let sym = ECMAScriptValue::from(Symbol::new(&mut agent, None));
+    let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
 
-    let result = construct(&mut agent, &error_constructor, &[sym], None).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Symbols may not be converted to strings");
+    let result = construct(&agent, &error_constructor, &[sym], None).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Symbols may not be converted to strings");
 }
 
 #[test]
 fn error_prototype_data_props() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_prototype = agent.intrinsic(IntrinsicId::ErrorPrototype);
 
-    let val = get(&mut agent, &error_prototype, &PropertyKey::from("constructor")).unwrap();
+    let val = get(&agent, &error_prototype, &PropertyKey::from("constructor")).unwrap();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
     assert_eq!(val, ECMAScriptValue::from(error_constructor));
 
-    let val = get(&mut agent, &error_prototype, &PropertyKey::from("message")).unwrap();
+    let val = get(&agent, &error_prototype, &PropertyKey::from("message")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(""));
 
-    let val = get(&mut agent, &error_prototype, &PropertyKey::from("name")).unwrap();
+    let val = get(&agent, &error_prototype, &PropertyKey::from("name")).unwrap();
     assert_eq!(val, ECMAScriptValue::from("Error"));
 }
 
 use crate::object::{define_property_or_throw, invoke, set};
 #[test]
 fn error_prototype_tostring_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobj = construct(&mut agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
 
-    let result = invoke(&mut agent, errobj, &PropertyKey::from("toString"), &[]).unwrap();
+    let result = invoke(&agent, errobj, &PropertyKey::from("toString"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Error: ErrorMessage"));
 }
 #[test]
 fn error_prototype_tostring_02() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&mut agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&mut agent, errobjval.clone()).unwrap();
-    set(&mut agent, &errobj, PropertyKey::from("name"), ECMAScriptValue::from("Bob"), false).unwrap();
-    set(&mut agent, &errobj, PropertyKey::from("message"), ECMAScriptValue::from("you have a phone call"), false)
-        .unwrap();
+    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(&agent, errobjval.clone()).unwrap();
+    set(&agent, &errobj, PropertyKey::from("name"), ECMAScriptValue::from("Bob"), false).unwrap();
+    set(&agent, &errobj, PropertyKey::from("message"), ECMAScriptValue::from("you have a phone call"), false).unwrap();
 
-    let result = invoke(&mut agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap();
+    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Bob: you have a phone call"));
 }
 #[test]
 fn error_prototype_tostring_03() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&mut agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&mut agent, errobjval.clone()).unwrap();
-    set(&mut agent, &errobj, PropertyKey::from("name"), ECMAScriptValue::Undefined, false).unwrap();
-    set(&mut agent, &errobj, PropertyKey::from("message"), ECMAScriptValue::Undefined, false).unwrap();
+    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(&agent, errobjval.clone()).unwrap();
+    set(&agent, &errobj, PropertyKey::from("name"), ECMAScriptValue::Undefined, false).unwrap();
+    set(&agent, &errobj, PropertyKey::from("message"), ECMAScriptValue::Undefined, false).unwrap();
 
-    let result = invoke(&mut agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap();
+    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Error"));
 }
 #[test]
 fn error_prototype_tostring_04() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&mut agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&mut agent, errobjval.clone()).unwrap();
-    set(&mut agent, &errobj, PropertyKey::from("name"), ECMAScriptValue::from("Bob"), false).unwrap();
-    set(&mut agent, &errobj, PropertyKey::from("message"), ECMAScriptValue::Undefined, false).unwrap();
+    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(&agent, errobjval.clone()).unwrap();
+    set(&agent, &errobj, PropertyKey::from("name"), ECMAScriptValue::from("Bob"), false).unwrap();
+    set(&agent, &errobj, PropertyKey::from("message"), ECMAScriptValue::Undefined, false).unwrap();
 
-    let result = invoke(&mut agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap();
+    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Bob"));
 }
 #[test]
 fn error_prototype_tostring_05() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&mut agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&mut agent, errobjval.clone()).unwrap();
-    set(&mut agent, &errobj, PropertyKey::from("name"), ECMAScriptValue::Undefined, false).unwrap();
-    set(&mut agent, &errobj, PropertyKey::from("message"), ECMAScriptValue::from("Message"), false).unwrap();
+    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(&agent, errobjval.clone()).unwrap();
+    set(&agent, &errobj, PropertyKey::from("name"), ECMAScriptValue::Undefined, false).unwrap();
+    set(&agent, &errobj, PropertyKey::from("message"), ECMAScriptValue::from("Message"), false).unwrap();
 
-    let result = invoke(&mut agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap();
+    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Error: Message"));
 }
 #[test]
 fn error_prototype_tostring_06() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&mut agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&mut agent, errobjval.clone()).unwrap();
-    set(&mut agent, &errobj, PropertyKey::from("name"), ECMAScriptValue::from(""), false).unwrap();
-    set(&mut agent, &errobj, PropertyKey::from("message"), ECMAScriptValue::from("Message"), false).unwrap();
+    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(&agent, errobjval.clone()).unwrap();
+    set(&agent, &errobj, PropertyKey::from("name"), ECMAScriptValue::from(""), false).unwrap();
+    set(&agent, &errobj, PropertyKey::from("message"), ECMAScriptValue::from("Message"), false).unwrap();
 
-    let result = invoke(&mut agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap();
+    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Message"));
 }
 #[test]
 fn error_prototype_tostring_07() {
     // getting property "name" throws
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&mut agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&mut agent, errobjval.clone()).unwrap();
+    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(&agent, errobjval.clone()).unwrap();
     let desc = PotentialPropertyDescriptor {
         get: Some(ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError))),
         ..Default::default()
     };
-    define_property_or_throw(&mut agent, &errobj, PropertyKey::from("name"), desc).unwrap();
+    define_property_or_throw(&agent, &errobj, PropertyKey::from("name"), desc).unwrap();
 
-    let result = invoke(&mut agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Generic TypeError");
+    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Generic TypeError");
 }
 #[test]
 fn error_prototype_tostring_08() {
     // getting property "message" throws
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&mut agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&mut agent, errobjval.clone()).unwrap();
+    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(&agent, errobjval.clone()).unwrap();
     let desc = PotentialPropertyDescriptor {
         get: Some(ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError))),
         ..Default::default()
     };
-    define_property_or_throw(&mut agent, &errobj, PropertyKey::from("message"), desc).unwrap();
+    define_property_or_throw(&agent, &errobj, PropertyKey::from("message"), desc).unwrap();
 
-    let result = invoke(&mut agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Generic TypeError");
+    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Generic TypeError");
 }
 #[test]
 fn error_prototype_tostring_09() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&mut agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&mut agent, errobjval.clone()).unwrap();
-    let sym = ECMAScriptValue::from(Symbol::new(&mut agent, None));
-    set(&mut agent, &errobj, PropertyKey::from("name"), sym, false).unwrap();
+    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(&agent, errobjval.clone()).unwrap();
+    let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
+    set(&agent, &errobj, PropertyKey::from("name"), sym, false).unwrap();
 
-    let result = invoke(&mut agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Symbols may not be converted to strings");
+    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Symbols may not be converted to strings");
 }
 #[test]
 fn error_prototype_tostring_10() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&mut agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&mut agent, errobjval.clone()).unwrap();
-    let sym = ECMAScriptValue::from(Symbol::new(&mut agent, None));
-    set(&mut agent, &errobj, PropertyKey::from("message"), sym, false).unwrap();
+    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(&agent, errobjval.clone()).unwrap();
+    let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
+    set(&agent, &errobj, PropertyKey::from("message"), sym, false).unwrap();
 
-    let result = invoke(&mut agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Symbols may not be converted to strings");
+    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Symbols may not be converted to strings");
 }
 #[test]
 fn error_prototype_to_string_11() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let error_prototype = agent.intrinsic(IntrinsicId::ErrorPrototype);
-    let func = get(&mut agent, &error_prototype, &PropertyKey::from("toString")).unwrap();
+    let func = get(&agent, &error_prototype, &PropertyKey::from("toString")).unwrap();
 
-    let result = call(&mut agent, &func, &ECMAScriptValue::Undefined, &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Error.prototype.toString called with non-object this value");
+    let result = call(&agent, &func, &ECMAScriptValue::Undefined, &[]).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Error.prototype.toString called with non-object this value");
 }
 
 fn native_error_constructor_properties(intrinsic: IntrinsicId, expected_name: &str) {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let constructor = agent.intrinsic(intrinsic);
 
-    let proto = constructor.o.get_prototype_of(&mut agent).unwrap().unwrap();
+    let proto = constructor.o.get_prototype_of(&agent).unwrap().unwrap();
     assert_eq!(proto, agent.intrinsic(IntrinsicId::Error));
-    let name = get(&mut agent, &constructor, &PropertyKey::from("name")).unwrap();
+    let name = get(&agent, &constructor, &PropertyKey::from("name")).unwrap();
     assert_eq!(name, ECMAScriptValue::from(expected_name));
 }
 
@@ -652,22 +644,22 @@ fn uri_error_constructor_properties() {
 }
 
 fn native_error_prototype_properties(prototype: IntrinsicId, constructor: IntrinsicId, name: &str) {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let prototype = agent.intrinsic(prototype);
     let constructor = agent.intrinsic(constructor);
     let error_prototype = agent.intrinsic(IntrinsicId::ErrorPrototype);
 
     assert!(!prototype.o.is_error_object());
-    let proto_proto = prototype.o.get_prototype_of(&mut agent).unwrap().unwrap();
+    let proto_proto = prototype.o.get_prototype_of(&agent).unwrap().unwrap();
     assert_eq!(proto_proto, error_prototype);
 
-    let cons = get(&mut agent, &prototype, &PropertyKey::from("constructor")).unwrap();
+    let cons = get(&agent, &prototype, &PropertyKey::from("constructor")).unwrap();
     assert_eq!(cons, ECMAScriptValue::from(constructor));
 
-    let msg = get(&mut agent, &prototype, &PropertyKey::from("message")).unwrap();
+    let msg = get(&agent, &prototype, &PropertyKey::from("message")).unwrap();
     assert_eq!(msg, ECMAScriptValue::from(""));
 
-    let myname = get(&mut agent, &prototype, &PropertyKey::from("name")).unwrap();
+    let myname = get(&agent, &prototype, &PropertyKey::from("name")).unwrap();
     assert_eq!(myname, ECMAScriptValue::from(name));
 }
 
@@ -701,16 +693,16 @@ fn uri_error_prototype_properties() {
 }
 
 fn test_error_constructor(const_id: IntrinsicId, proto_id: IntrinsicId, name: &str) {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let constructor = agent.intrinsic(const_id);
     let proto = agent.intrinsic(proto_id);
-    let objval = construct(&mut agent, &constructor, &[ECMAScriptValue::from("test message")], None).unwrap();
-    let obj = to_object(&mut agent, objval).unwrap();
+    let objval = construct(&agent, &constructor, &[ECMAScriptValue::from("test message")], None).unwrap();
+    let obj = to_object(&agent, objval).unwrap();
 
     assert!(obj.o.is_error_object());
-    assert_eq!(get(&mut agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from(name));
-    assert_eq!(get(&mut agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("test message"));
-    assert_eq!(obj.o.get_prototype_of(&mut agent).unwrap().unwrap(), proto);
+    assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from(name));
+    assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("test message"));
+    assert_eq!(obj.o.get_prototype_of(&agent).unwrap().unwrap(), proto);
 }
 
 #[test]
@@ -738,19 +730,19 @@ fn test_uri_error_constructor() {
     test_error_constructor(IntrinsicId::URIError, IntrinsicId::URIErrorPrototype, "URIError");
 }
 
-#[test_case(|a: &mut Agent| create_type_error_object(a, "message 1") => "TypeError: message 1"; "type error")]
-#[test_case(|a: &mut Agent| create_syntax_error_object(a, "message 2", None) => "SyntaxError: message 2"; "syntax error")]
-fn unwind_any_error_value(maker: fn(&mut Agent) -> Object) -> String {
-    let mut agent = test_agent();
-    let errobj = maker(&mut agent);
-    super::unwind_any_error_value(&mut agent, ECMAScriptValue::from(errobj))
+#[test_case(|a: &Agent| create_type_error_object(a, "message 1") => "TypeError: message 1"; "type error")]
+#[test_case(|a: &Agent| create_syntax_error_object(a, "message 2", None) => "SyntaxError: message 2"; "syntax error")]
+fn unwind_any_error_value(maker: fn(&Agent) -> Object) -> String {
+    let agent = test_agent();
+    let errobj = maker(&agent);
+    super::unwind_any_error_value(&agent, ECMAScriptValue::from(errobj))
 }
 
-#[test_case(|a: &mut Agent| create_type_error(a, "blue") => "TypeError: blue"; "type error")]
-#[test_case(|a: &mut Agent| create_syntax_error(a, "ouch", None) => "SyntaxError: ouch"; "syntax error")]
-#[test_case(|_: &mut Agent| AbruptCompletion::Break{value: NormalCompletion::Empty, target: None} => panics "Improper completion for error: "; "not error")]
-fn unwind_any_error(maker: fn(&mut Agent) -> AbruptCompletion) -> String {
-    let mut agent = test_agent();
-    let completion = maker(&mut agent);
-    super::unwind_any_error(&mut agent, completion)
+#[test_case(|a: &Agent| create_type_error(a, "blue") => "TypeError: blue"; "type error")]
+#[test_case(|a: &Agent| create_syntax_error(a, "ouch", None) => "SyntaxError: ouch"; "syntax error")]
+#[test_case(|_: &Agent| AbruptCompletion::Break{value: NormalCompletion::Empty, target: None} => panics "Improper completion for error: "; "not error")]
+fn unwind_any_error(maker: fn(&Agent) -> AbruptCompletion) -> String {
+    let agent = test_agent();
+    let completion = maker(&agent);
+    super::unwind_any_error(&agent, completion)
 }

--- a/src/execution_context/mod.rs
+++ b/src/execution_context/mod.rs
@@ -110,7 +110,7 @@ impl Agent {
     /// Determine the binding of the "this" keyword (and return it)
     ///
     /// See [ResolveThisBinding](https://tc39.es/ecma262/#sec-resolvethisbinding) in ECMA-262.
-    pub fn resolve_this_binding(&mut self) -> Completion<ECMAScriptValue> {
+    pub fn resolve_this_binding(&self) -> Completion<ECMAScriptValue> {
         // ResolveThisBinding ( )
         //
         // The abstract operation ResolveThisBinding takes no arguments and returns either a normal completion containing an
@@ -127,7 +127,7 @@ impl Agent {
     ///
     /// See [ResolveBinding](https://tc39.es/ecma262/#sec-resolvebinding) in ECMA-262.
     pub fn resolve_binding(
-        &mut self,
+        &self,
         name: &JSString,
         env: Option<Rc<dyn EnvironmentRecord>>,
         strict: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ struct VM {
 impl VM {
     fn new() -> Self {
         let sym_registry = Rc::new(RefCell::new(SymbolRegistry::new()));
-        let mut agent = Agent::new(sym_registry.clone());
+        let agent = Agent::new(sym_registry.clone());
         agent.initialize_host_defined_realm(false);
         VM { agent, symbols: sym_registry }
     }
@@ -89,11 +89,11 @@ impl VM {
 }
 
 fn interpret(vm: &mut VM, source: &str) -> Result<i32, String> {
-    let parsed = parse_text(&mut vm.agent, source, ParseGoal::Script);
+    let parsed = parse_text(&vm.agent, source, ParseGoal::Script);
     match parsed {
         ParsedText::Errors(errs) => {
             for err in errs {
-                println!("{}", to_string(&mut vm.agent, err).unwrap());
+                println!("{}", to_string(&vm.agent, err).unwrap());
             }
             Err("See above".to_string())
         }
@@ -132,7 +132,7 @@ fn run_file(vm: &mut VM, fname: &str) {
         Err(e) => println!("{}", e),
         Ok(file_content) => {
             let script_source = String::from_utf8_lossy(&file_content);
-            match process_ecmascript(&mut vm.agent, &script_source) {
+            match process_ecmascript(&vm.agent, &script_source) {
                 Ok(value) => println!("{:#?}", value),
                 Err(err) => println!("{}", err),
             }

--- a/src/number_object/mod.rs
+++ b/src/number_object/mod.rs
@@ -36,7 +36,7 @@ impl ObjectInterface for NumberObject {
         true
     }
 
-    fn get_prototype_of(&self, _agent: &mut Agent) -> Completion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &Agent) -> Completion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
 
@@ -46,7 +46,7 @@ impl ObjectInterface for NumberObject {
     // the following steps when called:
     //
     //  1. Return ! OrdinarySetPrototypeOf(O, V).
-    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<Object>) -> Completion<bool> {
+    fn set_prototype_of(&self, _agent: &Agent, obj: Option<Object>) -> Completion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
 
@@ -56,7 +56,7 @@ impl ObjectInterface for NumberObject {
     // when called:
     //
     //  1. Return ! OrdinaryIsExtensible(O).
-    fn is_extensible(&self, _agent: &mut Agent) -> Completion<bool> {
+    fn is_extensible(&self, _agent: &Agent) -> Completion<bool> {
         Ok(ordinary_is_extensible(self))
     }
 
@@ -66,7 +66,7 @@ impl ObjectInterface for NumberObject {
     // steps when called:
     //
     //  1. Return ! OrdinaryPreventExtensions(O).
-    fn prevent_extensions(&self, _agent: &mut Agent) -> Completion<bool> {
+    fn prevent_extensions(&self, _agent: &Agent) -> Completion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
 
@@ -76,7 +76,7 @@ impl ObjectInterface for NumberObject {
     // following steps when called:
     //
     //  1. Return ! OrdinaryGetOwnProperty(O, P).
-    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _agent: &Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(self, key))
     }
 
@@ -88,7 +88,7 @@ impl ObjectInterface for NumberObject {
     //  1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
     fn define_own_property(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         key: PropertyKey,
         desc: PotentialPropertyDescriptor,
     ) -> Completion<bool> {
@@ -101,7 +101,7 @@ impl ObjectInterface for NumberObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryHasProperty(O, P).
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
+    fn has_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_has_property(agent, self, key)
     }
 
@@ -111,7 +111,7 @@ impl ObjectInterface for NumberObject {
     // ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryGet(O, P, Receiver).
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+    fn get(&self, agent: &Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         ordinary_get(agent, self, key, receiver)
     }
 
@@ -121,13 +121,7 @@ impl ObjectInterface for NumberObject {
     // value), and Receiver (an ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinarySet(O, P, V, Receiver).
-    fn set(
-        &self,
-        agent: &mut Agent,
-        key: PropertyKey,
-        v: ECMAScriptValue,
-        receiver: &ECMAScriptValue,
-    ) -> Completion<bool> {
+    fn set(&self, agent: &Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
         ordinary_set(agent, self, key, v, receiver)
     }
 
@@ -137,7 +131,7 @@ impl ObjectInterface for NumberObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryDelete(O, P).
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
+    fn delete(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_delete(agent, self, key)
     }
 
@@ -147,7 +141,7 @@ impl ObjectInterface for NumberObject {
     // steps when called:
     //
     // 1. Return ! OrdinaryOwnPropertyKeys(O).
-    fn own_property_keys(&self, _agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, _agent: &Agent) -> Completion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(self))
     }
 }
@@ -159,7 +153,7 @@ impl NumberObjectInterface for NumberObject {
 }
 
 impl NumberObject {
-    pub fn object(agent: &mut Agent, prototype: Option<Object>) -> Object {
+    pub fn object(agent: &Agent, prototype: Option<Object>) -> Object {
         Object {
             o: Rc::new(Self {
                 common: RefCell::new(CommonObjectData::new(agent, prototype, true, NUMBER_OBJECT_SLOTS)),
@@ -169,7 +163,7 @@ impl NumberObject {
     }
 }
 
-pub fn provision_number_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_number_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -397,7 +391,7 @@ pub fn provision_number_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>)
 // 4. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%Number.prototype%", « [[NumberData]] »).
 // 5. Set O.[[NumberData]] to n.
 // 6. Return O.
-pub fn create_number_object(agent: &mut Agent, n: f64) -> Object {
+pub fn create_number_object(agent: &Agent, n: f64) -> Object {
     let constructor = agent.intrinsic(IntrinsicId::Number);
     let o = ordinary_create_from_constructor(
         agent,
@@ -425,7 +419,7 @@ pub fn create_number_object(agent: &mut Agent, n: f64) -> Object {
 //      5. Set O.[[NumberData]] to n.
 //      6. Return O.
 fn number_constructor_function(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -465,7 +459,7 @@ fn number_constructor_function(
 //      2. If number is NaN, +∞𝔽, or -∞𝔽, return false.
 //      3. Otherwise, return true.
 fn number_is_finite(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -484,7 +478,7 @@ fn number_is_finite(
 //
 //      1. Return ! IsIntegralNumber(number).
 fn number_is_integer(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -505,7 +499,7 @@ fn number_is_integer(
 // NOTE     This function differs from the global isNaN function (19.2.3) in that it does not convert its argument to a
 //          Number before determining whether it is NaN.
 fn number_is_nan(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -526,7 +520,7 @@ fn number_is_nan(
 //          a. If abs(ℝ(number)) ≤ 2**53 - 1, return true.
 //      2. Return false.
 fn number_is_safe_integer(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -550,7 +544,7 @@ fn number_is_safe_integer(
 //
 // The phrase “this Number value” within the specification of a method refers to the result returned by calling the
 // abstract operation thisNumberValue with the this value of the method invocation passed as the argument.
-fn this_number_value(agent: &mut Agent, value: ECMAScriptValue) -> Completion<f64> {
+fn this_number_value(agent: &Agent, value: ECMAScriptValue) -> Completion<f64> {
     match value {
         ECMAScriptValue::Number(x) => Ok(x),
         ECMAScriptValue::Object(o) if o.o.is_number_object() => {
@@ -621,7 +615,7 @@ fn this_number_value(agent: &mut Agent, value: ECMAScriptValue) -> Completion<f6
 //             - f) is closest in value to 𝔽(x). If there are two such possible values of n, choose the one that is
 //             even.
 fn number_prototype_to_exponential(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -731,7 +725,7 @@ fn number_prototype_to_exponential(
 //                  (1000000000000000128).toFixed(0) returns "1000000000000000128".
 //
 fn number_prototype_to_fixed(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -807,7 +801,7 @@ fn number_prototype_to_fixed(
 // The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations
 // that do not include ECMA-402 support must not use those parameter positions for anything else.
 fn number_prototype_to_locale_string(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -864,7 +858,7 @@ fn number_prototype_to_locale_string(
 //         -(e + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and the String m.
 //  14. Return the string-concatenation of s and m.
 fn number_prototype_to_precision(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -1108,7 +1102,7 @@ pub fn double_to_radix_string(val: f64, radix: i32) -> String {
 //
 // The "length" property of the toString method is 1𝔽.
 fn number_prototype_to_string(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -1132,7 +1126,7 @@ fn number_prototype_to_string(
 // Number.prototype.valueOf ( )
 //  1. Return ? thisNumberValue(this value).
 fn number_prototype_value_of(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],

--- a/src/number_object/tests.rs
+++ b/src/number_object/tests.rs
@@ -4,9 +4,9 @@ use num::BigInt;
 
 #[test]
 fn number_object_debug() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let no = NumberObject {
-        common: RefCell::new(CommonObjectData::new(&mut agent, None, false, NUMBER_OBJECT_SLOTS)),
+        common: RefCell::new(CommonObjectData::new(&agent, None, false, NUMBER_OBJECT_SLOTS)),
         number_data: RefCell::new(0.0),
     };
 
@@ -16,9 +16,9 @@ fn number_object_debug() {
 #[test]
 #[allow(clippy::float_cmp)]
 fn number_object_object() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
-    let no = NumberObject::object(&mut agent, Some(number_prototype.clone()));
+    let no = NumberObject::object(&agent, Some(number_prototype.clone()));
 
     assert_eq!(no.o.common_object_data().borrow().prototype, Some(number_prototype));
     assert_eq!(*no.o.to_number_obj().unwrap().number_data().borrow(), 0.0);
@@ -27,18 +27,18 @@ fn number_object_object() {
 #[test]
 #[allow(clippy::float_cmp)]
 fn create_number_object_01() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
     let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
-    assert_eq!(no.o.get_prototype_of(&mut agent).unwrap(), Some(number_prototype));
+    assert_eq!(no.o.get_prototype_of(&agent).unwrap(), Some(number_prototype));
     assert_eq!(*no.o.to_number_obj().unwrap().number_data().borrow(), 100.0);
 }
 
 #[test]
 fn number_object_common_object_data() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
     let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
 
     let cod = no.o.common_object_data();
@@ -51,8 +51,8 @@ fn number_object_common_object_data() {
 }
 #[test]
 fn number_object_is_ordinary() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
     let result = no.o.is_ordinary();
 
@@ -60,24 +60,24 @@ fn number_object_is_ordinary() {
 }
 #[test]
 fn number_object_id() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
     // ... essentially, assert that it doesn't panic.
     no.o.id();
 }
 #[test]
 fn number_object_to_number_object() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
     let result = no.o.to_number_obj();
     assert!(result.is_some());
 }
 #[test]
 fn number_object_is_number_object() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
     let result = no.o.is_number_object();
 
@@ -85,52 +85,52 @@ fn number_object_is_number_object() {
 }
 #[test]
 fn number_object_get_prototype_of() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
-    let result = no.o.get_prototype_of(&mut agent).unwrap();
+    let result = no.o.get_prototype_of(&agent).unwrap();
     assert!(result.is_some());
 }
 #[test]
 fn number_object_set_prototype_of() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
-    let result = no.o.set_prototype_of(&mut agent, None).unwrap();
+    let result = no.o.set_prototype_of(&agent, None).unwrap();
     assert!(result);
 }
 #[test]
 fn number_object_is_extensible() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
-    let result = no.o.is_extensible(&mut agent).unwrap();
+    let result = no.o.is_extensible(&agent).unwrap();
     assert!(result);
 }
 #[test]
 fn number_object_prevent_extensions() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
-    let result = no.o.prevent_extensions(&mut agent).unwrap();
+    let result = no.o.prevent_extensions(&agent).unwrap();
     assert!(result);
 }
 #[test]
 fn number_object_get_own_property() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
-    let result = no.o.get_own_property(&mut agent, &PropertyKey::from("a")).unwrap();
+    let result = no.o.get_own_property(&agent, &PropertyKey::from("a")).unwrap();
     assert!(result.is_none());
 }
 #[test]
 fn number_object_define_own_property() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
     let result =
         no.o.define_own_property(
-            &mut agent,
+            &agent,
             PropertyKey::from("a"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::Undefined), ..Default::default() },
         )
@@ -139,50 +139,50 @@ fn number_object_define_own_property() {
 }
 #[test]
 fn number_object_has_property() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
-    let result = no.o.has_property(&mut agent, &PropertyKey::from("a")).unwrap();
+    let result = no.o.has_property(&agent, &PropertyKey::from("a")).unwrap();
     assert!(!result);
 }
 #[test]
 fn number_object_get() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
-    let result = no.o.get(&mut agent, &PropertyKey::from("a"), &ECMAScriptValue::from(no.clone())).unwrap();
+    let result = no.o.get(&agent, &PropertyKey::from("a"), &ECMAScriptValue::from(no.clone())).unwrap();
     assert_eq!(result, ECMAScriptValue::Undefined);
 }
 #[test]
 fn number_object_set() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
     let result =
-        no.o.set(&mut agent, PropertyKey::from("a"), ECMAScriptValue::from(88.0), &ECMAScriptValue::from(no.clone()))
+        no.o.set(&agent, PropertyKey::from("a"), ECMAScriptValue::from(88.0), &ECMAScriptValue::from(no.clone()))
             .unwrap();
     assert!(result);
 }
 #[test]
 fn number_object_delete() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
-    let result = no.o.delete(&mut agent, &PropertyKey::from("a")).unwrap();
+    let result = no.o.delete(&agent, &PropertyKey::from("a")).unwrap();
     assert!(result);
 }
 #[test]
 fn number_object_own_property_keys() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
-    let result = no.o.own_property_keys(&mut agent).unwrap();
+    let result = no.o.own_property_keys(&agent).unwrap();
     assert_eq!(result, &[]);
 }
 #[test]
 fn number_object_other_automatic_functions() {
-    let mut agent = test_agent();
-    let no = create_number_object(&mut agent, 100.0);
+    let agent = test_agent();
+    let no = create_number_object(&agent, 100.0);
 
     assert!(!no.o.is_error_object());
     assert!(no.o.to_function_obj().is_none());
@@ -201,37 +201,37 @@ fn number_object_other_automatic_functions() {
 
 #[test]
 fn number_constructor_data_props() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let val = get(&mut agent, &number_constructor, &PropertyKey::from("EPSILON")).unwrap();
+    let val = get(&agent, &number_constructor, &PropertyKey::from("EPSILON")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(f64::EPSILON));
 
-    let val = get(&mut agent, &number_constructor, &PropertyKey::from("MAX_SAFE_INTEGER")).unwrap();
+    let val = get(&agent, &number_constructor, &PropertyKey::from("MAX_SAFE_INTEGER")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(9007199254740991.0));
 
-    let val = get(&mut agent, &number_constructor, &PropertyKey::from("MAX_VALUE")).unwrap();
+    let val = get(&agent, &number_constructor, &PropertyKey::from("MAX_VALUE")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(f64::MAX));
 
-    let val = get(&mut agent, &number_constructor, &PropertyKey::from("MIN_SAFE_INTEGER")).unwrap();
+    let val = get(&agent, &number_constructor, &PropertyKey::from("MIN_SAFE_INTEGER")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(-9007199254740991.0));
 
-    let val = get(&mut agent, &number_constructor, &PropertyKey::from("MIN_VALUE")).unwrap();
+    let val = get(&agent, &number_constructor, &PropertyKey::from("MIN_VALUE")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(5e-324));
 
-    let val = get(&mut agent, &number_constructor, &PropertyKey::from("NaN")).unwrap();
+    let val = get(&agent, &number_constructor, &PropertyKey::from("NaN")).unwrap();
     assert!(matches!(val, ECMAScriptValue::Number(_)));
     if let ECMAScriptValue::Number(n) = val {
         assert!(n.is_nan());
     }
 
-    let val = get(&mut agent, &number_constructor, &PropertyKey::from("NEGATIVE_INFINITY")).unwrap();
+    let val = get(&agent, &number_constructor, &PropertyKey::from("NEGATIVE_INFINITY")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(f64::NEG_INFINITY));
 
-    let val = get(&mut agent, &number_constructor, &PropertyKey::from("POSITIVE_INFINITY")).unwrap();
+    let val = get(&agent, &number_constructor, &PropertyKey::from("POSITIVE_INFINITY")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(f64::INFINITY));
 
-    let val = get(&mut agent, &number_constructor, &PropertyKey::from("prototype")).unwrap();
+    let val = get(&agent, &number_constructor, &PropertyKey::from("prototype")).unwrap();
     let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
     assert_eq!(val, ECMAScriptValue::from(number_prototype));
 }
@@ -241,10 +241,10 @@ fn number_constructor_called_as_function_01() {
     // No arguments passed:
     //   > Number()
     //   0
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Number));
 
-    let result = call(&mut agent, &number_constructor, &ECMAScriptValue::Undefined, &[]).unwrap();
+    let result = call(&agent, &number_constructor, &ECMAScriptValue::Undefined, &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(0));
 }
 #[test]
@@ -252,11 +252,11 @@ fn number_constructor_called_as_function_02() {
     // Argument with a "Number" result from ToNumeric.
     //   > Number(true)
     //   1
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Number));
 
     let result =
-        call(&mut agent, &number_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from(true)]).unwrap();
+        call(&agent, &number_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from(true)]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(1));
 }
 #[test]
@@ -264,11 +264,11 @@ fn number_constructor_called_as_function_03() {
     // Argument with a "BigInt" result from ToNumeric.
     //   > Number(10n)
     //   10
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Number));
 
     let result =
-        call(&mut agent, &number_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from(BigInt::from(10))])
+        call(&agent, &number_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from(BigInt::from(10))])
             .unwrap();
     assert_eq!(result, ECMAScriptValue::from(10));
 }
@@ -278,13 +278,13 @@ fn number_constructor_called_as_function_04() {
     //   > Number(Symbol())
     //   Uncaught TypeError: Cannot convert a Symbol value to a number
     //       at Number (<anonymous>)
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Number));
 
-    let sym = Symbol::new(&mut agent, None);
+    let sym = Symbol::new(&agent, None);
     let result =
-        call(&mut agent, &number_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from(sym)]).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Symbol values cannot be converted to Number values");
+        call(&agent, &number_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from(sym)]).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
 }
 
 #[test]
@@ -293,10 +293,10 @@ fn number_constructor_as_constructor_01() {
     // No arguments:
     //   > new Number()
     //   [Number: 0]
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let result = construct(&mut agent, &number_constructor, &[], None).unwrap();
+    let result = construct(&agent, &number_constructor, &[], None).unwrap();
 
     assert!(result.is_object());
     if let ECMAScriptValue::Object(o) = result {
@@ -311,11 +311,11 @@ fn number_constructor_as_constructor_02() {
     // Argument needing conversion:
     //   > new Number("0xbadfade")
     //   [Number: 195951326]
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let arg = ECMAScriptValue::from("0xbadfade");
 
-    let result = construct(&mut agent, &number_constructor, &[arg], None).unwrap();
+    let result = construct(&agent, &number_constructor, &[arg], None).unwrap();
 
     assert!(result.is_object());
     if let ECMAScriptValue::Object(o) = result {
@@ -328,7 +328,7 @@ fn number_constructor_as_constructor_02() {
 fn number_constructor_throws() {
     // ordinary_create_from_contructor throws.
     // This looks to be difficult to make happen, but I can imagine some class shenanigans that could do it.
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     // This hack is to get around the "not configurable" characteristic of Number.prototype.
@@ -343,8 +343,8 @@ fn number_constructor_throws() {
         prop.property = new_prop;
     }
 
-    let result = construct(&mut agent, &number_constructor, &[], None).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Generic TypeError");
+    let result = construct(&agent, &number_constructor, &[], None).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Generic TypeError");
 }
 
 #[test]
@@ -352,20 +352,20 @@ fn number_is_finite_no_args() {
     // no args
     //    > Number.isFinite()
     //    false
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_finite = get(&mut agent, &number_constructor, &PropertyKey::from("isFinite")).unwrap();
-    let this_value = ECMAScriptValue::from(number_constructor.clone());
+    let is_finite = get(&agent, &number_constructor, &PropertyKey::from("isFinite")).unwrap();
+    let this_value = ECMAScriptValue::from(number_constructor);
 
-    let result = call(&mut agent, &is_finite, &this_value, &[]).unwrap();
+    let result = call(&agent, &is_finite, &this_value, &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 #[test]
 fn number_is_finite_one_arg() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_finite = get(&mut agent, &number_constructor, &PropertyKey::from("isFinite")).unwrap();
-    let this_value = ECMAScriptValue::from(number_constructor.clone());
+    let is_finite = get(&agent, &number_constructor, &PropertyKey::from("isFinite")).unwrap();
+    let this_value = ECMAScriptValue::from(number_constructor);
 
     for (arg, expected) in [
         (f64::INFINITY, false),
@@ -376,30 +376,30 @@ fn number_is_finite_one_arg() {
         (89.3, true),
         (-89.3, true),
     ] {
-        let result = call(&mut agent, &is_finite, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
+        let result = call(&agent, &is_finite, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
         assert_eq!(result, ECMAScriptValue::from(expected));
     }
 
-    let result = call(&mut agent, &is_finite, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
+    let result = call(&agent, &is_finite, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 
 #[test]
 fn number_is_integer_no_args() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_integer = get(&mut agent, &number_constructor, &PropertyKey::from("isInteger")).unwrap();
-    let this_value = ECMAScriptValue::from(number_constructor.clone());
+    let is_integer = get(&agent, &number_constructor, &PropertyKey::from("isInteger")).unwrap();
+    let this_value = ECMAScriptValue::from(number_constructor);
 
-    let result = call(&mut agent, &is_integer, &this_value, &[]).unwrap();
+    let result = call(&agent, &is_integer, &this_value, &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 #[test]
 fn number_is_integer_one_arg() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_integer = get(&mut agent, &number_constructor, &PropertyKey::from("isInteger")).unwrap();
-    let this_value = ECMAScriptValue::from(number_constructor.clone());
+    let is_integer = get(&agent, &number_constructor, &PropertyKey::from("isInteger")).unwrap();
+    let this_value = ECMAScriptValue::from(number_constructor);
 
     for (arg, expected) in [
         (f64::INFINITY, false),
@@ -412,30 +412,30 @@ fn number_is_integer_one_arg() {
         (10.0, true),
         (3.33e200, true),
     ] {
-        let result = call(&mut agent, &is_integer, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
+        let result = call(&agent, &is_integer, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
         assert_eq!(result, ECMAScriptValue::from(expected));
     }
 
-    let result = call(&mut agent, &is_integer, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
+    let result = call(&agent, &is_integer, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 
 #[test]
 fn number_is_nan_no_args() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_nan = get(&mut agent, &number_constructor, &PropertyKey::from("isNaN")).unwrap();
-    let this_value = ECMAScriptValue::from(number_constructor.clone());
+    let is_nan = get(&agent, &number_constructor, &PropertyKey::from("isNaN")).unwrap();
+    let this_value = ECMAScriptValue::from(number_constructor);
 
-    let result = call(&mut agent, &is_nan, &this_value, &[]).unwrap();
+    let result = call(&agent, &is_nan, &this_value, &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 #[test]
 fn number_is_nan_one_arg() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_nan = get(&mut agent, &number_constructor, &PropertyKey::from("isNaN")).unwrap();
-    let this_value = ECMAScriptValue::from(number_constructor.clone());
+    let is_nan = get(&agent, &number_constructor, &PropertyKey::from("isNaN")).unwrap();
+    let this_value = ECMAScriptValue::from(number_constructor);
 
     for (arg, expected) in [
         (f64::INFINITY, false),
@@ -445,30 +445,30 @@ fn number_is_nan_one_arg() {
         (-0.0, false),
         (89.3, false),
     ] {
-        let result = call(&mut agent, &is_nan, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
+        let result = call(&agent, &is_nan, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
         assert_eq!(result, ECMAScriptValue::from(expected));
     }
 
-    let result = call(&mut agent, &is_nan, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
+    let result = call(&agent, &is_nan, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 
 #[test]
 fn number_is_safe_integer_no_args() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_safe_integer = get(&mut agent, &number_constructor, &PropertyKey::from("isSafeInteger")).unwrap();
-    let this_value = ECMAScriptValue::from(number_constructor.clone());
+    let is_safe_integer = get(&agent, &number_constructor, &PropertyKey::from("isSafeInteger")).unwrap();
+    let this_value = ECMAScriptValue::from(number_constructor);
 
-    let result = call(&mut agent, &is_safe_integer, &this_value, &[]).unwrap();
+    let result = call(&agent, &is_safe_integer, &this_value, &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 #[test]
 fn number_is_safe_integer_one_arg() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_safe_integer = get(&mut agent, &number_constructor, &PropertyKey::from("isSafeInteger")).unwrap();
-    let this_value = ECMAScriptValue::from(number_constructor.clone());
+    let is_safe_integer = get(&agent, &number_constructor, &PropertyKey::from("isSafeInteger")).unwrap();
+    let this_value = ECMAScriptValue::from(number_constructor);
 
     for (arg, expected) in [
         (f64::INFINITY, false),
@@ -483,11 +483,11 @@ fn number_is_safe_integer_one_arg() {
         (-0x1fffffffffffff_i64 as f64, true),
         (-0x20000000000000_i64 as f64, false),
     ] {
-        let result = call(&mut agent, &is_safe_integer, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
+        let result = call(&agent, &is_safe_integer, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
         assert_eq!(result, ECMAScriptValue::from(expected), "Tried {}, should have been {:?}", arg, expected);
     }
 
-    let result = call(&mut agent, &is_safe_integer, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
+    let result = call(&agent, &is_safe_integer, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 
@@ -495,129 +495,129 @@ fn number_is_safe_integer_one_arg() {
 #[allow(clippy::float_cmp)]
 fn this_number_value_01() {
     // called with number object
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
-    let result = this_number_value(&mut agent, number).unwrap();
+    let result = this_number_value(&agent, number).unwrap();
     assert_eq!(result, 123.0);
 }
 #[test]
 #[allow(clippy::float_cmp)]
 fn this_number_value_02() {
     // called with number value
-    let mut agent = test_agent();
+    let agent = test_agent();
 
-    let result = this_number_value(&mut agent, ECMAScriptValue::from(123)).unwrap();
+    let result = this_number_value(&agent, ECMAScriptValue::from(123)).unwrap();
     assert_eq!(result, 123.0);
 }
 #[test]
 fn this_number_value_03() {
     // called with non-number object
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
 
-    let result = this_number_value(&mut agent, ECMAScriptValue::from(obj)).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Number method called with non-number receiver");
+    let result = this_number_value(&agent, ECMAScriptValue::from(obj)).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Number method called with non-number receiver");
 }
 #[test]
 fn this_number_value_04() {
     // called with non-number, non-object value
-    let mut agent = test_agent();
+    let agent = test_agent();
 
-    let result = this_number_value(&mut agent, ECMAScriptValue::from(true)).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Number method called with non-number receiver");
+    let result = this_number_value(&agent, ECMAScriptValue::from(true)).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Number method called with non-number receiver");
 }
 
 #[test]
 fn number_proto_to_string_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
-    let result = invoke(&mut agent, number, &PropertyKey::from("toString"), &[]).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[]).unwrap();
 
     assert_eq!(result, ECMAScriptValue::from("123"));
 }
 #[test]
 fn number_proto_to_string_02() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(123.789)], None).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123.789)], None).unwrap();
 
-    let result = invoke(&mut agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(25)]).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(25)]).unwrap();
 
     assert_eq!(result, ECMAScriptValue::from("4n.ji33333333"));
 }
 
 #[test]
 fn number_proto_to_string_03() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(123.789)], None).unwrap();
-    let sym = Symbol::new(&mut agent, None);
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123.789)], None).unwrap();
+    let sym = Symbol::new(&agent, None);
 
-    let result = invoke(&mut agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(sym)]).unwrap_err();
+    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(sym)]).unwrap_err();
 
-    assert_eq!(unwind_type_error(&mut agent, result), "Symbol values cannot be converted to Number values");
+    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
 }
 #[test]
 fn number_proto_to_string_04() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
-    let result = invoke(&mut agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(2)]).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(2)]).unwrap();
 
     assert_eq!(result, ECMAScriptValue::from("1111011"));
 }
 #[test]
 fn number_proto_to_string_05() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
-    let result = invoke(&mut agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(36)]).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(36)]).unwrap();
 
     assert_eq!(result, ECMAScriptValue::from("3f"));
 }
 #[test]
 fn number_proto_to_string_06() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
-    let result = invoke(&mut agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(1)]).unwrap_err();
+    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(1)]).unwrap_err();
 
-    assert_eq!(unwind_range_error(&mut agent, result), "Radix 1 out of range (must be in 2..36)");
+    assert_eq!(unwind_range_error(&agent, result), "Radix 1 out of range (must be in 2..36)");
 }
 #[test]
 fn number_proto_to_string_07() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
-    let result = invoke(&mut agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(37)]).unwrap_err();
+    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(37)]).unwrap_err();
 
-    assert_eq!(unwind_range_error(&mut agent, result), "Radix 37 out of range (must be in 2..36)");
+    assert_eq!(unwind_range_error(&agent, result), "Radix 37 out of range (must be in 2..36)");
 }
 #[test]
 fn number_proto_to_string_08() {
     // this_number_value is not actually a number
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
-    let to_string = get(&mut agent, &number_prototype, &PropertyKey::from("toString")).unwrap();
+    let to_string = get(&agent, &number_prototype, &PropertyKey::from("toString")).unwrap();
 
-    let result = call(&mut agent, &to_string, &ECMAScriptValue::Null, &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Number method called with non-number receiver");
+    let result = call(&agent, &to_string, &ECMAScriptValue::Null, &[]).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Number method called with non-number receiver");
 }
 #[test]
 fn number_proto_to_string_09() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(1.0e100)], None).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(1.0e100)], None).unwrap();
 
-    let result = invoke(&mut agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(30)]).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(30)]).unwrap();
 
     assert_eq!(result, ECMAScriptValue::from("anhmc58j7ljq00000000000000000000000000000000000000000000000000000000"));
 }
@@ -630,12 +630,12 @@ fn double_to_radix_string_01() {
 }
 
 fn number_proto_to_precision_test(value: f64, precision: u32, expected: &str) {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(value)], None).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(value)], None).unwrap();
     let result =
-        invoke(&mut agent, number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(precision)]).unwrap();
+        invoke(&agent, number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(precision)]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(expected));
 }
 #[test]
@@ -690,64 +690,62 @@ fn number_proto_to_precision_15() {
 #[test]
 fn number_proto_to_precision_12() {
     // this_number_value is not actually a number
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
-    let func = get(&mut agent, &number_prototype, &PropertyKey::from("toPrecision")).unwrap();
+    let func = get(&agent, &number_prototype, &PropertyKey::from("toPrecision")).unwrap();
 
-    let result = call(&mut agent, &func, &ECMAScriptValue::Null, &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Number method called with non-number receiver");
+    let result = call(&agent, &func, &ECMAScriptValue::Null, &[]).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Number method called with non-number receiver");
 }
 #[test]
 fn number_proto_to_precision_13() {
     // precision not present
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
-    let result = invoke(&mut agent, number, &PropertyKey::from("toPrecision"), &[]).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toPrecision"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("548.333"));
 }
 #[test]
 fn number_proto_to_precision_14() {
     // precision not convertable to number
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let sym = ECMAScriptValue::from(Symbol::new(&mut agent, None));
+    let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
-    let result = invoke(&mut agent, number, &PropertyKey::from("toPrecision"), &[sym]).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Symbol values cannot be converted to Number values");
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toPrecision"), &[sym]).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
 }
 #[test]
 fn number_proto_to_precision_16() {
     // precision out of range
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
-    let result =
-        invoke(&mut agent, number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(0)]).unwrap_err();
-    assert_eq!(unwind_range_error(&mut agent, result), "Precision ‘0’ must lie within the range 1..100");
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(0)]).unwrap_err();
+    assert_eq!(unwind_range_error(&agent, result), "Precision ‘0’ must lie within the range 1..100");
 }
 #[test]
 fn number_proto_to_precision_17() {
     // precision out of range
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
-    let result =
-        invoke(&mut agent, number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(101)]).unwrap_err();
-    assert_eq!(unwind_range_error(&mut agent, result), "Precision ‘101’ must lie within the range 1..100");
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(101)]).unwrap_err();
+    assert_eq!(unwind_range_error(&agent, result), "Precision ‘101’ must lie within the range 1..100");
 }
 #[test]
 fn number_proto_to_precision_18() {
     // precision just in range
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
-    let result = invoke(&mut agent, number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(100)]).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(100)]).unwrap();
     assert_eq!(
         result,
         ECMAScriptValue::from(
@@ -757,13 +755,12 @@ fn number_proto_to_precision_18() {
 }
 
 fn number_proto_to_exponent_test(value: f64, fraction_digits: u32, expected: &str) {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(value)], None).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(value)], None).unwrap();
     let result =
-        invoke(&mut agent, number, &PropertyKey::from("toExponential"), &[ECMAScriptValue::from(fraction_digits)])
-            .unwrap();
+        invoke(&agent, number, &PropertyKey::from("toExponential"), &[ECMAScriptValue::from(fraction_digits)]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(expected));
 }
 #[test]
@@ -780,33 +777,33 @@ fn number_proto_to_exponential_02() {
 }
 #[test]
 fn number_proto_to_exponential_03() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
-    let result = invoke(&mut agent, number, &PropertyKey::from("toExponential"), &[]).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toExponential"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("1e-1"));
 }
 #[test]
 fn number_proto_to_exponential_04() {
     // this_number_value is not actually a number
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
-    let func = get(&mut agent, &number_prototype, &PropertyKey::from("toExponential")).unwrap();
+    let func = get(&agent, &number_prototype, &PropertyKey::from("toExponential")).unwrap();
 
-    let result = call(&mut agent, &func, &ECMAScriptValue::Null, &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Number method called with non-number receiver");
+    let result = call(&agent, &func, &ECMAScriptValue::Null, &[]).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Number method called with non-number receiver");
 }
 #[test]
 fn number_proto_to_exponential_05() {
     // fractionDigits not convertable to number
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let sym = ECMAScriptValue::from(Symbol::new(&mut agent, None));
+    let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
-    let result = invoke(&mut agent, number, &PropertyKey::from("toExponential"), &[sym]).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Symbol values cannot be converted to Number values");
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toExponential"), &[sym]).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
 }
 #[test]
 fn number_proto_to_exponential_06() {
@@ -815,24 +812,23 @@ fn number_proto_to_exponential_06() {
 #[test]
 fn number_proto_to_exponential_07() {
     // fractionDigits out of range
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
     let result =
-        invoke(&mut agent, number, &PropertyKey::from("toExponential"), &[ECMAScriptValue::from(101)]).unwrap_err();
-    assert_eq!(unwind_range_error(&mut agent, result), "FractionDigits ‘101’ must lie within the range 0..100");
+        invoke(&agent, number, &PropertyKey::from("toExponential"), &[ECMAScriptValue::from(101)]).unwrap_err();
+    assert_eq!(unwind_range_error(&agent, result), "FractionDigits ‘101’ must lie within the range 0..100");
 }
 #[test]
 fn number_proto_to_exponential_08() {
     // fractionDigits out of range
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
-    let result =
-        invoke(&mut agent, number, &PropertyKey::from("toExponential"), &[ECMAScriptValue::from(-1)]).unwrap_err();
-    assert_eq!(unwind_range_error(&mut agent, result), "FractionDigits ‘-1’ must lie within the range 0..100");
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toExponential"), &[ECMAScriptValue::from(-1)]).unwrap_err();
+    assert_eq!(unwind_range_error(&agent, result), "FractionDigits ‘-1’ must lie within the range 0..100");
 }
 #[test]
 fn number_proto_to_exponential_09() {
@@ -840,12 +836,12 @@ fn number_proto_to_exponential_09() {
 }
 
 fn number_proto_to_fixed_test(value: f64, fraction_digits: u32, expected: &str) {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(value)], None).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(value)], None).unwrap();
     let result =
-        invoke(&mut agent, number, &PropertyKey::from("toFixed"), &[ECMAScriptValue::from(fraction_digits)]).unwrap();
+        invoke(&agent, number, &PropertyKey::from("toFixed"), &[ECMAScriptValue::from(fraction_digits)]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(expected));
 }
 
@@ -913,43 +909,43 @@ fn number_proto_to_fixed_15() {
 #[test]
 fn number_proto_to_fixed_16() {
     // empty arg list
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
-    let result = invoke(&mut agent, number, &PropertyKey::from("toFixed"), &[]).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toFixed"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("0"));
 }
 #[test]
 fn number_proto_to_fixed_17() {
     // bad argument
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let sym = ECMAScriptValue::from(Symbol::new(&mut agent, None));
+    let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
-    let result = invoke(&mut agent, number, &PropertyKey::from("toFixed"), &[sym]).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Symbol values cannot be converted to Number values");
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toFixed"), &[sym]).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
 }
 #[test]
 fn number_proto_to_fixed_18() {
     // bad argument
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
-    let result = invoke(&mut agent, number, &PropertyKey::from("toFixed"), &[ECMAScriptValue::from(-1)]).unwrap_err();
-    assert_eq!(unwind_range_error(&mut agent, result), "Argument for Number.toFixed must be in the range 0..100");
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toFixed"), &[ECMAScriptValue::from(-1)]).unwrap_err();
+    assert_eq!(unwind_range_error(&agent, result), "Argument for Number.toFixed must be in the range 0..100");
 }
 #[test]
 fn number_proto_to_fixed_19() {
     // bad argument
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
-    let result = invoke(&mut agent, number, &PropertyKey::from("toFixed"), &[ECMAScriptValue::from(101)]).unwrap_err();
-    assert_eq!(unwind_range_error(&mut agent, result), "Argument for Number.toFixed must be in the range 0..100");
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toFixed"), &[ECMAScriptValue::from(101)]).unwrap_err();
+    assert_eq!(unwind_range_error(&agent, result), "Argument for Number.toFixed must be in the range 0..100");
 }
 #[test]
 fn number_proto_to_fixed_20() {
@@ -963,12 +959,12 @@ fn number_proto_to_fixed_20() {
 #[test]
 fn number_proto_to_fixed_21() {
     // this_number_value is not actually a number
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
-    let func = get(&mut agent, &number_prototype, &PropertyKey::from("toFixed")).unwrap();
+    let func = get(&agent, &number_prototype, &PropertyKey::from("toFixed")).unwrap();
 
-    let result = call(&mut agent, &func, &ECMAScriptValue::Null, &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Number method called with non-number receiver");
+    let result = call(&agent, &func, &ECMAScriptValue::Null, &[]).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Number method called with non-number receiver");
 }
 
 #[test]
@@ -999,22 +995,21 @@ fn next_double_test() {
 fn number_proto_to_locale_string_01() {
     // Implementations of toLocaleString may not use the arguments for any use beyond their ECMA-402 specified uses. In
     // particular, if we defer to toString, the first argument must _not_ be used as the radix argument.
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(10)], None).unwrap();
-    let result =
-        invoke(&mut agent, number, &PropertyKey::from("toLocaleString"), &[ECMAScriptValue::from(16)]).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(10)], None).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("toLocaleString"), &[ECMAScriptValue::from(16)]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("10"));
 }
 
 #[test]
 fn number_proto_value_of() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
-    let number = construct(&mut agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
-    let result = invoke(&mut agent, number, &PropertyKey::from("valueOf"), &[]).unwrap();
+    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
+    let result = invoke(&agent, number, &PropertyKey::from("valueOf"), &[]).unwrap();
 
     assert_eq!(result, ECMAScriptValue::from(0.1));
 }

--- a/src/object/tests.rs
+++ b/src/object/tests.rs
@@ -525,9 +525,9 @@ fn is_generic_descriptor_01() {
 
 #[test]
 fn ordinary_get_prototype_of_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto.clone()), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
 
     let result = ordinary_get_prototype_of(&obj);
     assert_eq!(result, Some(object_proto));
@@ -535,10 +535,10 @@ fn ordinary_get_prototype_of_01() {
 
 #[test]
 fn ordinary_set_prototype_of_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let new_proto = ordinary_object_create(&mut agent, Some(object_proto.clone()), &[]);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+    let new_proto = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
 
     let result = ordinary_set_prototype_of(&obj, Some(new_proto.clone()));
     assert!(result);
@@ -546,8 +546,8 @@ fn ordinary_set_prototype_of_01() {
 }
 #[test]
 fn ordinary_set_prototype_of_02() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     let result = ordinary_set_prototype_of(&obj, None);
     assert!(result);
@@ -555,9 +555,9 @@ fn ordinary_set_prototype_of_02() {
 }
 #[test]
 fn ordinary_set_prototype_of_03() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto.clone()), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
 
     let result = ordinary_set_prototype_of(&obj, Some(object_proto.clone()));
     assert!(result);
@@ -565,9 +565,9 @@ fn ordinary_set_prototype_of_03() {
 }
 #[test]
 fn ordinary_set_prototype_of_04() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     let result = ordinary_set_prototype_of(&obj, Some(object_proto.clone()));
     assert!(result);
@@ -575,10 +575,10 @@ fn ordinary_set_prototype_of_04() {
 }
 #[test]
 fn ordinary_set_prototype_of_05() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto.clone()), &[]);
-    obj.o.prevent_extensions(&mut agent).unwrap();
+    let obj = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
+    obj.o.prevent_extensions(&agent).unwrap();
 
     let result = ordinary_set_prototype_of(&obj, None);
     assert!(!result);
@@ -586,9 +586,9 @@ fn ordinary_set_prototype_of_05() {
 }
 #[test]
 fn ordinary_set_prototype_of_06() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto.clone()), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
 
     let result = ordinary_set_prototype_of(&obj, Some(obj.clone()));
     assert!(!result);
@@ -597,9 +597,9 @@ fn ordinary_set_prototype_of_06() {
 
 #[test]
 fn ordinary_is_extensible_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
 
     let result = ordinary_is_extensible(&obj);
     assert!(result);
@@ -611,9 +611,9 @@ fn ordinary_is_extensible_01() {
 
 #[test]
 fn ordinary_prevent_extensions_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
 
     let result = ordinary_prevent_extensions(&obj);
     assert!(result);
@@ -622,9 +622,9 @@ fn ordinary_prevent_extensions_01() {
 
 #[test]
 fn ordinary_get_own_property_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let key = PropertyKey::from("a");
 
     let result = ordinary_get_own_property(&obj, &key);
@@ -632,9 +632,9 @@ fn ordinary_get_own_property_01() {
 }
 #[test]
 fn ordinary_get_own_property_02() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let key = PropertyKey::from("a");
     let ppd = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(10)),
@@ -643,7 +643,7 @@ fn ordinary_get_own_property_02() {
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&mut agent, &obj, key.clone(), ppd).unwrap();
+    define_property_or_throw(&agent, &obj, key.clone(), ppd).unwrap();
 
     let result = ordinary_get_own_property(&obj, &key).unwrap();
     assert_eq!(result.configurable, true);
@@ -658,9 +658,9 @@ fn ordinary_get_own_property_02() {
 #[test]
 fn ordinary_define_own_property_01() {
     // Add a new property, object is extensible (the default)
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let key = PropertyKey::from("a");
     let ppd = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(10)),
@@ -670,10 +670,10 @@ fn ordinary_define_own_property_01() {
         ..Default::default()
     };
 
-    let result = ordinary_define_own_property(&mut agent, &obj, key.clone(), ppd).unwrap();
+    let result = ordinary_define_own_property(&agent, &obj, key.clone(), ppd).unwrap();
 
     assert!(result);
-    let prop = obj.o.get_own_property(&mut agent, &key).unwrap().unwrap();
+    let prop = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
     assert_eq!(prop.configurable, true);
     assert_eq!(prop.enumerable, true);
     assert!(matches!(prop.property, PropertyKind::Data(..)));
@@ -685,9 +685,9 @@ fn ordinary_define_own_property_01() {
 #[test]
 fn ordinary_define_own_property_02() {
     // Add a new property, object is not extensible
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let key = PropertyKey::from("a");
     let ppd = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(10)),
@@ -696,18 +696,18 @@ fn ordinary_define_own_property_02() {
         configurable: Some(true),
         ..Default::default()
     };
-    obj.o.prevent_extensions(&mut agent).unwrap();
+    obj.o.prevent_extensions(&agent).unwrap();
 
-    let result = ordinary_define_own_property(&mut agent, &obj, key, ppd).unwrap();
+    let result = ordinary_define_own_property(&agent, &obj, key, ppd).unwrap();
 
     assert!(!result);
 }
 #[test]
 fn ordinary_define_own_property_03() {
     // Change an existing property
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let key = PropertyKey::from("a");
     let initial = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(10)),
@@ -716,13 +716,13 @@ fn ordinary_define_own_property_03() {
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&mut agent, &obj, key.clone(), initial).unwrap();
+    define_property_or_throw(&agent, &obj, key.clone(), initial).unwrap();
     let ppd = PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from(0)), ..Default::default() };
 
-    let result = ordinary_define_own_property(&mut agent, &obj, key.clone(), ppd).unwrap();
+    let result = ordinary_define_own_property(&agent, &obj, key.clone(), ppd).unwrap();
 
     assert!(result);
-    let prop = obj.o.get_own_property(&mut agent, &key).unwrap().unwrap();
+    let prop = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
     assert_eq!(prop.configurable, true);
     assert_eq!(prop.enumerable, true);
     assert!(matches!(prop.property, PropertyKind::Data(..)));
@@ -734,8 +734,8 @@ fn ordinary_define_own_property_03() {
 #[test]
 fn ordinary_define_own_property_04() {
     // [[GetOwnProperty]] throws
-    let mut agent = test_agent();
-    let obj = TestObject::object(&mut agent, &[FunctionId::GetOwnProperty(None)]);
+    let agent = test_agent();
+    let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
     let ppd = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(10)),
@@ -745,16 +745,16 @@ fn ordinary_define_own_property_04() {
         ..Default::default()
     };
 
-    let result = ordinary_define_own_property(&mut agent, &obj, key, ppd).unwrap_err();
+    let result = ordinary_define_own_property(&agent, &obj, key, ppd).unwrap_err();
 
-    let msg = unwind_type_error(&mut agent, result);
+    let msg = unwind_type_error(&agent, result);
     assert_eq!(msg, "[[GetOwnProperty]] called on TestObject");
 }
 #[test]
 fn ordinary_define_own_property_05() {
     // [[IsExtensible]] throws
-    let mut agent = test_agent();
-    let obj = TestObject::object(&mut agent, &[FunctionId::IsExtensible]);
+    let agent = test_agent();
+    let obj = TestObject::object(&agent, &[FunctionId::IsExtensible]);
     let key = PropertyKey::from("a");
     let ppd = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(10)),
@@ -764,9 +764,9 @@ fn ordinary_define_own_property_05() {
         ..Default::default()
     };
 
-    let result = ordinary_define_own_property(&mut agent, &obj, key, ppd).unwrap_err();
+    let result = ordinary_define_own_property(&agent, &obj, key, ppd).unwrap_err();
 
-    let msg = unwind_type_error(&mut agent, result);
+    let msg = unwind_type_error(&agent, result);
     assert_eq!(msg, "[[IsExtensible]] called on TestObject");
 }
 
@@ -787,16 +787,16 @@ fn validate_and_apply_property_descriptor_02() {
 #[test]
 fn validate_and_apply_property_descriptor_03() {
     // current Undefined; empty descriptor
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let ppd = PotentialPropertyDescriptor { ..Default::default() };
     let key = PropertyKey::from("key");
 
     let result = validate_and_apply_property_descriptor(Some(&obj), Some(key.clone()), true, ppd, None);
 
     assert!(result);
-    let pd = obj.o.get_own_property(&mut agent, &key).unwrap().unwrap();
+    let pd = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
     assert_eq!(pd.configurable, false);
     assert_eq!(pd.enumerable, false);
     assert_eq!(pd.property, PropertyKind::Data(DataProperty { value: ECMAScriptValue::Undefined, writable: false }));
@@ -804,9 +804,9 @@ fn validate_and_apply_property_descriptor_03() {
 #[test]
 fn validate_and_apply_property_descriptor_04() {
     // current Undefined; overfull descriptor
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let ppd = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(true)),
         writable: Some(true),
@@ -820,7 +820,7 @@ fn validate_and_apply_property_descriptor_04() {
     let result = validate_and_apply_property_descriptor(Some(&obj), Some(key.clone()), true, ppd, None);
 
     assert!(result);
-    let pd = obj.o.get_own_property(&mut agent, &key).unwrap().unwrap();
+    let pd = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
     assert_eq!(pd.configurable, true);
     assert_eq!(pd.enumerable, true);
     assert_eq!(pd.property, PropertyKind::Data(DataProperty { value: ECMAScriptValue::from(true), writable: true }));
@@ -828,9 +828,9 @@ fn validate_and_apply_property_descriptor_04() {
 #[test]
 fn validate_and_apply_property_descriptor_05() {
     // current Undefined; accessor descriptor
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let ppd = PotentialPropertyDescriptor {
         enumerable: Some(true),
         configurable: Some(true),
@@ -843,7 +843,7 @@ fn validate_and_apply_property_descriptor_05() {
     let result = validate_and_apply_property_descriptor(Some(&obj), Some(key.clone()), true, ppd, None);
 
     assert!(result);
-    let pd = obj.o.get_own_property(&mut agent, &key).unwrap().unwrap();
+    let pd = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
     assert_eq!(pd.configurable, true);
     assert_eq!(pd.enumerable, true);
     assert_eq!(
@@ -857,9 +857,9 @@ fn validate_and_apply_property_descriptor_05() {
 #[test]
 fn validate_and_apply_property_descriptor_06() {
     // object Undefined; current reasonable; any valid input
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let existing = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(99)),
         writable: Some(true),
@@ -868,15 +868,15 @@ fn validate_and_apply_property_descriptor_06() {
         ..Default::default()
     };
     let key = PropertyKey::from("key");
-    define_property_or_throw(&mut agent, &obj, key.clone(), existing).unwrap();
-    let current = obj.o.get_own_property(&mut agent, &key).unwrap().unwrap();
+    define_property_or_throw(&agent, &obj, key.clone(), existing).unwrap();
+    let current = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
 
     let ppd = PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from(10)), ..Default::default() };
 
     let result = validate_and_apply_property_descriptor::<&Object>(None, Some(key.clone()), true, ppd, Some(&current));
 
     assert!(result);
-    let pd = obj.o.get_own_property(&mut agent, &key).unwrap().unwrap();
+    let pd = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
     assert_eq!(pd.configurable, true);
     assert_eq!(pd.enumerable, true);
     assert_eq!(pd.property, PropertyKind::Data(DataProperty { value: ECMAScriptValue::from(99), writable: true }));
@@ -1203,20 +1203,20 @@ fn figure_expectation(
 }
 #[test]
 fn validate_and_apply_property_descriptor_many() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     for (name, ppd) in VAPDIter::new(&agent) {
         for (idx, _) in VAPDCheck::new(&agent).enumerate() {
             let key = PropertyKey::from(format!("{}-{}", name, idx));
-            define_property_or_throw(&mut agent, &obj, key, ppd.clone()).unwrap();
+            define_property_or_throw(&agent, &obj, key, ppd.clone()).unwrap();
         }
     }
 
     for (name, _) in VAPDIter::new(&agent) {
         for (idx, check) in VAPDCheck::new(&agent).enumerate() {
             let key = PropertyKey::from(format!("{}-{}", name, idx));
-            let current = obj.o.get_own_property(&mut agent, &key).unwrap().unwrap();
+            let current = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
             let expected_prop = figure_expectation(&current, &check);
 
             let result = validate_and_apply_property_descriptor(
@@ -1235,7 +1235,7 @@ fn validate_and_apply_property_descriptor_many() {
                 check,
                 expected_prop
             );
-            let after = obj.o.get_own_property(&mut agent, &key).unwrap().unwrap();
+            let after = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
             assert_eq!(
                 &after,
                 expected_prop.as_ref().unwrap_or(&current),
@@ -1251,9 +1251,9 @@ fn validate_and_apply_property_descriptor_many() {
 
 #[test]
 fn ordinary_has_property_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let initial = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(true)),
         writable: Some(true),
@@ -1262,78 +1262,78 @@ fn ordinary_has_property_01() {
         ..Default::default()
     };
     let key = PropertyKey::from("a");
-    define_property_or_throw(&mut agent, &obj, key.clone(), initial).unwrap();
+    define_property_or_throw(&agent, &obj, key.clone(), initial).unwrap();
     let key2 = PropertyKey::from("b");
     let key3 = PropertyKey::from("toString");
 
     // own property
-    let result = ordinary_has_property(&mut agent, &obj, &key).unwrap();
+    let result = ordinary_has_property(&agent, &obj, &key).unwrap();
     assert!(result);
 
     // property not there
-    let result = ordinary_has_property(&mut agent, &obj, &key2).unwrap();
+    let result = ordinary_has_property(&agent, &obj, &key2).unwrap();
     assert!(!result);
 
     // parent property
-    let result = ordinary_has_property(&mut agent, &obj, &key3).unwrap();
+    let result = ordinary_has_property(&agent, &obj, &key3).unwrap();
     assert!(result);
 }
 #[test]
 fn ordinary_has_property_02() {
     // [[GetOwnProperty]] throws
-    let mut agent = test_agent();
-    let obj = TestObject::object(&mut agent, &[FunctionId::GetOwnProperty(None)]);
+    let agent = test_agent();
+    let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_has_property(&mut agent, &obj, &key).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "[[GetOwnProperty]] called on TestObject");
+    let result = ordinary_has_property(&agent, &obj, &key).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "[[GetOwnProperty]] called on TestObject");
 }
 #[test]
 fn ordinary_has_property_03() {
     // [GetPrototypeOf]] throws
-    let mut agent = test_agent();
-    let obj = TestObject::object(&mut agent, &[FunctionId::GetPrototypeOf]);
+    let agent = test_agent();
+    let obj = TestObject::object(&agent, &[FunctionId::GetPrototypeOf]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_has_property(&mut agent, &obj, &key).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "[[GetPrototypeOf]] called on TestObject");
+    let result = ordinary_has_property(&agent, &obj, &key).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "[[GetPrototypeOf]] called on TestObject");
 }
 
 #[test]
 fn ordinary_get_01() {
     // [[GetOwnProperty]] throws
-    let mut agent = test_agent();
-    let obj = TestObject::object(&mut agent, &[FunctionId::GetOwnProperty(None)]);
+    let agent = test_agent();
+    let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_get(&mut agent, &obj, &key, &ECMAScriptValue::Undefined).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "[[GetOwnProperty]] called on TestObject");
+    let result = ordinary_get(&agent, &obj, &key, &ECMAScriptValue::Undefined).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "[[GetOwnProperty]] called on TestObject");
 }
 #[test]
 fn ordinary_get_02() {
     // [[GetPrototypeOf]] throws
-    let mut agent = test_agent();
-    let obj = TestObject::object(&mut agent, &[FunctionId::GetPrototypeOf]);
+    let agent = test_agent();
+    let obj = TestObject::object(&agent, &[FunctionId::GetPrototypeOf]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_get(&mut agent, &obj, &key, &ECMAScriptValue::Undefined).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "[[GetPrototypeOf]] called on TestObject");
+    let result = ordinary_get(&agent, &obj, &key, &ECMAScriptValue::Undefined).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "[[GetPrototypeOf]] called on TestObject");
 }
 #[test]
 fn ordinary_get_03() {
     // Top of the prototype chain
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_get(&mut agent, &obj, &key, &ECMAScriptValue::Undefined).unwrap();
+    let result = ordinary_get(&agent, &obj, &key, &ECMAScriptValue::Undefined).unwrap();
     assert_eq!(result, ECMAScriptValue::Undefined);
 }
 #[test]
 fn ordinary_get_04() {
     // Normal data property
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let initial = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(0)),
@@ -1342,13 +1342,13 @@ fn ordinary_get_04() {
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&mut agent, &obj, key.clone(), initial).unwrap();
+    define_property_or_throw(&agent, &obj, key.clone(), initial).unwrap();
 
-    let result = ordinary_get(&mut agent, &obj, &key, &ECMAScriptValue::Undefined).unwrap();
+    let result = ordinary_get(&agent, &obj, &key, &ECMAScriptValue::Undefined).unwrap();
     assert_eq!(result, ECMAScriptValue::from(0));
 }
 fn test_getter(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -1362,11 +1362,11 @@ fn test_getter(
 #[test]
 fn ordinary_get_05() {
     // Normal accessor property
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let getter = create_builtin_function(
-        &mut agent,
+        &agent,
         test_getter,
         false,
         0_f64,
@@ -1382,9 +1382,9 @@ fn ordinary_get_05() {
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&mut agent, &obj, key.clone(), initial).unwrap();
+    define_property_or_throw(&agent, &obj, key.clone(), initial).unwrap();
     define_property_or_throw(
-        &mut agent,
+        &agent,
         &obj,
         PropertyKey::from("result"),
         PotentialPropertyDescriptor {
@@ -1397,17 +1397,17 @@ fn ordinary_get_05() {
     )
     .unwrap();
 
-    let result = ordinary_get(&mut agent, &obj, &key, &ECMAScriptValue::from(obj.clone())).unwrap();
+    let result = ordinary_get(&agent, &obj, &key, &ECMAScriptValue::from(obj.clone())).unwrap();
     assert_eq!(result, ECMAScriptValue::from("sentinel value"));
 }
 #[test]
 fn ordinary_get_06() {
     // Accessor property on parent (this ensures we're passing "receiver" properly)
-    let mut agent = test_agent();
-    let parent = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let parent = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let getter = create_builtin_function(
-        &mut agent,
+        &agent,
         test_getter,
         false,
         0_f64,
@@ -1424,11 +1424,11 @@ fn ordinary_get_06() {
         ..Default::default()
     };
     // GETTER ON PARENT
-    define_property_or_throw(&mut agent, &parent, key.clone(), initial).unwrap();
-    let child = ordinary_object_create(&mut agent, Some(parent), &[]);
+    define_property_or_throw(&agent, &parent, key.clone(), initial).unwrap();
+    let child = ordinary_object_create(&agent, Some(parent), &[]);
     // RESULT VALUE ON CHILD
     define_property_or_throw(
-        &mut agent,
+        &agent,
         &child,
         PropertyKey::from("result"),
         PotentialPropertyDescriptor {
@@ -1443,14 +1443,14 @@ fn ordinary_get_06() {
 
     // THEREFORE:
     //    child.a == "sentinel value"
-    let result = ordinary_get(&mut agent, &child, &key, &ECMAScriptValue::from(child.clone())).unwrap();
+    let result = ordinary_get(&agent, &child, &key, &ECMAScriptValue::from(child.clone())).unwrap();
     assert_eq!(result, ECMAScriptValue::from("sentinel value"));
 }
 #[test]
 fn ordinary_get_07() {
     // Accessor properties undefined
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let initial = PotentialPropertyDescriptor {
         get: Some(ECMAScriptValue::Undefined),
@@ -1458,81 +1458,69 @@ fn ordinary_get_07() {
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&mut agent, &obj, key.clone(), initial).unwrap();
+    define_property_or_throw(&agent, &obj, key.clone(), initial).unwrap();
 
-    let result = ordinary_get(&mut agent, &obj, &key, &ECMAScriptValue::from(obj.clone())).unwrap();
+    let result = ordinary_get(&agent, &obj, &key, &ECMAScriptValue::from(obj.clone())).unwrap();
     assert_eq!(result, ECMAScriptValue::Undefined);
 }
 
 #[test]
 fn ordinary_set_01() {
     // [[GetOwnProperty]] throws
-    let mut agent = test_agent();
-    let obj = TestObject::object(&mut agent, &[FunctionId::GetOwnProperty(None)]);
+    let agent = test_agent();
+    let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
     let receiver = ECMAScriptValue::from(obj.clone());
 
-    let result = ordinary_set(&mut agent, &obj, key, value, &receiver).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "[[GetOwnProperty]] called on TestObject");
+    let result = ordinary_set(&agent, &obj, key, value, &receiver).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "[[GetOwnProperty]] called on TestObject");
 }
 #[test]
 fn ordinary_set_02() {
     // success
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from("test sentinel");
     let receiver = ECMAScriptValue::from(obj.clone());
 
-    let result = ordinary_set(&mut agent, &obj, key.clone(), value.clone(), &receiver).unwrap();
+    let result = ordinary_set(&agent, &obj, key.clone(), value.clone(), &receiver).unwrap();
     assert!(result);
-    let item = get(&mut agent, &obj, &key).unwrap();
+    let item = get(&agent, &obj, &key).unwrap();
     assert_eq!(item, value);
 }
 
 #[test]
 fn ordinary_set_with_own_descriptor_01() {
     // [[GetPrototypeOf]] throws
-    let mut agent = test_agent();
-    let obj = TestObject::object(&mut agent, &[FunctionId::GetPrototypeOf]);
+    let agent = test_agent();
+    let obj = TestObject::object(&agent, &[FunctionId::GetPrototypeOf]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_set_with_own_descriptor(
-        &mut agent,
-        &obj,
-        key,
-        ECMAScriptValue::Undefined,
-        &ECMAScriptValue::Null,
-        None,
-    )
-    .unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "[[GetPrototypeOf]] called on TestObject");
+    let result =
+        ordinary_set_with_own_descriptor(&agent, &obj, key, ECMAScriptValue::Undefined, &ECMAScriptValue::Null, None)
+            .unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "[[GetPrototypeOf]] called on TestObject");
 }
 #[test]
 fn ordinary_set_with_own_descriptor_02() {
     // If ownDesc is None, call [[Set]] on the parent. (We check by having the parent throw when we call its [[Set]].)
-    let mut agent = test_agent();
-    let parent = TestObject::object(&mut agent, &[FunctionId::Set(None)]);
-    let obj = ordinary_object_create(&mut agent, Some(parent), &[]);
+    let agent = test_agent();
+    let parent = TestObject::object(&agent, &[FunctionId::Set(None)]);
+    let obj = ordinary_object_create(&agent, Some(parent), &[]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_set_with_own_descriptor(
-        &mut agent,
-        &obj,
-        key,
-        ECMAScriptValue::Undefined,
-        &ECMAScriptValue::Null,
-        None,
-    )
-    .unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "[[Set]] called on TestObject");
+    let result =
+        ordinary_set_with_own_descriptor(&agent, &obj, key, ECMAScriptValue::Undefined, &ECMAScriptValue::Null, None)
+            .unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "[[Set]] called on TestObject");
 }
 #[test]
 fn ordinary_set_with_own_descriptor_03() {
     // ownDesc has writable:false; function should return false.
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let own_desc = PropertyDescriptor {
         property: PropertyKind::Data(DataProperty { writable: false, value: ECMAScriptValue::Undefined }),
         enumerable: true,
@@ -1543,45 +1531,44 @@ fn ordinary_set_with_own_descriptor_03() {
     let value = ECMAScriptValue::Undefined;
     let receiver = ECMAScriptValue::from(obj.clone());
 
-    let result = ordinary_set_with_own_descriptor(&mut agent, &obj, key, value, &receiver, Some(own_desc)).unwrap();
+    let result = ordinary_set_with_own_descriptor(&agent, &obj, key, value, &receiver, Some(own_desc)).unwrap();
     assert!(!result);
 }
 #[test]
 fn ordinary_set_with_own_descriptor_04() {
     // Type(receiver) is not object -> return false
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
     let receiver = ECMAScriptValue::from(999);
 
-    let result = ordinary_set_with_own_descriptor(&mut agent, &obj, key, value, &receiver, None).unwrap();
+    let result = ordinary_set_with_own_descriptor(&agent, &obj, key, value, &receiver, None).unwrap();
     assert!(!result);
 }
 #[test]
 fn ordinary_set_with_own_descriptor_05() {
     // receiver.[[GetOwnProperty]] throws
-    let mut agent = test_agent();
-    let obj = TestObject::object(&mut agent, &[FunctionId::GetOwnProperty(None)]);
+    let agent = test_agent();
+    let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
     let receiver = ECMAScriptValue::from(obj.clone());
 
-    let result = ordinary_set_with_own_descriptor(&mut agent, &obj, key, value, &receiver, None).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "[[GetOwnProperty]] called on TestObject");
+    let result = ordinary_set_with_own_descriptor(&agent, &obj, key, value, &receiver, None).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "[[GetOwnProperty]] called on TestObject");
 }
 #[test]
 fn ordinary_set_with_own_descriptor_06() {
     // existing is an accessor
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
     let receiver = ECMAScriptValue::from(obj.clone());
-    create_data_property(&mut agent, &obj, PropertyKey::from("result"), ECMAScriptValue::from("sentinel value"))
-        .unwrap();
+    create_data_property(&agent, &obj, PropertyKey::from("result"), ECMAScriptValue::from("sentinel value")).unwrap();
     let getter = create_builtin_function(
-        &mut agent,
+        &agent,
         test_getter,
         false,
         0_f64,
@@ -1597,7 +1584,7 @@ fn ordinary_set_with_own_descriptor_06() {
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&mut agent, &obj, key.clone(), accessor_prop).unwrap();
+    define_property_or_throw(&agent, &obj, key.clone(), accessor_prop).unwrap();
     let own_desc = PropertyDescriptor {
         property: PropertyKind::Data(DataProperty { writable: true, value: ECMAScriptValue::Undefined }),
         enumerable: true,
@@ -1605,14 +1592,14 @@ fn ordinary_set_with_own_descriptor_06() {
         spot: 0,
     };
 
-    let result = ordinary_set_with_own_descriptor(&mut agent, &obj, key, value, &receiver, Some(own_desc)).unwrap();
+    let result = ordinary_set_with_own_descriptor(&agent, &obj, key, value, &receiver, Some(own_desc)).unwrap();
     assert!(!result);
 }
 #[test]
 fn ordinary_set_with_own_descriptor_07() {
     // existing is read-only
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
     let receiver = ECMAScriptValue::from(obj.clone());
@@ -1623,7 +1610,7 @@ fn ordinary_set_with_own_descriptor_07() {
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&mut agent, &obj, key.clone(), readonly).unwrap();
+    define_property_or_throw(&agent, &obj, key.clone(), readonly).unwrap();
     let own_desc = PropertyDescriptor {
         property: PropertyKind::Data(DataProperty { writable: true, value: ECMAScriptValue::Undefined }),
         enumerable: true,
@@ -1631,14 +1618,14 @@ fn ordinary_set_with_own_descriptor_07() {
         spot: 0,
     };
 
-    let result = ordinary_set_with_own_descriptor(&mut agent, &obj, key, value, &receiver, Some(own_desc)).unwrap();
+    let result = ordinary_set_with_own_descriptor(&agent, &obj, key, value, &receiver, Some(own_desc)).unwrap();
     assert!(!result);
 }
 #[test]
 fn ordinary_set_with_own_descriptor_08() {
     // existing exists
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
     let receiver = ECMAScriptValue::from(obj.clone());
@@ -1649,7 +1636,7 @@ fn ordinary_set_with_own_descriptor_08() {
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&mut agent, &obj, key.clone(), previously).unwrap();
+    define_property_or_throw(&agent, &obj, key.clone(), previously).unwrap();
     let own_desc = PropertyDescriptor {
         property: PropertyKind::Data(DataProperty { writable: true, value: ECMAScriptValue::from(0) }),
         enumerable: true,
@@ -1658,18 +1645,17 @@ fn ordinary_set_with_own_descriptor_08() {
     };
 
     let result =
-        ordinary_set_with_own_descriptor(&mut agent, &obj, key.clone(), value.clone(), &receiver, Some(own_desc))
-            .unwrap();
+        ordinary_set_with_own_descriptor(&agent, &obj, key.clone(), value.clone(), &receiver, Some(own_desc)).unwrap();
     assert!(result);
 
-    let item = get(&mut agent, &obj, &key).unwrap();
+    let item = get(&agent, &obj, &key).unwrap();
     assert_eq!(item, value);
 }
 #[test]
 fn ordinary_set_with_own_descriptor_09() {
     // existing does not exist
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from("test sentinel");
     let receiver = ECMAScriptValue::from(obj.clone());
@@ -1681,15 +1667,14 @@ fn ordinary_set_with_own_descriptor_09() {
     };
 
     let result =
-        ordinary_set_with_own_descriptor(&mut agent, &obj, key.clone(), value.clone(), &receiver, Some(own_desc))
-            .unwrap();
+        ordinary_set_with_own_descriptor(&agent, &obj, key.clone(), value.clone(), &receiver, Some(own_desc)).unwrap();
     assert!(result);
 
-    let item = get(&mut agent, &obj, &key).unwrap();
+    let item = get(&agent, &obj, &key).unwrap();
     assert_eq!(item, value);
 }
 fn test_setter(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -1706,15 +1691,14 @@ fn test_setter(
 #[test]
 fn ordinary_set_with_own_descriptor_10() {
     // own_desc is an accessor descriptor, with the above setter function
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from("test sentinel");
     let receiver = ECMAScriptValue::from(obj.clone());
-    create_data_property(&mut agent, &obj, PropertyKey::from("result"), ECMAScriptValue::from("initial value"))
-        .unwrap();
+    create_data_property(&agent, &obj, PropertyKey::from("result"), ECMAScriptValue::from("initial value")).unwrap();
     let setter = create_builtin_function(
-        &mut agent,
+        &agent,
         test_setter,
         false,
         1_f64,
@@ -1735,17 +1719,17 @@ fn ordinary_set_with_own_descriptor_10() {
     };
 
     let result =
-        ordinary_set_with_own_descriptor(&mut agent, &obj, key, value.clone(), &receiver, Some(accessor_prop)).unwrap();
+        ordinary_set_with_own_descriptor(&agent, &obj, key, value.clone(), &receiver, Some(accessor_prop)).unwrap();
     assert!(result);
 
-    let item = get(&mut agent, &obj, &PropertyKey::from("result")).unwrap();
+    let item = get(&agent, &obj, &PropertyKey::from("result")).unwrap();
     assert_eq!(item, value);
 }
 #[test]
 fn ordinary_set_with_own_descriptor_11() {
     // own_desc is an accessor descriptor, with a setter function that throws
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from("test sentinel");
     let receiver = ECMAScriptValue::from(obj.clone());
@@ -1761,14 +1745,14 @@ fn ordinary_set_with_own_descriptor_11() {
     };
 
     let result =
-        ordinary_set_with_own_descriptor(&mut agent, &obj, key, value, &receiver, Some(accessor_prop)).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Generic TypeError");
+        ordinary_set_with_own_descriptor(&agent, &obj, key, value, &receiver, Some(accessor_prop)).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Generic TypeError");
 }
 #[test]
 fn ordinary_set_with_own_descriptor_12() {
     // own_desc is an accessor descriptor, with an undefined setter function
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from("test sentinel");
     let receiver = ECMAScriptValue::from(obj.clone());
@@ -1782,40 +1766,39 @@ fn ordinary_set_with_own_descriptor_12() {
         spot: 0,
     };
 
-    let result =
-        ordinary_set_with_own_descriptor(&mut agent, &obj, key, value, &receiver, Some(accessor_prop)).unwrap();
+    let result = ordinary_set_with_own_descriptor(&agent, &obj, key, value, &receiver, Some(accessor_prop)).unwrap();
     assert!(!result);
 }
 
 #[test]
 fn ordinary_delete_01() {
     // [[GetOwnProperty]] throws
-    let mut agent = test_agent();
-    let obj = TestObject::object(&mut agent, &[FunctionId::GetOwnProperty(None)]);
+    let agent = test_agent();
+    let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_delete(&mut agent, &obj, &key).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "[[GetOwnProperty]] called on TestObject");
+    let result = ordinary_delete(&agent, &obj, &key).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "[[GetOwnProperty]] called on TestObject");
 }
 #[test]
 fn ordinary_delete_02() {
     // property isn't actually there
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_delete(&mut agent, &obj, &key).unwrap();
+    let result = ordinary_delete(&agent, &obj, &key).unwrap();
     assert!(result);
 }
 #[test]
 fn ordinary_delete_03() {
     // property isn't configurable
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from(0);
     define_property_or_throw(
-        &mut agent,
+        &agent,
         &obj,
         key.clone(),
         PotentialPropertyDescriptor {
@@ -1828,30 +1811,30 @@ fn ordinary_delete_03() {
     )
     .unwrap();
 
-    let result = ordinary_delete(&mut agent, &obj, &key).unwrap();
+    let result = ordinary_delete(&agent, &obj, &key).unwrap();
     assert!(!result);
-    let item = get(&mut agent, &obj, &key).unwrap();
+    let item = get(&agent, &obj, &key).unwrap();
     assert_eq!(item, value);
 }
 #[test]
 fn ordinary_delete_04() {
     // property is normal
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from(0);
-    create_data_property(&mut agent, &obj, key.clone(), value).unwrap();
+    create_data_property(&agent, &obj, key.clone(), value).unwrap();
 
-    let result = ordinary_delete(&mut agent, &obj, &key).unwrap();
+    let result = ordinary_delete(&agent, &obj, &key).unwrap();
     assert!(result);
-    let item = get(&mut agent, &obj, &key).unwrap();
+    let item = get(&agent, &obj, &key).unwrap();
     assert_eq!(item, ECMAScriptValue::Undefined);
 }
 
 #[test]
 fn ordinary_own_property_keys_01() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     let result = ordinary_own_property_keys(&obj);
     assert_eq!(result, &[]);
@@ -1859,19 +1842,19 @@ fn ordinary_own_property_keys_01() {
 use crate::values::Symbol;
 #[test]
 fn ordinary_own_property_keys_02() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
-    let sym1 = Symbol::new(&mut agent, Some(JSString::from("TestSymbol 1")));
-    let sym2 = Symbol::new(&mut agent, Some(JSString::from("TestSymbol 2")));
-    create_data_property(&mut agent, &obj, PropertyKey::from(sym1.clone()), ECMAScriptValue::Null).unwrap();
-    create_data_property(&mut agent, &obj, PropertyKey::from("hillbilly"), ECMAScriptValue::Null).unwrap();
-    create_data_property(&mut agent, &obj, PropertyKey::from("automobile"), ECMAScriptValue::Null).unwrap();
-    create_data_property(&mut agent, &obj, PropertyKey::from("888"), ECMAScriptValue::Null).unwrap();
-    create_data_property(&mut agent, &obj, PropertyKey::from(sym2.clone()), ECMAScriptValue::Null).unwrap();
-    create_data_property(&mut agent, &obj, PropertyKey::from("1002"), ECMAScriptValue::Null).unwrap();
-    create_data_property(&mut agent, &obj, PropertyKey::from("green"), ECMAScriptValue::Null).unwrap();
-    create_data_property(&mut agent, &obj, PropertyKey::from("-1"), ECMAScriptValue::Null).unwrap();
-    create_data_property(&mut agent, &obj, PropertyKey::from("0"), ECMAScriptValue::Null).unwrap();
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
+    let sym1 = Symbol::new(&agent, Some(JSString::from("TestSymbol 1")));
+    let sym2 = Symbol::new(&agent, Some(JSString::from("TestSymbol 2")));
+    create_data_property(&agent, &obj, PropertyKey::from(sym1.clone()), ECMAScriptValue::Null).unwrap();
+    create_data_property(&agent, &obj, PropertyKey::from("hillbilly"), ECMAScriptValue::Null).unwrap();
+    create_data_property(&agent, &obj, PropertyKey::from("automobile"), ECMAScriptValue::Null).unwrap();
+    create_data_property(&agent, &obj, PropertyKey::from("888"), ECMAScriptValue::Null).unwrap();
+    create_data_property(&agent, &obj, PropertyKey::from(sym2.clone()), ECMAScriptValue::Null).unwrap();
+    create_data_property(&agent, &obj, PropertyKey::from("1002"), ECMAScriptValue::Null).unwrap();
+    create_data_property(&agent, &obj, PropertyKey::from("green"), ECMAScriptValue::Null).unwrap();
+    create_data_property(&agent, &obj, PropertyKey::from("-1"), ECMAScriptValue::Null).unwrap();
+    create_data_property(&agent, &obj, PropertyKey::from("0"), ECMAScriptValue::Null).unwrap();
 
     let result = ordinary_own_property_keys(&obj);
     assert_eq!(
@@ -1902,91 +1885,91 @@ fn array_index_key_02() {
 #[test]
 #[should_panic(expected = "unreachable code")]
 fn array_index_key_03() {
-    let mut agent = test_agent();
-    array_index_key(&PropertyKey::from(Symbol::new(&mut agent, None)));
+    let agent = test_agent();
+    array_index_key(&PropertyKey::from(Symbol::new(&agent, None)));
 }
 
 #[test]
 fn object_interface_to_boolean_obj() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(obj.o.to_boolean_obj().is_none());
 }
 #[test]
 fn object_interface_to_function_obj() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(obj.o.to_function_obj().is_none());
 }
 #[test]
 fn object_interface_to_callable_obj() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(obj.o.to_callable_obj().is_none());
 }
 #[test]
 fn object_interface_to_builtin_function_obj() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(obj.o.to_builtin_function_obj().is_none());
 }
 #[test]
 fn object_interface_is_arguments_object() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_arguments_object());
 }
 #[test]
 fn object_interface_is_callable_obj() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_callable_obj());
 }
 #[test]
 fn object_interface_is_error_object() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_error_object());
 }
 #[test]
 fn object_interface_is_boolean_object() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_boolean_object());
 }
 #[test]
 fn object_interface_is_number_object() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_number_object());
 }
 #[test]
 fn object_interface_is_string_object() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_string_object());
 }
 #[test]
 fn object_interface_is_date_object() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_date_object());
 }
 #[test]
 fn object_interface_is_regexp_object() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_regexp_object());
 }
@@ -1994,10 +1977,10 @@ fn object_interface_is_regexp_object() {
 #[test]
 fn ordinary_object_create_01() {
     // When: An agent is given
-    let mut agent = test_agent();
+    let agent = test_agent();
 
     // Then requesting a new object with no prototype or extra slots
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let obj = ordinary_object_create(&agent, None, &[]);
 
     // Gives us the emptiest of all objects
     let data = obj.o.common_object_data().borrow();
@@ -2009,11 +1992,11 @@ fn ordinary_object_create_01() {
 #[test]
 fn ordinary_object_create_02() {
     // When an agent and a prototype are provided
-    let mut agent = test_agent();
-    let proto = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let proto = ordinary_object_create(&agent, None, &[]);
 
     // Then requesting a new object with that prototype but no extra slots
-    let obj = ordinary_object_create(&mut agent, Some(proto.clone()), &[]);
+    let obj = ordinary_object_create(&agent, Some(proto.clone()), &[]);
 
     // Gives us an empty object with its prototype slot filled.
     let data = obj.o.common_object_data().borrow();
@@ -2026,11 +2009,11 @@ fn ordinary_object_create_02() {
 #[test]
 fn ordinary_object_create_03a() {
     // When an agent and a prototype are provided
-    let mut agent = test_agent();
-    let proto = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let proto = ordinary_object_create(&agent, None, &[]);
 
     // Then requesting a new object with that prototype and needlessly requesting prototype or extensible slots
-    let obj = ordinary_object_create(&mut agent, Some(proto.clone()), &[InternalSlotName::Prototype]);
+    let obj = ordinary_object_create(&agent, Some(proto.clone()), &[InternalSlotName::Prototype]);
 
     // Gives us an empty object with its prototype slot filled.
     let data = obj.o.common_object_data().borrow();
@@ -2042,11 +2025,11 @@ fn ordinary_object_create_03a() {
 #[test]
 fn ordinary_object_create_03b() {
     // When an agent and a prototype are provided
-    let mut agent = test_agent();
-    let proto = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let proto = ordinary_object_create(&agent, None, &[]);
 
     // Then requesting a new object with that prototype and needlessly requesting prototype or extensible slots
-    let obj = ordinary_object_create(&mut agent, Some(proto.clone()), &[InternalSlotName::Extensible]);
+    let obj = ordinary_object_create(&agent, Some(proto.clone()), &[InternalSlotName::Extensible]);
 
     // Gives us an empty object with its prototype slot filled.
     let data = obj.o.common_object_data().borrow();
@@ -2058,12 +2041,12 @@ fn ordinary_object_create_03b() {
 #[test]
 fn ordinary_object_create_03c() {
     // When an agent and a prototype are provided
-    let mut agent = test_agent();
-    let proto = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let proto = ordinary_object_create(&agent, None, &[]);
 
     // Then requesting a new object with that prototype and needlessly requesting prototype or extensible slots
     let obj = ordinary_object_create(
-        &mut agent,
+        &agent,
         Some(proto.clone()),
         &[InternalSlotName::Prototype, InternalSlotName::Extensible],
     );
@@ -2088,24 +2071,24 @@ fn ordinary_object_create_03c() {
 #[test_case(FUNCTION_OBJECT_SLOTS => panics "More items are needed for initialization. Use FunctionObject::object directly instead"; "function obj")]
 #[test_case(GENERATOR_OBJECT_SLOTS => panics "Additional info needed for generator object; use direct constructor"; "generator obj")]
 fn make_basic_object(slots: &[InternalSlotName]) -> Object {
-    let mut agent = test_agent();
-    super::make_basic_object(&mut agent, slots, None)
+    let agent = test_agent();
+    super::make_basic_object(&agent, slots, None)
 }
 
 #[test]
 fn get_prototype_of_01() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut test_agent(), None, &[]);
-    let result = obj.o.get_prototype_of(&mut agent);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&test_agent(), None, &[]);
+    let result = obj.o.get_prototype_of(&agent);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), None);
 }
 #[test]
 fn get_prototype_of_02() {
-    let mut agent = test_agent();
-    let proto = ordinary_object_create(&mut agent, None, &[]);
-    let obj = ordinary_object_create(&mut agent, Some(proto.clone()), &[]);
-    let result = obj.o.get_prototype_of(&mut agent);
+    let agent = test_agent();
+    let proto = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(&agent, Some(proto.clone()), &[]);
+    let result = obj.o.get_prototype_of(&agent);
     assert!(result.is_ok());
     assert_eq!(result.unwrap().as_ref(), Some(&proto));
 }
@@ -2113,9 +2096,9 @@ fn get_prototype_of_02() {
 #[test]
 fn set_prototype_of_01() {
     // Not changing an empty prototype
-    let mut agent = test_agent();
-    let obj_a = ordinary_object_create(&mut agent, None, &[]);
-    let result = obj_a.o.set_prototype_of(&mut agent, None);
+    let agent = test_agent();
+    let obj_a = ordinary_object_create(&agent, None, &[]);
+    let result = obj_a.o.set_prototype_of(&agent, None);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), true);
     assert_eq!(obj_a.o.common_object_data().borrow().prototype, None);
@@ -2123,10 +2106,10 @@ fn set_prototype_of_01() {
 #[test]
 fn set_prototype_of_02() {
     // Not changing a Some() prototype
-    let mut agent = test_agent();
-    let obj_a = ordinary_object_create(&mut agent, None, &[]);
-    let obj_b = ordinary_object_create(&mut agent, Some(obj_a.clone()), &[]);
-    let result = obj_b.o.set_prototype_of(&mut agent, Some(obj_a.clone()));
+    let agent = test_agent();
+    let obj_a = ordinary_object_create(&agent, None, &[]);
+    let obj_b = ordinary_object_create(&agent, Some(obj_a.clone()), &[]);
+    let result = obj_b.o.set_prototype_of(&agent, Some(obj_a.clone()));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), true);
     assert_eq!(obj_b.o.common_object_data().borrow().prototype.as_ref(), Some(&obj_a));
@@ -2134,11 +2117,11 @@ fn set_prototype_of_02() {
 #[test]
 fn set_prototype_of_03() {
     // Changing a Some() prototype to a different Some() prototype
-    let mut agent = test_agent();
-    let proto = ordinary_object_create(&mut agent, None, &[]);
-    let obj_b = ordinary_object_create(&mut agent, Some(proto), &[]);
-    let new_proto = ordinary_object_create(&mut agent, None, &[]);
-    let result = obj_b.o.set_prototype_of(&mut agent, Some(new_proto.clone()));
+    let agent = test_agent();
+    let proto = ordinary_object_create(&agent, None, &[]);
+    let obj_b = ordinary_object_create(&agent, Some(proto), &[]);
+    let new_proto = ordinary_object_create(&agent, None, &[]);
+    let result = obj_b.o.set_prototype_of(&agent, Some(new_proto.clone()));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), true);
     assert_eq!(obj_b.o.common_object_data().borrow().prototype.as_ref(), Some(&new_proto));
@@ -2146,10 +2129,10 @@ fn set_prototype_of_03() {
 #[test]
 fn set_prototype_of_04() {
     // Trying to make a prototype loop
-    let mut agent = test_agent();
-    let proto = ordinary_object_create(&mut agent, None, &[]);
-    let obj_b = ordinary_object_create(&mut agent, Some(proto.clone()), &[]);
-    let result = proto.o.set_prototype_of(&mut agent, Some(obj_b));
+    let agent = test_agent();
+    let proto = ordinary_object_create(&agent, None, &[]);
+    let obj_b = ordinary_object_create(&agent, Some(proto.clone()), &[]);
+    let result = proto.o.set_prototype_of(&agent, Some(obj_b));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), false);
     assert_eq!(proto.o.common_object_data().borrow().prototype.as_ref(), None);
@@ -2157,12 +2140,12 @@ fn set_prototype_of_04() {
 #[test]
 fn set_prototype_of_05() {
     // Changing the prototype of an object that's not extensible
-    let mut agent = test_agent();
-    let proto = ordinary_object_create(&mut agent, None, &[]);
-    let obj_b = ordinary_object_create(&mut agent, Some(proto.clone()), &[]);
+    let agent = test_agent();
+    let proto = ordinary_object_create(&agent, None, &[]);
+    let obj_b = ordinary_object_create(&agent, Some(proto.clone()), &[]);
     obj_b.o.common_object_data().borrow_mut().extensible = false;
-    let new_proto = ordinary_object_create(&mut agent, None, &[]);
-    let result = obj_b.o.set_prototype_of(&mut agent, Some(new_proto));
+    let new_proto = ordinary_object_create(&agent, None, &[]);
+    let result = obj_b.o.set_prototype_of(&agent, Some(new_proto));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), false);
     assert_eq!(obj_b.o.common_object_data().borrow().prototype.as_ref(), Some(&proto));
@@ -2170,27 +2153,27 @@ fn set_prototype_of_05() {
 
 #[test]
 fn is_extensible_01() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
-    let result = obj.o.is_extensible(&mut agent);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
+    let result = obj.o.is_extensible(&agent);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), true);
 }
 #[test]
 fn is_extensible_02() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     obj.o.common_object_data().borrow_mut().extensible = false;
-    let result = obj.o.is_extensible(&mut agent);
+    let result = obj.o.is_extensible(&agent);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), false);
 }
 
 #[test]
 fn prevent_extensions_01() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
-    let result = obj.o.prevent_extensions(&mut agent);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
+    let result = obj.o.prevent_extensions(&agent);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), true);
     assert_eq!(obj.o.common_object_data().borrow().extensible, false);
@@ -2198,17 +2181,17 @@ fn prevent_extensions_01() {
 
 #[test]
 fn get_own_property_01() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::String(JSString::from("blue"));
-    let result = obj.o.get_own_property(&mut agent, &key);
+    let result = obj.o.get_own_property(&agent, &key);
     assert!(result.is_ok());
     assert!(result.unwrap().is_none());
 }
 #[test]
 fn get_own_property_02() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::String(JSString::from("blue"));
     let value = ECMAScriptValue::Number(89.0);
     let desc = PotentialPropertyDescriptor {
@@ -2219,9 +2202,9 @@ fn get_own_property_02() {
         get: None,
         set: None,
     };
-    obj.o.define_own_property(&mut agent, key.clone(), desc).unwrap();
+    obj.o.define_own_property(&agent, key.clone(), desc).unwrap();
 
-    let result = obj.o.get_own_property(&mut agent, &key);
+    let result = obj.o.get_own_property(&agent, &key);
     assert!(result.is_ok());
     let maybe_pd = result.unwrap();
     assert!(maybe_pd.is_some());
@@ -2237,14 +2220,14 @@ fn get_own_property_02() {
 
 #[test]
 fn set_and_get() {
-    let mut agent = test_agent();
+    let agent = test_agent();
 
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::String(JSString::from("blue"));
     let value = ECMAScriptValue::Number(56.7);
 
-    set(&mut agent, &obj, key.clone(), value, false).unwrap();
-    let result = get(&mut agent, &obj, &key).unwrap();
+    set(&agent, &obj, key.clone(), value, false).unwrap();
+    let result = get(&agent, &obj, &key).unwrap();
 
     assert_eq!(result, ECMAScriptValue::Number(56.7));
 }
@@ -2254,9 +2237,9 @@ mod private_element_find {
     use test_case::test_case;
 
     fn setup() -> (Object, Vec<PrivateName>) {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let obj = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+        let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
 
         let name1 = PrivateName::new("name1");
         let name2 = PrivateName::new("alice");
@@ -2310,7 +2293,7 @@ mod private_field_add {
     use super::*;
     use test_case::test_case;
 
-    fn setup(agent: &mut Agent) -> (Object, Vec<PrivateName>) {
+    fn setup(agent: &Agent) -> (Object, Vec<PrivateName>) {
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let obj = ordinary_object_create(agent, Some(object_proto), &[]);
 
@@ -2340,10 +2323,10 @@ mod private_field_add {
 
     #[test_case(PrivateName::new("orange") => (true, Some(ECMAScriptValue::Null)); "orange")]
     fn normal(name: PrivateName) -> (bool, Option<ECMAScriptValue>) {
-        let mut agent = test_agent();
-        let (obj, _) = setup(&mut agent);
+        let agent = test_agent();
+        let (obj, _) = setup(&agent);
 
-        let result = private_field_add(&mut agent, &obj, name.clone(), ECMAScriptValue::Null);
+        let result = private_field_add(&agent, &obj, name.clone(), ECMAScriptValue::Null);
 
         (
             result.is_ok(),
@@ -2360,11 +2343,11 @@ mod private_field_add {
     #[test_case(1; "second")]
     #[test_case(2; "last")]
     fn previously_added(idx: usize) {
-        let mut agent = test_agent();
-        let (obj, names) = setup(&mut agent);
+        let agent = test_agent();
+        let (obj, names) = setup(&agent);
 
-        let result = private_field_add(&mut agent, &obj, names[idx].clone(), ECMAScriptValue::Null).unwrap_err();
-        assert_eq!(unwind_type_error(&mut agent, result), "PrivateName already defined");
+        let result = private_field_add(&agent, &obj, names[idx].clone(), ECMAScriptValue::Null).unwrap_err();
+        assert_eq!(unwind_type_error(&agent, result), "PrivateName already defined");
     }
 }
 
@@ -2372,7 +2355,7 @@ mod private_method_or_accessor_add {
     use super::*;
     //use test_case::test_case;
 
-    fn setup(agent: &mut Agent) -> (Object, PrivateName) {
+    fn setup(agent: &Agent) -> (Object, PrivateName) {
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let obj = ordinary_object_create(agent, Some(object_proto), &[]);
 
@@ -2390,15 +2373,15 @@ mod private_method_or_accessor_add {
 
     #[test]
     fn add() {
-        let mut agent = test_agent();
-        let (obj, _) = setup(&mut agent);
+        let agent = test_agent();
+        let (obj, _) = setup(&agent);
         let key = PrivateName::new("orange");
         let method = Rc::new(PrivateElement {
             key: key.clone(),
             kind: PrivateElementKind::Method { value: ECMAScriptValue::from(100) },
         });
 
-        private_method_or_accessor_add(&mut agent, &obj, method).unwrap();
+        private_method_or_accessor_add(&agent, &obj, method).unwrap();
         let x = private_element_find(&obj, &key).map(|pe| match &pe.kind {
             PrivateElementKind::Method { value } => value.clone(),
             _ => {
@@ -2410,13 +2393,13 @@ mod private_method_or_accessor_add {
 
     #[test]
     fn replace() {
-        let mut agent = test_agent();
-        let (obj, key) = setup(&mut agent);
+        let agent = test_agent();
+        let (obj, key) = setup(&agent);
         let method =
             Rc::new(PrivateElement { key, kind: PrivateElementKind::Method { value: ECMAScriptValue::from(100) } });
 
-        let err = private_method_or_accessor_add(&mut agent, &obj, method).unwrap_err();
-        assert_eq!(unwind_type_error(&mut agent, err), "PrivateName already defined");
+        let err = private_method_or_accessor_add(&agent, &obj, method).unwrap_err();
+        assert_eq!(unwind_type_error(&agent, err), "PrivateName already defined");
     }
 }
 
@@ -2424,7 +2407,7 @@ mod private_get {
     use super::*;
     use test_case::test_case;
 
-    fn setup(agent: &mut Agent) -> (Object, PrivateName, PrivateName, PrivateName, PrivateName) {
+    fn setup(agent: &Agent) -> (Object, PrivateName, PrivateName, PrivateName, PrivateName) {
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let obj = ordinary_object_create(agent, Some(object_proto), &[]);
 
@@ -2488,8 +2471,8 @@ mod private_get {
     #[test_case(FieldName::NoGetter => Err(String::from("PrivateName has no getter")); "no getter")]
     #[test_case(FieldName::Unavailable => Err(String::from("PrivateName not defined")); "undefined")]
     fn f(field: FieldName) -> Result<ECMAScriptValue, String> {
-        let mut agent = test_agent();
-        let (obj, field_name, method_name, getter_name, nogetter_name) = setup(&mut agent);
+        let agent = test_agent();
+        let (obj, field_name, method_name, getter_name, nogetter_name) = setup(&agent);
 
         let query = match field {
             FieldName::Field => field_name,
@@ -2498,7 +2481,7 @@ mod private_get {
             FieldName::NoGetter => nogetter_name,
             FieldName::Unavailable => PrivateName::new("unavailable"),
         };
-        private_get(&mut agent, &obj, &query).map_err(|e| unwind_type_error(&mut agent, e))
+        private_get(&agent, &obj, &query).map_err(|e| unwind_type_error(&agent, e))
     }
 }
 
@@ -2506,7 +2489,7 @@ mod private_set {
     use super::*;
     use test_case::test_case;
 
-    fn setup(agent: &mut Agent) -> (Object, PrivateName, PrivateName, PrivateName, PrivateName) {
+    fn setup(agent: &Agent) -> (Object, PrivateName, PrivateName, PrivateName, PrivateName) {
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let obj = ordinary_object_create(agent, Some(object_proto), &[]);
 
@@ -2582,8 +2565,8 @@ mod private_set {
     #[test_case(FieldName::NoSetter => Err(String::from("PrivateName has no setter")); "no-setter")]
     #[test_case(FieldName::Unavailable => Err(String::from("PrivateName not defined")); "undefined")]
     fn f(field: FieldName) -> Result<ECMAScriptValue, String> {
-        let mut agent = test_agent();
-        let (obj, field_name, method_name, setter_name, nosetter_name) = setup(&mut agent);
+        let agent = test_agent();
+        let (obj, field_name, method_name, setter_name, nosetter_name) = setup(&agent);
         let new_value = ECMAScriptValue::from("NEW VALUE");
         let query = match field {
             FieldName::Field => field_name,
@@ -2593,9 +2576,9 @@ mod private_set {
             FieldName::Unavailable => PrivateName::new("unavailable"),
         };
 
-        private_set(&mut agent, &obj, &query, new_value).map_err(|e| unwind_type_error(&mut agent, e))?;
+        private_set(&agent, &obj, &query, new_value).map_err(|e| unwind_type_error(&agent, e))?;
 
-        Ok(private_get(&mut agent, &obj, &query).unwrap())
+        Ok(private_get(&agent, &obj, &query).unwrap())
     }
 }
 
@@ -2610,39 +2593,39 @@ mod create_data_property_or_throw {
         use super::*;
         #[test]
         fn string() {
-            let mut agent = test_agent();
-            let obj = ordinary_object_create(&mut agent, None, &[]);
+            let agent = test_agent();
+            let obj = ordinary_object_create(&agent, None, &[]);
 
-            create_data_property_or_throw(&mut agent, &obj, "key", "blue").unwrap();
+            create_data_property_or_throw(&agent, &obj, "key", "blue").unwrap();
 
-            assert_eq!(get(&mut agent, &obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::from("blue"));
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::from("blue"));
         }
         #[test]
         fn boolean() {
-            let mut agent = test_agent();
-            let obj = ordinary_object_create(&mut agent, None, &[]);
+            let agent = test_agent();
+            let obj = ordinary_object_create(&agent, None, &[]);
 
-            create_data_property_or_throw(&mut agent, &obj, "key", true).unwrap();
+            create_data_property_or_throw(&agent, &obj, "key", true).unwrap();
 
-            assert_eq!(get(&mut agent, &obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::from(true));
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::from(true));
         }
         #[test]
         fn value() {
-            let mut agent = test_agent();
-            let obj = ordinary_object_create(&mut agent, None, &[]);
+            let agent = test_agent();
+            let obj = ordinary_object_create(&agent, None, &[]);
 
-            create_data_property_or_throw(&mut agent, &obj, "key", ECMAScriptValue::Null).unwrap();
+            create_data_property_or_throw(&agent, &obj, "key", ECMAScriptValue::Null).unwrap();
 
-            assert_eq!(get(&mut agent, &obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::Null);
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::Null);
         }
         #[test]
         fn integer() {
-            let mut agent = test_agent();
-            let obj = ordinary_object_create(&mut agent, None, &[]);
+            let agent = test_agent();
+            let obj = ordinary_object_create(&agent, None, &[]);
 
-            create_data_property_or_throw(&mut agent, &obj, "key", 10).unwrap();
+            create_data_property_or_throw(&agent, &obj, "key", 10).unwrap();
 
-            assert_eq!(get(&mut agent, &obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::from(10));
+            assert_eq!(get(&agent, &obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::from(10));
         }
     }
 
@@ -2650,43 +2633,43 @@ mod create_data_property_or_throw {
         use super::*;
         #[test]
         fn string() {
-            let mut agent = test_agent();
-            let obj = ordinary_object_create(&mut agent, None, &[]);
-            obj.o.prevent_extensions(&mut agent).unwrap();
+            let agent = test_agent();
+            let obj = ordinary_object_create(&agent, None, &[]);
+            obj.o.prevent_extensions(&agent).unwrap();
 
-            let err = create_data_property_or_throw(&mut agent, &obj, "key", "blue").unwrap_err();
+            let err = create_data_property_or_throw(&agent, &obj, "key", "blue").unwrap_err();
 
-            assert_eq!(unwind_type_error(&mut agent, err), "Unable to create data property");
+            assert_eq!(unwind_type_error(&agent, err), "Unable to create data property");
         }
         #[test]
         fn boolean() {
-            let mut agent = test_agent();
-            let obj = ordinary_object_create(&mut agent, None, &[]);
-            obj.o.prevent_extensions(&mut agent).unwrap();
+            let agent = test_agent();
+            let obj = ordinary_object_create(&agent, None, &[]);
+            obj.o.prevent_extensions(&agent).unwrap();
 
-            let err = create_data_property_or_throw(&mut agent, &obj, "key", true).unwrap_err();
+            let err = create_data_property_or_throw(&agent, &obj, "key", true).unwrap_err();
 
-            assert_eq!(unwind_type_error(&mut agent, err), "Unable to create data property");
+            assert_eq!(unwind_type_error(&agent, err), "Unable to create data property");
         }
         #[test]
         fn value() {
-            let mut agent = test_agent();
-            let obj = ordinary_object_create(&mut agent, None, &[]);
-            obj.o.prevent_extensions(&mut agent).unwrap();
+            let agent = test_agent();
+            let obj = ordinary_object_create(&agent, None, &[]);
+            obj.o.prevent_extensions(&agent).unwrap();
 
-            let err = create_data_property_or_throw(&mut agent, &obj, "key", ECMAScriptValue::Null).unwrap_err();
+            let err = create_data_property_or_throw(&agent, &obj, "key", ECMAScriptValue::Null).unwrap_err();
 
-            assert_eq!(unwind_type_error(&mut agent, err), "Unable to create data property");
+            assert_eq!(unwind_type_error(&agent, err), "Unable to create data property");
         }
         #[test]
         fn integer() {
-            let mut agent = test_agent();
-            let obj = ordinary_object_create(&mut agent, None, &[]);
-            obj.o.prevent_extensions(&mut agent).unwrap();
+            let agent = test_agent();
+            let obj = ordinary_object_create(&agent, None, &[]);
+            obj.o.prevent_extensions(&agent).unwrap();
 
-            let err = create_data_property_or_throw(&mut agent, &obj, "key", 10).unwrap_err();
+            let err = create_data_property_or_throw(&agent, &obj, "key", 10).unwrap_err();
 
-            assert_eq!(unwind_type_error(&mut agent, err), "Unable to create data property");
+            assert_eq!(unwind_type_error(&agent, err), "Unable to create data property");
         }
     }
 
@@ -2694,39 +2677,39 @@ mod create_data_property_or_throw {
         use super::*;
         #[test]
         fn string() {
-            let mut agent = test_agent();
-            let obj = TestObject::object(&mut agent, &[FunctionId::DefineOwnProperty(None)]);
+            let agent = test_agent();
+            let obj = TestObject::object(&agent, &[FunctionId::DefineOwnProperty(None)]);
 
-            let err = create_data_property_or_throw(&mut agent, &obj, "key", "blue").unwrap_err();
+            let err = create_data_property_or_throw(&agent, &obj, "key", "blue").unwrap_err();
 
-            assert_eq!(unwind_type_error(&mut agent, err), "[[DefineOwnProperty]] called on TestObject");
+            assert_eq!(unwind_type_error(&agent, err), "[[DefineOwnProperty]] called on TestObject");
         }
         #[test]
         fn boolean() {
-            let mut agent = test_agent();
-            let obj = TestObject::object(&mut agent, &[FunctionId::DefineOwnProperty(None)]);
+            let agent = test_agent();
+            let obj = TestObject::object(&agent, &[FunctionId::DefineOwnProperty(None)]);
 
-            let err = create_data_property_or_throw(&mut agent, &obj, "key", true).unwrap_err();
+            let err = create_data_property_or_throw(&agent, &obj, "key", true).unwrap_err();
 
-            assert_eq!(unwind_type_error(&mut agent, err), "[[DefineOwnProperty]] called on TestObject");
+            assert_eq!(unwind_type_error(&agent, err), "[[DefineOwnProperty]] called on TestObject");
         }
         #[test]
         fn value() {
-            let mut agent = test_agent();
-            let obj = TestObject::object(&mut agent, &[FunctionId::DefineOwnProperty(None)]);
+            let agent = test_agent();
+            let obj = TestObject::object(&agent, &[FunctionId::DefineOwnProperty(None)]);
 
-            let err = create_data_property_or_throw(&mut agent, &obj, "key", ECMAScriptValue::Null).unwrap_err();
+            let err = create_data_property_or_throw(&agent, &obj, "key", ECMAScriptValue::Null).unwrap_err();
 
-            assert_eq!(unwind_type_error(&mut agent, err), "[[DefineOwnProperty]] called on TestObject");
+            assert_eq!(unwind_type_error(&agent, err), "[[DefineOwnProperty]] called on TestObject");
         }
         #[test]
         fn integer() {
-            let mut agent = test_agent();
-            let obj = TestObject::object(&mut agent, &[FunctionId::DefineOwnProperty(None)]);
+            let agent = test_agent();
+            let obj = TestObject::object(&agent, &[FunctionId::DefineOwnProperty(None)]);
 
-            let err = create_data_property_or_throw(&mut agent, &obj, "key", 10).unwrap_err();
+            let err = create_data_property_or_throw(&agent, &obj, "key", 10).unwrap_err();
 
-            assert_eq!(unwind_type_error(&mut agent, err), "[[DefineOwnProperty]] called on TestObject");
+            assert_eq!(unwind_type_error(&agent, err), "[[DefineOwnProperty]] called on TestObject");
         }
     }
 }
@@ -2735,7 +2718,7 @@ mod from_property_descriptor {
     use super::*;
     use test_case::test_case;
 
-    fn maybeprop(agent: &mut Agent, obj: &Object, key: impl Into<PropertyKey>) -> Option<ECMAScriptValue> {
+    fn maybeprop(agent: &Agent, obj: &Object, key: impl Into<PropertyKey>) -> Option<ECMAScriptValue> {
         let key = key.into();
         if has_property(agent, obj, &key).unwrap() {
             Some(get(agent, obj, &key).unwrap())
@@ -2782,14 +2765,14 @@ mod from_property_descriptor {
         configurable:ECMAScriptValue::from(true)
     }); "standard accessor")]
     fn happy(pd: Option<PropertyDescriptor>) -> Option<TestResult> {
-        let mut agent = test_agent();
-        from_property_descriptor(&mut agent, pd).map(|o| TestResult {
-            value: maybeprop(&mut agent, &o, "value"),
-            writable: maybeprop(&mut agent, &o, "writable"),
-            get: maybeprop(&mut agent, &o, "get"),
-            set: maybeprop(&mut agent, &o, "set"),
-            enumerable: maybeprop(&mut agent, &o, "enumerable").unwrap(),
-            configurable: maybeprop(&mut agent, &o, "configurable").unwrap(),
+        let agent = test_agent();
+        from_property_descriptor(&agent, pd).map(|o| TestResult {
+            value: maybeprop(&agent, &o, "value"),
+            writable: maybeprop(&agent, &o, "writable"),
+            get: maybeprop(&agent, &o, "get"),
+            set: maybeprop(&agent, &o, "set"),
+            enumerable: maybeprop(&agent, &o, "enumerable").unwrap(),
+            configurable: maybeprop(&agent, &o, "configurable").unwrap(),
         })
     }
 }
@@ -2798,7 +2781,7 @@ mod to_property_descriptor {
     use super::*;
     use test_case::test_case;
 
-    fn happy_data(agent: &mut Agent) -> ECMAScriptValue {
+    fn happy_data(agent: &Agent) -> ECMAScriptValue {
         let obj = ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
         create_data_property_or_throw(agent, &obj, "value", "blue").unwrap();
         create_data_property_or_throw(agent, &obj, "writable", true).unwrap();
@@ -2806,7 +2789,7 @@ mod to_property_descriptor {
         create_data_property_or_throw(agent, &obj, "configurable", true).unwrap();
         ECMAScriptValue::from(obj)
     }
-    fn fcn_data(agent: &mut Agent) -> ECMAScriptValue {
+    fn fcn_data(agent: &Agent) -> ECMAScriptValue {
         let obj = ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
         create_data_property_or_throw(agent, &obj, "get", ECMAScriptValue::Undefined).unwrap();
         create_data_property_or_throw(agent, &obj, "set", ECMAScriptValue::Undefined).unwrap();
@@ -2816,7 +2799,7 @@ mod to_property_descriptor {
     }
 
     fn faux_errors(
-        agent: &mut Agent,
+        agent: &Agent,
         _this_value: ECMAScriptValue,
         _new_target: Option<&Object>,
         _arguments: &[ECMAScriptValue],
@@ -2840,17 +2823,17 @@ mod to_property_descriptor {
         enumerable: Some(true),
         configurable: Some(true),
     }; "normal accessor")]
-    fn happy(create_input: fn(&mut Agent) -> ECMAScriptValue) -> PotentialPropertyDescriptor {
-        let mut agent = test_agent();
-        let input = create_input(&mut agent);
-        let result = to_property_descriptor(&mut agent, &input);
+    fn happy(create_input: fn(&Agent) -> ECMAScriptValue) -> PotentialPropertyDescriptor {
+        let agent = test_agent();
+        let input = create_input(&agent);
+        let result = to_property_descriptor(&agent, &input);
         result.unwrap()
     }
 
-    fn create_hasprop_error(agent: &mut Agent, name: &str) -> ECMAScriptValue {
+    fn create_hasprop_error(agent: &Agent, name: &str) -> ECMAScriptValue {
         ECMAScriptValue::from(TestObject::object(agent, &[FunctionId::GetOwnProperty(Some(PropertyKey::from(name)))]))
     }
-    fn create_getter_error(agent: &mut Agent, name: &str) -> ECMAScriptValue {
+    fn create_getter_error(agent: &Agent, name: &str) -> ECMAScriptValue {
         let realm = agent.current_realm_record().unwrap();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let obj = ordinary_object_create(agent, Some(object_prototype), &[]);
@@ -2876,7 +2859,7 @@ mod to_property_descriptor {
         define_property_or_throw(agent, &obj, key, desc).unwrap();
         ECMAScriptValue::from(obj)
     }
-    fn create_nonfcn(agent: &mut Agent, name: &str) -> ECMAScriptValue {
+    fn create_nonfcn(agent: &Agent, name: &str) -> ECMAScriptValue {
         let obj = ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
         create_data_property_or_throw(agent, &obj, name, name).unwrap();
         ECMAScriptValue::from(obj)
@@ -2897,11 +2880,11 @@ mod to_property_descriptor {
     #[test_case(|a| create_getter_error(a, "set") => "Test Sentinel"; "set getter throws")]
     #[test_case(|a| create_nonfcn(a, "get") => "Getter must be callable (or undefined)"; "uncallable getter")]
     #[test_case(|a| create_nonfcn(a, "set") => "Setter must be callable (or undefined)"; "uncallable setter")]
-    fn error(create_input: fn(&mut Agent) -> ECMAScriptValue) -> String {
-        let mut agent = test_agent();
-        let input = create_input(&mut agent);
-        let result = to_property_descriptor(&mut agent, &input);
-        unwind_type_error(&mut agent, result.unwrap_err())
+    fn error(create_input: fn(&Agent) -> ECMAScriptValue) -> String {
+        let agent = test_agent();
+        let input = create_input(&agent);
+        let result = to_property_descriptor(&agent, &input);
+        unwind_type_error(&agent, result.unwrap_err())
     }
 }
 
@@ -2959,8 +2942,8 @@ mod create_array_from_list {
         },
     ]; "some items")]
     fn cafl(items: &[ECMAScriptValue]) -> Vec<PropertyInfo> {
-        let mut agent = test_agent();
-        create_array_from_list(&mut agent, items).o.common_object_data().borrow().propdump()
+        let agent = test_agent();
+        create_array_from_list(&agent, items).o.common_object_data().borrow().propdump()
     }
 }
 
@@ -2968,10 +2951,10 @@ mod enumerable_own_property_names {
     use super::*;
     use test_case::test_case;
 
-    fn dead(agent: &mut Agent) -> Object {
+    fn dead(agent: &Agent) -> Object {
         DeadObject::object(agent)
     }
-    fn normal(agent: &mut Agent) -> Object {
+    fn normal(agent: &Agent) -> Object {
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let obj = ordinary_object_create(agent, Some(object_proto), &[]);
         create_data_property_or_throw(agent, &obj, "one", 1.0).unwrap();
@@ -2994,7 +2977,7 @@ mod enumerable_own_property_names {
         obj
     }
     fn gop_override(
-        agent: &mut Agent,
+        agent: &Agent,
         this: &AdaptableObject,
         key: &PropertyKey,
     ) -> Completion<Option<PropertyDescriptor>> {
@@ -3005,7 +2988,7 @@ mod enumerable_own_property_names {
             Err(create_type_error(agent, "[[GetOwnProperty]] called more than once"))
         }
     }
-    fn ownprop(agent: &mut Agent) -> Object {
+    fn ownprop(agent: &Agent) -> Object {
         let obj = AdaptableObject::object(
             agent,
             AdaptableMethods { get_own_property_override: Some(gop_override), ..Default::default() },
@@ -3013,15 +2996,15 @@ mod enumerable_own_property_names {
         create_data_property_or_throw(agent, &obj, "one", 1.0).unwrap();
         obj
     }
-    fn getthrows(agent: &mut Agent) -> Object {
+    fn getthrows(agent: &Agent) -> Object {
         let obj = TestObject::object(agent, &[FunctionId::Get(None)]);
         create_data_property_or_throw(agent, &obj, "one", 1.0).unwrap();
         obj
     }
-    fn lying_ownprops(_: &mut Agent, _: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
+    fn lying_ownprops(_: &Agent, _: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
         Ok(vec!["one".into(), "two".into(), "three".into()])
     }
-    fn lyingkeys(agent: &mut Agent) -> Object {
+    fn lyingkeys(agent: &Agent) -> Object {
         AdaptableObject::object(
             agent,
             AdaptableMethods { own_property_keys_override: Some(lying_ownprops), ..Default::default() },
@@ -3034,24 +3017,24 @@ mod enumerable_own_property_names {
     #[test_case(ownprop, EnumerationStyle::Value => Err("TypeError: [[GetOwnProperty]] called more than once".to_string()); "GetOwnProperty throws")]
     #[test_case(getthrows, EnumerationStyle::Value => Err("TypeError: [[Get]] called on TestObject".to_string()); "get throws")]
     #[test_case(lyingkeys, EnumerationStyle::Value => Ok(Vec::<ECMAScriptValue>::new()); "ownkeys lies")]
-    fn f(make_obj: fn(&mut Agent) -> Object, kind: EnumerationStyle) -> Result<Vec<ECMAScriptValue>, String> {
-        let mut agent = test_agent();
-        let obj = make_obj(&mut agent);
-        enumerable_own_property_names(&mut agent, &obj, kind).map_err(|err| unwind_any_error(&mut agent, err))
+    fn f(make_obj: fn(&Agent) -> Object, kind: EnumerationStyle) -> Result<Vec<ECMAScriptValue>, String> {
+        let agent = test_agent();
+        let obj = make_obj(&agent);
+        enumerable_own_property_names(&agent, &obj, kind).map_err(|err| unwind_any_error(&agent, err))
     }
 
     #[test]
     fn keyvalue() {
-        let mut agent = test_agent();
-        let obj = normal(&mut agent);
-        let result = enumerable_own_property_names(&mut agent, &obj, EnumerationStyle::KeyPlusValue).unwrap();
+        let agent = test_agent();
+        let obj = normal(&agent);
+        let result = enumerable_own_property_names(&agent, &obj, EnumerationStyle::KeyPlusValue).unwrap();
         assert_eq!(result.len(), 2);
-        assert_eq!(getv(&mut agent, &result[0], &"0".into()).unwrap(), "one".into());
-        assert_eq!(getv(&mut agent, &result[0], &"1".into()).unwrap(), 1.0.into());
-        assert_eq!(getv(&mut agent, &result[0], &"length".into()).unwrap(), 2.0.into());
-        assert_eq!(getv(&mut agent, &result[1], &"0".into()).unwrap(), "three".into());
-        assert_eq!(getv(&mut agent, &result[1], &"1".into()).unwrap(), 3.0.into());
-        assert_eq!(getv(&mut agent, &result[1], &"length".into()).unwrap(), 2.0.into());
+        assert_eq!(getv(&agent, &result[0], &"0".into()).unwrap(), "one".into());
+        assert_eq!(getv(&agent, &result[0], &"1".into()).unwrap(), 1.0.into());
+        assert_eq!(getv(&agent, &result[0], &"length".into()).unwrap(), 2.0.into());
+        assert_eq!(getv(&agent, &result[1], &"0".into()).unwrap(), "three".into());
+        assert_eq!(getv(&agent, &result[1], &"1".into()).unwrap(), 3.0.into());
+        assert_eq!(getv(&agent, &result[1], &"length".into()).unwrap(), 2.0.into());
     }
 }
 
@@ -3059,7 +3042,7 @@ mod set_integrity_level {
     use super::*;
     use test_case::test_case;
 
-    fn normal(agent: &mut Agent) -> Object {
+    fn normal(agent: &Agent) -> Object {
         let proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let obj = ordinary_object_create(agent, Some(proto), &[]);
         create_data_property_or_throw(agent, &obj, "property", 67).unwrap();
@@ -3078,19 +3061,19 @@ mod set_integrity_level {
         .unwrap();
         obj
     }
-    fn dead(agent: &mut Agent) -> Object {
+    fn dead(agent: &Agent) -> Object {
         DeadObject::object(agent)
     }
-    fn prevention_disabled(agent: &mut Agent) -> Object {
+    fn prevention_disabled(agent: &Agent) -> Object {
         AdaptableObject::object(
             agent,
             AdaptableMethods { prevent_extensions_override: Some(|_, _| Ok(false)), ..Default::default() },
         )
     }
-    fn opk_throws(agent: &mut Agent) -> Object {
+    fn opk_throws(agent: &Agent) -> Object {
         TestObject::object(agent, &[FunctionId::OwnPropertyKeys])
     }
-    fn dop_throws(agent: &mut Agent) -> Object {
+    fn dop_throws(agent: &Agent) -> Object {
         let obj = AdaptableObject::object(
             agent,
             AdaptableMethods {
@@ -3109,7 +3092,7 @@ mod set_integrity_level {
         obj
     }
     fn gop_override(
-        agent: &mut Agent,
+        agent: &Agent,
         this: &AdaptableObject,
         key: &PropertyKey,
     ) -> Completion<Option<PropertyDescriptor>> {
@@ -3120,7 +3103,7 @@ mod set_integrity_level {
             Err(create_type_error(agent, "[[GetOwnProperty]] called more than once"))
         }
     }
-    fn gop_throws(agent: &mut Agent) -> Object {
+    fn gop_throws(agent: &Agent) -> Object {
         let obj = AdaptableObject::object(
             agent,
             AdaptableMethods { get_own_property_override: Some(gop_override), ..Default::default() },
@@ -3128,10 +3111,10 @@ mod set_integrity_level {
         create_data_property_or_throw(agent, &obj, "one", 1.0).unwrap();
         obj
     }
-    fn lying_ownprops(_: &mut Agent, _: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
+    fn lying_ownprops(_: &Agent, _: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
         Ok(vec!["one".into(), "two".into(), "three".into()])
     }
-    fn lyingkeys(agent: &mut Agent) -> Object {
+    fn lyingkeys(agent: &Agent) -> Object {
         AdaptableObject::object(
             agent,
             AdaptableMethods { own_property_keys_override: Some(lying_ownprops), ..Default::default() },
@@ -3185,12 +3168,12 @@ mod set_integrity_level {
     #[test_case(dop_throws, IntegrityLevel::Frozen => Err("TypeError: Test Sentinel".to_string()); "Frozen: DefineOwn throws")]
     #[test_case(gop_throws, IntegrityLevel::Frozen => Err("TypeError: [[GetOwnProperty]] called more than once".to_string()); "GetOwnProp throws")]
     #[test_case(lyingkeys, IntegrityLevel::Frozen => Ok((true, Vec::<PropertyInfo>::new())); "lying own property keys")]
-    fn sil(make_obj: fn(&mut Agent) -> Object, level: IntegrityLevel) -> Result<(bool, Vec<PropertyInfo>), String> {
-        let mut agent = test_agent();
-        let obj = make_obj(&mut agent);
-        set_integrity_level(&mut agent, &obj, level)
+    fn sil(make_obj: fn(&Agent) -> Object, level: IntegrityLevel) -> Result<(bool, Vec<PropertyInfo>), String> {
+        let agent = test_agent();
+        let obj = make_obj(&agent);
+        set_integrity_level(&agent, &obj, level)
             .map(|success| (success, obj.o.common_object_data().borrow().propdump()))
-            .map_err(|err| unwind_any_error(&mut agent, err))
+            .map_err(|err| unwind_any_error(&agent, err))
     }
 }
 
@@ -3198,16 +3181,16 @@ mod ordinary_has_instance {
     use super::*;
     use test_case::test_case;
 
-    type ValueMaker = fn(&mut Agent) -> ECMAScriptValue;
+    type ValueMaker = fn(&Agent) -> ECMAScriptValue;
 
-    fn undef(_: &mut Agent) -> ECMAScriptValue {
+    fn undef(_: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::Undefined
     }
-    fn bool_class(agent: &mut Agent) -> ECMAScriptValue {
+    fn bool_class(agent: &Agent) -> ECMAScriptValue {
         let boolean = agent.intrinsic(IntrinsicId::Boolean);
         ECMAScriptValue::from(boolean)
     }
-    fn basic_constructor(agent: &mut Agent) -> Object {
+    fn basic_constructor(agent: &Agent) -> Object {
         let realm = agent.current_realm_record();
         let function_prototype = agent.intrinsic(IntrinsicId::FunctionPrototype);
         create_builtin_function(
@@ -3222,7 +3205,7 @@ mod ordinary_has_instance {
             None,
         )
     }
-    fn ungettable_prototype(agent: &mut Agent) -> ECMAScriptValue {
+    fn ungettable_prototype(agent: &Agent) -> ECMAScriptValue {
         let throw = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError));
         let constructor = basic_constructor(agent);
         define_property_or_throw(
@@ -3235,7 +3218,7 @@ mod ordinary_has_instance {
 
         ECMAScriptValue::from(constructor)
     }
-    fn nonobject_prototype(agent: &mut Agent) -> ECMAScriptValue {
+    fn nonobject_prototype(agent: &Agent) -> ECMAScriptValue {
         let constructor = basic_constructor(agent);
         define_property_or_throw(
             agent,
@@ -3251,20 +3234,20 @@ mod ordinary_has_instance {
 
         ECMAScriptValue::from(constructor)
     }
-    fn dead_object(agent: &mut Agent) -> ECMAScriptValue {
+    fn dead_object(agent: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::from(DeadObject::object(agent))
     }
-    fn empty_object(agent: &mut Agent) -> ECMAScriptValue {
+    fn empty_object(agent: &Agent) -> ECMAScriptValue {
         let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         ECMAScriptValue::from(ordinary_object_create(agent, Some(obj_proto), &[]))
     }
-    fn bool_child(agent: &mut Agent) -> ECMAScriptValue {
+    fn bool_child(agent: &Agent) -> ECMAScriptValue {
         let bool_constructor = agent.intrinsic(IntrinsicId::Boolean);
         ordinary_create_from_constructor(agent, &bool_constructor, IntrinsicId::BooleanPrototype, BOOLEAN_OBJECT_SLOTS)
             .unwrap()
             .into()
     }
-    fn bool_grandchild(agent: &mut Agent) -> ECMAScriptValue {
+    fn bool_grandchild(agent: &Agent) -> ECMAScriptValue {
         let bool_constructor = agent.intrinsic(IntrinsicId::Boolean);
         let bool_child = ordinary_create_from_constructor(
             agent,
@@ -3286,11 +3269,11 @@ mod ordinary_has_instance {
     #[test_case(bool_class, bool_child => Ok(true); "true instance via prototype chain (child)")]
     #[test_case(bool_class, bool_grandchild => Ok(true); "true instance via prototype chain (grandchild)")]
     fn ordinary_has_instance(make_c: ValueMaker, make_o: ValueMaker) -> Result<bool, String> {
-        let mut agent = test_agent();
-        let c = make_c(&mut agent);
-        let o = make_o(&mut agent);
+        let agent = test_agent();
+        let c = make_c(&agent);
+        let o = make_o(&agent);
 
-        agent.ordinary_has_instance(&c, &o).map_err(|completion| unwind_any_error(&mut agent, completion))
+        agent.ordinary_has_instance(&c, &o).map_err(|completion| unwind_any_error(&agent, completion))
     }
 }
 

--- a/src/object_object/mod.rs
+++ b/src/object_object/mod.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 //
 //      1. Return ? ToObject(this value).
 fn object_prototype_value_of(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -45,7 +45,7 @@ fn object_prototype_value_of(
 //            for other kinds of built-in or program defined objects. In addition, programs can use @@toStringTag in
 //            ways that will invalidate the reliability of such legacy type tests.
 fn object_prototype_to_string(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -90,7 +90,7 @@ fn object_prototype_to_string(
     Ok(ECMAScriptValue::from(result_vec))
 }
 
-pub fn provision_object_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_object_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -253,7 +253,7 @@ pub fn provision_object_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>)
 //  3. Return ! ToObject(value).
 // The "length" property of the Object function is 1𝔽.
 fn object_constructor_function(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -296,7 +296,7 @@ fn object_constructor_function(
 //
 // The "length" property of the assign function is 2𝔽.
 fn object_assign(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -333,7 +333,7 @@ fn object_assign(
 //      a. Return ? ObjectDefineProperties(obj, Properties).
 //  4. Return obj.
 fn object_create(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -376,7 +376,7 @@ fn object_create(
 //      c. Perform ? DefinePropertyOrThrow(O, P, desc).
 //  6. Return O.
 fn object_define_properties_helper(
-    agent: &mut Agent,
+    agent: &Agent,
     o: Object,
     properties: ECMAScriptValue,
 ) -> Completion<ECMAScriptValue> {
@@ -408,7 +408,7 @@ fn object_define_properties_helper(
 //  1. If Type(O) is not Object, throw a TypeError exception.
 //  2. Return ? ObjectDefineProperties(O, Properties).
 fn object_define_properties(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -435,7 +435,7 @@ fn object_define_properties(
 //  4. Perform ? DefinePropertyOrThrow(O, key, desc).
 //  5. Return O.
 fn object_define_property(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -468,7 +468,7 @@ fn object_define_property(
 //
 // https://tc39.es/ecma262/#sec-object.entries
 fn object_entries(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -491,7 +491,7 @@ fn object_entries(
 //
 // https://tc39.es/ecma262/#sec-object.freeze
 fn object_freeze(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -512,7 +512,7 @@ fn object_freeze(
 }
 
 fn object_from_entries(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -520,7 +520,7 @@ fn object_from_entries(
     todo!()
 }
 fn object_get_own_property_descriptor(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -528,7 +528,7 @@ fn object_get_own_property_descriptor(
     todo!()
 }
 fn object_get_own_property_descriptors(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -536,7 +536,7 @@ fn object_get_own_property_descriptors(
     todo!()
 }
 fn object_get_own_property_names(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -544,7 +544,7 @@ fn object_get_own_property_names(
     todo!()
 }
 fn object_get_own_property_symbols(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -552,7 +552,7 @@ fn object_get_own_property_symbols(
     todo!()
 }
 fn object_get_prototype_of(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -560,7 +560,7 @@ fn object_get_prototype_of(
     todo!()
 }
 fn object_has_own(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -568,7 +568,7 @@ fn object_has_own(
     todo!()
 }
 fn object_is(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -576,7 +576,7 @@ fn object_is(
     todo!()
 }
 fn object_is_extensible(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -584,7 +584,7 @@ fn object_is_extensible(
     todo!()
 }
 fn object_is_frozen(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -592,7 +592,7 @@ fn object_is_frozen(
     todo!()
 }
 fn object_is_sealed(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -600,7 +600,7 @@ fn object_is_sealed(
     todo!()
 }
 fn object_keys(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -608,7 +608,7 @@ fn object_keys(
     todo!()
 }
 fn object_prevent_extensions(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -616,7 +616,7 @@ fn object_prevent_extensions(
     todo!()
 }
 fn object_seal(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -624,7 +624,7 @@ fn object_seal(
     todo!()
 }
 fn object_set_prototype_of(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -632,7 +632,7 @@ fn object_set_prototype_of(
     todo!()
 }
 fn object_values(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -640,7 +640,7 @@ fn object_values(
     todo!()
 }
 fn object_prototype_has_own_property(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -648,7 +648,7 @@ fn object_prototype_has_own_property(
     todo!()
 }
 fn object_prototype_is_prototype_of(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -656,7 +656,7 @@ fn object_prototype_is_prototype_of(
     todo!()
 }
 fn object_prototype_property_is_enumerable(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -664,7 +664,7 @@ fn object_prototype_property_is_enumerable(
     todo!()
 }
 fn object_prototype_to_locale_string(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],

--- a/src/parser/additive_operators/mod.rs
+++ b/src/parser/additive_operators/mod.rs
@@ -163,7 +163,7 @@ impl AdditiveExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             AdditiveExpression::MultiplicativeExpression(n) => n.early_errors(agent, errs, strict),
             AdditiveExpression::Add(l, r) | AdditiveExpression::Subtract(l, r) => {

--- a/src/parser/additive_operators/tests.rs
+++ b/src/parser/additive_operators/tests.rs
@@ -153,13 +153,13 @@ mod additive_expression {
     #[test_case("package-3", true => sset(&[PACKAGE_NOT_ALLOWED]); "AE minus ME; AE bad")]
     #[test_case("3-package", true => sset(&[PACKAGE_NOT_ALLOWED]); "AE minus ME; ME bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         AdditiveExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/arrow_function_definitions/mod.rs
+++ b/src/parser/arrow_function_definitions/mod.rs
@@ -94,7 +94,7 @@ impl ArrowFunction {
         self.parameters.contains_arguments() || self.body.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  ArrowFunction : ArrowParameters => ConciseBody
         //  * It is a Syntax Error if ArrowParameters Contains YieldExpression is true.
@@ -276,7 +276,7 @@ impl ArrowParameters {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ArrowParameters::Identifier(id) => id.early_errors(agent, errs, strict),
             ArrowParameters::Formals(afp) => afp.early_errors(agent, errs, strict),
@@ -405,7 +405,7 @@ impl ArrowFormalParameters {
         self.params.is_simple_parameter_list()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.params.early_errors(agent, errs, strict);
     }
 
@@ -566,7 +566,7 @@ impl ConciseBody {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ConciseBody::Expression(exp) => exp.early_errors(agent, errs, strict),
             ConciseBody::Function { body, .. } => body.early_errors(agent, errs, strict),
@@ -686,7 +686,7 @@ impl ExpressionBody {
         self.expression.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.expression.early_errors(agent, errs, strict);
     }
 }

--- a/src/parser/arrow_function_definitions/tests.rs
+++ b/src/parser/arrow_function_definitions/tests.rs
@@ -125,10 +125,10 @@ mod arrow_function {
     #[test_case("a => { let a; }", false => sset(&[A_DUPLICATED]); "param/lex clash")]
     #[test_case("package => { 'use strict'; implements; }", false => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "strict mode trigger")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).arrow_function().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).arrow_function().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("(a=arguments) => a" => true; "left")]
@@ -253,10 +253,10 @@ mod arrow_parameters {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingIdentifier")]
     #[test_case("(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "ArrowFormalParameters")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).arrow_parameters().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).arrow_parameters().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "id")]
@@ -383,10 +383,10 @@ mod concise_body {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "ExpressionBody")]
     #[test_case("{ package; }", true => sset(&[PACKAGE_NOT_ALLOWED]); "{ FunctionBody }")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).concise_body().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).concise_body().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments" => true; "Exp (yes)")]
@@ -480,10 +480,10 @@ mod expression_body {
 
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "AssignmentExpression")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).expression_body().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).expression_body().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments" => true; "yes")]
@@ -571,10 +571,10 @@ mod arrow_formal_parameters {
 
     #[test_case("(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "( UniqueFormalParameters )")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).arrow_formal_parameters().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).arrow_formal_parameters().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("(a=arguments)" => true; "yes")]

--- a/src/parser/assignment_operators/mod.rs
+++ b/src/parser/assignment_operators/mod.rs
@@ -413,7 +413,7 @@ impl AssignmentExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         // AssignmentExpression :
         // LeftHandSideExpression AssignmentOperator AssignmentExpression
@@ -683,7 +683,7 @@ impl AssignmentPattern {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             AssignmentPattern::Object(obj) => obj.early_errors(agent, errs, strict),
             AssignmentPattern::Array(ary) => ary.early_errors(agent, errs, strict),
@@ -878,7 +878,7 @@ impl ObjectAssignmentPattern {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ObjectAssignmentPattern::Empty { .. } => (),
             ObjectAssignmentPattern::RestOnly { arp, .. } => arp.early_errors(agent, errs, strict),
@@ -1128,7 +1128,7 @@ impl ArrayAssignmentPattern {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ArrayAssignmentPattern::RestOnly { are: None, .. } => (),
             ArrayAssignmentPattern::RestOnly { are: Some(are), .. } => are.early_errors(agent, errs, strict),
@@ -1209,7 +1209,7 @@ impl AssignmentRestProperty {
         self.0.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         // AssignmentRestProperty : ... DestructuringAssignmentTarget
         //  * It is a Syntax Error if DestructuringAssignmentTarget is an ArrayLiteral or an ObjectLiteral.
@@ -1331,7 +1331,7 @@ impl AssignmentPropertyList {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             AssignmentPropertyList::Item(item) => item.early_errors(agent, errs, strict),
             AssignmentPropertyList::List(list, item) => {
@@ -1449,7 +1449,7 @@ impl AssignmentElementList {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             AssignmentElementList::Item(item) => item.early_errors(agent, errs, strict),
             AssignmentElementList::List(list, item) => {
@@ -1543,7 +1543,7 @@ impl AssignmentElisionElement {
         self.element.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.element.early_errors(agent, errs, strict);
     }
 }
@@ -1675,7 +1675,7 @@ impl AssignmentProperty {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         // AssignmentProperty : IdentifierReference Initializeropt
         //  * It is a Syntax Error if AssignmentTargetType of IdentifierReference is not simple.
@@ -1799,7 +1799,7 @@ impl AssignmentElement {
         self.target.contains_arguments() || self.initializer.as_ref().map_or(false, |izer| izer.contains_arguments())
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.target.early_errors(agent, errs, strict);
         if let Some(izer) = &self.initializer {
             izer.early_errors(agent, errs, strict);
@@ -1874,7 +1874,7 @@ impl AssignmentRestElement {
         self.0.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.0.early_errors(agent, errs, strict);
     }
 }
@@ -1974,7 +1974,7 @@ impl DestructuringAssignmentTarget {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         // DestructuringAssignmentTarget : LeftHandSideExpression
         //  * If LeftHandSideExpression is an ObjectLiteral or an ArrayLiteral, the following Early Error rules are applied:

--- a/src/parser/assignment_operators/tests.rs
+++ b/src/parser/assignment_operators/tests.rs
@@ -376,13 +376,13 @@ mod assignment_expression {
     #[test_case("(a=>a)||=b", true => sset(&[INVALID_LHS]); "LHS must be simple (logical or)")]
     #[test_case("(a=>a)??=b", true => sset(&[INVALID_LHS]); "LHS must be simple (coalesce)")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         AssignmentExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]
@@ -682,13 +682,13 @@ mod assignment_pattern {
     #[test_case("{package}", true => sset(&[PACKAGE_NOT_ALLOWED]); "ObjectAssignmentPattern")]
     #[test_case("[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "ArrayAssignmentPattern")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         AssignmentPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("[arguments]" => true; "array (yes)")]
@@ -810,13 +810,13 @@ mod object_assignment_pattern {
     #[test_case("{package,}", true => sset(&[PACKAGE_NOT_ALLOWED]); "{ AssignmentPropertyList , } (trailing comma)")]
     #[test_case("{package,...interface}", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "{ AssignmentPropertyList , AssignmentRestProperty }")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ObjectAssignmentPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("{}" => false; "empty")]
@@ -994,13 +994,13 @@ mod array_assignment_pattern {
     #[test_case("[package,...interface]", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "[ AssignmentElementList , AssignmentRestElement ]")]
     #[test_case("[package,,...interface]", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "[ AssignmentElementList , Elision AssignmentRestElement ]")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ArrayAssignmentPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("[]" => false; "Empty")]
@@ -1085,13 +1085,13 @@ mod assignment_rest_property {
     #[test_case("...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "... DestructuringAssignmentTarget")]
     #[test_case("...{a}", true => sset(&["`...` must be followed by an assignable reference in assignment contexts"]); "assignable refs")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         AssignmentRestProperty::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("...arguments" => true; "Rest (yes)")]
@@ -1166,13 +1166,13 @@ mod assignment_property_list {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "AssignmentProperty")]
     #[test_case("package,interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "AssignmentPropertyList , AssignmentProperty")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         AssignmentPropertyList::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments" => true; "Item (yes)")]
@@ -1250,13 +1250,13 @@ mod assignment_element_list {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "AssignmentElisionElement")]
     #[test_case("package,interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "AssignmentElementList , AssignmentElisionElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         AssignmentElementList::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments" => true; "Item (yes)")]
@@ -1331,13 +1331,13 @@ mod assignment_elision_element {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "AssignmentElement")]
     #[test_case(",package", true => sset(&[PACKAGE_NOT_ALLOWED]); "Elision AssignmentElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         AssignmentElisionElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments" => true; "Item (yes)")]
@@ -1428,13 +1428,13 @@ mod assignment_property {
     #[test_case("package=interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "IdentifierReference Initializer")]
     #[test_case("[package]:interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "PropertyName : AssignmentElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         AssignmentProperty::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments" => true; "id (yes)")]
@@ -1517,13 +1517,13 @@ mod assignment_element {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "DestructuringAssignmentTarget")]
     #[test_case("package=interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "DestructuringAssignmentTarget Initializer")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         AssignmentElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments" => true; "Item (yes)")]
@@ -1584,13 +1584,13 @@ mod assignment_rest_element {
 
     #[test_case("...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "... DestructuringAssignmentTarget")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         AssignmentRestElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("...arguments" => true; "yes")]
@@ -1666,13 +1666,13 @@ mod destructuring_assignment_target {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "lhs")]
     #[test_case("(a=>a)", true => sset(&[INVALID_LHS]); "not simple")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         DestructuringAssignmentTarget::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments" => true; "Exp (yes)")]

--- a/src/parser/async_arrow_function_definitions/mod.rs
+++ b/src/parser/async_arrow_function_definitions/mod.rs
@@ -171,7 +171,7 @@ impl AsyncArrowFunction {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -255,7 +255,7 @@ impl AsyncArrowHead {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -378,7 +378,7 @@ impl AsyncConciseBody {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 
@@ -459,7 +459,7 @@ impl AsyncArrowBindingIdentifier {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 
@@ -540,7 +540,7 @@ impl CoverCallExpressionAndAsyncArrowHead {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/async_arrow_function_definitions/tests.rs
+++ b/src/parser/async_arrow_function_definitions/tests.rs
@@ -250,7 +250,7 @@ fn async_arrow_function_test_early_errors() {
     AsyncArrowFunction::parse(&mut newparser("async x => x"), Scanner::new(), true, true, true)
         .unwrap()
         .0
-        .early_errors(&mut test_agent(), &mut vec![], true);
+        .early_errors(&test_agent(), &mut vec![], true);
 }
 
 mod async_arrow_function {
@@ -357,7 +357,7 @@ fn async_concise_body_test_all_private_identifiers_valid(src: &str) -> bool {
 #[should_panic(expected = "not yet implemented")]
 fn async_concise_body_test_early_errors() {
     AsyncConciseBody::parse(&mut newparser("x"), Scanner::new(), true).unwrap().0.early_errors(
-        &mut test_agent(),
+        &test_agent(),
         &mut vec![],
         true,
     );
@@ -414,7 +414,7 @@ fn async_arrow_binding_identifier_test_contains_01() {
 #[should_panic(expected = "not yet implemented")]
 fn async_arrow_binding_identifier_test_early_errors() {
     AsyncArrowBindingIdentifier::parse(&mut newparser("x"), Scanner::new(), true).unwrap().0.early_errors(
-        &mut test_agent(),
+        &test_agent(),
         &mut vec![],
         true,
     );
@@ -503,7 +503,7 @@ fn cceaaah_test_early_errors() {
     CoverCallExpressionAndAsyncArrowHead::parse(&mut newparser("x()"), Scanner::new(), true, true)
         .unwrap()
         .0
-        .early_errors(&mut test_agent(), &mut vec![], true);
+        .early_errors(&test_agent(), &mut vec![], true);
 }
 
 // ASYNC ARROW HEAD
@@ -557,7 +557,7 @@ fn async_arrow_head_test_all_private_identifiers_valid(src: &str) -> bool {
 #[should_panic(expected = "not yet implemented")]
 fn async_arrow_head_test_early_errors() {
     AsyncArrowHead::parse(&mut newparser("async(a)"), Scanner::new()).unwrap().0.early_errors(
-        &mut test_agent(),
+        &test_agent(),
         &mut vec![],
         true,
     );

--- a/src/parser/async_function_definitions/mod.rs
+++ b/src/parser/async_function_definitions/mod.rs
@@ -135,7 +135,7 @@ impl AsyncFunctionDeclaration {
     /// See [Early Errors for Async Function Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-async-function-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         // AsyncFunctionDeclaration :
         //     async function BindingIdentifier ( FormalParameters ) { AsyncFunctionBody }
@@ -361,7 +361,7 @@ impl AsyncFunctionExpression {
     /// See [Early Errors for Async Function Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-async-function-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  AsyncFunctionExpression :
         //      async function BindingIdentifier[opt] ( FormalParameters ) { AsyncFunctionBody }
@@ -597,7 +597,7 @@ impl AsyncMethod {
     /// See [Early Errors for Async Function Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-async-function-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  AsyncMethod : async ClassElementName ( UniqueFormalParameters ) { AsyncFunctionBody }
         //  * It is a Syntax Error if FunctionBodyContainsUseStrict of AsyncFunctionBody is true and
@@ -742,7 +742,7 @@ impl AsyncFunctionBody {
         self.0.lexically_declared_names()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.0.early_errors(agent, errs, strict);
     }
 
@@ -831,7 +831,7 @@ impl AwaitExpression {
         self.exp.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.exp.early_errors(agent, errs, strict);
     }
 

--- a/src/parser/async_function_definitions/tests.rs
+++ b/src/parser/async_function_definitions/tests.rs
@@ -264,13 +264,13 @@ mod async_function_declaration {
     #[test_case("async function package(interface){implements;}", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "without default")]
     #[test_case("async function(package){interface;}", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "with default")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         AsyncFunctionDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("   async function abc() {}" => Location{ starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 23 } }; "typical")]
@@ -471,10 +471,10 @@ mod async_function_expression {
     #[test_case("async function package(interface){implements;}", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "without default")]
     #[test_case("async function(package){interface;}", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "with default")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).async_function_expression().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).async_function_expression().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("async function a(){}" => true; "named")]
@@ -648,13 +648,13 @@ mod async_method {
     #[test_case("async w(a){let a; const bb=0;}", false => sset(&[A_ALREADY_DEFN]); "duplicate lex")]
     #[test_case("async f(a){'use strict'; package;}", false => sset(&[PACKAGE_NOT_ALLOWED]); "directive works")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         AsyncMethod::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("async [arguments](){}" => true; "yes")]
@@ -732,10 +732,10 @@ mod async_function_body {
 
     #[test_case("package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "FunctionBody")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        AsyncFunctionBody::parse(&mut newparser(src), Scanner::new()).0.early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        AsyncFunctionBody::parse(&mut newparser(src), Scanner::new()).0.early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments;" => true; "yes")]
@@ -820,13 +820,13 @@ mod await_expression {
 
     #[test_case("await package", true => sset(&[PACKAGE_NOT_ALLOWED]); "await UnaryExpression")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         AwaitExpression::parse(&mut newparser(src), Scanner::new(), true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("await arguments" => true; "yes")]

--- a/src/parser/async_generator_function_definitions/mod.rs
+++ b/src/parser/async_generator_function_definitions/mod.rs
@@ -121,7 +121,7 @@ impl AsyncGeneratorMethod {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 
@@ -263,7 +263,7 @@ impl AsyncGeneratorDeclaration {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 
@@ -379,7 +379,7 @@ impl AsyncGeneratorExpression {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 
@@ -449,7 +449,7 @@ impl AsyncGeneratorBody {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &mut Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 

--- a/src/parser/async_generator_function_definitions/tests.rs
+++ b/src/parser/async_generator_function_definitions/tests.rs
@@ -181,7 +181,7 @@ mod async_generator_method {
         AsyncGeneratorMethod::parse(&mut newparser("async *a(){}"), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut test_agent(), &mut vec![], true);
+            .early_errors(&test_agent(), &mut vec![], true);
     }
 
     #[test]
@@ -523,7 +523,7 @@ mod async_generator_declaration {
         AsyncGeneratorDeclaration::parse(&mut newparser("async function *a(){}"), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut test_agent(), &mut vec![], true);
+            .early_errors(&test_agent(), &mut vec![], true);
     }
 
     #[test_case("   async function *a(){}" => Location { starting_line: 1, starting_column: 4, span: Span{ starting_index: 3, length: 21 }})]
@@ -754,7 +754,7 @@ mod async_generator_expression {
         AsyncGeneratorExpression::parse(&mut newparser("async function *a(){}"), Scanner::new())
             .unwrap()
             .0
-            .early_errors(&mut test_agent(), &mut vec![], true);
+            .early_errors(&test_agent(), &mut vec![], true);
     }
 
     #[test_case("async function *a(){}" => true; "named")]
@@ -820,7 +820,7 @@ mod async_generator_body {
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
         AsyncGeneratorBody::parse(&mut newparser("yield 3;"), Scanner::new()).0.early_errors(
-            &mut test_agent(),
+            &test_agent(),
             &mut vec![],
             true,
         );

--- a/src/parser/binary_bitwise_operators/mod.rs
+++ b/src/parser/binary_bitwise_operators/mod.rs
@@ -139,7 +139,7 @@ impl BitwiseANDExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             BitwiseANDExpression::EqualityExpression(n) => n.early_errors(agent, errs, strict),
             BitwiseANDExpression::BitwiseAND(l, r) => {
@@ -314,7 +314,7 @@ impl BitwiseXORExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             BitwiseXORExpression::BitwiseANDExpression(n) => n.early_errors(agent, errs, strict),
             BitwiseXORExpression::BitwiseXOR(l, r) => {
@@ -506,7 +506,7 @@ impl BitwiseORExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             BitwiseORExpression::BitwiseXORExpression(n) => n.early_errors(agent, errs, strict),
             BitwiseORExpression::BitwiseOR(l, r) => {

--- a/src/parser/binary_bitwise_operators/tests.rs
+++ b/src/parser/binary_bitwise_operators/tests.rs
@@ -115,13 +115,13 @@ mod bitwise_and_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "fall thru")]
     #[test_case("package&interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "bitwise and")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         BitwiseANDExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]
@@ -266,13 +266,13 @@ mod bitwise_xor_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "fall thru")]
     #[test_case("package^interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "bitwise xor")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         BitwiseXORExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]
@@ -423,13 +423,13 @@ mod bitwise_or_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "fall thru")]
     #[test_case("package|interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "bitwise or")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         BitwiseORExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/binary_logical_operators/mod.rs
+++ b/src/parser/binary_logical_operators/mod.rs
@@ -143,7 +143,7 @@ impl LogicalANDExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             LogicalANDExpression::BitwiseORExpression(n) => n.early_errors(agent, errs, strict),
             LogicalANDExpression::LogicalAND(l, r) => {
@@ -319,7 +319,7 @@ impl LogicalORExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             LogicalORExpression::LogicalANDExpression(n) => n.early_errors(agent, errs, strict),
             LogicalORExpression::LogicalOR(l, r) => {
@@ -473,7 +473,7 @@ impl CoalesceExpression {
         self.head.contains_arguments() || self.tail.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.head.early_errors(agent, errs, strict);
         self.tail.early_errors(agent, errs, strict);
     }
@@ -574,7 +574,7 @@ impl CoalesceExpressionHead {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             CoalesceExpressionHead::CoalesceExpression(n) => n.early_errors(agent, errs, strict),
             CoalesceExpressionHead::BitwiseORExpression(n) => n.early_errors(agent, errs, strict),
@@ -707,7 +707,7 @@ impl ShortCircuitExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ShortCircuitExpression::LogicalORExpression(n) => n.early_errors(agent, errs, strict),
             ShortCircuitExpression::CoalesceExpression(n) => n.early_errors(agent, errs, strict),

--- a/src/parser/binary_logical_operators/tests.rs
+++ b/src/parser/binary_logical_operators/tests.rs
@@ -117,13 +117,13 @@ mod logical_and_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "fall thru")]
     #[test_case("package&&interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "logical and")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         LogicalANDExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]
@@ -278,13 +278,13 @@ mod logical_or_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "fall thru")]
     #[test_case("package||interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "logical or")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         LogicalORExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]
@@ -429,13 +429,13 @@ mod coalesce_expression {
 
     #[test_case("package??interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "coalesce")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         CoalesceExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments??bob" => true; "a coal b (left)")]
@@ -536,12 +536,12 @@ mod coalesce_expression_head {
     #[test_case("package??interface", true => sset(&[PACKAGE_NOT_ALLOWED]); "MultiplicativeExpression")]
     #[test_case("package??interface??q", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "AE plus ME; AE bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         let ce = CoalesceExpression::parse(&mut newparser(src), Scanner::new(), false, true, true).unwrap().0;
         let ceh = &ce.head;
-        ceh.early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        ceh.early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments??bob" => true; "Exp (yes)")]
@@ -659,13 +659,13 @@ mod short_circuit_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "fall thru")]
     #[test_case("package??interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "coalesce")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ShortCircuitExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/bitwise_shift_operators/mod.rs
+++ b/src/parser/bitwise_shift_operators/mod.rs
@@ -172,7 +172,7 @@ impl ShiftExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ShiftExpression::AdditiveExpression(n) => n.early_errors(agent, errs, strict),
             ShiftExpression::LeftShift(l, r)

--- a/src/parser/bitwise_shift_operators/tests.rs
+++ b/src/parser/bitwise_shift_operators/tests.rs
@@ -193,13 +193,13 @@ mod shift_expression {
     #[test_case("package>>>3", true => sset(&[PACKAGE_NOT_ALLOWED]); "left ushr right; left bad")]
     #[test_case("3>>>package", true => sset(&[PACKAGE_NOT_ALLOWED]); "left ushr right; right bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ShiftExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/block/mod.rs
+++ b/src/parser/block/mod.rs
@@ -95,7 +95,7 @@ impl BlockStatement {
 
     pub fn early_errors(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         errs: &mut Vec<Object>,
         strict: bool,
         within_iteration: bool,
@@ -292,7 +292,7 @@ impl Block {
 
     pub fn early_errors(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         errs: &mut Vec<Object>,
         strict: bool,
         within_iteration: bool,
@@ -496,7 +496,7 @@ impl StatementList {
 
     pub fn early_errors(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         errs: &mut Vec<Object>,
         strict: bool,
         within_iteration: bool,
@@ -719,7 +719,7 @@ impl StatementListItem {
 
     pub fn early_errors(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         errs: &mut Vec<Object>,
         strict: bool,
         within_iteration: bool,

--- a/src/parser/block/tests.rs
+++ b/src/parser/block/tests.rs
@@ -89,13 +89,13 @@ mod block_statement {
 
     #[test_case("{package;}", true => sset(&[PACKAGE_NOT_ALLOWED]); "Block")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         BlockStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("{arguments;}" => true; "yes")]
@@ -260,13 +260,13 @@ mod block {
     #[test_case("{ let a = 10; const a = 20; }", true => sset(&[DUPLICATE_LEXICAL]); "Duplicate lexically declared names")]
     #[test_case("{ var x; print(x); let x = 27; }", true => sset(&[LEX_DUPED_BY_VAR]); "Name declared both lex & var")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         Block::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("{arguments;}" => true; "yes")]
@@ -519,13 +519,13 @@ mod statement_list {
     #[test_case("package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "StatementListItem")]
     #[test_case("package;implements;", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "StatementList StatementListItem")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         StatementList::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
     #[test_case("arguments;" => true; "Item (yes)")]
     #[test_case("no;" => false; "Item (no)")]
@@ -778,13 +778,13 @@ mod statement_list_item {
     #[test_case("let package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "Declaration")]
     #[test_case("package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "Statement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         StatementListItem::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments;" => true; "Stmt (yes)")]

--- a/src/parser/break_statement/mod.rs
+++ b/src/parser/break_statement/mod.rs
@@ -84,7 +84,7 @@ impl BreakStatement {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, within_breakable: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, within_breakable: bool) {
         // Static Semantics: Early Errors
         //  BreakStatement : break ;
         //      * It is a Syntax Error if this BreakStatement is not nested, directly or indirectly (but not crossing

--- a/src/parser/break_statement/tests.rs
+++ b/src/parser/break_statement/tests.rs
@@ -112,15 +112,15 @@ mod break_statement {
     #[test_case("break;", true, false => sset(&[ILLEGAL_BREAK]); "break not in a good spot")]
     #[test_case("break package;", true, true => sset(&[PACKAGE_NOT_ALLOWED]); "break LabelIdentifier ;")]
     fn early_errors(src: &str, strict: bool, within_breakable: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         BreakStatement::parse(&mut newparser(src), Scanner::new(), true, true).unwrap().0.early_errors(
-            &mut agent,
+            &agent,
             &mut errs,
             strict,
             within_breakable,
         );
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("   break;" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 6 } }; "no label")]

--- a/src/parser/class_definitions/mod.rs
+++ b/src/parser/class_definitions/mod.rs
@@ -149,7 +149,7 @@ impl ClassDeclaration {
     /// See [Early Errors for Class Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>) {
         if let ClassDeclaration::Named { ident, .. } = self {
             ident.early_errors(agent, errs, true);
         }
@@ -271,7 +271,7 @@ impl ClassExpression {
     /// See [Early Errors for Class Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>) {
         if let Some(name) = &self.ident {
             name.early_errors(agent, errs, true);
         }
@@ -426,7 +426,7 @@ impl ClassTail {
     /// See [Early Errors for Class Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // ClassTail : ClassHeritageopt { ClassBody }
         //  * It is a Syntax Error if ClassHeritage is not present and the following algorithm returns true:
         //
@@ -542,7 +542,7 @@ impl ClassHeritage {
     /// See [Early Errors for Class Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.exp.early_errors(agent, errs, strict);
     }
 }
@@ -633,7 +633,7 @@ impl ClassBody {
     /// See [Early Errors for Class Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // ClassBody : ClassElementList
         //  * It is a Syntax Error if PrototypePropertyNameList of ClassElementList contains more than one occurrence
         //    of "constructor".
@@ -919,7 +919,7 @@ impl ClassElementList {
     /// See [Early Errors for Class Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ClassElementList::Item(ce) => ce.early_errors(agent, errs, strict),
             ClassElementList::List(cel, ce) => {
@@ -1214,7 +1214,7 @@ impl ClassElement {
     /// See [Early Errors for Class Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ClassElement::Standard { method } => {
                 // ClassElement : MethodDefinition
@@ -1474,7 +1474,7 @@ impl FieldDefinition {
     /// See [Early Errors for Class Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // FieldDefinition :
         //  ClassElementName Initializer[opt]
         //  * It is a Syntax Error if Initializer is present and ContainsArguments of Initializer is true.
@@ -1638,7 +1638,7 @@ impl ClassElementName {
     /// See [Early Errors for Class Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ClassElementName::PrivateIdentifier { data: pid, location } => {
                 // ClassElementName : PrivateIdentifier
@@ -1761,7 +1761,7 @@ impl ClassStaticBlock {
     /// See [Early Errors for Class Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.block.early_errors(agent, errs, strict);
     }
 }
@@ -1821,7 +1821,7 @@ impl ClassStaticBlockBody {
     /// See [Early Errors for Class Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  ClassStaticBlockBody : ClassStaticBlockStatementList
         //  * It is a Syntax Error if the LexicallyDeclaredNames of ClassStaticBlockStatementList contains any duplicate
@@ -1975,7 +1975,7 @@ impl ClassStaticBlockStatementList {
     /// See [Early Errors for Class Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         if let ClassStaticBlockStatementList::Statements(sl) = self {
             sl.early_errors(agent, errs, strict, false, false);
         }

--- a/src/parser/class_definitions/tests.rs
+++ b/src/parser/class_definitions/tests.rs
@@ -136,10 +136,10 @@ mod class_declaration {
     #[test_case("class { a=package; }" => sset(&[PACKAGE_NOT_ALLOWED]); "class tail only")]
     #[test_case("class package { a=implements; }" => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "id + tail")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_declaration().early_errors(&mut agent, &mut errs);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).class_declaration().early_errors(&agent, &mut errs);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("class a { [arguments]; }" => true; "named (yes)")]
@@ -252,10 +252,10 @@ mod class_expression {
     #[test_case("class { a=package; }" => sset(&[PACKAGE_NOT_ALLOWED]); "class tail only")]
     #[test_case("class package { a=implements; }" => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "id + tail")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_expression().early_errors(&mut agent, &mut errs);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).class_expression().early_errors(&agent, &mut errs);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("class a { [arguments]; }" => true; "named (yes)")]
@@ -444,10 +444,10 @@ mod class_tail {
     #[test_case("{}" => sset(&[]); "no body")]
 
     fn early_errors(src: &str) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_tail().early_errors(&mut agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).class_tail().early_errors(&agent, &mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("{}" => false; "empty")]
@@ -523,10 +523,10 @@ mod class_heritage {
     #[test_case("extends package" => sset(&[PACKAGE_NOT_ALLOWED]); "err")]
     #[test_case("extends Boolean" => sset(&[]); "ok")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_heritage().early_errors(&mut agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).class_heritage().early_errors(&agent, &mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("extends arguments" => true; "yes")]
@@ -612,10 +612,10 @@ mod class_body {
     #[test_case("static set #a(val){this.val=val;} #a(){}" => sset(&[PREV_STATIC_SETTER]); "static setter / method")]
     #[test_case("static #a(){} get #a(){return this.val;}" => sset(&[PRIVATE_A_ALREADY_DEFN]); "static method / getter")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_body().early_errors(&mut agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).class_body().early_errors(&agent, &mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("[arguments];" => true; "yes")]
@@ -793,10 +793,10 @@ mod class_element_list {
     #[test_case("a=package; b=implements;" => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "list (errs)")]
     #[test_case("a=10; b=20;" => sset(&[]); "list (ok)")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_element_list().early_errors(&mut agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).class_element_list().early_errors(&agent, &mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("[arguments];" => true; "item (yes)")]
@@ -1108,10 +1108,10 @@ mod class_element {
     #[test_case("static prototype;" => sset(&[STATIC_PROTO]); "static proto field")]
     #[test_case("static constructor;" => sset(&[CONSTRUCTOR_FIELD]); "static constructor field")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_element().early_errors(&mut agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).class_element().early_errors(&agent, &mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("[arguments](){}" => true; "Method (yes)")]
@@ -1328,10 +1328,10 @@ mod field_definition {
     #[test_case("a=arguments" => sset(&[UNEXPECTED_ARGS]); "args in izer")]
     #[test_case("a=super()" => sset(&[UNEXPECTED_SUPER]); "super in izer")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).field_definition().early_errors(&mut agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).field_definition().early_errors(&agent, &mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("[arguments]" => true; "name (yes)")]
@@ -1454,10 +1454,10 @@ mod class_element_name {
     #[test_case("#constructor" => sset(&[PRIVATE_CONSTRUCTOR]); "private constructor")]
     #[test_case("#private" => sset(&[]); "simple private")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_element_name().early_errors(&mut agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).class_element_name().early_errors(&agent, &mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => Some(JSString::from("a")); "normal")]
@@ -1534,10 +1534,10 @@ mod class_static_block {
     #[test_case("static {}" => sset(&[]); "empty")]
     #[test_case("static {package;}" => sset(&[PACKAGE_NOT_ALLOWED]); "something")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_static_block().early_errors(&mut agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).class_static_block().early_errors(&agent, &mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("static { arguments; }" => true; "yes")]
@@ -1592,10 +1592,10 @@ mod class_static_block_body {
     #[test_case("super();" => sset(&[UNEXPECTED_SUPER]); "super call")]
     #[test_case("await a();" => sset(&[UNEXPECTED_AWAIT]); "await expr")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_static_block_body().early_errors(&mut agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).class_static_block_body().early_errors(&agent, &mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments;" => true; "yes")]
@@ -1649,10 +1649,10 @@ mod class_static_block_statement_list {
     #[test_case("0;" => sset(&[]); "normal")]
     #[test_case("" => sset(&[]); "empty")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_static_block_statement_list().early_errors(&mut agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).class_static_block_statement_list().early_errors(&agent, &mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("", &[] => false; "empty")]

--- a/src/parser/comma_operator/mod.rs
+++ b/src/parser/comma_operator/mod.rs
@@ -163,7 +163,7 @@ impl Expression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             Expression::FallThru(node) => node.early_errors(agent, errs, strict),
             Expression::Comma(left, right) => {

--- a/src/parser/comma_operator/tests.rs
+++ b/src/parser/comma_operator/tests.rs
@@ -82,13 +82,13 @@ mod expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "AssignmentExpression")]
     #[test_case("package,implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "Expression , AssignmentExpression")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         Expression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/conditional_operator/mod.rs
+++ b/src/parser/conditional_operator/mod.rs
@@ -152,7 +152,7 @@ impl ConditionalExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ConditionalExpression::FallThru(node) => node.early_errors(agent, errs, strict),
             ConditionalExpression::Conditional(a, b, c) => {

--- a/src/parser/conditional_operator/tests.rs
+++ b/src/parser/conditional_operator/tests.rs
@@ -130,13 +130,13 @@ mod conditional_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "fall thru")]
     #[test_case("package?interface:implements", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "conditional")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ConditionalExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/continue_statement/mod.rs
+++ b/src/parser/continue_statement/mod.rs
@@ -87,7 +87,7 @@ impl ContinueStatement {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, within_iteration: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, within_iteration: bool) {
         // Static Semantics: Early Errors
         // ContinueStatement :
         //      continue ;

--- a/src/parser/continue_statement/tests.rs
+++ b/src/parser/continue_statement/tests.rs
@@ -127,15 +127,15 @@ mod continue_statement {
     #[test_case("continue package;", true, true => sset(&[PACKAGE_NOT_ALLOWED]); "continue LabelIdentifier ; (within)")]
     #[test_case("continue package;", true, false => sset(&[PACKAGE_NOT_ALLOWED, CONTINUE_ITER]); "continue LabelIdentifier ; (beyond)")]
     fn early_errors(src: &str, strict: bool, within_iteration: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ContinueStatement::parse(&mut newparser(src), Scanner::new(), true, true).unwrap().0.early_errors(
-            &mut agent,
+            &agent,
             &mut errs,
             strict,
             within_iteration,
         );
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("   continue;" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 9 } }; "no label")]

--- a/src/parser/declarations_and_variables/mod.rs
+++ b/src/parser/declarations_and_variables/mod.rs
@@ -120,7 +120,7 @@ impl LexicalDeclaration {
         self.style.is_constant_declaration()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  LexicalDeclaration : LetOrConst BindingList ;
         //  * It is a Syntax Error if the BoundNames of BindingList contains "let".
@@ -325,7 +325,7 @@ impl BindingList {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, is_constant_declaration: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, is_constant_declaration: bool) {
         match self {
             BindingList::Item(node) => node.early_errors(agent, errs, strict, is_constant_declaration),
             BindingList::List(lst, tail) => {
@@ -482,7 +482,7 @@ impl LexicalBinding {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, is_constant_declaration: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, is_constant_declaration: bool) {
         // Static Semantics: Early Errors
         //  LexicalBinding : BindingIdentifier Initializer[opt]
         //  * It is a Syntax Error if Initializer is not present and IsConstantDeclaration of the LexicalDeclaration containing this LexicalBinding is true.
@@ -591,7 +591,7 @@ impl VariableStatement {
         self.list.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.list.early_errors(agent, errs, strict);
     }
 
@@ -726,7 +726,7 @@ impl VariableDeclarationList {
         self.list.iter().any(|item| item.contains_arguments())
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         for item in self.list.iter() {
             item.early_errors(agent, errs, strict);
         }
@@ -878,7 +878,7 @@ impl VariableDeclaration {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             VariableDeclaration::Identifier(bi, Some(i)) => {
                 bi.early_errors(agent, errs, strict);
@@ -1011,7 +1011,7 @@ impl BindingPattern {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             BindingPattern::Object(node) => node.early_errors(agent, errs, strict),
             BindingPattern::Array(node) => node.early_errors(agent, errs, strict),
@@ -1264,7 +1264,7 @@ impl ObjectBindingPattern {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ObjectBindingPattern::Empty { .. } => (),
             ObjectBindingPattern::RestOnly { brp, .. } => brp.early_errors(agent, errs, strict),
@@ -1590,7 +1590,7 @@ impl ArrayBindingPattern {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ArrayBindingPattern::RestOnly { bre: Some(node), .. } => node.early_errors(agent, errs, strict),
             ArrayBindingPattern::RestOnly { bre: None, .. } => (),
@@ -1687,7 +1687,7 @@ impl BindingRestProperty {
         node.contains(kind)
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         let BindingRestProperty::Id(node) = self;
         node.early_errors(agent, errs, strict);
     }
@@ -1810,7 +1810,7 @@ impl BindingPropertyList {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             BindingPropertyList::Item(node) => node.early_errors(agent, errs, strict),
             BindingPropertyList::List(lst, item) => {
@@ -1954,7 +1954,7 @@ impl BindingElementList {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             BindingElementList::Item(node) => node.early_errors(agent, errs, strict),
             BindingElementList::List(lst, item) => {
@@ -2072,7 +2072,7 @@ impl BindingElisionElement {
         be.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         let BindingElisionElement::Element(_, elem) = self;
         elem.early_errors(agent, errs, strict);
     }
@@ -2200,7 +2200,7 @@ impl BindingProperty {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             BindingProperty::Single(node) => node.early_errors(agent, errs, strict),
             BindingProperty::Property(name, elem) => {
@@ -2379,7 +2379,7 @@ impl BindingElement {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             BindingElement::Single(node) => node.early_errors(agent, errs, strict),
             BindingElement::Pattern(node, None) => node.early_errors(agent, errs, strict),
@@ -2535,7 +2535,7 @@ impl SingleNameBinding {
         initializer.is_none()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             SingleNameBinding::Id(id, Some(init)) => {
                 id.early_errors(agent, errs, strict);
@@ -2687,7 +2687,7 @@ impl BindingRestElement {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             BindingRestElement::Identifier(node, ..) => node.early_errors(agent, errs, strict),
             BindingRestElement::Pattern(node, ..) => node.early_errors(agent, errs, strict),

--- a/src/parser/declarations_and_variables/tests.rs
+++ b/src/parser/declarations_and_variables/tests.rs
@@ -121,13 +121,13 @@ mod lexical_declaration {
     #[test_case("let a=1,a=2,b=3,b=4,c=5,c=6;", true => sset(&[DUPLICATE_LEX_ABC]); "many duplicates")]
     #[test_case("let package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "sub-productions")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         LexicalDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("let a=arguments;" => true; "yes")]
@@ -254,15 +254,15 @@ mod binding_list {
     #[test_case("package", true, true => sset(&[PACKAGE_NOT_ALLOWED, MISSING_INITIALIZER]); "LexicalBinding")]
     #[test_case("package,implements", true, false => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingList , LexicalBinding")]
     fn early_errors(src: &str, strict: bool, is_constant_declaration: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         BindingList::parse(&mut newparser(src), Scanner::new(), true, true, true).unwrap().0.early_errors(
-            &mut agent,
+            &agent,
             &mut errs,
             strict,
             is_constant_declaration,
         );
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Item (yes)")]
@@ -386,15 +386,15 @@ mod lexical_binding {
     #[test_case("package=implements", true, true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingIdentifier Initializer")]
     #[test_case("[package]=implements", true, false => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingPattern Initializer")]
     fn early_errors(src: &str, strict: bool, is_constant_declaration: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         LexicalBinding::parse(&mut newparser(src), Scanner::new(), true, true, true).unwrap().0.early_errors(
-            &mut agent,
+            &agent,
             &mut errs,
             strict,
             is_constant_declaration,
         );
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "id")]
@@ -480,13 +480,13 @@ mod variable_statement {
 
     #[test_case("var package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "var VariableDeclarationList ;")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         VariableStatement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("var a=arguments;" => true; "yes")]
@@ -606,13 +606,13 @@ mod variable_declaration_list {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "VariableDeclaration")]
     #[test_case("package,implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "VariableDeclarationList , VariableDeclaration")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         VariableDeclarationList::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Item (yes)")]
@@ -751,13 +751,13 @@ mod variable_declaration {
     #[test_case("package=implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingIdentifier Initializer")]
     #[test_case("[package]=implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingPattern Initializer")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         VariableDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "Id")]
@@ -854,13 +854,13 @@ mod binding_pattern {
     #[test_case("{package}", true => sset(&[PACKAGE_NOT_ALLOWED]); "ObjectBindingPattern")]
     #[test_case("[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "ArrayBindingPattern")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         BindingPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("{a=arguments}" => true; "Object (yes)")]
@@ -1079,13 +1079,13 @@ mod object_binding_pattern {
     #[test_case("{package,}", true => sset(&[PACKAGE_NOT_ALLOWED]); "{ BindingPropertyList , } (trailing comma)")]
     #[test_case("{package,...implements}", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "{ BindingPropertyList , BindingRestProperty }")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ObjectBindingPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("{}" => false; "empty")]
@@ -1473,13 +1473,13 @@ mod array_binding_pattern {
     #[test_case("[package,...implements]", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "[ BindingElementList , BindingRestElement ]")]
     #[test_case("[package,,...implements]", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "[ BindingElementList , Elision BindingRestElement ]")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ArrayBindingPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("[]" => false; "emtpy")]
@@ -1575,13 +1575,13 @@ mod binding_rest_property {
 
     #[test_case("...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "... BindingIdentifier")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         BindingRestProperty::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 }
 
@@ -1684,13 +1684,13 @@ mod binding_property_list {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingProperty")]
     #[test_case("package,implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingPropertyList , BindingProperty")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         BindingPropertyList::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Item (yes)")]
@@ -1807,13 +1807,13 @@ mod binding_element_list {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingElisionElement")]
     #[test_case("package,implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingElementList , BindingElisionElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         BindingElementList::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Item (yes)")]
@@ -1907,13 +1907,13 @@ mod binding_elision_element {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingElement")]
     #[test_case(",package", true => sset(&[PACKAGE_NOT_ALLOWED]); "Elision BindingElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         BindingElisionElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Item (yes)")]
@@ -2028,13 +2028,13 @@ mod binding_property {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "SingleNameBinding")]
     #[test_case("[package]:implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "PropertyName : BindingElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         BindingProperty::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Single (yes)")]
@@ -2175,13 +2175,13 @@ mod binding_element {
     #[test_case("[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingPattern")]
     #[test_case("[package]=implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingPattern Initializer")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         BindingElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Single (yes)")]
@@ -2300,13 +2300,13 @@ mod single_name_binding {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingIdentifier")]
     #[test_case("package=implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingIdentifier Initializer")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         SingleNameBinding::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "Id")]
@@ -2418,13 +2418,13 @@ mod binding_rest_element {
     #[test_case("...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "... BindingIdentifier")]
     #[test_case("...[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "... BindingPattern")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         BindingRestElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("...a" => false; "id")]

--- a/src/parser/equality_operators/mod.rs
+++ b/src/parser/equality_operators/mod.rs
@@ -183,7 +183,7 @@ impl EqualityExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             EqualityExpression::RelationalExpression(n) => n.early_errors(agent, errs, strict),
             EqualityExpression::Equal(l, r)

--- a/src/parser/equality_operators/tests.rs
+++ b/src/parser/equality_operators/tests.rs
@@ -260,13 +260,13 @@ mod equality_expression {
     #[test_case("package!==3", true => sset(&[PACKAGE_NOT_ALLOWED]); "left nse right; left bad")]
     #[test_case("3!==package", true => sset(&[PACKAGE_NOT_ALLOWED]); "left nse right; right bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         EqualityExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/exponentiation_operator/mod.rs
+++ b/src/parser/exponentiation_operator/mod.rs
@@ -138,7 +138,7 @@ impl ExponentiationExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ExponentiationExpression::UnaryExpression(n) => n.early_errors(agent, errs, strict),
             ExponentiationExpression::Exponentiation(l, r) => {

--- a/src/parser/exponentiation_operator/tests.rs
+++ b/src/parser/exponentiation_operator/tests.rs
@@ -127,13 +127,13 @@ mod exponentiation_expression {
     #[test_case("package**3", true => sset(&[PACKAGE_NOT_ALLOWED]); "left ** right; left bad")]
     #[test_case("3**package", true => sset(&[PACKAGE_NOT_ALLOWED]); "left ** right; right bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ExponentiationExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/expression_statement/mod.rs
+++ b/src/parser/expression_statement/mod.rs
@@ -105,7 +105,7 @@ impl ExpressionStatement {
         self.exp.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.exp.early_errors(agent, errs, strict);
     }
 }

--- a/src/parser/expression_statement/tests.rs
+++ b/src/parser/expression_statement/tests.rs
@@ -123,10 +123,10 @@ mod expression_statement {
 
     #[test_case("package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "normal")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).expression_statement().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).expression_statement().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments;" => true; "yes")]

--- a/src/parser/function_definitions/mod.rs
+++ b/src/parser/function_definitions/mod.rs
@@ -136,7 +136,7 @@ impl FunctionDeclaration {
         self.params.all_private_identifiers_valid(names) && self.body.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         function_early_errors(agent, errs, strict, self.ident.as_ref(), &self.params, &self.body);
     }
 
@@ -146,7 +146,7 @@ impl FunctionDeclaration {
 }
 
 pub fn function_early_errors(
-    agent: &mut Agent,
+    agent: &Agent,
     errs: &mut Vec<Object>,
     strict: bool,
     ident: Option<&Rc<BindingIdentifier>>,
@@ -321,7 +321,7 @@ impl FunctionExpression {
         self.params.all_private_identifiers_valid(names) && self.body.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         function_early_errors(agent, errs, strict, self.ident.as_ref(), &self.params, &self.body);
     }
 
@@ -432,7 +432,7 @@ impl FunctionBody {
         self.statements.lexically_declared_names()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // FunctionBody : FunctionStatementList
         //  * It is a Syntax Error if the LexicallyDeclaredNames of FunctionStatementList contains any duplicate
         //    entries.
@@ -658,7 +658,7 @@ impl FunctionStatementList {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         if let FunctionStatementList::Statements(sl) = self {
             sl.early_errors(agent, errs, strict, false, false);
         }

--- a/src/parser/function_definitions/tests.rs
+++ b/src/parser/function_definitions/tests.rs
@@ -223,13 +223,13 @@ mod function_declaration {
     #[test_case("function a(){super();}", false => sset(&[BAD_SUPER]); "SuperCall in body")]
     #[test_case("function a(){super.b;}", false => sset(&[BAD_SUPER]); "SuperProperty in body")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         FunctionDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("   function a(){}" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 14 } }; "typical")]
@@ -375,13 +375,13 @@ mod function_expression {
     #[test_case("function a(){super();}", false => sset(&[BAD_SUPER]); "SuperCall in body")]
     #[test_case("function a(){super.b;}", false => sset(&[BAD_SUPER]); "SuperProperty in body")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         FunctionExpression::parse(&mut newparser(src), Scanner::new())
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("function a(){}" => true; "named")]
@@ -473,10 +473,10 @@ mod function_body {
     #[test_case("break a;", false => sset(&[UNDEF_BREAK]); "undefined break")]
     #[test_case("while (1) continue a;", false => sset(&[UNDEF_CONTINUE]); "undefined continue")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).function_body().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).function_body().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments;" => true; "yes")]
@@ -605,10 +605,10 @@ mod function_statement_list {
     #[test_case("package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "StatementList")]
     #[test_case("", true => sset(&[]); "[empty]")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).function_statement_list().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).function_statement_list().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("" => false; "empty")]

--- a/src/parser/generator_function_definitions/mod.rs
+++ b/src/parser/generator_function_definitions/mod.rs
@@ -127,7 +127,7 @@ impl GeneratorMethod {
     /// See [Early Errors for Generator Function Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-generator-function-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  GeneratorMethod : * ClassElementName ( UniqueFormalParameters ) { GeneratorBody }
         //  * It is a Syntax Error if HasDirectSuper of GeneratorMethod is true.
@@ -310,7 +310,7 @@ impl GeneratorDeclaration {
     /// See [Early Errors for Generator Function Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-generator-function-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  GeneratorDeclaration :
         //      function * BindingIdentifier ( FormalParameters ) { GeneratorBody }
@@ -452,7 +452,7 @@ impl GeneratorExpression {
     /// See [Early Errors for Generator Function Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-generator-function-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  GeneratorExpression :
         //      function * BindingIdentifier[opt] ( FormalParameters ) { GeneratorBody }
@@ -558,7 +558,7 @@ impl GeneratorBody {
     /// See [Early Errors for Generator Function Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-generator-function-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.0.early_errors(agent, errs, strict);
     }
 
@@ -740,7 +740,7 @@ impl YieldExpression {
     /// See [Early Errors for Generator Function Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-generator-function-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             YieldExpression::Expression { exp, .. } | YieldExpression::From { exp, .. } => {
                 exp.early_errors(agent, errs, strict)

--- a/src/parser/generator_function_definitions/tests.rs
+++ b/src/parser/generator_function_definitions/tests.rs
@@ -132,10 +132,10 @@ mod generator_method {
     #[test_case("*a(b=yield 10){}", false => sset(&[YIELD_IN_GENPARAM]); "yield in generator params")]
     #[test_case("*a(b){super(b);}", false => sset(&[UNEXPECTED_SUPER]); "direct super")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).generator_method().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).generator_method().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test]
@@ -393,10 +393,10 @@ mod generator_declaration {
     #[test_case("function *a(){super.b;}", false => sset(&[UNEXPECTED_SUPER2]); "SuperProperty in body")]
     #[test_case("function *a(b=yield 10){}", false => sset(&[YIELD_IN_GENPARAM]); "yield in generator params")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).generator_declaration().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).generator_declaration().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("   function *a(){}" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 15 } }; "typical")]
@@ -568,10 +568,10 @@ mod generator_expression {
     #[test_case("function *a(){super.b;}", false => sset(&[UNEXPECTED_SUPER2]); "SuperProperty in body")]
     #[test_case("function *a(b=yield 10){}", false => sset(&[YIELD_IN_GENPARAM]); "yield in generator params")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).generator_expression().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).generator_expression().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("function *a(){}" => true; "named")]
@@ -635,10 +635,10 @@ mod generator_body {
 
     #[test_case("package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "statements")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).generator_body().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).generator_body().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("'one'; 3;" => false; "directive no strict")]
@@ -811,10 +811,10 @@ mod yield_expression {
     #[test_case("yield", true => sset(&[]); "no expresion")]
     #[test_case("yield *package", true => sset(&[PACKAGE_NOT_ALLOWED]); "yield from")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).yield_expression().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).yield_expression().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("yield" => false; "bare")]

--- a/src/parser/identifiers/mod.rs
+++ b/src/parser/identifiers/mod.rs
@@ -106,7 +106,7 @@ impl Identifier {
         false
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, in_module: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, in_module: bool) {
         // Static Semantics: Early Errors
         //      Identifier : IdentifierName but not ReservedWord
         //  * It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of IdentifierName
@@ -317,7 +317,7 @@ impl IdentifierReference {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             IdentifierReference::Identifier { identifier: id, data } => {
@@ -552,7 +552,7 @@ impl BindingIdentifier {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             BindingIdentifier::Identifier { identifier: id, data } => {
@@ -769,7 +769,7 @@ impl LabelIdentifier {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             LabelIdentifier::Identifier { identifier: id, data } => {

--- a/src/parser/identifiers/tests.rs
+++ b/src/parser/identifiers/tests.rs
@@ -214,16 +214,16 @@ mod identifier {
         #[test_case("static", false => Ok(()); "static non-strict")]
         #[test_case("yield", false => Ok(()); "yield non-strict")]
         fn strict(id: &str, strict: bool) -> Result<(), String> {
-            let mut agent = test_agent();
+            let agent = test_agent();
             let (identifier, _) =
                 Identifier::parse(&mut newparser(uify_first_ch(id).as_str()), Scanner::new()).unwrap();
             let mut errs = vec![];
-            identifier.early_errors(&mut agent, &mut errs, strict, false);
+            identifier.early_errors(&agent, &mut errs, strict, false);
             if errs.is_empty() {
                 Ok(())
             } else {
                 assert_eq!(errs.len(), 1);
-                Err(unwind_syntax_error_object(&mut agent, errs.swap_remove(0)))
+                Err(unwind_syntax_error_object(&agent, errs.swap_remove(0)))
             }
         }
 
@@ -264,27 +264,27 @@ mod identifier {
         #[test_case("while" => String::from("‘while’ is a reserved word and may not be used as an identifier"); "keyword while")]
         #[test_case("with" => String::from("‘with’ is a reserved word and may not be used as an identifier"); "keyword with")]
         fn keyword(id: &str) -> String {
-            let mut agent = test_agent();
+            let agent = test_agent();
             let (identifier, _) =
                 Identifier::parse(&mut newparser(uify_first_ch(id).as_str()), Scanner::new()).unwrap();
             let mut errs = vec![];
-            identifier.early_errors(&mut agent, &mut errs, false, false);
+            identifier.early_errors(&agent, &mut errs, false, false);
             assert_eq!(errs.len(), 1);
-            unwind_syntax_error_object(&mut agent, errs.swap_remove(0))
+            unwind_syntax_error_object(&agent, errs.swap_remove(0))
         }
 
         #[test_case("aw\\u0061it", true => Err(String::from("‘await’ not allowed as an identifier in modules")); "await in module")]
         #[test_case("aw\\u0061it", false => Ok(()); "await in script")]
         fn module(src: &str, in_module: bool) -> Result<(), String> {
-            let mut agent = test_agent();
+            let agent = test_agent();
             let (ident, _) = Identifier::parse(&mut newparser(src), Scanner::new()).unwrap();
             let mut errs = vec![];
-            ident.early_errors(&mut agent, &mut errs, false, in_module);
+            ident.early_errors(&agent, &mut errs, false, in_module);
             if errs.is_empty() {
                 Ok(())
             } else {
                 assert_eq!(errs.len(), 1);
-                Err(unwind_syntax_error_object(&mut agent, errs.swap_remove(0)))
+                Err(unwind_syntax_error_object(&agent, errs.swap_remove(0)))
             }
         }
     }
@@ -533,7 +533,7 @@ mod identifier_reference {
         yield_expr_allowed: bool,
         await_expr_allowed: bool,
     ) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let goal = if in_module { ParseGoal::Module } else { ParseGoal::Script };
         let (item, _) = IdentifierReference::parse(
             &mut Parser::new(src, false, goal),
@@ -543,8 +543,8 @@ mod identifier_reference {
         )
         .unwrap();
         let mut errs = vec![];
-        item.early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        item.early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "IdentifierName/no")]
@@ -832,7 +832,7 @@ mod binding_identifier {
             yield_expr_allowed: bool,
             await_expr_allowed: bool,
         ) -> AHashSet<String> {
-            let mut agent = test_agent();
+            let agent = test_agent();
             let goal = if in_module { ParseGoal::Module } else { ParseGoal::Script };
             let (item, _) = BindingIdentifier::parse(
                 &mut Parser::new(src, false, goal),
@@ -842,8 +842,8 @@ mod binding_identifier {
             )
             .unwrap();
             let mut errs = vec![];
-            item.early_errors(&mut agent, &mut errs, strict);
-            AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            item.early_errors(&agent, &mut errs, strict);
+            AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
         }
     }
 
@@ -1100,7 +1100,7 @@ mod label_identifier {
             yield_expr_allowed: bool,
             await_expr_allowed: bool,
         ) -> AHashSet<String> {
-            let mut agent = test_agent();
+            let agent = test_agent();
             let goal = if in_module { ParseGoal::Module } else { ParseGoal::Script };
             let (item, _) = LabelIdentifier::parse(
                 &mut Parser::new(src, false, goal),
@@ -1110,8 +1110,8 @@ mod label_identifier {
             )
             .unwrap();
             let mut errs = vec![];
-            item.early_errors(&mut agent, &mut errs, strict);
-            AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            item.early_errors(&agent, &mut errs, strict);
+            AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
         }
     }
 

--- a/src/parser/if_statement/mod.rs
+++ b/src/parser/if_statement/mod.rs
@@ -202,7 +202,7 @@ impl IfStatement {
 
     pub fn early_errors(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         errs: &mut Vec<Object>,
         strict: bool,
         within_iteration: bool,

--- a/src/parser/if_statement/tests.rs
+++ b/src/parser/if_statement/tests.rs
@@ -242,13 +242,13 @@ mod if_statement {
     #[test_case("if (a) alpha; else b: function f(){}", false => sset(&[LABELLED_FUNCTION_NOT_ALLOWED]); "labelled function (in else clause)")]
     #[test_case("if (a) b: function f(){} else c;", false => sset(&[LABELLED_FUNCTION_NOT_ALLOWED]); "labelled fucntion (in then clause)")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         IfStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("if(arguments);else;" => true; "trinary (left)")]

--- a/src/parser/iteration_statements/mod.rs
+++ b/src/parser/iteration_statements/mod.rs
@@ -172,7 +172,7 @@ impl IterationStatement {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
         match self {
             IterationStatement::DoWhile(node) => node.early_errors(agent, errs, strict, within_switch),
             IterationStatement::While(node) => node.early_errors(agent, errs, strict, within_switch),
@@ -307,7 +307,7 @@ impl DoWhileStatement {
         self.stmt.contains_arguments() || self.exp.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
         self.stmt.early_errors(agent, errs, strict, true, within_switch);
         self.exp.early_errors(agent, errs, strict);
     }
@@ -427,7 +427,7 @@ impl WhileStatement {
         self.exp.contains_arguments() || self.stmt.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
         self.exp.early_errors(agent, errs, strict);
         self.stmt.early_errors(agent, errs, strict, true, within_switch);
     }
@@ -799,7 +799,7 @@ impl ForStatement {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
         // Static Semantics: Early Errors
         if let ForStatement::ForLex(lex, _, _, stmt, _) = self {
             // ForStatement : for ( LexicalDeclaration Expression[opt] ; Expression[opt] ) Statement
@@ -1422,7 +1422,7 @@ impl ForInOfStatement {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
         // Static Semantics: Early Errors
         match self {
             ForInOfStatement::LexIn(fd, _, stmt, ..)
@@ -1668,7 +1668,7 @@ impl ForDeclaration {
         self.binding.bound_names()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.binding.early_errors(agent, errs, strict);
     }
 }
@@ -1791,7 +1791,7 @@ impl ForBinding {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ForBinding::Identifier(id) => id.early_errors(agent, errs, strict),
             ForBinding::Pattern(pat) => pat.early_errors(agent, errs, strict),

--- a/src/parser/iteration_statements/tests.rs
+++ b/src/parser/iteration_statements/tests.rs
@@ -293,13 +293,13 @@ mod iteration_statement {
     #[test_case("for(;;)package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "ForStatement")]
     #[test_case("for(let package in b);", true => sset(&[PACKAGE_NOT_ALLOWED]); "ForInOfStatement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         IterationStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("do arguments; while(0);" => true; "dowhile (yes)")]
@@ -491,13 +491,13 @@ mod do_while_statement {
 
     #[test_case("do package; while(implements);", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "do Statement while ( Expression ) ;")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         DoWhileStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("do arguments;while(0);" => true; "binary (left)")]
@@ -626,13 +626,13 @@ mod while_statement {
 
     #[test_case("while(package)implements;", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "while ( Expression ) Statement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         WhileStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("while(arguments);" => true; "left")]
@@ -1541,13 +1541,13 @@ mod for_statement {
     #[test_case("for (let package; ; ) private;", true => sset(&[PACKAGE_NOT_ALLOWED, PRIVATE_NOT_ALLOWED]); "for ( LexicalDeclaration ;  ;  ) Statement")]
     #[test_case("for (let a;;) { var a; }", false => sset(&[A_LEXVARCLASH]); "lex/var clash")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ForStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("for(;;)arguments;" => true; "000-for (yes)")]
@@ -2449,13 +2449,13 @@ mod for_in_of_statement {
     #[test_case("for await (var package of implements) interface;", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "for await ( var ForBinding of AssignmentExpresion ) Statement")]
     #[test_case("for await (let package of implements) interface;", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "for await ( ForDeclaration of AssignmentExpresion ) Statement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ForInOfStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("for(arguments in a);" => true; "lhs-in (left)")]
@@ -2620,10 +2620,10 @@ mod for_declaration {
 
     #[test_case("let package", true => sset(&[PACKAGE_NOT_ALLOWED]); "normal")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).for_declaration().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).for_declaration().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("let {a=arguments}" => true; "yes")]
@@ -2726,10 +2726,10 @@ mod for_binding {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "identifier")]
     #[test_case("[a, package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "pattern")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).for_binding().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).for_binding().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "id")]

--- a/src/parser/labelled_statements/mod.rs
+++ b/src/parser/labelled_statements/mod.rs
@@ -128,7 +128,7 @@ impl LabelledStatement {
 
     pub fn early_errors(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         errs: &mut Vec<Object>,
         strict: bool,
         within_iteration: bool,
@@ -334,7 +334,7 @@ impl LabelledItem {
 
     pub fn early_errors(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         errs: &mut Vec<Object>,
         strict: bool,
         within_iteration: bool,

--- a/src/parser/labelled_statements/tests.rs
+++ b/src/parser/labelled_statements/tests.rs
@@ -141,10 +141,10 @@ mod labelled_statement {
 
     #[test_case("package:implements;", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "LabelIdentifier : LabelledItem")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).labelled_statement().early_errors(&mut agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).labelled_statement().early_errors(&agent, &mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("bob: function alice(){}" => true; "direct labelled function")]
@@ -362,10 +362,10 @@ mod labelled_item {
     #[test_case("function package(){}", true => sset(&[PACKAGE_NOT_ALLOWED, LBL_FUNC_NOT_ALLOWED]); "FunctionDeclaration (strict)")]
     #[test_case("function a(){}", false => sset(&[LBL_FUNC_NOT_ALLOWED]); "FunctionDeclaration (non-strict)")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).labelled_item().early_errors(&mut agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).labelled_item().early_errors(&agent, &mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("function alice(){}" => true; "direct labelled function")]

--- a/src/parser/left_hand_side_expressions/mod.rs
+++ b/src/parser/left_hand_side_expressions/mod.rs
@@ -373,7 +373,7 @@ impl MemberExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             MemberExpression::PrimaryExpression(n) => n.early_errors(agent, errs, strict),
             MemberExpression::Expression(l, r, ..) => {
@@ -580,7 +580,7 @@ impl SuperProperty {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             SuperProperty::Expression { exp, .. } => exp.early_errors(agent, errs, strict),
@@ -685,7 +685,7 @@ impl MetaProperty {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>) {
         match self {
             MetaProperty::NewTarget { .. } => {}
             MetaProperty::ImportMeta { goal, .. } => {
@@ -853,7 +853,7 @@ impl Arguments {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             Arguments::Empty { .. } => {}
@@ -1093,7 +1093,7 @@ impl ArgumentList {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             ArgumentList::FallThru(boxed) | ArgumentList::Dots(boxed) => boxed.early_errors(agent, errs, strict),
@@ -1234,7 +1234,7 @@ impl NewExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             NewExpression::MemberExpression(boxed) => boxed.early_errors(agent, errs, strict),
             NewExpression::NewExpression(boxed, ..) => boxed.early_errors(agent, errs, strict),
@@ -1357,7 +1357,7 @@ impl CallMemberExpression {
         self.member_expression.contains_arguments() || self.arguments.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.member_expression.early_errors(agent, errs, strict);
         self.arguments.early_errors(agent, errs, strict);
     }
@@ -1438,7 +1438,7 @@ impl SuperCall {
         self.arguments.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.arguments.early_errors(agent, errs, strict);
     }
 }
@@ -1524,7 +1524,7 @@ impl ImportCall {
         self.assignment_expression.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.assignment_expression.early_errors(agent, errs, strict);
     }
 }
@@ -1820,7 +1820,7 @@ impl CallExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             CallExpression::CallMemberExpression(node) => node.early_errors(agent, errs, strict),
             CallExpression::SuperCall(node) => node.early_errors(agent, errs, strict),
@@ -2009,7 +2009,7 @@ impl LeftHandSideExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             LeftHandSideExpression::New(boxed) => boxed.early_errors(agent, errs, strict),
             LeftHandSideExpression::Call(boxed) => boxed.early_errors(agent, errs, strict),
@@ -2209,7 +2209,7 @@ impl OptionalExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             OptionalExpression::Member(left, right) => {
                 left.early_errors(agent, errs, strict);
@@ -2568,7 +2568,7 @@ impl OptionalChain {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  OptionalChain :
         //      ?. TemplateLiteral

--- a/src/parser/left_hand_side_expressions/tests.rs
+++ b/src/parser/left_hand_side_expressions/tests.rs
@@ -391,13 +391,13 @@ mod member_expression {
     #[test_case("new a(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "new expr (args bad)")]
     #[test_case("package.#a", true => sset(&[PACKAGE_NOT_ALLOWED]); "private id")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         MemberExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]
@@ -606,13 +606,13 @@ mod super_property {
     #[test_case("super.package", true => sset(&[]); "super.member")]
     #[test_case("super[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "super[exp]")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         SuperProperty::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("super[arguments]" => true; "Expression (yes)")]
@@ -713,13 +713,13 @@ mod meta_property {
     #[test_case("import.meta", ParseGoal::Script => sset(&["import.meta allowed only in Module code"]); "import.meta (in script)")]
     #[test_case("import.meta", ParseGoal::Module => AHashSet::<String>::new(); "import.meta (in module)")]
     fn early_errors(src: &str, goal: ParseGoal) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         MetaProperty::parse(&mut Parser::new(src, false, goal), Scanner::new())
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("  new.target" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 10 }}; "new.target")]
@@ -856,13 +856,13 @@ mod arguments {
     #[test_case("(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "argument list")]
     #[test_case("(package,)", true => sset(&[PACKAGE_NOT_ALLOWED]); "argument list; comma")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         Arguments::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("()" => false; "empty")]
@@ -1072,13 +1072,13 @@ mod argument_list {
     #[test_case("package,...a", true => sset(&[PACKAGE_NOT_ALLOWED]); "list, rest; head bad")]
     #[test_case("0,...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "list, rest; rest bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ArgumentList::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments" => true; "AssignmentExpression (yes)")]
@@ -1212,13 +1212,13 @@ mod new_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "exp")]
     #[test_case("new package", true => sset(&[PACKAGE_NOT_ALLOWED]); "new exp")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         NewExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]
@@ -1342,13 +1342,13 @@ mod call_member_expression {
     #[test_case("package()", true => sset(&[PACKAGE_NOT_ALLOWED]); "exp bad")]
     #[test_case("a(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "args bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         CallMemberExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("arguments()" => true; "Exp Args (left)")]
@@ -1417,13 +1417,13 @@ mod super_call {
 
     #[test_case("super(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "normal")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         SuperCall::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("super(arguments)" => true; "yes")]
@@ -1505,13 +1505,13 @@ mod import_call {
 
     #[test_case("import(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "normal")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ImportCall::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("import(arguments)" => true; "yes")]
@@ -1891,13 +1891,13 @@ mod call_expression {
     #[test_case("package(0)`${0}`", true => sset(&[PACKAGE_NOT_ALLOWED]); "call templ; id bad")]
     #[test_case("a(0)`${package}`", true => sset(&[PACKAGE_NOT_ALLOWED]); "call templ; templ bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         CallExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a()" => true; "standard")]
@@ -2129,13 +2129,13 @@ mod optional_expression {
     #[test_case("package?.a?.(0)", true => sset(&[PACKAGE_NOT_ALLOWED]); "opt opt; head bad")]
     #[test_case("a?.b?.(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "opt opt; tail bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         OptionalExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a?.b" => true; "member exp")]
@@ -2576,13 +2576,13 @@ mod optional_chain {
     #[test_case("?.(package)`${interface}`", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED, TEMPLATE_NOT_ALLOWED]); "chain template lit")]
     #[test_case("?.(package).#interface", true => sset(&[PACKAGE_NOT_ALLOWED]); "chain private")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         OptionalChain::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("?.()" => true; "args")]
@@ -2768,13 +2768,13 @@ mod left_hand_side_expression {
     #[test_case("package()", true => sset(&[PACKAGE_NOT_ALLOWED]); "call expression")]
     #[test_case("package?.()", true => sset(&[PACKAGE_NOT_ALLOWED]); "optional expression")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         LeftHandSideExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/method_definitions/mod.rs
+++ b/src/parser/method_definitions/mod.rs
@@ -338,7 +338,7 @@ impl MethodDefinition {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             MethodDefinition::NamedFunction(cen, ufp, fb, _) => {
@@ -507,7 +507,7 @@ impl PropertySetParameterList {
         self.node.is_simple_parameter_list()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.node.early_errors(agent, errs, strict);
     }
 }

--- a/src/parser/method_definitions/tests.rs
+++ b/src/parser/method_definitions/tests.rs
@@ -565,10 +565,10 @@ mod method_definition {
     #[test_case("set foo(a){let a;}", false => sset(&[A_ALREADY_DEFN]); "setter; duped lexical")]
     #[test_case("set foo([a, a]){}", false => sset(&[A_ALREADY_DEFN]); "setter; duped params")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).method_definition().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).method_definition().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a(){}" => Some(JSString::from("a")); "simple")]
@@ -675,13 +675,13 @@ mod property_set_parameter_list {
 
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "FormalParameter")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         PropertySetParameterList::parse(&mut newparser(src), Scanner::new())
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => vec!["a"]; "FormalParameter")]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -654,7 +654,7 @@ pub enum ParsedText {
     // ... more to come
 }
 
-pub fn parse_text(agent: &mut Agent, src: &str, goal_symbol: ParseGoal) -> ParsedText {
+pub fn parse_text(agent: &Agent, src: &str, goal_symbol: ParseGoal) -> ParsedText {
     let mut parser = Parser::new(src, false, goal_symbol);
     match goal_symbol {
         ParseGoal::Script => {

--- a/src/parser/multiplicative_operators/mod.rs
+++ b/src/parser/multiplicative_operators/mod.rs
@@ -204,7 +204,7 @@ impl MultiplicativeExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             MultiplicativeExpression::ExponentiationExpression(n) => n.early_errors(agent, errs, strict),
             MultiplicativeExpression::MultiplicativeExpressionExponentiationExpression(l, _, r) => {

--- a/src/parser/multiplicative_operators/tests.rs
+++ b/src/parser/multiplicative_operators/tests.rs
@@ -209,13 +209,13 @@ mod multiplicative_expression {
     #[test_case("package%3", true => sset(&[PACKAGE_NOT_ALLOWED]); "left mod right; left bad")]
     #[test_case("3%package", true => sset(&[PACKAGE_NOT_ALLOWED]); "left mod right; right bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         MultiplicativeExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/parameter_lists/mod.rs
+++ b/src/parser/parameter_lists/mod.rs
@@ -84,7 +84,7 @@ impl UniqueFormalParameters {
         self.formals.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  UniqueFormalParameters : FormalParameters
         //  * It is a Syntax Error if BoundNames of FormalParameters contains any duplicate elements.
@@ -356,7 +356,7 @@ impl FormalParameters {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, dups_already_checked: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, dups_already_checked: bool) {
         // Static Semantics: Early Errors
         //  FormalParameters : FormalParameterList
         //    If BoundNames of FormalParameterList contains any duplicate elements, it is a Syntax Error:
@@ -566,7 +566,7 @@ impl FormalParameterList {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             FormalParameterList::Item(fp) => fp.early_errors(agent, errs, strict),
             FormalParameterList::List(fpl, fp) => {
@@ -696,7 +696,7 @@ impl FunctionRestParameter {
         self.element.bound_names()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.element.early_errors(agent, errs, strict);
     }
 
@@ -803,7 +803,7 @@ impl FormalParameter {
         self.element.bound_names()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.element.early_errors(agent, errs, strict)
     }
 

--- a/src/parser/parameter_lists/tests.rs
+++ b/src/parser/parameter_lists/tests.rs
@@ -58,10 +58,10 @@ mod unique_formal_parameters {
     #[test_case("a,b,a", true => sset(&[A_ALREADY_DEFINED]); "strict: duplicate ids")]
     #[test_case("a,b,a", false => sset(&[A_ALREADY_DEFINED]); "non-strict: duplicate ids")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).unique_formal_parameters().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).unique_formal_parameters().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a,b" => vec!["a", "b"]; "FormalParameters")]
@@ -310,10 +310,10 @@ mod formal_parameters {
     #[test_case("a,a", true, true => sset(&[]); "strict; duplicates; already reported")]
     #[test_case("a,...a", false, false => sset(&[A_ALREADY_DEFINED]); "not-simple")]
     fn early_errors(src: &str, strict: bool, dups_already_checked: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).formal_parameters().early_errors(&mut agent, &mut errs, strict, dups_already_checked);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).formal_parameters().early_errors(&agent, &mut errs, strict, dups_already_checked);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("" => false; "empty")]
@@ -477,10 +477,10 @@ mod formal_parameter_list {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "FormalParameter")]
     #[test_case("package,interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "FormalParameterList , FormalParameter")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).formal_parameter_list().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).formal_parameter_list().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Item (yes)")]
@@ -579,10 +579,10 @@ mod function_rest_parameter {
 
     #[test_case("...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingRestElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).function_rest_parameter().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).function_rest_parameter().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("...{a=arguments}" => true; "yes")]
@@ -675,10 +675,10 @@ mod formal_parameter {
 
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).formal_parameter().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).formal_parameter().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a=arguments" => true; "yes")]

--- a/src/parser/primary_expressions/mod.rs
+++ b/src/parser/primary_expressions/mod.rs
@@ -397,7 +397,7 @@ impl PrimaryExpression {
         matches!(self, PrimaryExpression::ArrayLiteral { .. } | PrimaryExpression::ObjectLiteral { .. })
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             PrimaryExpression::This { .. } => {}
             PrimaryExpression::IdentifierReference { node: id } => id.early_errors(agent, errs, strict),
@@ -649,7 +649,7 @@ impl SpreadElement {
         self.ae.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.ae.early_errors(agent, errs, strict);
     }
 }
@@ -925,7 +925,7 @@ impl ElementList {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ElementList::AssignmentExpression { ae: b, .. } => {
                 b.early_errors(agent, errs, strict);
@@ -1140,7 +1140,7 @@ impl ArrayLiteral {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ArrayLiteral::Empty { .. } => {}
             ArrayLiteral::ElementList { el: node, .. } | ArrayLiteral::ElementListElision { el: node, .. } => {
@@ -1254,7 +1254,7 @@ impl Initializer {
         self.ae.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.ae.early_errors(agent, errs, strict);
     }
 
@@ -1335,7 +1335,7 @@ impl CoverInitializedName {
         izer.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         let CoverInitializedName::InitializedName(a, b) = self;
         a.early_errors(agent, errs, strict);
         b.early_errors(agent, errs, strict);
@@ -1426,7 +1426,7 @@ impl ComputedPropertyName {
         self.ae.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.ae.early_errors(agent, errs, strict);
     }
 
@@ -1677,7 +1677,7 @@ impl PropertyName {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             PropertyName::LiteralPropertyName(_) => (),
             PropertyName::ComputedPropertyName(x) => x.early_errors(agent, errs, strict),
@@ -1890,7 +1890,7 @@ impl PropertyDefinition {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             PropertyDefinition::IdentifierReference(idref) => idref.early_errors(agent, errs, strict),
@@ -2095,7 +2095,7 @@ impl PropertyDefinitionList {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             PropertyDefinitionList::OneDef(pd) => pd.early_errors(agent, errs, strict),
@@ -2255,7 +2255,7 @@ impl ObjectLiteral {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             ObjectLiteral::Empty { .. } => {}
@@ -2587,7 +2587,7 @@ impl TemplateLiteral {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, ts_limit: usize) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, ts_limit: usize) {
         // Static Semantics: Early Errors
         match self {
             TemplateLiteral::NoSubstitutionTemplate { data: td, tagged, location } => {
@@ -2750,7 +2750,7 @@ impl SubstitutionTemplate {
         self.expression.contains_arguments() || self.template_spans.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         // SubstitutionTemplate : TemplateHead Expression TemplateSpans
         //  * It is a Syntax Error if the [Tagged] parameter was not set and TemplateHead Contains NotEscapeSequence.
@@ -2927,7 +2927,7 @@ impl TemplateSpans {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  TemplateSpans :
         //      TemplateTail
@@ -3142,7 +3142,7 @@ impl TemplateMiddleList {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  TemplateMiddleList :
         //      TemplateMiddle Expression
@@ -3288,7 +3288,7 @@ impl ParenthesizedExpression {
         self.exp.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.exp.early_errors(agent, errs, strict)
     }
 
@@ -3614,7 +3614,7 @@ impl CoverParenthesizedExpressionAndArrowParameterList {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             CoverParenthesizedExpressionAndArrowParameterList::Expression { exp: node, .. }
             | CoverParenthesizedExpressionAndArrowParameterList::ExpComma { exp: node, .. } => {

--- a/src/parser/primary_expressions/tests.rs
+++ b/src/parser/primary_expressions/tests.rs
@@ -515,13 +515,13 @@ mod primary_expression {
     #[test_case("`${package}`", true => sset(&[PACKAGE_NOT_ALLOWED]); "TemplateLiteral")]
     #[test_case("(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "ParenthesizedExpression")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         PrimaryExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("this" => true; "this")]
@@ -991,13 +991,13 @@ mod spread_element {
 
     #[test_case("...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "... AssignmentExpression")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         SpreadElement::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("...xyzzy" => false; "no")]
@@ -1354,13 +1354,13 @@ mod element_list {
     #[test_case("package,,...b", true => sset(&[PACKAGE_NOT_ALLOWED]); "ElementList Elision SpreadElement: list err")]
     #[test_case("a,,...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "ElementList Elision SpreadElement: element err")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ElementList::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("xyzzy" => false; "AssignmentExpression (no)")]
@@ -1627,13 +1627,13 @@ mod array_literal {
     #[test_case("[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "ElementList")]
     #[test_case("[package,,]", true => sset(&[PACKAGE_NOT_ALLOWED]); "ElementList Elision")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ArrayLiteral::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("[]" => false; "empty")]
@@ -1724,13 +1724,13 @@ mod initializer {
 
     #[test_case("=package", true => sset(&[PACKAGE_NOT_ALLOWED]); "normal")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         Initializer::parse(&mut newparser(src), Scanner::new(), true, false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("=xyzzy" => false; "no")]
@@ -1809,13 +1809,13 @@ mod cover_initialized_name {
     #[test_case("a=package", true => sset(&[PACKAGE_NOT_ALLOWED]); "exp errs")]
     #[test_case("package=3", true => sset(&[PACKAGE_NOT_ALLOWED]); "id errs")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         CoverInitializedName::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test]
@@ -1895,13 +1895,13 @@ mod computed_property_name {
 
     #[test_case("[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "[ AssignmentExpression ]")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ComputedPropertyName::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
     #[test_case("[xyzzy]" => false; "no")]
     #[test_case("[arguments]" => true; "yes")]
@@ -2137,13 +2137,13 @@ mod property_name {
     #[test_case("package", true => sset(&[]); "LiteralPropertyName")]
     #[test_case("[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "ComputedPropertyName")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         PropertyName::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => Some(JSString::from("a")); "normal")]
@@ -2396,13 +2396,13 @@ mod property_definition {
     #[test_case("a(b=super()){}", true => sset(&[UNEXPECTED_SUPER]); "HasDirectSuper of MethodDefinition")]
     #[test_case("#a(){}", true => sset(&[UNEXPECTED_PRIVATE]); "unexpected private id in MethodDef")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         PropertyDefinition::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => Some(JSString::from("a")); "identifier")]
@@ -2554,13 +2554,13 @@ mod property_definition_list {
     #[test_case("[package]:3,b", true => sset(&[PACKAGE_NOT_ALLOWED]); "list head")]
     #[test_case("a,[package]:3", true => sset(&[PACKAGE_NOT_ALLOWED]); "list tail")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         PropertyDefinitionList::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a:x" => 0; "one item, not proto")]
@@ -2740,13 +2740,13 @@ mod object_literal {
     #[test_case("{__proto__:a,__proto__:b}", true => sset(&[DUP_PROTO]); "duplicate proto")]
     #[test_case("{__proto__:a,__proto__:b,}", true => sset(&[DUP_PROTO]); "duplicate proto; trailing comma")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ObjectLiteral::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("{}" => false; "{} (empty)")]
@@ -2831,13 +2831,13 @@ mod parenthesized_expression {
 
     #[test_case("(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "( Expression )")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         ParenthesizedExpression::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("(a)" => false; "parenthesized idref")]
@@ -3003,13 +3003,13 @@ mod template_middle_list {
     #[test_case("}list${1}\\u{}${3", true, true => sset(&[]); "list mid exp; mid bad, but tagged")]
     #[test_case("}list${1}${package", true, false => sset(&[PACKAGE_NOT_ALLOWED]); "list mid exp; exp bad")]
     fn early_errors(src: &str, strict: bool, tagged: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         TemplateMiddleList::parse(&mut newparser(src), Scanner::new(), false, true, tagged)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("}\\u{66}${0", true => vec![Some(JSString::from("\\u{66}"))]; "item-raw")]
@@ -3124,13 +3124,13 @@ mod template_spans {
     #[test_case("}${0}\\u{}`", true, false => sset(&[RE_ESCAPE_ONE]); "list tail; tail bad")]
     #[test_case("}${0}\\u{}`", true, true => sset(&[]); "list tail; tail bad, but tagged")]
     fn early_errors(src: &str, strict: bool, tagged: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         TemplateSpans::parse(&mut newparser(src), Scanner::new(), false, true, tagged)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("}\\u{66}`", true => vec![Some(JSString::from("\\u{66}"))]; "tail-raw")]
@@ -3247,10 +3247,10 @@ mod substitution_template {
     #[test_case("`\\u{999999999999}${package}\\u{0x987654321987654321}`", true, true => sset(&[PACKAGE_NOT_ALLOWED]); "tagged")]
     #[test_case("`\\u{99}${package}\\u{98}`", true, false => sset(&[PACKAGE_NOT_ALLOWED]); "not tagged, but no unicode errs")]
     fn early_errors(src: &str, strict: bool, tagged: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).tagged_ok(tagged).substitution_template().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).tagged_ok(tagged).substitution_template().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("`a${0}\\u{66}`", true => vec![Some(JSString::from("a")), Some(JSString::from("\\u{66}"))]; "raw")]
@@ -3384,19 +3384,19 @@ mod template_literal {
         #[test_case("`\\u{`", true, true => sset(&[]); "no-substitution bad escape; tagged")]
         #[test_case("`${package}`", true, false => sset(&[PACKAGE_NOT_ALLOWED]); "substitution template")]
         fn simple(src: &str, strict: bool, tagged: bool) -> AHashSet<String> {
-            let mut agent = test_agent();
+            let agent = test_agent();
             let mut errs = vec![];
             TemplateLiteral::parse(&mut newparser(src), Scanner::new(), false, true, tagged)
                 .unwrap()
                 .0
-                .early_errors(&mut agent, &mut errs, strict, 4294967295);
-            AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+                .early_errors(&agent, &mut errs, strict, 4294967295);
+            AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
         }
 
         #[test]
         fn complex() {
             let limit = 1000;
-            let mut agent = test_agent();
+            let agent = test_agent();
             let mut src = String::with_capacity(2 + 4 * limit);
             src.push('`');
             for _ in 0..limit {
@@ -3405,14 +3405,13 @@ mod template_literal {
             src.push('`');
             let mut errs = vec![];
             TemplateLiteral::parse(&mut newparser(&src), Scanner::new(), false, true, false).unwrap().0.early_errors(
-                &mut agent,
+                &agent,
                 &mut errs,
                 false,
                 limit - 1,
             );
-            let err_set = AHashSet::<String>::from_iter(
-                errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())),
-            );
+            let err_set =
+                AHashSet::<String>::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())));
             assert_eq!(err_set, sset(&["Template literal too complex"]));
         }
     }
@@ -3993,13 +3992,13 @@ mod cover_parenthesized_expression_and_arrow_parameter_list {
     #[test_case("(package, ...{a=b})", true => sset(&[PACKAGE_NOT_ALLOWED]); "exp rest pat; exp bad")]
     #[test_case("(a, ...{package=b})", true => sset(&[PACKAGE_NOT_ALLOWED]); "exp rest pat; pat bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         CoverParenthesizedExpressionAndArrowParameterList::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("   (a)" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 3 } }; "parenthesized")]

--- a/src/parser/relational_operators/mod.rs
+++ b/src/parser/relational_operators/mod.rs
@@ -272,7 +272,7 @@ impl RelationalExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             RelationalExpression::ShiftExpression(n) => n.early_errors(agent, errs, strict),
             RelationalExpression::Less(l, r)

--- a/src/parser/relational_operators/tests.rs
+++ b/src/parser/relational_operators/tests.rs
@@ -448,13 +448,13 @@ mod relational_expression {
     #[test_case("3 in package", true => sset(&[PACKAGE_NOT_ALLOWED]); "left in right; right bad")]
     #[test_case("#a in package", true => sset(&[PACKAGE_NOT_ALLOWED]); "privateid")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         RelationalExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/return_statement/mod.rs
+++ b/src/parser/return_statement/mod.rs
@@ -106,7 +106,7 @@ impl ReturnStatement {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ReturnStatement::Bare { .. } => {}
             ReturnStatement::Expression { exp, .. } => exp.early_errors(agent, errs, strict),

--- a/src/parser/return_statement/tests.rs
+++ b/src/parser/return_statement/tests.rs
@@ -104,10 +104,10 @@ mod return_statement {
     #[test_case("return;", true => sset(&[]); "return ;")]
     #[test_case("return package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "return Expression ;")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).return_statement().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).return_statement().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("return;" => false; "no exp")]

--- a/src/parser/scripts/mod.rs
+++ b/src/parser/scripts/mod.rs
@@ -125,7 +125,7 @@ impl Script {
     // * It is a Syntax Error if the LexicallyDeclaredNames of ScriptBody contains any duplicate entries.
     // * It is a Syntax Error if any element of the LexicallyDeclaredNames of ScriptBody also occurs in the
     //   VarDeclaredNames of ScriptBody.
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>) {
         match &self.body {
             Some(body) => {
                 let lex_names = body.lexically_declared_names();
@@ -268,7 +268,7 @@ impl ScriptBody {
     //  * It is a Syntax Error if ContainsUndefinedContinueTarget of StatementList with arguments « » and « » is true.
     //  * It is a Syntax Error if AllPrivateIdentifiersValid of StatementList with argument « » is false unless the
     //    source code containing ScriptBody is eval code that is being processed by a direct eval.
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>) {
         if !self.direct {
             if self.statement_list.contains(ParseNodeKind::Super) {
                 errs.push(create_syntax_error_object(

--- a/src/parser/scripts/tests.rs
+++ b/src/parser/scripts/tests.rs
@@ -138,10 +138,10 @@ mod script {
     #[test_case("let x; var x=10;" => sset(&[LEX_DUPED_BY_VAR]); "lex duped by var")]
     #[test_case("break a;" => sset(&[UNDEF_BREAK]); "undefined break target")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Script::parse(&mut newparser(src), Scanner::new()).unwrap().0.early_errors(&mut agent, &mut errs);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Script::parse(&mut newparser(src), Scanner::new()).unwrap().0.early_errors(&agent, &mut errs);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("" => svec(&[]); "empty")]
@@ -278,13 +278,10 @@ mod script_body {
     #[test_case("continue bob;", false => sset(&[CONTINUE_ITER, "undefined continue target detected"]); "undefined continue")]
     #[test_case("a.#mystery;", false => sset(&["invalid private identifier detected"]); "invalid private id")]
     fn early_errors(src: &str, direct: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        ScriptBody::parse(&mut directparser(src, direct), Scanner::new())
-            .unwrap()
-            .0
-            .early_errors(&mut agent, &mut errs);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        ScriptBody::parse(&mut directparser(src, direct), Scanner::new()).unwrap().0.early_errors(&agent, &mut errs);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("var a; function b(){}" => svec(&["a", "function b (  ) {  }"]); "statements")]

--- a/src/parser/statements_and_declarations/mod.rs
+++ b/src/parser/statements_and_declarations/mod.rs
@@ -356,7 +356,7 @@ impl Statement {
 
     pub fn early_errors(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         errs: &mut Vec<Object>,
         strict: bool,
         within_iteration: bool,
@@ -639,7 +639,7 @@ impl Declaration {
     /// See [Early Errors][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#early-error
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             Declaration::Hoistable(node) => node.early_errors(agent, errs, strict),
             Declaration::Class(node) => node.early_errors(agent, errs),
@@ -814,7 +814,7 @@ impl HoistableDeclaration {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             HoistableDeclaration::Function(node) => node.early_errors(agent, errs, strict),
             HoistableDeclaration::Generator(node) => node.early_errors(agent, errs, strict),
@@ -978,7 +978,7 @@ impl BreakableStatement {
 
     pub fn early_errors(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         errs: &mut Vec<Object>,
         strict: bool,
         within_iteration: bool,

--- a/src/parser/statements_and_declarations/tests.rs
+++ b/src/parser/statements_and_declarations/tests.rs
@@ -520,13 +520,13 @@ mod statement {
     #[test_case("try {} catch (package) {}", true, false => sset(&[PACKAGE_NOT_ALLOWED]); "TryStatement")]
     #[test_case("debugger;", true, false => sset(&[]); "DebuggerStatement")]
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         Statement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict, wi, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict, wi, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("bob: function alice(){}" => true; "direct labelled function")]
@@ -807,13 +807,13 @@ mod declaration {
     #[test_case("class package{}", true => sset(&[PACKAGE_NOT_ALLOWED]); "ClassDeclaration")]
     #[test_case("let package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "LexicalDeclaration")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         Declaration::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("function a(){}" => false; "Hoistable")]
@@ -1062,13 +1062,13 @@ mod hoistable_declaration {
     #[test_case("async function package(){}", true => sset(&[PACKAGE_NOT_ALLOWED]); "AsyncFunctionDeclaration")]
     #[test_case("async function *package(){}", true => panics "not yet implemented" /* sset(&[PACKAGE_NOT_ALLOWED]) */; "AsyncGeneratorDeclaration")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         HoistableDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, false)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("function a(){}" => "function a (  ) {  }"; "function def")]
@@ -1216,13 +1216,13 @@ mod breakable_statement {
     #[test_case("while(package);", true => sset(&[PACKAGE_NOT_ALLOWED]); "IterationStatement")]
     #[test_case("switch(package){}", true => sset(&[PACKAGE_NOT_ALLOWED]); "SwitchStatement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         BreakableStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("for(;;)arguments;" => true; "Iteration (yes)")]

--- a/src/parser/switch_statement/mod.rs
+++ b/src/parser/switch_statement/mod.rs
@@ -111,7 +111,7 @@ impl SwitchStatement {
         self.expression.contains_arguments() || self.case_block.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, within_iteration: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, within_iteration: bool) {
         // Static Semantics: Early Errors
         //  SwitchStatement : switch ( Expression ) CaseBlock
         //  * It is a Syntax Error if the LexicallyDeclaredNames of CaseBlock contains any duplicate entries.
@@ -411,7 +411,7 @@ impl CaseBlock {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, within_iteration: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, within_iteration: bool) {
         let (before, default, after) = match self {
             CaseBlock::NoDefault(cc, _) => (cc.as_ref(), None, None),
             CaseBlock::HasDefault(cc1, def, cc2, _) => (cc1.as_ref(), Some(def), cc2.as_ref()),
@@ -607,7 +607,7 @@ impl CaseClauses {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, within_iteration: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, within_iteration: bool) {
         let (list, item) = match self {
             CaseClauses::Item(node) => (None, node),
             CaseClauses::List(list, node) => (Some(list), node),
@@ -770,7 +770,7 @@ impl CaseClause {
         self.expression.contains_arguments() || self.statements.as_ref().map_or(false, |s| s.contains_arguments())
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, within_iteration: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, within_iteration: bool) {
         self.expression.early_errors(agent, errs, strict);
         if let Some(stmt) = &self.statements {
             stmt.early_errors(agent, errs, strict, within_iteration, true);
@@ -918,7 +918,7 @@ impl DefaultClause {
         self.0.as_ref().map_or(false, |sl| sl.contains_arguments())
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool, within_iteration: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, within_iteration: bool) {
         if let Some(stmt) = &self.0 {
             stmt.early_errors(agent, errs, strict, within_iteration, true);
         }

--- a/src/parser/switch_statement/tests.rs
+++ b/src/parser/switch_statement/tests.rs
@@ -120,10 +120,10 @@ mod switch_statement {
     #[test_case("switch (a) { case 1: let b=20; case 2: let b=30; case 3: let a=3; }", false, false => sset(&[B_ALREADY]); "duplicate lexicals")]
     #[test_case("switch (a) { case 1: let b=20; case 2: var b=30; case 3: var left; let right; }", false, false => sset(&[B_DUPLEX]); "lex/var dups")]
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).switch_statement().early_errors(&mut agent, &mut errs, strict, wi);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).switch_statement().early_errors(&agent, &mut errs, strict, wi);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("switch(arguments){}" => true; "left")]
@@ -386,10 +386,10 @@ mod case_block {
     #[test_case("{ case package:; default: implements;}", true, false => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "before+default")]
     #[test_case("{ default:package; case implements:;}", true, false => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "default+after")]
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).case_block().early_errors(&mut agent, &mut errs, strict, wi);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).case_block().early_errors(&agent, &mut errs, strict, wi);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("{ }" => Vec::<String>::new(); "empty")]
@@ -554,10 +554,10 @@ mod case_clauses {
     #[test_case("case implements: package; continue; case interface: break;", true, false => sset(&[PACKAGE_NOT_ALLOWED, CONTINUE_ITER, INTERFACE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "list")]
     #[test_case("case implements: package; continue; case interface: break;", false, true => sset(&[]); "not strict; in iter; list")]
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).case_clauses().early_errors(&mut agent, &mut errs, strict, wi);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).case_clauses().early_errors(&agent, &mut errs, strict, wi);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("case 0: let a;" => vec!["a"]; "single")]
@@ -692,10 +692,10 @@ mod case_clause {
     #[test_case("case implements: package; continue;", true, false => sset(&[PACKAGE_NOT_ALLOWED, CONTINUE_ITER, IMPLEMENTS_NOT_ALLOWED]); "statement")]
     #[test_case("case implements: package; continue;", false, true => sset(&[]); "not strict; in iter")]
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).case_clause().early_errors(&mut agent, &mut errs, strict, wi);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).case_clause().early_errors(&agent, &mut errs, strict, wi);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("case 0:" => Vec::<String>::new(); "no statements")]
@@ -820,10 +820,10 @@ mod default_clause {
     #[test_case("default: package; continue;", true, false => sset(&[PACKAGE_NOT_ALLOWED, CONTINUE_ITER]); "statement")]
     #[test_case("default: package; continue;", false, true => sset(&[]); "not strict; in iter")]
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).default_clause().early_errors(&mut agent, &mut errs, strict, wi);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).default_clause().early_errors(&agent, &mut errs, strict, wi);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("default:" => Vec::<String>::new(); "no statements")]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -797,27 +797,27 @@ mod parse_node_kind {
 }
 #[test]
 fn parse_text_01() {
-    let mut agent = test_agent();
-    let res = parse_text(&mut agent, "0;", ParseGoal::Script);
+    let agent = test_agent();
+    let res = parse_text(&agent, "0;", ParseGoal::Script);
     assert!(matches!(res, ParsedText::Script(_)));
 }
 #[test]
 fn parse_text_02() {
-    let mut agent = test_agent();
-    let res = parse_text(&mut agent, "for", ParseGoal::Script);
+    let agent = test_agent();
+    let res = parse_text(&agent, "for", ParseGoal::Script);
     assert!(matches!(res, ParsedText::Errors(_)));
 }
 #[test]
 fn parse_text_03() {
-    let mut agent = test_agent();
-    let res = parse_text(&mut agent, "let x; let x;", ParseGoal::Script);
+    let agent = test_agent();
+    let res = parse_text(&agent, "let x; let x;", ParseGoal::Script);
     assert!(matches!(res, ParsedText::Errors(_)));
 }
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn parse_text_04() {
-    let mut agent = test_agent();
-    parse_text(&mut agent, "let x; let x;", ParseGoal::Module);
+    let agent = test_agent();
+    parse_text(&agent, "let x; let x;", ParseGoal::Module);
 }
 
 #[test_case(&["a"] => Vec::<String>::new(); "no dups")]

--- a/src/parser/throw_statement/mod.rs
+++ b/src/parser/throw_statement/mod.rs
@@ -81,7 +81,7 @@ impl ThrowStatement {
         self.exp.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         self.exp.early_errors(agent, errs, strict);
     }
 }

--- a/src/parser/throw_statement/tests.rs
+++ b/src/parser/throw_statement/tests.rs
@@ -63,10 +63,10 @@ mod throw_statement {
 
     #[test_case("throw package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "normal")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).throw_statement().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).throw_statement().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("throw arguments;" => true; "yes")]

--- a/src/parser/try_statement/mod.rs
+++ b/src/parser/try_statement/mod.rs
@@ -259,7 +259,7 @@ impl TryStatement {
 
     pub fn early_errors(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         errs: &mut Vec<Object>,
         strict: bool,
         within_iteration: bool,
@@ -429,7 +429,7 @@ impl Catch {
 
     pub fn early_errors(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         errs: &mut Vec<Object>,
         strict: bool,
         within_iteration: bool,
@@ -574,7 +574,7 @@ impl Finally {
 
     pub fn early_errors(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         errs: &mut Vec<Object>,
         strict: bool,
         within_iteration: bool,
@@ -702,7 +702,7 @@ impl CatchParameter {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             CatchParameter::Ident(id) => id.early_errors(agent, errs, strict),
             CatchParameter::Pattern(pat) => pat.early_errors(agent, errs, strict),

--- a/src/parser/try_statement/tests.rs
+++ b/src/parser/try_statement/tests.rs
@@ -230,10 +230,10 @@ mod try_statement {
     #[test_case("try{package;}finally{implements;}", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "try Block Finally")]
     #[test_case("try{package;}catch(implements){}finally{interface;}", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "try Block Catch Finally")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).try_statement().early_errors(&mut agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).try_statement().early_errors(&agent, &mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("try { arguments; } catch {}" => true; "try-catch (left)")]
@@ -396,10 +396,10 @@ mod catch {
     #[test_case("catch({a,b}){let a, c;}", true => sset(&[A_ALREADY_DEFINED]); "duplicates in lexical")]
     #[test_case("catch({a,b}){var a, c;}", true => sset(&[A_ALREADY_DEFINED]); "duplicates in var")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).catch().early_errors(&mut agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).catch().early_errors(&agent, &mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("catch({a=arguments}){}" => true; "param (left)")]
@@ -496,10 +496,10 @@ mod finally {
 
     #[test_case("finally{package;}", true => sset(&[PACKAGE_NOT_ALLOWED]); "finally Block")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).finally().early_errors(&mut agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).finally().early_errors(&agent, &mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("finally{arguments;}" => true; "yes")]
@@ -598,10 +598,10 @@ mod catch_parameter {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingIdentifier")]
     #[test_case("{package}", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingPattern")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).catch_parameter().early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).catch_parameter().early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "id")]

--- a/src/parser/unary_operators/mod.rs
+++ b/src/parser/unary_operators/mod.rs
@@ -261,7 +261,7 @@ impl UnaryExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         match self {
             UnaryExpression::UpdateExpression(n) => n.early_errors(agent, errs, strict),
             UnaryExpression::Delete { ue: n, .. } => {

--- a/src/parser/unary_operators/tests.rs
+++ b/src/parser/unary_operators/tests.rs
@@ -399,13 +399,13 @@ mod unary_expression {
     #[test_case("! package", true => sset(&[PACKAGE_NOT_ALLOWED]); "not")]
     #[test_case("await package", true => sset(&[PACKAGE_NOT_ALLOWED]); "await_")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         UnaryExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/update_expressions/mod.rs
+++ b/src/parser/update_expressions/mod.rs
@@ -228,7 +228,7 @@ impl UpdateExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &mut Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             UpdateExpression::LeftHandSideExpression(n) => n.early_errors(agent, errs, strict),

--- a/src/parser/update_expressions/tests.rs
+++ b/src/parser/update_expressions/tests.rs
@@ -247,13 +247,13 @@ mod update_expression {
     #[test_case("--package", true => sset(&[PACKAGE_NOT_ALLOWED]); "pre-dec, simple")]
     #[test_case("--a(b)", true => sset(&["Invalid target for update"]); "pre-dec, complex")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
         UpdateExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&mut agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+            .early_errors(&agent, &mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/with_statement/mod.rs
+++ b/src/parser/with_statement/mod.rs
@@ -118,7 +118,7 @@ impl WithStatement {
 
     pub fn early_errors(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         errs: &mut Vec<Object>,
         strict: bool,
         within_iteration: bool,

--- a/src/parser/with_statement/tests.rs
+++ b/src/parser/with_statement/tests.rs
@@ -143,10 +143,10 @@ mod with_statement {
     #[test_case("with(a){}", true => sset(&[WITH_NOT_ALLOWED]); "strict")]
     #[test_case("with(function (){break;}()){continue;}", false => sset(&[BAD_BREAK, BAD_CONTINUE]); "non-strict")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let mut errs = vec![];
-        Maker::new(src).with_statement().early_errors(&mut agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&mut agent, err.clone())))
+        Maker::new(src).with_statement().early_errors(&agent, &mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
 
     #[test_case("with(arguments);" => true; "Left")]

--- a/src/realm/mod.rs
+++ b/src/realm/mod.rs
@@ -130,7 +130,7 @@ pub struct Intrinsics {
 }
 
 impl Intrinsics {
-    fn new(agent: &mut Agent) -> Self {
+    fn new(agent: &Agent) -> Self {
         // Since an intrinsics struct needs to be populated in a particular order and then fixed up, RAII doesn't work
         // so grand. Therefore, a "dead object" is placed in each field instead. This quickly gives us an initialized
         // struct, and also generates run-time panics if any "un-initialized" members are actually used. (Option<Object>
@@ -299,7 +299,7 @@ pub struct Realm {
 //  4. Set realmRec.[[GlobalEnv]] to undefined.
 //  5. Set realmRec.[[TemplateMap]] to a new empty List.
 //  6. Return realmRec.
-pub fn create_realm(agent: &mut Agent) -> Rc<RefCell<Realm>> {
+pub fn create_realm(agent: &Agent) -> Rc<RefCell<Realm>> {
     let r = Rc::new(RefCell::new(Realm { intrinsics: Intrinsics::new(agent), global_object: None, global_env: None }));
     create_intrinsics(agent, r.clone());
     r
@@ -323,7 +323,7 @@ pub fn create_realm(agent: &mut Agent) -> Rc<RefCell<Realm>> {
 //     not yet been created.
 //  4. Perform AddRestrictedFunctionProperties(intrinsics.[[%Function.prototype%]], realmRec).
 //  5. Return intrinsics.
-pub fn create_intrinsics(agent: &mut Agent, realm_rec: Rc<RefCell<Realm>>) {
+pub fn create_intrinsics(agent: &Agent, realm_rec: Rc<RefCell<Realm>>) {
     // ToDo: All of step 3.
 
     // %Object.prototype%
@@ -393,7 +393,7 @@ pub fn create_intrinsics(agent: &mut Agent, realm_rec: Rc<RefCell<Realm>>) {
     agent.provision_iterator_prototype(&realm_rec);
     agent.provision_generator_function_intrinsics(&realm_rec);
 
-    add_restricted_function_properties(agent, &function_prototype, realm_rec.clone());
+    add_restricted_function_properties(agent, &function_prototype, realm_rec);
 }
 
 // From function objects...
@@ -408,7 +408,7 @@ pub fn create_intrinsics(agent: &mut Agent, realm_rec: Rc<RefCell<Realm>>) {
 //    [[Enumerable]]: false, [[Configurable]]: true }).
 // 4. Return ! DefinePropertyOrThrow(F, "arguments", PropertyDescriptor { [[Get]]: thrower, [[Set]]: thrower,
 //    [[Enumerable]]: false, [[Configurable]]: true }).
-pub fn add_restricted_function_properties(agent: &mut Agent, f: &Object, realm: Rc<RefCell<Realm>>) {
+pub fn add_restricted_function_properties(agent: &Agent, f: &Object, realm: Rc<RefCell<Realm>>) {
     let thrower = ECMAScriptValue::Object(realm.borrow().intrinsics.get(IntrinsicId::ThrowTypeError));
     define_property_or_throw(
         agent,
@@ -445,7 +445,7 @@ pub fn add_restricted_function_properties(agent: &mut Agent, f: &Object, realm: 
 // The "name" property of a %ThrowTypeError% function has the attributes { [[Writable]]: false, [[Enumerable]]: false,
 // [[Configurable]]: false }.
 pub fn throw_type_error(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -453,7 +453,7 @@ pub fn throw_type_error(
     Err(create_type_error(agent, "Generic TypeError"))
 }
 
-fn create_throw_type_error_builtin(agent: &mut Agent, realm: Rc<RefCell<Realm>>) -> Object {
+fn create_throw_type_error_builtin(agent: &Agent, realm: Rc<RefCell<Realm>>) -> Object {
     let function_proto = realm.borrow().intrinsics.get(IntrinsicId::FunctionPrototype);
     let fcn = create_builtin_function(
         agent,

--- a/src/realm/tests.rs
+++ b/src/realm/tests.rs
@@ -74,8 +74,8 @@ fn intrinsic_id_clone() {
 
 #[test]
 fn intrinsics_debug() {
-    let mut agent = test_agent();
-    assert_ne!(format!("{:?}", Intrinsics::new(&mut agent)), "")
+    let agent = test_agent();
+    assert_ne!(format!("{:?}", Intrinsics::new(&agent)), "")
 }
 
 #[test]
@@ -133,8 +133,8 @@ fn realm_debug() {
 
 #[test]
 fn throw_type_error_test() {
-    let mut agent = test_agent();
-    let err = throw_type_error(&mut agent, ECMAScriptValue::Undefined, None, &[]).unwrap_err();
-    let msg = unwind_type_error(&mut agent, err);
+    let agent = test_agent();
+    let err = throw_type_error(&agent, ECMAScriptValue::Undefined, None, &[]).unwrap_err();
+    let msg = unwind_type_error(&agent, err);
     assert_eq!(msg, "Generic TypeError");
 }

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -243,7 +243,7 @@ impl Reference {
 // NOTE     The object that may be created in step 4.a is not accessible outside of the above abstract operation and the
 //          ordinary object [[Get]] internal method. An implementation might choose to avoid the actual creation of the
 //          object.
-pub fn get_value(agent: &mut Agent, v_completion: FullCompletion) -> Completion<ECMAScriptValue> {
+pub fn get_value(agent: &Agent, v_completion: FullCompletion) -> Completion<ECMAScriptValue> {
     let v = v_completion?;
     match v {
         NormalCompletion::Value(val) => Ok(val),
@@ -295,7 +295,7 @@ pub fn get_value(agent: &mut Agent, v_completion: FullCompletion) -> Completion<
 //          ordinary object [[Set]] internal method. An implementation might choose to avoid the actual creation of that
 //          object.
 pub fn put_value(
-    agent: &mut Agent,
+    agent: &Agent,
     v_completion: FullCompletion,
     w_completion: Completion<ECMAScriptValue>,
 ) -> Completion<()> {
@@ -350,7 +350,7 @@ pub fn put_value(
 //  6. Assert: base is an Environment Record.
 //  7. Return base.InitializeBinding(V.[[ReferencedName]], W).
 pub fn initialize_referenced_binding(
-    agent: &mut Agent,
+    agent: &Agent,
     v_completion: FullCompletion,
     w_completion: Completion<ECMAScriptValue>,
 ) -> Completion<()> {

--- a/src/reference/tests.rs
+++ b/src/reference/tests.rs
@@ -137,8 +137,8 @@ mod referenced_name {
         }
         #[test]
         fn symbol() {
-            let mut agent = test_agent();
-            let sym = Symbol::new(&mut agent, None);
+            let agent = test_agent();
+            let sym = Symbol::new(&agent, None);
             let rn = ReferencedName::from(sym.clone());
             assert_eq!(rn, ReferencedName::Symbol(sym));
         }
@@ -158,8 +158,8 @@ mod referenced_name {
             }
             #[test]
             fn symbol() {
-                let mut agent = test_agent();
-                let sym = Symbol::new(&mut agent, Some(JSString::from("crazy")));
+                let agent = test_agent();
+                let sym = Symbol::new(&agent, Some(JSString::from("crazy")));
                 let pk = PropertyKey::from(sym.clone());
                 let rn = ReferencedName::from(pk);
                 assert_eq!(rn, ReferencedName::Symbol(sym));
@@ -180,8 +180,8 @@ mod referenced_name {
             }
             #[test]
             fn symbol() {
-                let mut agent = test_agent();
-                let sym = Symbol::new(&mut agent, None);
+                let agent = test_agent();
+                let sym = Symbol::new(&agent, None);
                 let rn = ReferencedName::from(sym);
                 let err = JSString::try_from(rn).unwrap_err();
                 assert_eq!(err, "invalid string");
@@ -205,8 +205,8 @@ mod referenced_name {
             }
             #[test]
             fn symbol() {
-                let mut agent = test_agent();
-                let sym = Symbol::new(&mut agent, None);
+                let agent = test_agent();
+                let sym = Symbol::new(&agent, None);
                 let rn = ReferencedName::from(sym.clone());
                 let pk: PropertyKey = rn.try_into().unwrap();
                 assert_eq!(pk, PropertyKey::Symbol(sym));
@@ -232,8 +232,8 @@ mod referenced_name {
 
         #[test]
         fn symbol() {
-            let mut agent = test_agent();
-            let sym = Symbol::new(&mut agent, Some("symbol-test".into()));
+            let agent = test_agent();
+            let sym = Symbol::new(&agent, Some("symbol-test".into()));
             let rn = ReferencedName::from(sym);
             let result = format!("{rn}");
             assert_eq!(result, "Symbol(symbol-test)");
@@ -381,9 +381,9 @@ mod reference {
         }
         #[test]
         fn value_has_this() {
-            let mut agent = test_agent();
+            let agent = test_agent();
             let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let normal_object = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+            let normal_object = ordinary_object_create(&agent, Some(object_proto), &[]);
             let this_value = ECMAScriptValue::from(normal_object);
             let value = ECMAScriptValue::from("Gatsby turned out all right at the end");
             let reference = Reference::new(Base::Value(value), "phrase", true, Some(this_value.clone()));
@@ -413,39 +413,39 @@ mod get_value {
 
     #[test]
     fn abrupt() {
-        let mut agent = test_agent();
-        let err = create_type_error(&mut agent, "Test Path");
-        let result = get_value(&mut agent, Err(err)).unwrap_err();
-        assert_eq!(unwind_type_error(&mut agent, result), "Test Path");
+        let agent = test_agent();
+        let err = create_type_error(&agent, "Test Path");
+        let result = get_value(&agent, Err(err)).unwrap_err();
+        assert_eq!(unwind_type_error(&agent, result), "Test Path");
     }
 
     #[test]
     fn simple_value() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let val = ECMAScriptValue::from("a value");
-        let result = get_value(&mut agent, Ok(NormalCompletion::from(val))).unwrap();
+        let result = get_value(&agent, Ok(NormalCompletion::from(val))).unwrap();
         assert_eq!(result, ECMAScriptValue::from("a value"));
     }
 
     #[test]
     fn unresolvable() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let badref = Reference::new(Base::Unresolvable, "no_ref", true, None);
-        let result = get_value(&mut agent, Ok(NormalCompletion::from(badref))).unwrap_err();
-        assert_eq!(unwind_reference_error(&mut agent, result), "Unresolvable Reference");
+        let result = get_value(&agent, Ok(NormalCompletion::from(badref))).unwrap_err();
+        assert_eq!(unwind_reference_error(&agent, result), "Unresolvable Reference");
     }
     #[test]
     fn empty() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let val = Ok(NormalCompletion::Empty);
-        let result = get_value(&mut agent, val).unwrap_err();
-        assert_eq!(unwind_reference_error(&mut agent, result), "Unresolvable Reference");
+        let result = get_value(&agent, val).unwrap_err();
+        assert_eq!(unwind_reference_error(&agent, result), "Unresolvable Reference");
     }
     #[test]
     fn value_base() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let normal_object = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+        let normal_object = ordinary_object_create(&agent, Some(object_proto), &[]);
         let value = ECMAScriptValue::from("value_base test value");
         let descriptor = PotentialPropertyDescriptor {
             writable: Some(true),
@@ -454,44 +454,44 @@ mod get_value {
             value: Some(value.clone()),
             ..Default::default()
         };
-        define_property_or_throw(&mut agent, &normal_object, PropertyKey::from("test_value"), descriptor).unwrap();
+        define_property_or_throw(&agent, &normal_object, PropertyKey::from("test_value"), descriptor).unwrap();
         let reference = Reference::new(Base::Value(ECMAScriptValue::from(normal_object)), "test_value", true, None);
 
-        let result = get_value(&mut agent, Ok(NormalCompletion::from(reference))).unwrap();
+        let result = get_value(&agent, Ok(NormalCompletion::from(reference))).unwrap();
         assert_eq!(result, value);
     }
     #[test]
     fn to_object_err() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let reference = Reference::new(Base::Value(ECMAScriptValue::Undefined), "test_value", true, None);
-        let result = get_value(&mut agent, Ok(NormalCompletion::from(reference))).unwrap_err();
-        assert_eq!(unwind_type_error(&mut agent, result), "Undefined and null cannot be converted to objects");
+        let result = get_value(&agent, Ok(NormalCompletion::from(reference))).unwrap_err();
+        assert_eq!(unwind_type_error(&agent, result), "Undefined and null cannot be converted to objects");
     }
     #[test]
     fn private() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let pn = PrivateName::new("test name");
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let normal_object = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+        let normal_object = ordinary_object_create(&agent, Some(object_proto), &[]);
         let value = ECMAScriptValue::from("test value for private identifier");
-        private_field_add(&mut agent, &normal_object, pn.clone(), value.clone()).unwrap();
+        private_field_add(&agent, &normal_object, pn.clone(), value.clone()).unwrap();
         let reference = Reference::new(Base::Value(ECMAScriptValue::from(normal_object)), pn, true, None);
-        let result = get_value(&mut agent, Ok(NormalCompletion::from(reference))).unwrap();
+        let result = get_value(&agent, Ok(NormalCompletion::from(reference))).unwrap();
         assert_eq!(result, value);
     }
     #[test]
     fn environment() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+        let global = ordinary_object_create(&agent, Some(object_proto), &[]);
         let this_obj = global.clone();
         let env = GlobalEnvironmentRecord::new(global, this_obj, "test-global");
         let value = ECMAScriptValue::from("sentinel string for environment test");
-        env.create_immutable_binding(&mut agent, JSString::from("test_var"), true).unwrap();
-        env.initialize_binding(&mut agent, &JSString::from("test_var"), value.clone()).unwrap();
+        env.create_immutable_binding(&agent, JSString::from("test_var"), true).unwrap();
+        env.initialize_binding(&agent, &JSString::from("test_var"), value.clone()).unwrap();
         let reference = Reference::new(Base::Environment(Rc::new(env)), "test_var", true, None);
 
-        let result = get_value(&mut agent, Ok(NormalCompletion::from(reference))).unwrap();
+        let result = get_value(&agent, Ok(NormalCompletion::from(reference))).unwrap();
         assert_eq!(result, value);
     }
 }
@@ -502,61 +502,58 @@ mod put_value {
 
     #[test]
     fn err_v() {
-        let mut agent = test_agent();
-        let v = create_type_error(&mut agent, "Error in V");
-        let w = create_type_error(&mut agent, "Error in W");
-        let result = put_value(&mut agent, Err(v), Err(w)).unwrap_err();
+        let agent = test_agent();
+        let v = create_type_error(&agent, "Error in V");
+        let w = create_type_error(&agent, "Error in W");
+        let result = put_value(&agent, Err(v), Err(w)).unwrap_err();
 
-        assert_eq!(unwind_type_error(&mut agent, result), "Error in V");
+        assert_eq!(unwind_type_error(&agent, result), "Error in V");
     }
     #[test]
     fn err_w() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let v = ECMAScriptValue::Undefined;
-        let w = create_type_error(&mut agent, "Error in W");
-        let result = put_value(&mut agent, Ok(NormalCompletion::from(v)), Err(w)).unwrap_err();
+        let w = create_type_error(&agent, "Error in W");
+        let result = put_value(&agent, Ok(NormalCompletion::from(v)), Err(w)).unwrap_err();
 
-        assert_eq!(unwind_type_error(&mut agent, result), "Error in W");
+        assert_eq!(unwind_type_error(&agent, result), "Error in W");
     }
     #[test]
     fn bad_lhs() {
-        let mut agent = test_agent();
-        let result = put_value(
-            &mut agent,
-            Ok(NormalCompletion::from(ECMAScriptValue::Undefined)),
-            Ok(ECMAScriptValue::Undefined),
-        )
-        .unwrap_err();
+        let agent = test_agent();
+        let result =
+            put_value(&agent, Ok(NormalCompletion::from(ECMAScriptValue::Undefined)), Ok(ECMAScriptValue::Undefined))
+                .unwrap_err();
 
-        assert_eq!(unwind_reference_error(&mut agent, result), "Invalid Reference");
+        assert_eq!(unwind_reference_error(&agent, result), "Invalid Reference");
     }
     #[test]
     fn unresolvable_strict() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let reference = Reference::new(Base::Unresolvable, "blue", true, None);
         let result =
-            put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(ECMAScriptValue::Undefined)).unwrap_err();
-        assert_eq!(unwind_reference_error(&mut agent, result), "Unknown reference");
+            put_value(&agent, Ok(NormalCompletion::from(reference)), Ok(ECMAScriptValue::Undefined)).unwrap_err();
+        assert_eq!(unwind_reference_error(&agent, result), "Unknown reference");
     }
     #[test]
     fn unresolvable_nonstrict() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let value = ECMAScriptValue::from("Test Value for Unresolvable, non-strict writes");
         let reference = Reference::new(Base::Unresolvable, "blue", false, None);
-        put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
+        put_value(&agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
         let global = get_global_object(&agent).unwrap();
-        let from_global = get(&mut agent, &global, &PropertyKey::from("blue")).unwrap();
+        let from_global = get(&agent, &global, &PropertyKey::from("blue")).unwrap();
         assert_eq!(from_global, value);
     }
     #[test]
     fn unresolvable_throws() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let value = ECMAScriptValue::from("Test Value");
         let reference = Reference::new(Base::Unresolvable, "thrower", false, None);
         let thrower = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError));
         let global = get_global_object(&agent).unwrap();
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &global,
             PropertyKey::from("thrower"),
             PotentialPropertyDescriptor {
@@ -569,61 +566,60 @@ mod put_value {
         )
         .unwrap();
 
-        let result = put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value)).unwrap_err();
-        assert_eq!(unwind_type_error(&mut agent, result), "Generic TypeError");
+        let result = put_value(&agent, Ok(NormalCompletion::from(reference)), Ok(value)).unwrap_err();
+        assert_eq!(unwind_type_error(&agent, result), "Generic TypeError");
     }
     #[test]
     fn private() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let value = ECMAScriptValue::from("In my younger and more vulnerable years");
         let pn = PrivateName::new("test name");
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let normal_object = ordinary_object_create(&mut agent, Some(object_proto), &[]);
-        private_field_add(&mut agent, &normal_object, pn.clone(), ECMAScriptValue::Undefined).unwrap();
+        let normal_object = ordinary_object_create(&agent, Some(object_proto), &[]);
+        private_field_add(&agent, &normal_object, pn.clone(), ECMAScriptValue::Undefined).unwrap();
         let reference =
             Reference::new(Base::Value(ECMAScriptValue::from(normal_object.clone())), pn.clone(), true, None);
 
-        put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
+        put_value(&agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
 
-        let from_private = private_get(&mut agent, &normal_object, &pn).unwrap();
+        let from_private = private_get(&agent, &normal_object, &pn).unwrap();
         assert_eq!(from_private, value);
     }
 
     #[test]
     fn bad_value() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let reference = Reference::new(Base::Value(ECMAScriptValue::Undefined), "test", true, None);
-        let result =
-            put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(ECMAScriptValue::Null)).unwrap_err();
-        assert_eq!(unwind_type_error(&mut agent, result), "Undefined and null cannot be converted to objects");
+        let result = put_value(&agent, Ok(NormalCompletion::from(reference)), Ok(ECMAScriptValue::Null)).unwrap_err();
+        assert_eq!(unwind_type_error(&agent, result), "Undefined and null cannot be converted to objects");
     }
     #[test]
     fn ordinary() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let value = ECMAScriptValue::from("my father gave me some advice");
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let normal_object = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+        let normal_object = ordinary_object_create(&agent, Some(object_proto), &[]);
         let key = PropertyKey::from("phrase");
         let reference =
             Reference::new(Base::Value(ECMAScriptValue::from(normal_object.clone())), key.clone(), true, None);
 
-        put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
+        put_value(&agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
 
-        let from_object = get(&mut agent, &normal_object, &key).unwrap();
+        let from_object = get(&agent, &normal_object, &key).unwrap();
         assert_eq!(from_object, value);
     }
     #[test]
     fn object_throws() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let value = ECMAScriptValue::from("that I’ve been turning over in my mind ever since.");
         let thrower = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError));
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let normal_object = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+        let normal_object = ordinary_object_create(&agent, Some(object_proto), &[]);
         let key = PropertyKey::from("phrase");
         let reference =
             Reference::new(Base::Value(ECMAScriptValue::from(normal_object.clone())), key.clone(), true, None);
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &normal_object,
             key,
             PotentialPropertyDescriptor {
@@ -635,19 +631,19 @@ mod put_value {
         )
         .unwrap();
 
-        let result = put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value)).unwrap_err();
-        assert_eq!(unwind_type_error(&mut agent, result), "Generic TypeError");
+        let result = put_value(&agent, Ok(NormalCompletion::from(reference)), Ok(value)).unwrap_err();
+        assert_eq!(unwind_type_error(&agent, result), "Generic TypeError");
     }
     #[test_case(false => Ok(()); "non-strict")]
     #[test_case(true => Err(String::from("Invalid Assignment Target")); "strict")]
     fn immutable(strict: bool) -> Result<(), String> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let value = ECMAScriptValue::from("“Whenever you feel like criticizing anyone,”");
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let normal_object = ordinary_object_create(&mut agent, Some(object_proto), &[]);
+        let normal_object = ordinary_object_create(&agent, Some(object_proto), &[]);
         let key = PropertyKey::from("phrase");
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &normal_object,
             key.clone(),
             PotentialPropertyDescriptor {
@@ -662,29 +658,29 @@ mod put_value {
         let reference =
             Reference::new(Base::Value(ECMAScriptValue::from(normal_object.clone())), key.clone(), strict, None);
 
-        let r = put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value))
-            .map_err(|ac| unwind_type_error(&mut agent, ac));
+        let r = put_value(&agent, Ok(NormalCompletion::from(reference)), Ok(value))
+            .map_err(|ac| unwind_type_error(&agent, ac));
 
-        let from_obj = get(&mut agent, &normal_object, &key).unwrap();
+        let from_obj = get(&agent, &normal_object, &key).unwrap();
         assert_eq!(from_obj, ECMAScriptValue::Undefined);
 
         r
     }
     #[test]
     fn environment() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let value = ECMAScriptValue::from(
             "he told me, “just remember that all the people in this world haven’t had the advantages that you’ve had.”",
         );
         let der = Rc::new(DeclarativeEnvironmentRecord::new(None, "test"));
         let key = JSString::from("env_test");
-        der.create_mutable_binding(&mut agent, key.clone(), true).unwrap();
-        der.initialize_binding(&mut agent, &key, ECMAScriptValue::Undefined).unwrap();
+        der.create_mutable_binding(&agent, key.clone(), true).unwrap();
+        der.initialize_binding(&agent, &key, ECMAScriptValue::Undefined).unwrap();
         let reference = Reference::new(Base::Environment(der.clone()), key.clone(), true, None);
 
-        put_value(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
+        put_value(&agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
 
-        let from_env = der.get_binding_value(&mut agent, &key, true).unwrap();
+        let from_env = der.get_binding_value(&agent, &key, true).unwrap();
         assert_eq!(from_env, value);
     }
 }
@@ -694,66 +690,58 @@ mod initialize_referenced_binding {
 
     #[test]
     fn err_v() {
-        let mut agent = test_agent();
-        let v = create_type_error(&mut agent, "Error in V");
-        let w = create_type_error(&mut agent, "Error in W");
-        let result = initialize_referenced_binding(&mut agent, Err(v), Err(w)).unwrap_err();
+        let agent = test_agent();
+        let v = create_type_error(&agent, "Error in V");
+        let w = create_type_error(&agent, "Error in W");
+        let result = initialize_referenced_binding(&agent, Err(v), Err(w)).unwrap_err();
 
-        assert_eq!(unwind_type_error(&mut agent, result), "Error in V");
+        assert_eq!(unwind_type_error(&agent, result), "Error in V");
     }
     #[test]
     fn err_w() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let v = ECMAScriptValue::Undefined;
-        let w = create_type_error(&mut agent, "Error in W");
-        let result = initialize_referenced_binding(&mut agent, Ok(NormalCompletion::from(v)), Err(w)).unwrap_err();
+        let w = create_type_error(&agent, "Error in W");
+        let result = initialize_referenced_binding(&agent, Ok(NormalCompletion::from(v)), Err(w)).unwrap_err();
 
-        assert_eq!(unwind_type_error(&mut agent, result), "Error in W");
+        assert_eq!(unwind_type_error(&agent, result), "Error in W");
     }
     #[test]
     fn happy() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let key = JSString::from("variable");
         let env = Rc::new(DeclarativeEnvironmentRecord::new(None, "test"));
-        env.create_mutable_binding(&mut agent, key.clone(), true).unwrap();
+        env.create_mutable_binding(&agent, key.clone(), true).unwrap();
         let reference = Reference::new(Base::Environment(env.clone()), key.clone(), true, None);
         let value = ECMAScriptValue::from("There was so much to read, for one thing,");
 
-        initialize_referenced_binding(&mut agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
+        initialize_referenced_binding(&agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
 
-        let from_env = env.get_binding_value(&mut agent, &key, true).unwrap();
+        let from_env = env.get_binding_value(&agent, &key, true).unwrap();
         assert_eq!(from_env, value);
     }
     #[test]
     #[should_panic(expected = "unreachable code")]
     fn value_ref() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let reference = Reference::new(Base::Value(ECMAScriptValue::Undefined), "phrase", true, None);
-        initialize_referenced_binding(
-            &mut agent,
-            Ok(NormalCompletion::from(reference)),
-            Ok(ECMAScriptValue::Undefined),
-        )
-        .unwrap();
+        initialize_referenced_binding(&agent, Ok(NormalCompletion::from(reference)), Ok(ECMAScriptValue::Undefined))
+            .unwrap();
     }
     #[test]
     #[should_panic(expected = "unreachable code")]
     fn unresolveable_ref() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let reference = Reference::new(Base::Unresolvable, "phrase", true, None);
-        initialize_referenced_binding(
-            &mut agent,
-            Ok(NormalCompletion::from(reference)),
-            Ok(ECMAScriptValue::Undefined),
-        )
-        .unwrap();
+        initialize_referenced_binding(&agent, Ok(NormalCompletion::from(reference)), Ok(ECMAScriptValue::Undefined))
+            .unwrap();
     }
     #[test]
     #[should_panic(expected = "unreachable code")]
     fn value() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         initialize_referenced_binding(
-            &mut agent,
+            &agent,
             Ok(NormalCompletion::from(ECMAScriptValue::Undefined)),
             Ok(ECMAScriptValue::Undefined),
         )

--- a/src/string_object/mod.rs
+++ b/src/string_object/mod.rs
@@ -56,23 +56,23 @@ impl ObjectInterface for StringObject {
         true
     }
 
-    fn get_prototype_of(&self, _agent: &mut Agent) -> Completion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &Agent) -> Completion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
 
-    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<Object>) -> Completion<bool> {
+    fn set_prototype_of(&self, _agent: &Agent, obj: Option<Object>) -> Completion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
 
-    fn is_extensible(&self, _agent: &mut Agent) -> Completion<bool> {
+    fn is_extensible(&self, _agent: &Agent) -> Completion<bool> {
         Ok(ordinary_is_extensible(self))
     }
 
-    fn prevent_extensions(&self, _agent: &mut Agent) -> Completion<bool> {
+    fn prevent_extensions(&self, _agent: &Agent) -> Completion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
 
-    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _agent: &Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         // [[GetOwnProperty]] ( P )
         //
         // The [[GetOwnProperty]] internal method of a String exotic object S takes argument P (a property
@@ -87,7 +87,7 @@ impl ObjectInterface for StringObject {
 
     fn define_own_property(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         key: PropertyKey,
         desc: PotentialPropertyDescriptor,
     ) -> Completion<bool> {
@@ -111,17 +111,17 @@ impl ObjectInterface for StringObject {
         }
     }
 
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
+    fn has_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_has_property(agent, self, key)
     }
 
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+    fn get(&self, agent: &Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         ordinary_get(agent, self, key, receiver)
     }
 
     fn set(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         key: PropertyKey,
         value: ECMAScriptValue,
         receiver: &ECMAScriptValue,
@@ -129,11 +129,11 @@ impl ObjectInterface for StringObject {
         ordinary_set(agent, self, key, value, receiver)
     }
 
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
+    fn delete(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_delete(agent, self, key)
     }
 
-    fn own_property_keys(&self, _agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, _agent: &Agent) -> Completion<Vec<PropertyKey>> {
         // [[OwnPropertyKeys]] ( )
         //
         // The [[OwnPropertyKeys]] internal method of a String exotic object O takes no arguments and returns
@@ -195,17 +195,17 @@ impl ObjectInterface for StringObject {
 }
 
 impl Agent {
-    pub fn string_create(&mut self, value: JSString, prototype: Option<Object>) -> Object {
+    pub fn string_create(&self, value: JSString, prototype: Option<Object>) -> Object {
         StringObject::object(self, value, prototype)
     }
-    pub fn create_string_object(&mut self, s: JSString) -> Object {
+    pub fn create_string_object(&self, s: JSString) -> Object {
         let prototype = self.intrinsic(IntrinsicId::StringPrototype);
         self.string_create(s, Some(prototype))
     }
 }
 
 impl StringObject {
-    pub fn object(agent: &mut Agent, value: JSString, prototype: Option<Object>) -> Object {
+    pub fn object(agent: &Agent, value: JSString, prototype: Option<Object>) -> Object {
         // StringCreate ( value, prototype )
         //
         // The abstract operation StringCreate takes arguments value (a String) and prototype and returns a
@@ -281,7 +281,7 @@ impl StringObject {
 }
 
 impl Agent {
-    pub fn provision_string_intrinsic(&mut self, realm: &Rc<RefCell<Realm>>) {
+    pub fn provision_string_intrinsic(&self, realm: &Rc<RefCell<Realm>>) {
         let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
         let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -458,7 +458,7 @@ impl Agent {
 }
 
 fn string_constructor_function(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -491,7 +491,7 @@ fn string_constructor_function(
 }
 
 impl Agent {
-    fn this_string_value(&mut self, value: ECMAScriptValue, from_where: &str) -> Completion<JSString> {
+    fn this_string_value(&self, value: ECMAScriptValue, from_where: &str) -> Completion<JSString> {
         // The abstract operation thisStringValue takes argument value. It performs the following steps when
         // called:
         //
@@ -513,7 +513,7 @@ impl Agent {
 }
 
 fn string_from_char_code(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -536,7 +536,7 @@ fn string_from_char_code(
     .into())
 }
 fn string_from_code_point(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -544,7 +544,7 @@ fn string_from_code_point(
     todo!()
 }
 fn string_raw(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -554,7 +554,7 @@ fn string_raw(
 
 // 22.1.3.1 String.prototype.at ( index )
 fn string_prototype_at(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -563,7 +563,7 @@ fn string_prototype_at(
 }
 // 22.1.3.2 String.prototype.charAt ( pos )
 fn string_prototype_char_at(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -572,7 +572,7 @@ fn string_prototype_char_at(
 }
 // 22.1.3.3 String.prototype.charCodeAt ( pos )
 fn string_prototype_char_code_at(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -581,7 +581,7 @@ fn string_prototype_char_code_at(
 }
 // 22.1.3.4 String.prototype.codePointAt ( pos )
 fn string_prototype_code_point_at(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -590,7 +590,7 @@ fn string_prototype_code_point_at(
 }
 // 22.1.3.5 String.prototype.concat ( ...args )
 fn string_prototype_concat(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -599,7 +599,7 @@ fn string_prototype_concat(
 }
 // 22.1.3.7 String.prototype.endsWith ( searchString [ , endPosition ] )
 fn string_prototype_ends_with(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -608,7 +608,7 @@ fn string_prototype_ends_with(
 }
 // 22.1.3.8 String.prototype.includes ( searchString [ , position ] )
 fn string_prototype_includes(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -617,7 +617,7 @@ fn string_prototype_includes(
 }
 // 22.1.3.9 String.prototype.indexOf ( searchString [ , position ] )
 fn string_prototype_index_of(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -657,7 +657,7 @@ fn string_prototype_index_of(
 
 // 22.1.3.10 String.prototype.lastIndexOf ( searchString [ , position ] )
 fn string_prototype_last_index_of(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -666,7 +666,7 @@ fn string_prototype_last_index_of(
 }
 // 22.1.3.11 String.prototype.localeCompare ( that [ , reserved1 [ , reserved2 ] ] )
 fn string_prototype_locale_compare(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -675,7 +675,7 @@ fn string_prototype_locale_compare(
 }
 // 22.1.3.12 String.prototype.match ( regexp )
 fn string_prototype_match(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -684,7 +684,7 @@ fn string_prototype_match(
 }
 // 22.1.3.13 String.prototype.matchAll ( regexp )
 fn string_prototype_match_all(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -693,7 +693,7 @@ fn string_prototype_match_all(
 }
 // 22.1.3.14 String.prototype.normalize ( [ form ] )
 fn string_prototype_normalize(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -702,7 +702,7 @@ fn string_prototype_normalize(
 }
 // 22.1.3.15 String.prototype.padEnd ( maxLength [ , fillString ] )
 fn string_prototype_pad_end(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -711,7 +711,7 @@ fn string_prototype_pad_end(
 }
 // 22.1.3.16 String.prototype.padStart ( maxLength [ , fillString ] )
 fn string_prototype_pad_start(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -720,7 +720,7 @@ fn string_prototype_pad_start(
 }
 // 22.1.3.17 String.prototype.repeat ( count )
 fn string_prototype_repeat(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -729,7 +729,7 @@ fn string_prototype_repeat(
 }
 // 22.1.3.18 String.prototype.replace ( searchValue, replaceValue )
 fn string_prototype_replace(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -738,7 +738,7 @@ fn string_prototype_replace(
 }
 // 22.1.3.19 String.prototype.replaceAll ( searchValue, replaceValue )
 fn string_prototype_replace_all(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -747,7 +747,7 @@ fn string_prototype_replace_all(
 }
 // 22.1.3.20 String.prototype.search ( regexp )
 fn string_prototype_search(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -756,7 +756,7 @@ fn string_prototype_search(
 }
 // 22.1.3.21 String.prototype.slice ( start, end )
 fn string_prototype_slice(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -765,7 +765,7 @@ fn string_prototype_slice(
 }
 // 22.1.3.22 String.prototype.split ( separator, limit )
 fn string_prototype_split(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -774,7 +774,7 @@ fn string_prototype_split(
 }
 // 22.1.3.23 String.prototype.startsWith ( searchString [ , position ] )
 fn string_prototype_starts_with(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -783,7 +783,7 @@ fn string_prototype_starts_with(
 }
 // 22.1.3.24 String.prototype.substring ( start, end )
 fn string_prototype_substring(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -792,7 +792,7 @@ fn string_prototype_substring(
 }
 // 22.1.3.25 String.prototype.toLocaleLowerCase ( [ reserved1 [ , reserved2 ] ] )
 fn string_prototype_to_locale_lower_case(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -801,7 +801,7 @@ fn string_prototype_to_locale_lower_case(
 }
 // 22.1.3.26 String.prototype.toLocaleUpperCase ( [ reserved1 [ , reserved2 ] ] )
 fn string_prototype_to_locale_upper_case(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -810,7 +810,7 @@ fn string_prototype_to_locale_upper_case(
 }
 // 22.1.3.27 String.prototype.toLowerCase ( )
 fn string_prototype_to_lower_case(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -819,7 +819,7 @@ fn string_prototype_to_lower_case(
 }
 // 22.1.3.28 String.prototype.toString ( )
 fn string_prototype_to_string(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -833,7 +833,7 @@ fn string_prototype_to_string(
 }
 // 22.1.3.29 String.prototype.toUpperCase ( )
 fn string_prototype_to_upper_case(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -842,7 +842,7 @@ fn string_prototype_to_upper_case(
 }
 // 22.1.3.30 String.prototype.trim ( )
 fn string_prototype_trim(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -851,7 +851,7 @@ fn string_prototype_trim(
 }
 // 22.1.3.31 String.prototype.trimEnd ( )
 fn string_prototype_trim_end(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -860,7 +860,7 @@ fn string_prototype_trim_end(
 }
 // 22.1.3.32 String.prototype.trimStart ( )
 fn string_prototype_trim_start(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -869,7 +869,7 @@ fn string_prototype_trim_start(
 }
 // 22.1.3.33 String.prototype.valueOf ( )
 fn string_prototype_value_of(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
@@ -883,7 +883,7 @@ fn string_prototype_value_of(
 }
 
 fn string_prototype_iterator(
-    _: &mut Agent,
+    _: &Agent,
     _: ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],

--- a/src/string_object/tests.rs
+++ b/src/string_object/tests.rs
@@ -9,10 +9,10 @@ mod string_object {
 
     #[test]
     fn debug() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject {
-            common: RefCell::new(CommonObjectData::new(&mut agent, Some(prototype), true, STRING_OBJECT_SLOTS)),
+            common: RefCell::new(CommonObjectData::new(&agent, Some(prototype), true, STRING_OBJECT_SLOTS)),
             string_data: RefCell::new(JSString::from("baloney")),
         };
         assert_ne!(format!("{:?}", so), "");
@@ -20,11 +20,11 @@ mod string_object {
 
     #[test]
     fn object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
-        let length = super::get(&mut agent, &so, &"length".into()).unwrap();
+        let length = super::get(&agent, &so, &"length".into()).unwrap();
         assert_eq!(length, ECMAScriptValue::from(6));
 
         let sobj = so.o.to_string_obj().unwrap();
@@ -33,243 +33,243 @@ mod string_object {
 
     #[test]
     fn is_boolean_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(!so.o.is_boolean_object());
     }
 
     #[test]
     fn is_date_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(!so.o.is_date_object());
     }
 
     #[test]
     fn is_array_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(!so.o.is_array_object());
     }
 
     #[test]
     fn is_proxy_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(!so.o.is_proxy_object());
     }
 
     #[test]
     fn is_symbol_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(!so.o.is_symbol_object());
     }
 
     #[test]
     fn is_number_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(!so.o.is_number_object());
     }
 
     #[test]
     fn is_arguments_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(!so.o.is_arguments_object());
     }
 
     #[test]
     fn is_plain_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(!so.o.is_plain_object());
     }
 
     #[test]
     fn is_regexp_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(!so.o.is_regexp_object());
     }
 
     #[test]
     fn is_error_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(!so.o.is_error_object());
     }
 
     #[test]
     fn is_callable_obj() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(!so.o.is_callable_obj());
     }
 
     #[test]
     fn is_string_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(so.o.is_string_object());
     }
 
     #[test]
     fn is_ordinary() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(so.o.is_ordinary());
     }
 
     #[test]
     fn to_arguments_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(so.o.to_arguments_object().is_none());
     }
 
     #[test]
     fn to_boolean_obj() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(so.o.to_boolean_obj().is_none());
     }
 
     #[test]
     fn to_array_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(so.o.to_array_object().is_none());
     }
 
     #[test]
     fn to_callable_obj() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(so.o.to_callable_obj().is_none());
     }
 
     #[test]
     fn to_function_obj() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(so.o.to_function_obj().is_none());
     }
 
     #[test]
     fn to_error_obj() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(so.o.to_error_obj().is_none());
     }
 
     #[test]
     fn to_builtin_function_obj() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(so.o.to_builtin_function_obj().is_none());
     }
 
     #[test]
     fn to_symbol_obj() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(so.o.to_symbol_obj().is_none());
     }
 
     #[test]
     fn to_number_obj() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(so.o.to_number_obj().is_none());
     }
 
     #[test]
     fn to_constructable() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&mut agent, "orange".into(), Some(prototype));
+        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
         assert!(so.o.to_constructable().is_none());
     }
 
     #[test]
     fn get_prototype_of() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let str_obj = agent.create_string_object("orange".into());
-        let proto = str_obj.o.get_prototype_of(&mut agent).unwrap().unwrap();
+        let proto = str_obj.o.get_prototype_of(&agent).unwrap().unwrap();
         assert_eq!(proto, agent.intrinsic(IntrinsicId::StringPrototype));
     }
 
     #[test]
     fn set_prototype_of() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let str_obj = agent.create_string_object("orange".into());
-        let res = str_obj.o.set_prototype_of(&mut agent, None).unwrap();
+        let res = str_obj.o.set_prototype_of(&agent, None).unwrap();
         assert!(res);
-        assert!(str_obj.o.get_prototype_of(&mut agent).unwrap().is_none());
+        assert!(str_obj.o.get_prototype_of(&agent).unwrap().is_none());
     }
 
     #[test]
     fn is_extensible() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let str_obj = agent.create_string_object("orange".into());
-        let res = str_obj.o.is_extensible(&mut agent).unwrap();
+        let res = str_obj.o.is_extensible(&agent).unwrap();
         assert!(res);
     }
 
     #[test]
     fn prevent_extensions() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let str_obj = agent.create_string_object("orange".into());
-        let res = str_obj.o.prevent_extensions(&mut agent).unwrap();
+        let res = str_obj.o.prevent_extensions(&agent).unwrap();
         assert!(res);
-        assert!(!str_obj.o.is_extensible(&mut agent).unwrap());
+        assert!(!str_obj.o.is_extensible(&agent).unwrap());
     }
 
     #[test_case(
@@ -326,10 +326,10 @@ mod string_object {
         new_val: impl Into<ECMAScriptValue>,
         key: impl Into<PropertyKey>,
     ) -> (bool, AHashMap<PropertyKey, IdealizedPropertyDescriptor>) {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let str_obj = agent.create_string_object(value.into());
         let receiver = ECMAScriptValue::Object(str_obj.clone());
-        let success = str_obj.o.set(&mut agent, key.into(), new_val.into(), &receiver).unwrap();
+        let success = str_obj.o.set(&agent, key.into(), new_val.into(), &receiver).unwrap();
         let properties = str_obj
             .o
             .common_object_data()
@@ -343,15 +343,15 @@ mod string_object {
 
     #[test]
     fn delete() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let str_obj = agent.create_string_object("orange".into());
-        let res = str_obj.o.delete(&mut agent, &PropertyKey::from("rust")).unwrap();
+        let res = str_obj.o.delete(&agent, &PropertyKey::from("rust")).unwrap();
         assert_eq!(res, true);
     }
 
     #[test]
     fn id() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let str_obj = agent.create_string_object("orange".into());
         let str_obj2 = agent.create_string_object("orange".into());
         assert_ne!(str_obj.o.id(), str_obj2.o.id());
@@ -359,17 +359,17 @@ mod string_object {
 
     #[test]
     fn has_property() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let str_obj = agent.create_string_object("orange".into());
-        let res = str_obj.o.has_property(&mut agent, &PropertyKey::from("rust")).unwrap();
+        let res = str_obj.o.has_property(&agent, &PropertyKey::from("rust")).unwrap();
         assert_eq!(res, false);
-        let res2 = str_obj.o.has_property(&mut agent, &PropertyKey::from("length")).unwrap();
+        let res2 = str_obj.o.has_property(&agent, &PropertyKey::from("length")).unwrap();
         assert_eq!(res2, true);
     }
 
     #[test]
     fn common_object_data() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let str_obj = agent.create_string_object("orange".into());
         let cod = str_obj.o.common_object_data().borrow();
 
@@ -396,10 +396,10 @@ mod string_object {
     #[test_case("orange", |_| "5".into() => Some(IdealizedPropertyDescriptor{configurable: false, enumerable:  true, writable: Some(false), value: Some("e".into()), get: None, set: None }); "valid; index 5")]
     fn string_get_own_property(
         value: &str,
-        make_key: impl FnOnce(&mut Agent) -> PropertyKey,
+        make_key: impl FnOnce(&Agent) -> PropertyKey,
     ) -> Option<IdealizedPropertyDescriptor> {
-        let mut agent = test_agent();
-        let probe = make_key(&mut agent);
+        let agent = test_agent();
+        let probe = make_key(&agent);
         let str_obj = agent.create_string_object(value.into());
         str_obj.o.to_string_obj().unwrap().string_get_own_property(&probe).map(IdealizedPropertyDescriptor::from)
     }
@@ -408,9 +408,9 @@ mod string_object {
     #[test_case("orange", "3" => Some(IdealizedPropertyDescriptor{configurable: false, enumerable: true, writable: Some(false), value: Some(ECMAScriptValue::from("n")), get: None, set: None}); "stringish get")]
     #[test_case("orange", "color" => None; "key not present")]
     fn get_own_property(value: &str, key: &str) -> Option<IdealizedPropertyDescriptor> {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let str_obj = agent.create_string_object(value.into());
-        str_obj.o.get_own_property(&mut agent, &key.into()).unwrap().map(IdealizedPropertyDescriptor::from)
+        str_obj.o.get_own_property(&agent, &key.into()).unwrap().map(IdealizedPropertyDescriptor::from)
     }
 
     #[test_case(
@@ -504,10 +504,10 @@ mod string_object {
         new_value: PotentialPropertyDescriptor,
         key: &str,
     ) -> (bool, AHashMap<PropertyKey, IdealizedPropertyDescriptor>) {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let str_obj = agent.create_string_object(value.into());
 
-        let success = str_obj.o.define_own_property(&mut agent, key.into(), new_value).unwrap();
+        let success = str_obj.o.define_own_property(&agent, key.into(), new_value).unwrap();
         let properties = str_obj
             .o
             .common_object_data()
@@ -522,16 +522,16 @@ mod string_object {
     #[test_case("orange", "length" => ECMAScriptValue::from(6); "exists")]
     #[test_case("orange", "friendliness" => ECMAScriptValue::Undefined; "doesn't exist")]
     fn get(value: &str, key: &str) -> ECMAScriptValue {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let str_obj = agent.create_string_object(value.into());
 
         let receiver = ECMAScriptValue::from(str_obj.clone());
-        str_obj.o.get(&mut agent, &key.into(), &receiver).unwrap()
+        str_obj.o.get(&agent, &key.into(), &receiver).unwrap()
     }
 
     #[test]
     fn own_property_keys() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let str_obj = agent.create_string_object("orange".into());
 
         let to_prim = agent.wks(WksId::ToPrimitive);
@@ -540,7 +540,7 @@ mod string_object {
         str_obj
             .o
             .define_own_property(
-                &mut agent,
+                &agent,
                 "60".into(),
                 PotentialPropertyDescriptor::new().value("q").writable(true).enumerable(true).configurable(true),
             )
@@ -548,7 +548,7 @@ mod string_object {
         str_obj
             .o
             .define_own_property(
-                &mut agent,
+                &agent,
                 "6".into(),
                 PotentialPropertyDescriptor::new().value("s").writable(true).enumerable(true).configurable(true),
             )
@@ -556,7 +556,7 @@ mod string_object {
         str_obj
             .o
             .define_own_property(
-                &mut agent,
+                &agent,
                 "zebra".into(),
                 PotentialPropertyDescriptor::new().value(0).writable(true).enumerable(true).configurable(true),
             )
@@ -564,7 +564,7 @@ mod string_object {
         str_obj
             .o
             .define_own_property(
-                &mut agent,
+                &agent,
                 "alpha".into(),
                 PotentialPropertyDescriptor::new().value(1).writable(true).enumerable(true).configurable(true),
             )
@@ -572,7 +572,7 @@ mod string_object {
         str_obj
             .o
             .define_own_property(
-                &mut agent,
+                &agent,
                 to_prim.clone().into(),
                 PotentialPropertyDescriptor::new().value(2).writable(true).enumerable(true).configurable(true),
             )
@@ -580,13 +580,13 @@ mod string_object {
         str_obj
             .o
             .define_own_property(
-                &mut agent,
+                &agent,
                 species.clone().into(),
                 PotentialPropertyDescriptor::new().value(3).writable(true).enumerable(true).configurable(true),
             )
             .unwrap();
 
-        let keys = str_obj.o.own_property_keys(&mut agent).unwrap();
+        let keys = str_obj.o.own_property_keys(&agent).unwrap();
 
         assert_eq!(
             keys,
@@ -615,7 +615,7 @@ mod agent {
 
     #[test]
     fn string_create() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let s = agent.string_create("value".into(), Some(object_prototype.clone()));
 
@@ -628,7 +628,7 @@ mod agent {
 
     #[test]
     fn create_string_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let string_prototype = agent.intrinsic(IntrinsicId::StringPrototype);
         let s = agent.create_string_object("value".into());
 
@@ -663,7 +663,7 @@ mod agent {
 
         #[test]
         fn string_prototype_intrinsic() {
-            let mut agent = test_agent();
+            let agent = test_agent();
 
             // The String prototype object: is %String.prototype%.
             let string_proto = agent.intrinsic(IntrinsicId::StringPrototype);
@@ -677,7 +677,7 @@ mod agent {
             // attributes are { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.
             assert_eq!(
                 IdealizedPropertyDescriptor::from(
-                    string_proto.o.get_own_property(&mut agent, &"length".into()).unwrap().unwrap()
+                    string_proto.o.get_own_property(&agent, &"length".into()).unwrap().unwrap()
                 ),
                 IdealizedPropertyDescriptor {
                     configurable: false,
@@ -699,7 +699,7 @@ mod agent {
             let string_constructor = agent.intrinsic(IntrinsicId::String);
             assert_eq!(
                 IdealizedPropertyDescriptor::from(
-                    string_proto.o.get_own_property(&mut agent, &"constructor".into()).unwrap().unwrap()
+                    string_proto.o.get_own_property(&agent, &"constructor".into()).unwrap().unwrap()
                 ),
                 IdealizedPropertyDescriptor {
                     configurable: true,
@@ -746,31 +746,31 @@ mod agent {
         #[test_case("valueOf" => "valueOf;0"; "valueOf function")]
         #[test_case(WksId::Iterator => "[Symbol.iterator];0"; "@@iterator function")]
         fn prototype_func(key: impl Into<ToKey>) -> String {
-            let mut agent = test_agent();
+            let agent = test_agent();
             let key = match key.into() {
                 ToKey::String(s) => PropertyKey::from(s),
                 ToKey::Symbol(id) => PropertyKey::from(agent.wks(id)),
             };
             let proto = agent.intrinsic(IntrinsicId::StringPrototype);
-            let val = super::get(&mut agent, &proto, &key).unwrap();
+            let val = super::get(&agent, &proto, &key).unwrap();
             assert!(is_callable(&val));
-            let name = getv(&mut agent, &val, &"name".into()).unwrap();
-            let name = to_string(&mut agent, name).unwrap();
-            let length = getv(&mut agent, &val, &"length".into()).unwrap();
-            let length = to_string(&mut agent, length).unwrap();
+            let name = getv(&agent, &val, &"name".into()).unwrap();
+            let name = to_string(&agent, name).unwrap();
+            let length = getv(&agent, &val, &"length".into()).unwrap();
+            let length = to_string(&agent, length).unwrap();
             format!("{};{}", String::from(name), length)
         }
 
         #[test]
         fn string_intrinsic() {
-            let mut agent = test_agent();
+            let agent = test_agent();
             // The String constructor: is %String%.
             let string_object = agent.intrinsic(IntrinsicId::String);
 
             // The String constructor: is the initial value of the "String" property of the global object.
             let global = agent.current_realm_record().unwrap().borrow().global_object.as_ref().unwrap().clone();
-            let sfg_val = get(&mut agent, &global, &"String".into()).unwrap();
-            let string_from_global = to_object(&mut agent, sfg_val).unwrap();
+            let sfg_val = get(&agent, &global, &"String".into()).unwrap();
+            let string_from_global = to_object(&agent, sfg_val).unwrap();
             assert_eq!(string_object, string_from_global);
 
             // The String constructor: has a [[Prototype]] internal slot whose value is %Function.prototype%.
@@ -783,7 +783,7 @@ mod agent {
             let string_prototype = agent.intrinsic(IntrinsicId::StringPrototype);
             assert_eq!(
                 IdealizedPropertyDescriptor::from(
-                    string_object.o.get_own_property(&mut agent, &"prototype".into()).unwrap().unwrap(),
+                    string_object.o.get_own_property(&agent, &"prototype".into()).unwrap().unwrap(),
                 ),
                 IdealizedPropertyDescriptor {
                     configurable: false,
@@ -800,18 +800,18 @@ mod agent {
         #[test_case("fromCodePoint" => "fromCodePoint;1"; "String.fromCodePoint")]
         #[test_case("raw" => "raw;1"; "String.raw")]
         fn constructor_func(key: impl Into<ToKey>) -> String {
-            let mut agent = test_agent();
+            let agent = test_agent();
             let key = match key.into() {
                 ToKey::String(s) => PropertyKey::from(s),
                 ToKey::Symbol(id) => PropertyKey::from(agent.wks(id)),
             };
             let cstr = agent.intrinsic(IntrinsicId::String);
-            let val = super::get(&mut agent, &cstr, &key).unwrap();
+            let val = super::get(&agent, &cstr, &key).unwrap();
             assert!(is_callable(&val));
-            let name = getv(&mut agent, &val, &"name".into()).unwrap();
-            let name = to_string(&mut agent, name).unwrap();
-            let length = getv(&mut agent, &val, &"length".into()).unwrap();
-            let length = to_string(&mut agent, length).unwrap();
+            let name = getv(&agent, &val, &"name".into()).unwrap();
+            let name = to_string(&agent, name).unwrap();
+            let length = getv(&agent, &val, &"length".into()).unwrap();
+            let length = to_string(&agent, length).unwrap();
             format!("{};{}", String::from(name), length)
         }
     }
@@ -820,10 +820,10 @@ mod agent {
     #[test_case(|a| ECMAScriptValue::from(a.create_string_object(JSString::from("red"))) => sok("red"); "string object value")]
     #[test_case(|_| ECMAScriptValue::Undefined => serr("TypeError: unit testing requires that 'this' be a String"); "bad value")]
     #[test_case(|a| ECMAScriptValue::from(ordinary_object_create(a, None, &[])) => serr("TypeError: unit testing requires that 'this' be a String"); "bad object value")]
-    fn this_string_value(make_val: impl FnOnce(&mut Agent) -> ECMAScriptValue) -> Result<String, String> {
-        let mut agent = test_agent();
-        let val = make_val(&mut agent);
-        agent.this_string_value(val, "unit testing").map(String::from).map_err(|e| unwind_any_error(&mut agent, e))
+    fn this_string_value(make_val: impl FnOnce(&Agent) -> ECMAScriptValue) -> Result<String, String> {
+        let agent = test_agent();
+        let val = make_val(&agent);
+        agent.this_string_value(val, "unit testing").map(String::from).map_err(|e| unwind_any_error(&agent, e))
     }
 }
 
@@ -834,11 +834,11 @@ mod agent {
 #[test_case(|a| (Some(DeadObject::object(a)), vec![ECMAScriptValue::Null]) => serr("TypeError: get called on DeadObject"); "get_proto_from_cstr failure")]
 #[test_case(|a| (Some(a.intrinsic(IntrinsicId::String)), vec![ECMAScriptValue::Undefined]) => Ok((true, "undefined".to_string())); "AsCstr / stringable")]
 fn string_constructor_function(
-    make_params: impl FnOnce(&mut Agent) -> (Option<Object>, Vec<ECMAScriptValue>),
+    make_params: impl FnOnce(&Agent) -> (Option<Object>, Vec<ECMAScriptValue>),
 ) -> Result<(bool, String), String> {
-    let mut agent = test_agent();
-    let (new_target, arguments) = make_params(&mut agent);
-    super::string_constructor_function(&mut agent, ECMAScriptValue::Undefined, new_target.as_ref(), &arguments)
+    let agent = test_agent();
+    let (new_target, arguments) = make_params(&agent);
+    super::string_constructor_function(&agent, ECMAScriptValue::Undefined, new_target.as_ref(), &arguments)
         .map(|val| match val {
             ECMAScriptValue::String(s) => (false, String::from(s)),
             ECMAScriptValue::Object(o) => {
@@ -846,21 +846,21 @@ fn string_constructor_function(
             }
             _ => panic!("Bad value from string_constructor_function: {:?}", val),
         })
-        .map_err(|err| unwind_any_error(&mut agent, err))
+        .map_err(|err| unwind_any_error(&agent, err))
 }
 
 #[test_case(|_| vec![ECMAScriptValue::from(112), ECMAScriptValue::from(97), ECMAScriptValue::from(115), ECMAScriptValue::from(115)] => sok("pass"); "normal")]
 #[test_case(|a| vec![ECMAScriptValue::from(a.wks(WksId::ToPrimitive))] => serr("TypeError: Symbol values cannot be converted to Number values"); "bad args")]
 #[test_case(|_| vec![] => sok(""); "emtpy args")]
-fn string_from_char_code(make_params: impl FnOnce(&mut Agent) -> Vec<ECMAScriptValue>) -> Result<String, String> {
-    let mut agent = test_agent();
-    let args = make_params(&mut agent);
-    super::string_from_char_code(&mut agent, ECMAScriptValue::Undefined, None, &args)
+fn string_from_char_code(make_params: impl FnOnce(&Agent) -> Vec<ECMAScriptValue>) -> Result<String, String> {
+    let agent = test_agent();
+    let args = make_params(&agent);
+    super::string_from_char_code(&agent, ECMAScriptValue::Undefined, None, &args)
         .map(|val| match val {
             ECMAScriptValue::String(s) => String::from(s),
             _ => panic!("Expected String value from String.fromCharCode: {:?}", val),
         })
-        .map_err(|e| unwind_any_error(&mut agent, e))
+        .map_err(|e| unwind_any_error(&agent, e))
 }
 
 #[test_case(|_| (ECMAScriptValue::Undefined, vec![]) => serr("TypeError: Undefined and null are not allowed in this context"); "'this' bad")]
@@ -870,42 +870,42 @@ fn string_from_char_code(make_params: impl FnOnce(&mut Agent) -> Vec<ECMAScriptV
 #[test_case(|a| (ECMAScriptValue::from(""), vec![ECMAScriptValue::from(DeadObject::object(a))]) => serr("TypeError: get called on DeadObject"); "unstringable search")]
 #[test_case(|a| (ECMAScriptValue::from(""), vec![ECMAScriptValue::from(""), ECMAScriptValue::from(DeadObject::object(a))]) => serr("TypeError: get called on DeadObject"); "unnumberable position")]
 fn string_prototype_index_of(
-    make_params: impl FnOnce(&mut Agent) -> (ECMAScriptValue, Vec<ECMAScriptValue>),
+    make_params: impl FnOnce(&Agent) -> (ECMAScriptValue, Vec<ECMAScriptValue>),
 ) -> Result<f64, String> {
-    let mut agent = test_agent();
-    let (this_value, arguments) = make_params(&mut agent);
-    super::string_prototype_index_of(&mut agent, this_value, None, &arguments)
+    let agent = test_agent();
+    let (this_value, arguments) = make_params(&agent);
+    super::string_prototype_index_of(&agent, this_value, None, &arguments)
         .map(|val| match val {
             ECMAScriptValue::Number(n) => n,
             _ => panic!("Expected number value from String.prototype.indexOf: {:?}", val),
         })
-        .map_err(|e| unwind_any_error(&mut agent, e))
+        .map_err(|e| unwind_any_error(&agent, e))
 }
 
 #[test_case(|a| ECMAScriptValue::from(a.create_string_object("a string".into())) => sok("a string"); "from string object")]
 #[test_case(|a| ECMAScriptValue::from(DeadObject::object(a)) => serr("TypeError: String.prototype.toString requires that 'this' be a String"); "bad this value")]
-fn string_prototype_to_string(make_params: impl FnOnce(&mut Agent) -> ECMAScriptValue) -> Result<String, String> {
-    let mut agent = test_agent();
-    let this_value = make_params(&mut agent);
-    super::string_prototype_to_string(&mut agent, this_value, None, &[])
+fn string_prototype_to_string(make_params: impl FnOnce(&Agent) -> ECMAScriptValue) -> Result<String, String> {
+    let agent = test_agent();
+    let this_value = make_params(&agent);
+    super::string_prototype_to_string(&agent, this_value, None, &[])
         .map(|val| match val {
             ECMAScriptValue::String(s) => String::from(s),
             _ => panic!("Expected string value from String.prototype.toString: {:?}", val),
         })
-        .map_err(|e| unwind_any_error(&mut agent, e))
+        .map_err(|e| unwind_any_error(&agent, e))
 }
 
 #[test_case(|a| ECMAScriptValue::from(a.create_string_object("a string".into())) => sok("a string"); "from string object")]
 #[test_case(|a| ECMAScriptValue::from(DeadObject::object(a)) => serr("TypeError: String.prototype.valueOf requires that 'this' be a String"); "bad this value")]
-fn string_prototype_value_of(make_params: impl FnOnce(&mut Agent) -> ECMAScriptValue) -> Result<String, String> {
-    let mut agent = test_agent();
-    let this_value = make_params(&mut agent);
-    super::string_prototype_value_of(&mut agent, this_value, None, &[])
+fn string_prototype_value_of(make_params: impl FnOnce(&Agent) -> ECMAScriptValue) -> Result<String, String> {
+    let agent = test_agent();
+    let this_value = make_params(&agent);
+    super::string_prototype_value_of(&agent, this_value, None, &[])
         .map(|val| match val {
             ECMAScriptValue::String(s) => String::from(s),
             _ => panic!("Expected string value from String.prototype.valueOf: {:?}", val),
         })
-        .map_err(|e| unwind_any_error(&mut agent, e))
+        .map_err(|e| unwind_any_error(&agent, e))
 }
 
 tbd_function!(string_from_code_point);

--- a/src/symbol_object/mod.rs
+++ b/src/symbol_object/mod.rs
@@ -49,7 +49,7 @@ impl ObjectInterface for SymbolObject {
         true
     }
 
-    fn get_prototype_of(&self, _agent: &mut Agent) -> Completion<Option<Object>> {
+    fn get_prototype_of(&self, _agent: &Agent) -> Completion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
 
@@ -59,7 +59,7 @@ impl ObjectInterface for SymbolObject {
     // the following steps when called:
     //
     //  1. Return ! OrdinarySetPrototypeOf(O, V).
-    fn set_prototype_of(&self, _agent: &mut Agent, obj: Option<Object>) -> Completion<bool> {
+    fn set_prototype_of(&self, _agent: &Agent, obj: Option<Object>) -> Completion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
 
@@ -69,7 +69,7 @@ impl ObjectInterface for SymbolObject {
     // when called:
     //
     //  1. Return ! OrdinaryIsExtensible(O).
-    fn is_extensible(&self, _agent: &mut Agent) -> Completion<bool> {
+    fn is_extensible(&self, _agent: &Agent) -> Completion<bool> {
         Ok(ordinary_is_extensible(self))
     }
 
@@ -79,7 +79,7 @@ impl ObjectInterface for SymbolObject {
     // steps when called:
     //
     //  1. Return ! OrdinaryPreventExtensions(O).
-    fn prevent_extensions(&self, _agent: &mut Agent) -> Completion<bool> {
+    fn prevent_extensions(&self, _agent: &Agent) -> Completion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
 
@@ -89,7 +89,7 @@ impl ObjectInterface for SymbolObject {
     // following steps when called:
     //
     //  1. Return ! OrdinaryGetOwnProperty(O, P).
-    fn get_own_property(&self, _agent: &mut Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _agent: &Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(self, key))
     }
 
@@ -101,7 +101,7 @@ impl ObjectInterface for SymbolObject {
     //  1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
     fn define_own_property(
         &self,
-        agent: &mut Agent,
+        agent: &Agent,
         key: PropertyKey,
         desc: PotentialPropertyDescriptor,
     ) -> Completion<bool> {
@@ -114,7 +114,7 @@ impl ObjectInterface for SymbolObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryHasProperty(O, P).
-    fn has_property(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
+    fn has_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_has_property(agent, self, key)
     }
 
@@ -124,7 +124,7 @@ impl ObjectInterface for SymbolObject {
     // ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryGet(O, P, Receiver).
-    fn get(&self, agent: &mut Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+    fn get(&self, agent: &Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         ordinary_get(agent, self, key, receiver)
     }
 
@@ -134,13 +134,7 @@ impl ObjectInterface for SymbolObject {
     // value), and Receiver (an ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinarySet(O, P, V, Receiver).
-    fn set(
-        &self,
-        agent: &mut Agent,
-        key: PropertyKey,
-        v: ECMAScriptValue,
-        receiver: &ECMAScriptValue,
-    ) -> Completion<bool> {
+    fn set(&self, agent: &Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
         ordinary_set(agent, self, key, v, receiver)
     }
 
@@ -150,7 +144,7 @@ impl ObjectInterface for SymbolObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryDelete(O, P).
-    fn delete(&self, agent: &mut Agent, key: &PropertyKey) -> Completion<bool> {
+    fn delete(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
         ordinary_delete(agent, self, key)
     }
 
@@ -160,7 +154,7 @@ impl ObjectInterface for SymbolObject {
     // steps when called:
     //
     // 1. Return ! OrdinaryOwnPropertyKeys(O).
-    fn own_property_keys(&self, _agent: &mut Agent) -> Completion<Vec<PropertyKey>> {
+    fn own_property_keys(&self, _agent: &Agent) -> Completion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(self))
     }
 }
@@ -172,7 +166,7 @@ impl SymbolObjectInterface for SymbolObject {
 }
 
 impl SymbolObject {
-    pub fn object(agent: &mut Agent, prototype: Option<Object>) -> Object {
+    pub fn object(agent: &Agent, prototype: Option<Object>) -> Object {
         Object {
             o: Rc::new(Self {
                 common: RefCell::new(CommonObjectData::new(agent, prototype, true, SYMBOL_OBJECT_SLOTS)),
@@ -182,14 +176,14 @@ impl SymbolObject {
     }
 }
 
-pub fn create_symbol_object(agent: &mut Agent, sym: Symbol) -> Object {
+pub fn create_symbol_object(agent: &Agent, sym: Symbol) -> Object {
     let symbol_proto = agent.intrinsic(IntrinsicId::SymbolPrototype);
     let obj = SymbolObject::object(agent, Some(symbol_proto));
     *obj.o.to_symbol_obj().unwrap().symbol_data().borrow_mut() = Some(sym);
     obj
 }
 
-pub fn provision_symbol_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_symbol_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -404,7 +398,7 @@ pub fn provision_symbol_intrinsic(agent: &mut Agent, realm: &Rc<RefCell<Realm>>)
 /// can be found in the global Symbol registry, that Symbol is returned. Otherwise, a new Symbol is created, added to
 /// the global Symbol registry under the given key, and returned.
 fn symbol_constructor_function(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -437,7 +431,7 @@ fn symbol_constructor_function(
 ///
 /// See [Symbol.for](https://tc39.es/ecma262/#sec-symbol.for) in ECMA-262.
 fn symbol_for(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -487,7 +481,7 @@ fn symbol_for(
 ///
 /// See [Symbol.keyFor](https://tc39.es/ecma262/#sec-symbol.keyfor) in ECMA-262.
 fn symbol_key_for(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -515,7 +509,7 @@ fn symbol_key_for(
     }
 }
 
-fn this_symbol_value(agent: &mut Agent, this_value: ECMAScriptValue) -> Completion<Symbol> {
+fn this_symbol_value(agent: &Agent, this_value: ECMAScriptValue) -> Completion<Symbol> {
     match this_value {
         ECMAScriptValue::Symbol(s) => Ok(s),
         ECMAScriptValue::Object(o) if o.o.is_symbol_object() => {
@@ -527,7 +521,7 @@ fn this_symbol_value(agent: &mut Agent, this_value: ECMAScriptValue) -> Completi
 }
 
 fn symbol_to_string(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -537,7 +531,7 @@ fn symbol_to_string(
 }
 
 fn symbol_value_of(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -546,7 +540,7 @@ fn symbol_value_of(
 }
 
 fn symbol_description(
-    agent: &mut Agent,
+    agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],

--- a/src/symbol_object/tests.rs
+++ b/src/symbol_object/tests.rs
@@ -7,10 +7,10 @@ mod symbol_object {
 
     #[test]
     fn debug() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = SymbolObject {
-            common: RefCell::new(CommonObjectData::new(&mut agent, Some(prototype), true, SYMBOL_OBJECT_SLOTS)),
+            common: RefCell::new(CommonObjectData::new(&agent, Some(prototype), true, SYMBOL_OBJECT_SLOTS)),
             symbol_data: RefCell::new(None),
         };
         assert_ne!(format!("{:?}", so), "");
@@ -18,31 +18,26 @@ mod symbol_object {
 
     #[test]
     fn object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let prototype = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
-        define_property_or_throw(
-            &mut agent,
-            &prototype,
-            "marker",
-            PotentialPropertyDescriptor::new().value("sentinel"),
-        )
-        .unwrap();
+        let prototype = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        define_property_or_throw(&agent, &prototype, "marker", PotentialPropertyDescriptor::new().value("sentinel"))
+            .unwrap();
 
-        let obj = SymbolObject::object(&mut agent, Some(prototype));
+        let obj = SymbolObject::object(&agent, Some(prototype));
 
         assert!(obj.o.is_symbol_object());
-        let recovered_proto = obj.o.get_prototype_of(&mut agent).unwrap().unwrap();
-        let prop = super::get(&mut agent, &recovered_proto, &PropertyKey::from("marker")).unwrap();
+        let recovered_proto = obj.o.get_prototype_of(&agent).unwrap().unwrap();
+        let prop = super::get(&agent, &recovered_proto, &PropertyKey::from("marker")).unwrap();
         assert_eq!(prop, ECMAScriptValue::from("sentinel"));
     }
 
     #[test]
     fn symbol_data() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = SymbolObject {
-            common: RefCell::new(CommonObjectData::new(&mut agent, Some(prototype), true, SYMBOL_OBJECT_SLOTS)),
+            common: RefCell::new(CommonObjectData::new(&agent, Some(prototype), true, SYMBOL_OBJECT_SLOTS)),
             symbol_data: RefCell::new(Some(agent.wks(WksId::ToPrimitive))),
         };
 
@@ -53,246 +48,246 @@ mod symbol_object {
 
     #[test]
     fn is_callable_obj() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(!obj.o.is_callable_obj());
     }
 
     #[test]
     fn is_number_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(!obj.o.is_number_object());
     }
 
     #[test]
     fn is_arguments_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(!obj.o.is_arguments_object());
     }
 
     #[test]
     fn is_boolean_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(!obj.o.is_boolean_object());
     }
 
     #[test]
     fn is_array_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(!obj.o.is_array_object());
     }
 
     #[test]
     fn is_error_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(!obj.o.is_error_object());
     }
 
     #[test]
     fn is_regexp_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(!obj.o.is_regexp_object());
     }
 
     #[test]
     fn is_proxy_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(!obj.o.is_proxy_object());
     }
 
     #[test]
     fn is_string_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(!obj.o.is_string_object());
     }
 
     #[test]
     fn is_date_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(!obj.o.is_date_object());
     }
 
     #[test]
     fn to_callable_obj() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(obj.o.to_callable_obj().is_none());
     }
 
     #[test]
     fn to_error_obj() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(obj.o.to_error_obj().is_none());
     }
 
     #[test]
     fn to_constructable() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(obj.o.to_constructable().is_none());
     }
 
     #[test]
     fn to_array_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(obj.o.to_array_object().is_none());
     }
 
     #[test]
     fn to_boolean_obj() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(obj.o.to_boolean_obj().is_none());
     }
 
     #[test]
     fn to_number_obj() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(obj.o.to_number_obj().is_none());
     }
 
     #[test]
     fn to_function_obj() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(obj.o.to_function_obj().is_none());
     }
 
     #[test]
     fn to_builtin_function_obj() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(obj.o.to_builtin_function_obj().is_none());
     }
 
     #[test]
     fn is_ordinary() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(obj.o.is_ordinary());
     }
 
     #[test]
     fn is_plain_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(!obj.o.is_plain_object());
     }
 
     #[test]
     fn to_arguments_object() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&mut agent, sym);
+        let obj = create_symbol_object(&agent, sym);
 
         assert!(obj.o.to_arguments_object().is_none());
     }
 
     #[test]
     fn get_prototype_of() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&mut agent, sym);
-        let proto = sym_obj.o.get_prototype_of(&mut agent).unwrap().unwrap();
+        let sym_obj = create_symbol_object(&agent, sym);
+        let proto = sym_obj.o.get_prototype_of(&agent).unwrap().unwrap();
         assert_eq!(proto, agent.intrinsic(IntrinsicId::SymbolPrototype));
     }
 
     #[test]
     fn set_prototype_of() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&mut agent, sym);
-        let res = sym_obj.o.set_prototype_of(&mut agent, None).unwrap();
+        let sym_obj = create_symbol_object(&agent, sym);
+        let res = sym_obj.o.set_prototype_of(&agent, None).unwrap();
         assert!(res);
-        assert!(sym_obj.o.get_prototype_of(&mut agent).unwrap().is_none());
+        assert!(sym_obj.o.get_prototype_of(&agent).unwrap().is_none());
     }
 
     #[test]
     fn is_extensible() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&mut agent, sym);
-        let res = sym_obj.o.is_extensible(&mut agent).unwrap();
+        let sym_obj = create_symbol_object(&agent, sym);
+        let res = sym_obj.o.is_extensible(&agent).unwrap();
         assert!(res);
     }
 
     #[test]
     fn prevent_extensions() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&mut agent, sym);
-        let res = sym_obj.o.prevent_extensions(&mut agent).unwrap();
+        let sym_obj = create_symbol_object(&agent, sym);
+        let res = sym_obj.o.prevent_extensions(&agent).unwrap();
         assert!(res);
-        assert!(!sym_obj.o.is_extensible(&mut agent).unwrap());
+        assert!(!sym_obj.o.is_extensible(&agent).unwrap());
     }
 
     #[test]
     fn define_and_get_own_property() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&mut agent, sym);
+        let sym_obj = create_symbol_object(&agent, sym);
         let res = sym_obj
             .o
             .define_own_property(
-                &mut agent,
+                &agent,
                 PropertyKey::from("rust"),
                 PotentialPropertyDescriptor::new().value("is awesome"),
             )
             .unwrap();
         assert!(res);
-        let val = sym_obj.o.get_own_property(&mut agent, &PropertyKey::from("rust")).unwrap().unwrap();
+        let val = sym_obj.o.get_own_property(&agent, &PropertyKey::from("rust")).unwrap().unwrap();
         assert_eq!(val.enumerable, false);
         assert_eq!(val.configurable, false);
         assert!(matches!(val.property, PropertyKind::Data(..)));
@@ -304,62 +299,62 @@ mod symbol_object {
 
     #[test]
     fn has_property() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&mut agent, sym);
-        let res = sym_obj.o.has_property(&mut agent, &PropertyKey::from("rust")).unwrap();
+        let sym_obj = create_symbol_object(&agent, sym);
+        let res = sym_obj.o.has_property(&agent, &PropertyKey::from("rust")).unwrap();
         assert_eq!(res, false);
         let tst = agent.wks(WksId::ToStringTag);
-        let res2 = sym_obj.o.has_property(&mut agent, &PropertyKey::from(tst)).unwrap();
+        let res2 = sym_obj.o.has_property(&agent, &PropertyKey::from(tst)).unwrap();
         assert_eq!(res2, true);
     }
 
     #[test]
     fn get() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&mut agent, sym);
-        let res = sym_obj.o.get(&mut agent, &PropertyKey::from("rust"), &ECMAScriptValue::Undefined).unwrap();
+        let sym_obj = create_symbol_object(&agent, sym);
+        let res = sym_obj.o.get(&agent, &PropertyKey::from("rust"), &ECMAScriptValue::Undefined).unwrap();
         assert_eq!(res, ECMAScriptValue::Undefined);
         let tst = agent.wks(WksId::ToStringTag);
-        let res2 = sym_obj.o.get(&mut agent, &PropertyKey::from(tst), &ECMAScriptValue::Undefined).unwrap();
+        let res2 = sym_obj.o.get(&agent, &PropertyKey::from(tst), &ECMAScriptValue::Undefined).unwrap();
         assert_eq!(res2, ECMAScriptValue::from("Symbol"));
     }
 
     #[test]
     fn set() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&mut agent, sym);
+        let sym_obj = create_symbol_object(&agent, sym);
         let receiver = ECMAScriptValue::Object(sym_obj.clone());
-        let res = sym_obj.o.set(&mut agent, PropertyKey::from("rust"), ECMAScriptValue::Null, &receiver).unwrap();
+        let res = sym_obj.o.set(&agent, PropertyKey::from("rust"), ECMAScriptValue::Null, &receiver).unwrap();
         assert_eq!(res, true);
     }
 
     #[test]
     fn delete() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&mut agent, sym);
-        let res = sym_obj.o.delete(&mut agent, &PropertyKey::from("rust")).unwrap();
+        let sym_obj = create_symbol_object(&agent, sym);
+        let res = sym_obj.o.delete(&agent, &PropertyKey::from("rust")).unwrap();
         assert_eq!(res, true);
     }
 
     #[test]
     fn own_keys() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&mut agent, sym);
-        let res = sym_obj.o.own_property_keys(&mut agent).unwrap();
+        let sym_obj = create_symbol_object(&agent, sym);
+        let res = sym_obj.o.own_property_keys(&agent).unwrap();
         assert!(res.is_empty())
     }
 
     #[test]
     fn id() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&mut agent, sym.clone());
-        let sym_obj2 = create_symbol_object(&mut agent, sym);
+        let sym_obj = create_symbol_object(&agent, sym.clone());
+        let sym_obj2 = create_symbol_object(&agent, sym);
         assert_ne!(sym_obj.o.id(), sym_obj2.o.id());
     }
 }
@@ -380,14 +375,14 @@ fn symbol_match(expected: &str) -> impl FnOnce(Result<ECMAScriptValue, String>) 
 #[test_case(|_| None, |_| vec![ECMAScriptValue::from("giants")] => using symbol_match("Symbol(giants)"); "with description")]
 #[test_case(|_| None, |a| vec![ECMAScriptValue::from(a.wks(WksId::ToPrimitive))] => serr("TypeError: Symbols may not be converted to strings"); "with bad description")]
 fn symbol_constructor_function(
-    tgt_maker: fn(&mut Agent) -> Option<Object>,
-    arg_maker: fn(&mut Agent) -> Vec<ECMAScriptValue>,
+    tgt_maker: fn(&Agent) -> Option<Object>,
+    arg_maker: fn(&Agent) -> Vec<ECMAScriptValue>,
 ) -> Result<ECMAScriptValue, String> {
-    let mut agent = test_agent();
-    let nt = tgt_maker(&mut agent);
-    let args = arg_maker(&mut agent);
-    super::symbol_constructor_function(&mut agent, ECMAScriptValue::Undefined, nt.as_ref(), &args)
-        .map_err(|e| unwind_any_error(&mut agent, e))
+    let agent = test_agent();
+    let nt = tgt_maker(&agent);
+    let args = arg_maker(&agent);
+    super::symbol_constructor_function(&agent, ECMAScriptValue::Undefined, nt.as_ref(), &args)
+        .map_err(|e| unwind_any_error(&agent, e))
 }
 
 mod symbol_for {
@@ -395,10 +390,10 @@ mod symbol_for {
 
     #[test]
     fn new() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let gsr = agent.global_symbol_registry();
         let count_prior = gsr.borrow().len();
-        let result = symbol_for(&mut agent, ECMAScriptValue::Undefined, None, &["key".into()]);
+        let result = symbol_for(&agent, ECMAScriptValue::Undefined, None, &["key".into()]);
         if let Ok(ECMAScriptValue::Symbol(sym)) = result {
             assert_eq!(sym.descriptive_string(), "Symbol(key)");
             let count_after = gsr.borrow().len();
@@ -410,11 +405,11 @@ mod symbol_for {
 
     #[test]
     fn duplicate() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let gsr = agent.global_symbol_registry();
         let count_prior = gsr.borrow().len();
-        let first = symbol_for(&mut agent, ECMAScriptValue::Undefined, None, &["key".into()]);
-        let second = symbol_for(&mut agent, ECMAScriptValue::Undefined, None, &["key".into()]);
+        let first = symbol_for(&agent, ECMAScriptValue::Undefined, None, &["key".into()]);
+        let second = symbol_for(&agent, ECMAScriptValue::Undefined, None, &["key".into()]);
         if let (Ok(ECMAScriptValue::Symbol(first)), Ok(ECMAScriptValue::Symbol(second))) = (first, second) {
             assert_eq!(first, second);
             assert_eq!(first.descriptive_string(), "Symbol(key)");
@@ -427,10 +422,10 @@ mod symbol_for {
 
     #[test]
     fn bad_key() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let to_primitive = agent.wks(WksId::ToPrimitive);
-        let result = symbol_for(&mut agent, ECMAScriptValue::Undefined, None, &[to_primitive.into()]).unwrap_err();
-        assert_eq!(unwind_any_error(&mut agent, result), "TypeError: Symbols may not be converted to strings");
+        let result = symbol_for(&agent, ECMAScriptValue::Undefined, None, &[to_primitive.into()]).unwrap_err();
+        assert_eq!(unwind_any_error(&agent, result), "TypeError: Symbols may not be converted to strings");
     }
 }
 
@@ -439,39 +434,39 @@ mod symbol_key_for {
 
     #[test]
     fn not_symbol() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let this_value = ECMAScriptValue::Undefined;
         let new_target = None;
         let arguments = &[];
 
-        let result = symbol_key_for(&mut agent, this_value, new_target, arguments);
+        let result = symbol_key_for(&agent, this_value, new_target, arguments);
 
-        assert_eq!(unwind_any_error(&mut agent, result.unwrap_err()), "TypeError: value is not a symbol");
+        assert_eq!(unwind_any_error(&agent, result.unwrap_err()), "TypeError: value is not a symbol");
     }
 
     #[test]
     fn not_in_registry() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let this_value = ECMAScriptValue::Undefined;
         let new_target = None;
         let sym = agent.wks(WksId::ToPrimitive);
         let arguments = &[ECMAScriptValue::from(sym)];
 
-        let result = symbol_key_for(&mut agent, this_value, new_target, arguments);
+        let result = symbol_key_for(&agent, this_value, new_target, arguments);
 
         assert_eq!(result.unwrap(), ECMAScriptValue::Undefined);
     }
 
     #[test]
     fn in_registry() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let this_value = ECMAScriptValue::Undefined;
         let new_target = None;
         let registry_sym =
-            symbol_for(&mut agent, ECMAScriptValue::Undefined, new_target, &["test_sentinel".into()]).unwrap();
+            symbol_for(&agent, ECMAScriptValue::Undefined, new_target, &["test_sentinel".into()]).unwrap();
         let arguments = &[registry_sym];
 
-        let results = symbol_key_for(&mut agent, this_value, new_target, arguments);
+        let results = symbol_key_for(&agent, this_value, new_target, arguments);
 
         assert_eq!(results.unwrap().to_string(), "test_sentinel");
     }
@@ -482,21 +477,21 @@ mod this_symbol_value {
 
     #[test]
     fn not_symbol() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let this_value = ECMAScriptValue::Undefined;
 
-        let result = this_symbol_value(&mut agent, this_value);
+        let result = this_symbol_value(&agent, this_value);
 
-        assert_eq!(unwind_any_error(&mut agent, result.unwrap_err()), "TypeError: Not a symbol");
+        assert_eq!(unwind_any_error(&agent, result.unwrap_err()), "TypeError: Not a symbol");
     }
 
     #[test]
     fn symbol() {
-        let mut agent = test_agent();
-        let sym = Symbol::new(&mut agent, Some("test_sentinel".into()));
+        let agent = test_agent();
+        let sym = Symbol::new(&agent, Some("test_sentinel".into()));
         let this_value = ECMAScriptValue::from(sym.clone());
 
-        let result = this_symbol_value(&mut agent, this_value).unwrap();
+        let result = this_symbol_value(&agent, this_value).unwrap();
 
         assert_eq!(result, sym);
         assert_eq!(result.description(), sym.description());
@@ -504,12 +499,12 @@ mod this_symbol_value {
 
     #[test]
     fn symbol_in_object() {
-        let mut agent = test_agent();
-        let sym = Symbol::new(&mut agent, Some("test_sentinel".into()));
-        let o = create_symbol_object(&mut agent, sym.clone());
+        let agent = test_agent();
+        let sym = Symbol::new(&agent, Some("test_sentinel".into()));
+        let o = create_symbol_object(&agent, sym.clone());
         let this_value = ECMAScriptValue::from(o);
 
-        let result = this_symbol_value(&mut agent, this_value).unwrap();
+        let result = this_symbol_value(&agent, this_value).unwrap();
 
         assert_eq!(result, sym);
         assert_eq!(String::from(result.description().unwrap()), "test_sentinel");
@@ -541,10 +536,10 @@ mod symbol_registry {
     fn len() {
         let mut sr = SymbolRegistry::new();
         assert_eq!(sr.len(), 0);
-        let mut agent = test_agent();
-        let s1 = Symbol::new(&mut agent, Some("fisrt".into()));
-        let s2 = Symbol::new(&mut agent, Some("second".into()));
-        let s3: Symbol = Symbol::new(&mut agent, Some("third".into()));
+        let agent = test_agent();
+        let s1 = Symbol::new(&agent, Some("fisrt".into()));
+        let s2 = Symbol::new(&agent, Some("second".into()));
+        let s3: Symbol = Symbol::new(&agent, Some("third".into()));
         sr.add("1".into(), s1);
         sr.add("2".into(), s2);
         sr.add("3".into(), s3);
@@ -555,8 +550,8 @@ mod symbol_registry {
     fn is_empty() {
         let mut sr = SymbolRegistry::new();
         assert!(sr.is_empty());
-        let mut agent = test_agent();
-        let s1 = Symbol::new(&mut agent, Some("fisrt".into()));
+        let agent = test_agent();
+        let s1 = Symbol::new(&agent, Some("fisrt".into()));
         sr.add("1".into(), s1);
         assert!(!sr.is_empty());
     }
@@ -567,10 +562,10 @@ mod symbol_registry {
         #[test]
         fn safe() {
             let mut sr = SymbolRegistry::new();
-            let mut agent = test_agent();
-            let s1 = Symbol::new(&mut agent, Some("fisrt".into()));
-            let s2 = Symbol::new(&mut agent, Some("second".into()));
-            let s3: Symbol = Symbol::new(&mut agent, Some("third".into()));
+            let agent = test_agent();
+            let s1 = Symbol::new(&agent, Some("fisrt".into()));
+            let s2 = Symbol::new(&agent, Some("second".into()));
+            let s3: Symbol = Symbol::new(&agent, Some("third".into()));
             sr.add("1".into(), s1);
             sr.add("2".into(), s2);
             sr.add("3".into(), s3);
@@ -581,9 +576,9 @@ mod symbol_registry {
         #[should_panic(expected = "second")]
         fn duplicates() {
             let mut sr = SymbolRegistry::new();
-            let mut agent = test_agent();
-            let s1 = Symbol::new(&mut agent, Some("fisrt".into()));
-            let s2 = Symbol::new(&mut agent, Some("second".into()));
+            let agent = test_agent();
+            let s1 = Symbol::new(&agent, Some("fisrt".into()));
+            let s2 = Symbol::new(&agent, Some("second".into()));
             sr.add("1".into(), s1);
             sr.add("1".into(), s2);
         }
@@ -592,11 +587,11 @@ mod symbol_registry {
     #[test]
     fn key_by_symbol() {
         let mut sr = SymbolRegistry::new();
-        let mut agent = test_agent();
-        let s1 = Symbol::new(&mut agent, Some("fisrt".into()));
-        let s2 = Symbol::new(&mut agent, Some("second".into()));
-        let s3 = Symbol::new(&mut agent, Some("third".into()));
-        let s4 = Symbol::new(&mut agent, Some("fourth".into()));
+        let agent = test_agent();
+        let s1 = Symbol::new(&agent, Some("fisrt".into()));
+        let s2 = Symbol::new(&agent, Some("second".into()));
+        let s3 = Symbol::new(&agent, Some("third".into()));
+        let s4 = Symbol::new(&agent, Some("fourth".into()));
         sr.add("1".into(), s1.clone());
         sr.add("2".into(), s2.clone());
         sr.add("3".into(), s3.clone());
@@ -610,10 +605,10 @@ mod symbol_registry {
     #[test]
     fn symbol_by_key() {
         let mut sr = SymbolRegistry::new();
-        let mut agent = test_agent();
-        let s1 = Symbol::new(&mut agent, Some("fisrt".into()));
-        let s2 = Symbol::new(&mut agent, Some("second".into()));
-        let s3 = Symbol::new(&mut agent, Some("third".into()));
+        let agent = test_agent();
+        let s1 = Symbol::new(&agent, Some("fisrt".into()));
+        let s2 = Symbol::new(&agent, Some("second".into()));
+        let s3 = Symbol::new(&agent, Some("third".into()));
         sr.add("1".into(), s1.clone());
         sr.add("2".into(), s2.clone());
         sr.add("3".into(), s3.clone());
@@ -630,10 +625,10 @@ mod create_symbol_object {
 
     #[test]
     fn normal() {
-        let mut agent = test_agent();
-        let s1 = Symbol::new(&mut agent, Some("train".into()));
-        let sobj = create_symbol_object(&mut agent, s1.clone());
-        assert_eq!(s1, this_symbol_value(&mut agent, sobj.into()).unwrap());
+        let agent = test_agent();
+        let s1 = Symbol::new(&agent, Some("train".into()));
+        let sobj = create_symbol_object(&agent, s1.clone());
+        assert_eq!(s1, this_symbol_value(&agent, sobj.into()).unwrap());
     }
 }
 
@@ -643,12 +638,12 @@ mod symbol_to_string {
 
     #[test_case(|_| ECMAScriptValue::Undefined => serr("TypeError: Not a symbol"); "Not a symbol")]
     #[test_case(|a| ECMAScriptValue::from(Symbol::new(a, Some("test sentinel".into()))) => sok("Symbol(test sentinel)"); "true symbol")]
-    fn normal(maker: fn(&mut Agent) -> ECMAScriptValue) -> Result<String, String> {
-        let mut agent = test_agent();
-        let this_value = maker(&mut agent);
-        symbol_to_string(&mut agent, this_value, None, &[])
+    fn normal(maker: fn(&Agent) -> ECMAScriptValue) -> Result<String, String> {
+        let agent = test_agent();
+        let this_value = maker(&agent);
+        symbol_to_string(&agent, this_value, None, &[])
             .map(|val| format!("{val}"))
-            .map_err(|ac| unwind_any_error(&mut agent, ac))
+            .map_err(|ac| unwind_any_error(&agent, ac))
     }
 }
 
@@ -657,19 +652,19 @@ mod symbol_value_of {
 
     #[test]
     fn symbol() {
-        let mut agent = test_agent();
-        let s = Symbol::new(&mut agent, Some("test sentinel".into()));
+        let agent = test_agent();
+        let s = Symbol::new(&agent, Some("test sentinel".into()));
         let this_value = ECMAScriptValue::from(s.clone());
-        let result = symbol_value_of(&mut agent, this_value, None, &[]).unwrap();
+        let result = symbol_value_of(&agent, this_value, None, &[]).unwrap();
         assert_eq!(result, ECMAScriptValue::from(s));
     }
 
     #[test]
     fn error() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let this_value = ECMAScriptValue::Undefined;
-        let result = symbol_value_of(&mut agent, this_value, None, &[]).unwrap_err();
-        assert_eq!(unwind_any_error(&mut agent, result), "TypeError: Not a symbol");
+        let result = symbol_value_of(&agent, this_value, None, &[]).unwrap_err();
+        assert_eq!(unwind_any_error(&agent, result), "TypeError: Not a symbol");
     }
 }
 
@@ -680,17 +675,17 @@ mod symbol_description {
     #[test_case(None => ECMAScriptValue::Undefined; "no description")]
     #[test_case(Some("alice") => ECMAScriptValue::from("alice"); "with description")]
     fn normal(src: Option<&str>) -> ECMAScriptValue {
-        let mut agent = test_agent();
-        let sym = Symbol::new(&mut agent, src.map(JSString::from));
+        let agent = test_agent();
+        let sym = Symbol::new(&agent, src.map(JSString::from));
         let this_value = ECMAScriptValue::from(sym);
-        symbol_description(&mut agent, this_value, None, &[]).unwrap()
+        symbol_description(&agent, this_value, None, &[]).unwrap()
     }
 
     #[test]
     fn bad_this() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         let this_value = ECMAScriptValue::Undefined;
-        let result = symbol_description(&mut agent, this_value, None, &[]).unwrap_err();
-        assert_eq!(unwind_any_error(&mut agent, result), "TypeError: Not a symbol");
+        let result = symbol_description(&agent, this_value, None, &[]).unwrap_err();
+        assert_eq!(unwind_any_error(&agent, result), "TypeError: Not a symbol");
     }
 }

--- a/src/tests/integration.rs
+++ b/src/tests/integration.rs
@@ -12,12 +12,12 @@ mod update_expression {
         #[test_case("let a = 10;let b = a++;({ a, b })" => (11.into(), 10.into()); "number")]
         #[test_case("let a = 10n;let b = a++;({ a, b })" => (BigInt::from(11).into(), BigInt::from(10).into()); "bigint")]
         fn normal(src: &str) -> (ECMAScriptValue, ECMAScriptValue) {
-            let mut agent = test_agent();
-            let result = process_ecmascript(&mut agent, src).unwrap();
+            let agent = test_agent();
+            let result = process_ecmascript(&agent, src).unwrap();
 
-            let result_obj = to_object(&mut agent, result).unwrap();
-            let a = get(&mut agent, &result_obj, &"a".into()).unwrap();
-            let b = get(&mut agent, &result_obj, &"b".into()).unwrap();
+            let result_obj = to_object(&agent, result).unwrap();
+            let a = get(&agent, &result_obj, &"a".into()).unwrap();
+            let b = get(&agent, &result_obj, &"b".into()).unwrap();
             (a, b)
         }
 
@@ -26,8 +26,8 @@ mod update_expression {
         #[test_case("let a={ toString: undefined, valueOf: undefined };a++;" => "Thrown: TypeError: Cannot convert object to primitive value"; "ToNumeric errs")]
         #[test_case("const a=0;a++;" => "Thrown: TypeError: Cannot change read-only value"; "PutValue errs")]
         fn errors(src: &str) -> String {
-            let mut agent = test_agent();
-            let result = process_ecmascript(&mut agent, src).unwrap_err();
+            let agent = test_agent();
+            let result = process_ecmascript(&agent, src).unwrap_err();
             result.to_string()
         }
     }
@@ -39,12 +39,12 @@ mod update_expression {
         #[test_case("let a = 10;let b = a--;({ a, b })" => (9.into(), 10.into()); "number")]
         #[test_case("let a = 10n;let b = a--;({ a, b })" => (BigInt::from(9).into(), BigInt::from(10).into()); "bigint")]
         fn normal(src: &str) -> (ECMAScriptValue, ECMAScriptValue) {
-            let mut agent = test_agent();
-            let result = process_ecmascript(&mut agent, src).unwrap();
+            let agent = test_agent();
+            let result = process_ecmascript(&agent, src).unwrap();
 
-            let result_obj = to_object(&mut agent, result).unwrap();
-            let a = get(&mut agent, &result_obj, &"a".into()).unwrap();
-            let b = get(&mut agent, &result_obj, &"b".into()).unwrap();
+            let result_obj = to_object(&agent, result).unwrap();
+            let a = get(&agent, &result_obj, &"a".into()).unwrap();
+            let b = get(&agent, &result_obj, &"b".into()).unwrap();
             (a, b)
         }
 
@@ -53,8 +53,8 @@ mod update_expression {
         #[test_case("let a={ toString: undefined, valueOf: undefined };a--;" => "Thrown: TypeError: Cannot convert object to primitive value"; "ToNumeric errs")]
         #[test_case("const a=0;a--;" => "Thrown: TypeError: Cannot change read-only value"; "PutValue errs")]
         fn errors(src: &str) -> String {
-            let mut agent = test_agent();
-            let result = process_ecmascript(&mut agent, src).unwrap_err();
+            let agent = test_agent();
+            let result = process_ecmascript(&agent, src).unwrap_err();
             result.to_string()
         }
     }
@@ -66,12 +66,12 @@ mod update_expression {
         #[test_case("let a = 10;let b = ++a;({ a, b })" => (11.into(), 11.into()); "number")]
         #[test_case("let a = 10n;let b = ++a;({ a, b })" => (BigInt::from(11).into(), BigInt::from(11).into()); "bigint")]
         fn normal(src: &str) -> (ECMAScriptValue, ECMAScriptValue) {
-            let mut agent = test_agent();
-            let result = process_ecmascript(&mut agent, src).unwrap();
+            let agent = test_agent();
+            let result = process_ecmascript(&agent, src).unwrap();
 
-            let result_obj = to_object(&mut agent, result).unwrap();
-            let a = get(&mut agent, &result_obj, &"a".into()).unwrap();
-            let b = get(&mut agent, &result_obj, &"b".into()).unwrap();
+            let result_obj = to_object(&agent, result).unwrap();
+            let a = get(&agent, &result_obj, &"a".into()).unwrap();
+            let b = get(&agent, &result_obj, &"b".into()).unwrap();
             (a, b)
         }
 
@@ -80,8 +80,8 @@ mod update_expression {
         #[test_case("let a={ toString: undefined, valueOf: undefined };++a;" => "Thrown: TypeError: Cannot convert object to primitive value"; "ToNumeric errs")]
         #[test_case("const a=0;++a;" => "Thrown: TypeError: Cannot change read-only value"; "PutValue errs")]
         fn errors(src: &str) -> String {
-            let mut agent = test_agent();
-            let result = process_ecmascript(&mut agent, src).unwrap_err();
+            let agent = test_agent();
+            let result = process_ecmascript(&agent, src).unwrap_err();
             result.to_string()
         }
     }
@@ -93,12 +93,12 @@ mod update_expression {
         #[test_case("let a = 10;let b = --a;({ a, b })" => (9.into(), 9.into()); "number")]
         #[test_case("let a = 10n;let b = --a;({ a, b })" => (BigInt::from(9).into(), BigInt::from(9).into()); "bigint")]
         fn normal(src: &str) -> (ECMAScriptValue, ECMAScriptValue) {
-            let mut agent = test_agent();
-            let result = process_ecmascript(&mut agent, src).unwrap();
+            let agent = test_agent();
+            let result = process_ecmascript(&agent, src).unwrap();
 
-            let result_obj = to_object(&mut agent, result).unwrap();
-            let a = get(&mut agent, &result_obj, &"a".into()).unwrap();
-            let b = get(&mut agent, &result_obj, &"b".into()).unwrap();
+            let result_obj = to_object(&agent, result).unwrap();
+            let a = get(&agent, &result_obj, &"a".into()).unwrap();
+            let b = get(&agent, &result_obj, &"b".into()).unwrap();
             (a, b)
         }
 
@@ -107,8 +107,8 @@ mod update_expression {
         #[test_case("let a={ toString: undefined, valueOf: undefined };--a;" => "Thrown: TypeError: Cannot convert object to primitive value"; "ToNumeric errs")]
         #[test_case("const a=0;--a;" => "Thrown: TypeError: Cannot change read-only value"; "PutValue errs")]
         fn errors(src: &str) -> String {
-            let mut agent = test_agent();
-            let result = process_ecmascript(&mut agent, src).unwrap_err();
+            let agent = test_agent();
+            let result = process_ecmascript(&agent, src).unwrap_err();
             result.to_string()
         }
     }
@@ -126,15 +126,15 @@ mod unary_expression {
     #[test_case("delete a.b;" => serr("Thrown: ReferenceError: Unresolvable Reference"); "error from expression")]
     #[test_case("'use strict'; delete Boolean.prototype" => serr("Thrown: TypeError: property not deletable"); "strict, not deletable")]
     fn delete(src: &str) -> Result<ECMAScriptValue, String> {
-        let mut agent = test_agent();
-        process_ecmascript(&mut agent, src).map_err(|e| e.to_string())
+        let agent = test_agent();
+        process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 
     #[test_case("void 3;" => Ok(ECMAScriptValue::Undefined); "simple")]
     #[test_case("void a;" => serr("Thrown: ReferenceError: Unresolvable Reference"); "err")]
     fn void(src: &str) -> Result<ECMAScriptValue, String> {
-        let mut agent = test_agent();
-        process_ecmascript(&mut agent, src).map_err(|e| e.to_string())
+        let agent = test_agent();
+        process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 
     #[test_case("typeof a;" => Ok("undefined".into()); "undefined via unresolvable")]
@@ -149,8 +149,8 @@ mod unary_expression {
     #[test_case("typeof {};" => Ok("object".into()); "object")]
     #[test_case("typeof Boolean;" => Ok("function".into()); "function")]
     fn typeof_op(src: &str) -> Result<ECMAScriptValue, String> {
-        let mut agent = test_agent();
-        process_ecmascript(&mut agent, src).map_err(|e| e.to_string())
+        let agent = test_agent();
+        process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 }
 
@@ -167,8 +167,8 @@ mod member_expression {
     #[test_case("let m={},c={toString:undefined, valueOf:undefined};m[c]" => serr("Thrown: TypeError: Cannot convert object to primitive value"); "exp syntax; tokey throws")]
     #[test_case("let m={'1':99};m[1]" => vok(99); "exp member exp")]
     fn run(src: &str) -> Result<ECMAScriptValue, String> {
-        let mut agent = test_agent();
-        process_ecmascript(&mut agent, src).map_err(|e| e.to_string())
+        let agent = test_agent();
+        process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 }
 
@@ -184,8 +184,8 @@ mod exponentiation_expression {
     #[test_case("(-Infinity) ** 3" => vok(f64::NEG_INFINITY); "-Inf ** 3")]
     #[test_case("(-Infinity) ** 8" => vok(f64::INFINITY) ; "-Inf ** 8")]
     fn run(src: &str) -> Result<ECMAScriptValue, String> {
-        let mut agent = test_agent();
-        process_ecmascript(&mut agent, src).map_err(|e| e.to_string())
+        let agent = test_agent();
+        process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 }
 
@@ -201,8 +201,8 @@ mod if_statement {
     #[test_case("if (true) a; else -1;" => serr("Thrown: ReferenceError: Unresolvable Reference"); "err in stmt1")]
     #[test_case("if (false) 1; else a;" => serr("Thrown: ReferenceError: Unresolvable Reference"); "err in stmt2")]
     fn run(src: &str) -> Result<ECMAScriptValue, String> {
-        let mut agent = test_agent();
-        process_ecmascript(&mut agent, src).map_err(|e| e.to_string())
+        let agent = test_agent();
+        process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 }
 
@@ -217,8 +217,8 @@ mod do_while {
     #[test_case("do a; while (false);" => serr("Thrown: ReferenceError: Unresolvable Reference"); "err in stmt")]
     #[test_case("do null; while (a);" => serr("Thrown: ReferenceError: Unresolvable Reference"); "err in expr")]
     fn run(src: &str) -> Result<ECMAScriptValue, String> {
-        let mut agent = test_agent();
-        process_ecmascript(&mut agent, src).map_err(|e| e.to_string())
+        let agent = test_agent();
+        process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 }
 
@@ -253,8 +253,8 @@ mod labelled_statement {
         result;
     " => vok("1 "); "loopless targeted break")]
     fn run(src: &str) -> Result<ECMAScriptValue, String> {
-        let mut agent = test_agent();
-        process_ecmascript(&mut agent, src).map_err(|e| e.to_string())
+        let agent = test_agent();
+        process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 }
 
@@ -263,8 +263,8 @@ mod labelled_statement {
 #[test_case(r"'9876543210'[2];" => vok("7"); "coerced string indexed properties")]
 #[test_case(r"'9876543210'.length;" => vok(10); "coerced string length")]
 fn string_exotic_object(src: &str) -> Result<ECMAScriptValue, String> {
-    let mut agent = test_agent();
-    process_ecmascript(&mut agent, src).map_err(|e| e.to_string())
+    let agent = test_agent();
+    process_ecmascript(&agent, src).map_err(|e| e.to_string())
 }
 
 #[test_case("String()" => vok(""); "no args")]
@@ -273,8 +273,8 @@ fn string_exotic_object(src: &str) -> Result<ECMAScriptValue, String> {
 #[test_case("new String(Symbol('oops'))" => serr("Thrown: TypeError: Symbols may not be converted to strings"); "error in constructor")]
 #[test_case("String(Symbol('oops'))" => vok("Symbol(oops)"); "symbol in function")]
 fn string_constructor(src: &str) -> Result<ECMAScriptValue, String> {
-    let mut agent = test_agent();
-    process_ecmascript(&mut agent, src).map_err(|e| e.to_string())
+    let agent = test_agent();
+    process_ecmascript(&agent, src).map_err(|e| e.to_string())
 }
 
 #[test_case("String.fromCharCode(112, 97, 115, 115)" => vok("pass"); "normal")]
@@ -283,8 +283,8 @@ fn string_constructor(src: &str) -> Result<ECMAScriptValue, String> {
 #[test_case("String.fromCharCode.name" => vok("fromCharCode"); "name")]
 #[test_case("String.fromCharCode.length" => vok(1); "length")]
 fn string_from_char_code(src: &str) -> Result<ECMAScriptValue, String> {
-    let mut agent = test_agent();
-    process_ecmascript(&mut agent, src).map_err(|e| e.to_string())
+    let agent = test_agent();
+    process_ecmascript(&agent, src).map_err(|e| e.to_string())
 }
 
 #[test_case("'12345'.indexOf('2')" => vok(1); "found a match")]
@@ -297,29 +297,29 @@ fn string_from_char_code(src: &str) -> Result<ECMAScriptValue, String> {
 #[test_case("'a'.indexOf('a', Symbol('a'))" => serr("Thrown: TypeError: Symbol values cannot be converted to Number values"); "fail location 4")]
 #[test_case("'what if things are undefined?'.indexOf()" => vok(19); "first arg missing")]
 fn string_prototype_index_of(src: &str) -> Result<ECMAScriptValue, String> {
-    let mut agent = test_agent();
-    process_ecmascript(&mut agent, src).map_err(|e| e.to_string())
+    let agent = test_agent();
+    process_ecmascript(&agent, src).map_err(|e| e.to_string())
 }
 
 #[test_case("String.prototype.toString.call(0)" => serr("Thrown: TypeError: String.prototype.toString requires that 'this' be a String"); "bad this")]
 #[test_case("new String('alpha').toString()" => vok("alpha"); "string object")]
 #[test_case("'alpha'.toString()" => vok("alpha"); "string literal")]
 fn string_prototype_to_string(src: &str) -> Result<ECMAScriptValue, String> {
-    let mut agent = test_agent();
-    process_ecmascript(&mut agent, src).map_err(|e| e.to_string())
+    let agent = test_agent();
+    process_ecmascript(&agent, src).map_err(|e| e.to_string())
 }
 
 #[test_case("String.prototype.valueOf.call(0)" => serr("Thrown: TypeError: String.prototype.valueOf requires that 'this' be a String"); "bad this")]
 #[test_case("new String('alpha').valueOf()" => vok("alpha"); "string object")]
 #[test_case("'alpha'.valueOf()" => vok("alpha"); "string literal")]
 fn string_prototype_value_of(src: &str) -> Result<ECMAScriptValue, String> {
-    let mut agent = test_agent();
-    process_ecmascript(&mut agent, src).map_err(|e| e.to_string())
+    let agent = test_agent();
+    process_ecmascript(&agent, src).map_err(|e| e.to_string())
 }
 
 #[test_case("(x => x * 2).call(undefined, 99);" => vok(198); "call a user defined func")]
 #[test_case("Number.prototype.toString.call(991)" => vok("991"); "call a builtin func")]
 fn function_prototype_call(src: &str) -> Result<ECMAScriptValue, String> {
-    let mut agent = test_agent();
-    process_ecmascript(&mut agent, src).map_err(|e| e.to_string())
+    let agent = test_agent();
+    process_ecmascript(&agent, src).map_err(|e| e.to_string())
 }

--- a/src/values/tests.rs
+++ b/src/values/tests.rs
@@ -135,8 +135,8 @@ mod ecmascript_value {
     }
     #[test]
     fn from_object_ref() {
-        let mut agent = test_agent();
-        let o = ordinary_object_create(&mut agent, None, &[]);
+        let agent = test_agent();
+        let o = ordinary_object_create(&agent, None, &[]);
 
         let val = ECMAScriptValue::from(&o);
         assert!(val.is_object());
@@ -145,8 +145,8 @@ mod ecmascript_value {
     }
     #[test]
     fn from_object() {
-        let mut agent = test_agent();
-        let o = ordinary_object_create(&mut agent, None, &[]);
+        let agent = test_agent();
+        let o = ordinary_object_create(&agent, None, &[]);
         let orig_id = o.o.id();
 
         let val = ECMAScriptValue::from(o);
@@ -166,9 +166,9 @@ mod ecmascript_value {
     }
     #[test_case(|_| PropertyKey::String("key".into()) => "key"; "string")]
     #[test_case(|a| PropertyKey::Symbol(a.wks(WksId::ToPrimitive)) => "Symbol(Symbol.toPrimitive)"; "symbol")]
-    fn from_property_key(maker: fn(&mut Agent) -> PropertyKey) -> String {
-        let mut agent = test_agent();
-        let key = maker(&mut agent);
+    fn from_property_key(maker: fn(&Agent) -> PropertyKey) -> String {
+        let agent = test_agent();
+        let key = maker(&agent);
         format!("{}", ECMAScriptValue::from(key))
     }
     #[test_case(String::from("blue") => ECMAScriptValue::String("blue".into()); "String")]
@@ -206,12 +206,9 @@ mod ecmascript_value {
     }
     #[test]
     fn is_symbol() {
-        let mut agent = test_agent();
+        let agent = test_agent();
         assert_eq!(ECMAScriptValue::Undefined.is_symbol(), false);
-        assert_eq!(
-            ECMAScriptValue::from(Symbol::new(&mut agent, Some(JSString::from("Test Symbol")))).is_symbol(),
-            true
-        );
+        assert_eq!(ECMAScriptValue::from(Symbol::new(&agent, Some(JSString::from("Test Symbol")))).is_symbol(), true);
         assert_eq!(ECMAScriptValue::Null.is_symbol(), false);
     }
     #[test]
@@ -222,8 +219,8 @@ mod ecmascript_value {
     }
     #[test]
     fn is_object() {
-        let mut agent = test_agent();
-        let o = ordinary_object_create(&mut agent, None, &[]);
+        let agent = test_agent();
+        let o = ordinary_object_create(&agent, None, &[]);
         assert_eq!(ECMAScriptValue::Undefined.is_object(), false);
         assert_eq!(ECMAScriptValue::from(o).is_object(), true);
         assert_eq!(ECMAScriptValue::Null.is_object(), false);
@@ -238,54 +235,54 @@ mod ecmascript_value {
     #[test]
     fn concise() {
         // Calling this on our own isn't really do-able; we need to get there via Display or Debug.
-        let mut agent = test_agent();
+        let agent = test_agent();
         let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let obj = ordinary_object_create(&mut agent, Some(obj_proto), &[]);
+        let obj = ordinary_object_create(&agent, Some(obj_proto), &[]);
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &obj,
             PropertyKey::from("Undefined"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::Undefined), ..Default::default() },
         )
         .unwrap();
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &obj,
             PropertyKey::from("Null"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::Null), ..Default::default() },
         )
         .unwrap();
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &obj,
             PropertyKey::from("Number"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from(10.0)), ..Default::default() },
         )
         .unwrap();
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &obj,
             PropertyKey::from("String"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from("bob")), ..Default::default() },
         )
         .unwrap();
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &obj,
             PropertyKey::from("Boolean"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from(true)), ..Default::default() },
         )
         .unwrap();
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &obj,
             PropertyKey::from("BigInt"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from(BigInt::from(11))), ..Default::default() },
         )
         .unwrap();
-        let sym = Symbol::new(&mut agent, Some(JSString::from("San Francisco")));
+        let sym = Symbol::new(&agent, Some(JSString::from("San Francisco")));
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &obj,
             PropertyKey::from("Symbol"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from(sym)), ..Default::default() },
@@ -293,7 +290,7 @@ mod ecmascript_value {
         .unwrap();
         let propobj = &agent.intrinsic(IntrinsicId::Boolean);
         define_property_or_throw(
-            &mut agent,
+            &agent,
             &obj,
             PropertyKey::from("Object"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from(propobj)), ..Default::default() },
@@ -304,12 +301,12 @@ mod ecmascript_value {
     }
     #[test]
     fn is_array() {
-        let mut agent = test_agent();
-        let a = array_create(&mut agent, 0, None).unwrap();
+        let agent = test_agent();
+        let a = array_create(&agent, 0, None).unwrap();
         let v1: ECMAScriptValue = a.into();
         let v2 = ECMAScriptValue::Null;
-        assert!(v1.is_array(&mut agent).unwrap());
-        assert!(!v2.is_array(&mut agent).unwrap());
+        assert!(v1.is_array(&agent).unwrap());
+        assert!(!v2.is_array(&agent).unwrap());
     }
 
     mod display {
@@ -332,63 +329,63 @@ mod ecmascript_value {
             let obj = ordinary_object_create(a, None, &[]);
             ECMAScriptValue::Object(obj)
         } => with |s: String| assert!(Regex::new("^<Object [0-9]+>$").unwrap().is_match(&s)); "object")]
-        fn complex(maker: fn(&mut Agent) -> ECMAScriptValue) -> String {
-            let mut agent = test_agent();
-            let val = maker(&mut agent);
+        fn complex(maker: fn(&Agent) -> ECMAScriptValue) -> String {
+            let agent = test_agent();
+            let val = maker(&agent);
             format!("{val}")
         }
     }
 
-    type ValueMaker = fn(&mut Agent) -> ECMAScriptValue;
-    fn undef(_: &mut Agent) -> ECMAScriptValue {
+    type ValueMaker = fn(&Agent) -> ECMAScriptValue;
+    fn undef(_: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::Undefined
     }
-    fn null(_: &mut Agent) -> ECMAScriptValue {
+    fn null(_: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::Null
     }
-    fn string_a(_: &mut Agent) -> ECMAScriptValue {
+    fn string_a(_: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::from("A")
     }
-    fn string_b(_: &mut Agent) -> ECMAScriptValue {
+    fn string_b(_: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::from("B")
     }
-    fn bool_a(_: &mut Agent) -> ECMAScriptValue {
+    fn bool_a(_: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::from(true)
     }
-    fn bool_b(_: &mut Agent) -> ECMAScriptValue {
+    fn bool_b(_: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::from(false)
     }
-    fn symbol_a(agent: &mut Agent) -> ECMAScriptValue {
+    fn symbol_a(agent: &Agent) -> ECMAScriptValue {
         agent.wks(WksId::ToPrimitive).into()
     }
-    fn symbol_b(agent: &mut Agent) -> ECMAScriptValue {
+    fn symbol_b(agent: &Agent) -> ECMAScriptValue {
         agent.wks(WksId::HasInstance).into()
     }
-    fn object_a(agent: &mut Agent) -> ECMAScriptValue {
+    fn object_a(agent: &Agent) -> ECMAScriptValue {
         agent.intrinsic(IntrinsicId::FunctionPrototype).into()
     }
-    fn object_b(agent: &mut Agent) -> ECMAScriptValue {
+    fn object_b(agent: &Agent) -> ECMAScriptValue {
         agent.intrinsic(IntrinsicId::ObjectPrototype).into()
     }
-    fn number_10(_: &mut Agent) -> ECMAScriptValue {
+    fn number_10(_: &Agent) -> ECMAScriptValue {
         10.into()
     }
-    fn number_100(_: &mut Agent) -> ECMAScriptValue {
+    fn number_100(_: &Agent) -> ECMAScriptValue {
         100.into()
     }
-    fn number_zero(_: &mut Agent) -> ECMAScriptValue {
+    fn number_zero(_: &Agent) -> ECMAScriptValue {
         0.into()
     }
-    fn number_neg_zero(_: &mut Agent) -> ECMAScriptValue {
+    fn number_neg_zero(_: &Agent) -> ECMAScriptValue {
         (-0.0).into()
     }
-    fn number_nan(_: &mut Agent) -> ECMAScriptValue {
+    fn number_nan(_: &Agent) -> ECMAScriptValue {
         f64::NAN.into()
     }
-    fn bigint_a(_: &mut Agent) -> ECMAScriptValue {
+    fn bigint_a(_: &Agent) -> ECMAScriptValue {
         BigInt::from(10).into()
     }
-    fn bigint_b(_: &mut Agent) -> ECMAScriptValue {
+    fn bigint_b(_: &Agent) -> ECMAScriptValue {
         BigInt::from(-1097631).into()
     }
 
@@ -404,9 +401,9 @@ mod ecmascript_value {
     #[test_case(object_a, object_a => true; "equal objects")]
     #[test_case(undef, symbol_b => panics "Invalid input args"; "Invalid Input")]
     fn same_value_non_numeric(make_x: ValueMaker, make_y: ValueMaker) -> bool {
-        let mut agent = test_agent();
-        let x = make_x(&mut agent);
-        let y = make_y(&mut agent);
+        let agent = test_agent();
+        let x = make_x(&agent);
+        let y = make_y(&agent);
 
         x.same_value_non_numeric(&y)
     }
@@ -420,9 +417,9 @@ mod ecmascript_value {
     #[test_case(bigint_a, bigint_b => false; "different bigints")]
     #[test_case(string_a, string_a => true; "fallthru for nonnumbers")]
     fn same_value_zero(make_x: ValueMaker, make_y: ValueMaker) -> bool {
-        let mut agent = test_agent();
-        let x = make_x(&mut agent);
-        let y = make_y(&mut agent);
+        let agent = test_agent();
+        let x = make_x(&agent);
+        let y = make_y(&agent);
 
         x.same_value_zero(&y)
     }
@@ -436,9 +433,9 @@ mod ecmascript_value {
     #[test_case(bigint_a, bigint_b => false; "different bigints")]
     #[test_case(string_a, string_a => true; "fallthru for nonnumbers")]
     fn same_value(make_x: ValueMaker, make_y: ValueMaker) -> bool {
-        let mut agent = test_agent();
-        let x = make_x(&mut agent);
-        let y = make_y(&mut agent);
+        let agent = test_agent();
+        let x = make_x(&agent);
+        let y = make_y(&agent);
 
         x.same_value(&y)
     }
@@ -452,9 +449,9 @@ mod ecmascript_value {
     #[test_case(bigint_a, bigint_b => false; "different bigints")]
     #[test_case(string_a, string_a => true; "fallthru for nonnumbers")]
     fn is_strictly_equal(make_x: ValueMaker, make_y: ValueMaker) -> bool {
-        let mut agent = test_agent();
-        let x = make_x(&mut agent);
-        let y = make_y(&mut agent);
+        let agent = test_agent();
+        let x = make_x(&agent);
+        let y = make_y(&agent);
 
         x.is_strictly_equal(&y)
     }
@@ -467,14 +464,14 @@ fn symbol_debug() {
 }
 #[test]
 fn symbol_display_normal() {
-    let mut agent = test_agent();
-    let symbol = Symbol::new(&mut agent, Some(JSString::from("Normal")));
+    let agent = test_agent();
+    let symbol = Symbol::new(&agent, Some(JSString::from("Normal")));
     assert_eq!(format!("{}", symbol), "Symbol(Normal)");
 }
 #[test]
 fn symbol_display_empty() {
-    let mut agent = test_agent();
-    let symbol = Symbol::new(&mut agent, None);
+    let agent = test_agent();
+    let symbol = Symbol::new(&agent, None);
     assert_eq!(format!("{}", symbol), "Symbol()");
 }
 #[test]
@@ -506,10 +503,10 @@ fn symbol_hash() {
 }
 #[test]
 fn symbol_new() {
-    let mut agent = test_agent();
-    let s1 = Symbol::new(&mut agent, Some(JSString::from("Symbol #1")));
-    let s2 = Symbol::new(&mut agent, Some(JSString::from("Symbol #2")));
-    let s3 = Symbol::new(&mut agent, Some(JSString::from("Symbol #1")));
+    let agent = test_agent();
+    let s1 = Symbol::new(&agent, Some(JSString::from("Symbol #1")));
+    let s2 = Symbol::new(&agent, Some(JSString::from("Symbol #2")));
+    let s3 = Symbol::new(&agent, Some(JSString::from("Symbol #1")));
     let s4 = s1.clone();
 
     assert_ne!(s1, s2);
@@ -521,8 +518,8 @@ fn symbol_new() {
 }
 #[test]
 fn symbol_description() {
-    let mut agent = test_agent();
-    let s1 = Symbol::new(&mut agent, Some(JSString::from("Test Symbol")));
+    let agent = test_agent();
+    let s1 = Symbol::new(&agent, Some(JSString::from("Test Symbol")));
     assert_eq!(s1.description(), Some(JSString::from("Test Symbol")));
 }
 #[test]
@@ -667,9 +664,9 @@ fn to_boolean_01() {
     assert_eq!(to_boolean(ECMAScriptValue::from(BigInt::from(22))), true);
     assert_eq!(to_boolean(ECMAScriptValue::from(BigInt::from(0))), false);
 
-    let mut agent = test_agent();
+    let agent = test_agent();
     assert_eq!(to_boolean(ECMAScriptValue::from(agent.wks(WksId::ToPrimitive))), true);
-    let o = ordinary_object_create(&mut agent, None, &[]);
+    let o = ordinary_object_create(&agent, None, &[]);
     assert_eq!(to_boolean(ECMAScriptValue::from(o)), true);
 }
 
@@ -737,10 +734,10 @@ mod property_key {
     }
     #[test_case(|_| PropertyKey::from("alice"), |_| ECMAScriptValue::from("alice"); "string")]
     #[test_case(|a| PropertyKey::from(a.wks(WksId::ToPrimitive)), |a| ECMAScriptValue::from(a.wks(WksId::ToPrimitive)); "symbol")]
-    fn into_ecmascriptvalue(make_key: fn(&mut Agent) -> PropertyKey, make_expected: fn(&mut Agent) -> ECMAScriptValue) {
-        let mut agent = test_agent();
-        let key = make_key(&mut agent);
-        let expected = make_expected(&mut agent);
+    fn into_ecmascriptvalue(make_key: fn(&Agent) -> PropertyKey, make_expected: fn(&Agent) -> ECMAScriptValue) {
+        let agent = test_agent();
+        let key = make_key(&agent);
+        let expected = make_expected(&agent);
         assert_eq!(ECMAScriptValue::from(key), expected);
     }
 
@@ -773,16 +770,16 @@ mod jsstring {
 
         #[test_case(|_| PropertyKey::from("key") => sok("key"); "string")]
         #[test_case(|a| PropertyKey::from(a.wks(WksId::ToPrimitive)) => serr("Expected String-valued property key"); "symbol")]
-        fn property_key(maker: fn(&mut Agent) -> PropertyKey) -> Result<String, String> {
-            let mut agent = test_agent();
-            let key = maker(&mut agent);
+        fn property_key(maker: fn(&Agent) -> PropertyKey) -> Result<String, String> {
+            let agent = test_agent();
+            let key = maker(&agent);
             JSString::try_from(key).map_err(|e| e.to_string()).map(String::from)
         }
         #[test_case(|_| PropertyKey::from("key") => sok("key"); "string")]
         #[test_case(|a| PropertyKey::from(a.wks(WksId::ToPrimitive)) => serr("Expected String-valued property key"); "symbol")]
-        fn property_key_ref(maker: fn(&mut Agent) -> PropertyKey) -> Result<String, String> {
-            let mut agent = test_agent();
-            let key = maker(&mut agent);
+        fn property_key_ref(maker: fn(&Agent) -> PropertyKey) -> Result<String, String> {
+            let agent = test_agent();
+            let key = maker(&agent);
             JSString::try_from(&key).map_err(|e| e.to_string()).map(String::from)
         }
 
@@ -798,9 +795,9 @@ mod jsstring {
             let obj = ordinary_object_create(a, None, &[]);
             ECMAScriptValue::Object(obj)
         } => serr("Object to string conversions require an agent"); "object")]
-        fn ecmasript_value(maker: fn(&mut Agent) -> ECMAScriptValue) -> Result<String, String> {
-            let mut agent = test_agent();
-            let value = maker(&mut agent);
+        fn ecmasript_value(maker: fn(&Agent) -> ECMAScriptValue) -> Result<String, String> {
+            let agent = test_agent();
+            let value = maker(&agent);
             JSString::try_from(value).map_err(|e| e.to_string()).map(String::from)
         }
     }
@@ -833,87 +830,87 @@ mod numeric {
 
 #[test]
 fn to_numeric_01() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
-    let result = to_numeric(&mut agent, ECMAScriptValue::from(obj)).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Cannot convert object to primitive value");
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
+    let result = to_numeric(&agent, ECMAScriptValue::from(obj)).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Cannot convert object to primitive value");
 }
 #[test]
 fn to_numeric_02() {
-    let mut agent = test_agent();
-    let result = to_numeric(&mut agent, ECMAScriptValue::from(BigInt::from(4747474))).unwrap();
+    let agent = test_agent();
+    let result = to_numeric(&agent, ECMAScriptValue::from(BigInt::from(4747474))).unwrap();
     assert_eq!(result, Numeric::BigInt(Rc::new(BigInt::from(4747474))));
 }
 #[test]
 fn to_numeric_03() {
-    let mut agent = test_agent();
-    let result = to_numeric(&mut agent, ECMAScriptValue::from(10)).unwrap();
+    let agent = test_agent();
+    let result = to_numeric(&agent, ECMAScriptValue::from(10)).unwrap();
     assert_eq!(result, Numeric::Number(10.0));
 }
 #[test]
 fn to_numeric_04() {
-    let mut agent = test_agent();
-    let sym = Symbol::new(&mut agent, None);
-    let result = to_numeric(&mut agent, ECMAScriptValue::from(sym)).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Symbol values cannot be converted to Number values");
+    let agent = test_agent();
+    let sym = Symbol::new(&agent, None);
+    let result = to_numeric(&agent, ECMAScriptValue::from(sym)).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
 }
 
 #[test]
 fn to_number_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let input = ECMAScriptValue::Undefined;
 
-    let result = to_number(&mut agent, input).unwrap();
+    let result = to_number(&agent, input).unwrap();
     assert!(result.is_nan());
 }
 #[test]
 #[allow(clippy::float_cmp)]
 fn to_number_02() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let input = ECMAScriptValue::Null;
 
-    let result = to_number(&mut agent, input).unwrap();
+    let result = to_number(&agent, input).unwrap();
     assert_eq!(result, 0.0);
 }
 #[test]
 #[allow(clippy::float_cmp)]
 fn to_number_03() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let input = ECMAScriptValue::from(true);
 
-    let result = to_number(&mut agent, input).unwrap();
+    let result = to_number(&agent, input).unwrap();
     assert_eq!(result, 1.0);
 }
 #[test]
 #[allow(clippy::float_cmp)]
 fn to_number_04() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let input = ECMAScriptValue::from(false);
 
-    let result = to_number(&mut agent, input).unwrap();
+    let result = to_number(&agent, input).unwrap();
     assert_eq!(result, 0.0);
 }
 #[test]
 #[allow(clippy::float_cmp)]
 fn to_number_05() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let input = ECMAScriptValue::from(37.6);
 
-    let result = to_number(&mut agent, input).unwrap();
+    let result = to_number(&agent, input).unwrap();
     assert_eq!(result, 37.6);
 }
 #[test]
 fn to_number_06() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let input = ECMAScriptValue::from("blue");
 
-    let result = to_number(&mut agent, input).unwrap();
+    let result = to_number(&agent, input).unwrap();
     assert!(result.is_nan());
 }
 #[test]
 #[allow(clippy::float_cmp)]
 fn to_number_07() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let testcases = [
         ("", 0.0),
         ("1", 1.0),
@@ -931,50 +928,50 @@ fn to_number_07() {
     ];
 
     for (s, e) in testcases {
-        let result = to_number(&mut agent, ECMAScriptValue::from(s)).unwrap();
+        let result = to_number(&agent, ECMAScriptValue::from(s)).unwrap();
         assert_eq!(result, e);
     }
 }
 #[test]
 fn to_number_08() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let input = ECMAScriptValue::from(BigInt::from(10));
 
-    let result = to_number(&mut agent, input).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "BigInt values cannot be converted to Number values");
+    let result = to_number(&agent, input).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "BigInt values cannot be converted to Number values");
 }
 #[test]
 fn to_number_09() {
-    let mut agent = test_agent();
-    let input = ECMAScriptValue::from(Symbol::new(&mut agent, None));
+    let agent = test_agent();
+    let input = ECMAScriptValue::from(Symbol::new(&agent, None));
 
-    let result = to_number(&mut agent, input).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Symbol values cannot be converted to Number values");
+    let result = to_number(&agent, input).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
 }
 #[test]
 fn to_number_10() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let input = ECMAScriptValue::from(obj);
 
-    let result = to_number(&mut agent, input).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Cannot convert object to primitive value");
+    let result = to_number(&agent, input).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Cannot convert object to primitive value");
 }
 #[test]
 fn to_number_11() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(obj_proto), &[]);
+    let obj = ordinary_object_create(&agent, Some(obj_proto), &[]);
     let input = ECMAScriptValue::from(obj);
 
-    let result = to_number(&mut agent, input).unwrap();
+    let result = to_number(&agent, input).unwrap();
     assert!(result.is_nan());
 }
 
 #[test]
 #[allow(clippy::float_cmp)]
 fn to_integer_or_infinity_01() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let testcases = &[
         (f64::NAN, 0.0),
         (f64::INFINITY, f64::INFINITY),
@@ -986,79 +983,79 @@ fn to_integer_or_infinity_01() {
     ];
 
     for (val, expected) in testcases {
-        let result = to_integer_or_infinity(&mut agent, ECMAScriptValue::from(*val)).unwrap();
+        let result = to_integer_or_infinity(&agent, ECMAScriptValue::from(*val)).unwrap();
         assert_eq!(result, *expected);
     }
 }
 #[test]
 fn to_integer_or_infinity_02() {
-    let mut agent = test_agent();
-    let sym = Symbol::new(&mut agent, None);
+    let agent = test_agent();
+    let sym = Symbol::new(&agent, None);
 
-    let result = to_integer_or_infinity(&mut agent, ECMAScriptValue::from(sym)).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Symbol values cannot be converted to Number values");
+    let result = to_integer_or_infinity(&agent, ECMAScriptValue::from(sym)).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
 }
 
 #[test]
 fn to_string_01() {
-    let mut agent = test_agent();
-    let result = to_string(&mut agent, ECMAScriptValue::Undefined).unwrap();
+    let agent = test_agent();
+    let result = to_string(&agent, ECMAScriptValue::Undefined).unwrap();
     assert_eq!(result, "undefined");
 }
 #[test]
 fn to_string_02() {
-    let mut agent = test_agent();
-    let result = to_string(&mut agent, ECMAScriptValue::Null).unwrap();
+    let agent = test_agent();
+    let result = to_string(&agent, ECMAScriptValue::Null).unwrap();
     assert_eq!(result, "null");
 }
 #[test]
 fn to_string_03() {
-    let mut agent = test_agent();
-    let result = to_string(&mut agent, ECMAScriptValue::from(true)).unwrap();
+    let agent = test_agent();
+    let result = to_string(&agent, ECMAScriptValue::from(true)).unwrap();
     assert_eq!(result, "true");
 }
 #[test]
 fn to_string_04() {
-    let mut agent = test_agent();
-    let result = to_string(&mut agent, ECMAScriptValue::from(false)).unwrap();
+    let agent = test_agent();
+    let result = to_string(&agent, ECMAScriptValue::from(false)).unwrap();
     assert_eq!(result, "false");
 }
 #[test]
 fn to_string_05() {
-    let mut agent = test_agent();
-    let result = to_string(&mut agent, ECMAScriptValue::from(10)).unwrap();
+    let agent = test_agent();
+    let result = to_string(&agent, ECMAScriptValue::from(10)).unwrap();
     assert_eq!(result, "10");
 }
 #[test]
 fn to_string_06() {
-    let mut agent = test_agent();
-    let result = to_string(&mut agent, ECMAScriptValue::from("blue")).unwrap();
+    let agent = test_agent();
+    let result = to_string(&agent, ECMAScriptValue::from("blue")).unwrap();
     assert_eq!(result, "blue");
 }
 #[test]
 fn to_string_07() {
-    let mut agent = test_agent();
-    let sym = Symbol::new(&mut agent, None);
-    let result = to_string(&mut agent, ECMAScriptValue::Symbol(sym)).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Symbols may not be converted to strings");
+    let agent = test_agent();
+    let sym = Symbol::new(&agent, None);
+    let result = to_string(&agent, ECMAScriptValue::Symbol(sym)).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Symbols may not be converted to strings");
 }
 #[test]
 fn to_string_08() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&mut agent, Some(obj_proto), &[]);
-    let result = to_string(&mut agent, ECMAScriptValue::from(obj)).unwrap();
+    let obj = ordinary_object_create(&agent, Some(obj_proto), &[]);
+    let result = to_string(&agent, ECMAScriptValue::from(obj)).unwrap();
     assert_eq!(result, "[object Object]");
 }
 #[test]
 fn to_string_09() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
-    let result = to_string(&mut agent, ECMAScriptValue::from(obj)).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Cannot convert object to primitive value");
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
+    let result = to_string(&agent, ECMAScriptValue::from(obj)).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Cannot convert object to primitive value");
 }
 fn tostring_symbol(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -1068,10 +1065,10 @@ fn tostring_symbol(
 }
 #[test]
 fn to_string_10() {
-    let mut agent = test_agent();
-    let obj = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let obj = ordinary_object_create(&agent, None, &[]);
     let badtostring = create_builtin_function(
-        &mut agent,
+        &agent,
         tostring_symbol,
         false,
         0_f64,
@@ -1081,37 +1078,37 @@ fn to_string_10() {
         None,
         None,
     );
-    create_data_property(&mut agent, &obj, PropertyKey::from("toString"), ECMAScriptValue::from(badtostring)).unwrap();
+    create_data_property(&agent, &obj, PropertyKey::from("toString"), ECMAScriptValue::from(badtostring)).unwrap();
 
-    let result = to_string(&mut agent, ECMAScriptValue::from(obj)).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Symbols may not be converted to strings");
+    let result = to_string(&agent, ECMAScriptValue::from(obj)).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Symbols may not be converted to strings");
 }
 #[test]
 fn to_string_11() {
-    let mut agent = test_agent();
-    let result = to_string(&mut agent, ECMAScriptValue::from(BigInt::from(789123))).unwrap();
+    let agent = test_agent();
+    let result = to_string(&agent, ECMAScriptValue::from(BigInt::from(789123))).unwrap();
     assert_eq!(result, "789123");
 }
 
 #[test]
 fn to_object_01() {
-    let mut agent = test_agent();
-    let err = to_object(&mut agent, ECMAScriptValue::Undefined).unwrap_err();
-    let msg = unwind_type_error(&mut agent, err);
+    let agent = test_agent();
+    let err = to_object(&agent, ECMAScriptValue::Undefined).unwrap_err();
+    let msg = unwind_type_error(&agent, err);
     assert_eq!(msg, "Undefined and null cannot be converted to objects");
 }
 #[test]
 fn to_object_02() {
-    let mut agent = test_agent();
-    let err = to_object(&mut agent, ECMAScriptValue::Null).unwrap_err();
-    let msg = unwind_type_error(&mut agent, err);
+    let agent = test_agent();
+    let err = to_object(&agent, ECMAScriptValue::Null).unwrap_err();
+    let msg = unwind_type_error(&agent, err);
     assert_eq!(msg, "Undefined and null cannot be converted to objects");
 }
 #[test]
 fn to_object_03() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let test_value = true;
-    let result = to_object(&mut agent, ECMAScriptValue::from(test_value)).unwrap();
+    let result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
 
     let boolean_obj = result.o.to_boolean_obj().unwrap();
     assert_eq!(*boolean_obj.boolean_data().borrow(), test_value);
@@ -1119,43 +1116,43 @@ fn to_object_03() {
 #[test]
 #[allow(clippy::float_cmp)]
 fn to_object_04() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let test_value = 1337.0;
-    let result = to_object(&mut agent, ECMAScriptValue::from(test_value)).unwrap();
+    let result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
 
     let number_obj = result.o.to_number_obj().unwrap();
     assert_eq!(*number_obj.number_data().borrow(), test_value);
 }
 #[test]
 fn to_object_05() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let test_value = "orange";
-    let result = to_object(&mut agent, ECMAScriptValue::from(test_value)).unwrap();
+    let result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
 
-    let val = to_string(&mut agent, result).unwrap();
+    let val = to_string(&agent, result).unwrap();
     assert_eq!(val, JSString::from(test_value));
 }
 #[test]
 fn to_object_06() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let test_value = agent.wks(WksId::ToPrimitive);
-    let result = to_object(&mut agent, ECMAScriptValue::from(test_value)).unwrap();
-    let desc = get(&mut agent, &result, &"description".into()).unwrap();
+    let result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
+    let desc = get(&agent, &result, &"description".into()).unwrap();
     assert_eq!(desc, ECMAScriptValue::from("Symbol.toPrimitive"));
 }
 #[test]
 #[should_panic(expected = "not yet implemented")] // An XFAIL. BigInt objects not yet implemented.
 fn to_object_07() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let test_value = BigInt::from(10);
-    let _result = to_object(&mut agent, ECMAScriptValue::from(test_value)).unwrap();
+    let _result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
 }
 #[test]
 fn to_object_08() {
-    let mut agent = test_agent();
-    let test_value = ordinary_object_create(&mut agent, None, &[]);
+    let agent = test_agent();
+    let test_value = ordinary_object_create(&agent, None, &[]);
     let id = test_value.o.id();
-    let result = to_object(&mut agent, ECMAScriptValue::from(test_value)).unwrap();
+    let result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
     assert_eq!(result.o.id(), id);
 }
 
@@ -1167,7 +1164,7 @@ fn to_object_08() {
 
 // non-object number
 fn faux_makes_number(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -1176,7 +1173,7 @@ fn faux_makes_number(
 }
 // non-object string
 fn faux_makes_string(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -1185,7 +1182,7 @@ fn faux_makes_string(
 }
 // object value
 fn faux_makes_obj(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -1196,7 +1193,7 @@ fn faux_makes_obj(
 }
 // error
 fn faux_errors(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -1208,12 +1205,12 @@ enum FauxKind {
     Primitive,
     Error,
 }
-fn make_test_obj(agent: &mut Agent, valueof: FauxKind, tostring: FauxKind) -> Object {
+fn make_test_obj(agent: &Agent, valueof: FauxKind, tostring: FauxKind) -> Object {
     let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
     let target = ordinary_object_create(agent, Some(object_prototype), &[]);
-    let mut connect = |name, length, steps| {
+    let connect = |name, length, steps| {
         let key = PropertyKey::from(name);
         let fcn = create_builtin_function(
             agent,
@@ -1262,7 +1259,7 @@ fn make_test_obj(agent: &mut Agent, valueof: FauxKind, tostring: FauxKind) -> Ob
 
     target
 }
-pub fn make_tostring_getter_error(agent: &mut Agent) -> Object {
+pub fn make_tostring_getter_error(agent: &Agent) -> Object {
     // valueOf returns 123456; tostring is a getter that errors
     let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
@@ -1321,11 +1318,11 @@ pub fn make_tostring_getter_error(agent: &mut Agent) -> Object {
 
     target
 }
-pub fn make_test_obj_uncallable(agent: &mut Agent) -> Object {
+pub fn make_test_obj_uncallable(agent: &Agent) -> Object {
     let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let target = ordinary_object_create(agent, Some(object_prototype), &[]);
-    let mut connect = |name| {
+    let connect = |name| {
         let key = PropertyKey::from(name);
         define_property_or_throw(
             agent,
@@ -1349,117 +1346,117 @@ pub fn make_test_obj_uncallable(agent: &mut Agent) -> Object {
 
 #[test]
 fn ordinary_to_primitive_nonoobj() {
-    let mut agent = test_agent();
-    let test_obj = make_test_obj(&mut agent, FauxKind::Primitive, FauxKind::Primitive);
-    let result_1 = ordinary_to_primitive(&mut agent, &test_obj, ConversionHint::Number).unwrap();
+    let agent = test_agent();
+    let test_obj = make_test_obj(&agent, FauxKind::Primitive, FauxKind::Primitive);
+    let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap();
     assert_eq!(result_1, ECMAScriptValue::from(123456));
 
-    let result_2 = ordinary_to_primitive(&mut agent, &test_obj, ConversionHint::String).unwrap();
+    let result_2 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::String).unwrap();
     assert_eq!(result_2, ECMAScriptValue::from("test result"));
 }
 #[test]
 fn ordinary_to_primitive_obj() {
-    let mut agent = test_agent();
-    let test_obj = make_test_obj(&mut agent, FauxKind::Object, FauxKind::Object);
-    let result_1 = ordinary_to_primitive(&mut agent, &test_obj, ConversionHint::Number).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result_1), "Cannot convert object to primitive value");
+    let agent = test_agent();
+    let test_obj = make_test_obj(&agent, FauxKind::Object, FauxKind::Object);
+    let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result_1), "Cannot convert object to primitive value");
 
-    let result_2 = ordinary_to_primitive(&mut agent, &test_obj, ConversionHint::String).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result_2), "Cannot convert object to primitive value");
+    let result_2 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::String).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result_2), "Cannot convert object to primitive value");
 }
 #[test]
 fn ordinary_to_primitive_obj_nonobj() {
-    let mut agent = test_agent();
-    let test_obj = make_test_obj(&mut agent, FauxKind::Object, FauxKind::Primitive);
-    let result_1 = ordinary_to_primitive(&mut agent, &test_obj, ConversionHint::Number).unwrap();
+    let agent = test_agent();
+    let test_obj = make_test_obj(&agent, FauxKind::Object, FauxKind::Primitive);
+    let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap();
     assert_eq!(result_1, ECMAScriptValue::from("test result"));
 
-    let result_2 = ordinary_to_primitive(&mut agent, &test_obj, ConversionHint::String).unwrap();
+    let result_2 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::String).unwrap();
     assert_eq!(result_2, ECMAScriptValue::from("test result"));
 }
 #[test]
 fn ordinary_to_primitive_nonobj_obj() {
-    let mut agent = test_agent();
-    let test_obj = make_test_obj(&mut agent, FauxKind::Primitive, FauxKind::Object);
-    let result_1 = ordinary_to_primitive(&mut agent, &test_obj, ConversionHint::Number).unwrap();
+    let agent = test_agent();
+    let test_obj = make_test_obj(&agent, FauxKind::Primitive, FauxKind::Object);
+    let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap();
     assert_eq!(result_1, ECMAScriptValue::from(123456));
 
-    let result_2 = ordinary_to_primitive(&mut agent, &test_obj, ConversionHint::String).unwrap();
+    let result_2 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::String).unwrap();
     assert_eq!(result_2, ECMAScriptValue::from(123456));
 }
 #[test]
 fn ordinary_to_primitive_call_errors() {
-    let mut agent = test_agent();
-    let test_obj = make_test_obj(&mut agent, FauxKind::Primitive, FauxKind::Error);
-    let result_1 = ordinary_to_primitive(&mut agent, &test_obj, ConversionHint::Number).unwrap();
+    let agent = test_agent();
+    let test_obj = make_test_obj(&agent, FauxKind::Primitive, FauxKind::Error);
+    let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap();
     assert_eq!(result_1, ECMAScriptValue::from(123456));
 
-    let result_2 = ordinary_to_primitive(&mut agent, &test_obj, ConversionHint::String).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result_2), "Test Sentinel");
+    let result_2 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::String).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result_2), "Test Sentinel");
 }
 #[test]
 fn ordinary_to_primitive_get_errors() {
-    let mut agent = test_agent();
-    let test_obj = make_tostring_getter_error(&mut agent);
-    let result_1 = ordinary_to_primitive(&mut agent, &test_obj, ConversionHint::Number).unwrap();
+    let agent = test_agent();
+    let test_obj = make_tostring_getter_error(&agent);
+    let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap();
     assert_eq!(result_1, ECMAScriptValue::from(123456));
 
-    let result_2 = ordinary_to_primitive(&mut agent, &test_obj, ConversionHint::String).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result_2), "Test Sentinel");
+    let result_2 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::String).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result_2), "Test Sentinel");
 }
 #[test]
 fn ordinary_to_primitive_uncallables() {
-    let mut agent = test_agent();
-    let test_obj = make_test_obj_uncallable(&mut agent);
-    let result_1 = ordinary_to_primitive(&mut agent, &test_obj, ConversionHint::Number).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result_1), "Cannot convert object to primitive value");
+    let agent = test_agent();
+    let test_obj = make_test_obj_uncallable(&agent);
+    let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result_1), "Cannot convert object to primitive value");
 
-    let result_2 = ordinary_to_primitive(&mut agent, &test_obj, ConversionHint::String).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result_2), "Cannot convert object to primitive value");
+    let result_2 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::String).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result_2), "Cannot convert object to primitive value");
 }
 
 #[test]
 fn to_primitive_no_change() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     // Undefined
-    let result = to_primitive(&mut agent, ECMAScriptValue::Undefined, None).unwrap();
+    let result = to_primitive(&agent, ECMAScriptValue::Undefined, None).unwrap();
     assert!(result.is_undefined());
     // Null
-    let result = to_primitive(&mut agent, ECMAScriptValue::Null, None).unwrap();
+    let result = to_primitive(&agent, ECMAScriptValue::Null, None).unwrap();
     assert!(result.is_null());
     // Boolean
-    let result = to_primitive(&mut agent, ECMAScriptValue::from(true), None).unwrap();
+    let result = to_primitive(&agent, ECMAScriptValue::from(true), None).unwrap();
     assert_eq!(result, ECMAScriptValue::from(true));
     // Number
-    let result = to_primitive(&mut agent, ECMAScriptValue::from(20), None).unwrap();
+    let result = to_primitive(&agent, ECMAScriptValue::from(20), None).unwrap();
     assert_eq!(result, ECMAScriptValue::from(20));
     // String
-    let result = to_primitive(&mut agent, ECMAScriptValue::from("test"), None).unwrap();
+    let result = to_primitive(&agent, ECMAScriptValue::from("test"), None).unwrap();
     assert_eq!(result, ECMAScriptValue::from("test"));
     // Symbol
-    let sym = Symbol::new(&mut agent, Some(JSString::from("Symbolic")));
-    let result = to_primitive(&mut agent, ECMAScriptValue::from(sym.clone()), None).unwrap();
+    let sym = Symbol::new(&agent, Some(JSString::from("Symbolic")));
+    let result = to_primitive(&agent, ECMAScriptValue::from(sym.clone()), None).unwrap();
     assert_eq!(result, ECMAScriptValue::from(sym));
     // BigInt
     let bi = "123456789012345678901234567890".parse::<BigInt>().unwrap();
-    let result = to_primitive(&mut agent, ECMAScriptValue::from(bi), None).unwrap();
+    let result = to_primitive(&agent, ECMAScriptValue::from(bi), None).unwrap();
     assert_eq!(result, ECMAScriptValue::from("123456789012345678901234567890".parse::<BigInt>().unwrap()));
 }
 #[test]
 fn to_primitive_prefer_number() {
-    let mut agent = test_agent();
-    let test_obj = make_test_obj(&mut agent, FauxKind::Primitive, FauxKind::Primitive);
+    let agent = test_agent();
+    let test_obj = make_test_obj(&agent, FauxKind::Primitive, FauxKind::Primitive);
     let test_value = ECMAScriptValue::from(test_obj);
 
-    let result = to_primitive(&mut agent, test_value.clone(), None).unwrap();
+    let result = to_primitive(&agent, test_value.clone(), None).unwrap();
     assert_eq!(result, ECMAScriptValue::from(123456));
-    let result = to_primitive(&mut agent, test_value.clone(), Some(ConversionHint::Number)).unwrap();
+    let result = to_primitive(&agent, test_value.clone(), Some(ConversionHint::Number)).unwrap();
     assert_eq!(result, ECMAScriptValue::from(123456));
-    let result = to_primitive(&mut agent, test_value, Some(ConversionHint::String)).unwrap();
+    let result = to_primitive(&agent, test_value, Some(ConversionHint::String)).unwrap();
     assert_eq!(result, ECMAScriptValue::from("test result"));
 }
 fn exotic_to_prim(
-    _agent: &mut Agent,
+    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -1478,8 +1475,8 @@ fn exotic_to_prim(
     }
 }
 fn make_toprimitive_obj(
-    agent: &mut Agent,
-    steps: fn(&mut Agent, ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion<ECMAScriptValue>,
+    agent: &Agent,
+    steps: fn(&Agent, ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion<ECMAScriptValue>,
 ) -> Object {
     let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
@@ -1514,19 +1511,19 @@ fn make_toprimitive_obj(
 }
 #[test]
 fn to_primitive_uses_exotics() {
-    let mut agent = test_agent();
-    let test_obj = make_toprimitive_obj(&mut agent, exotic_to_prim);
+    let agent = test_agent();
+    let test_obj = make_toprimitive_obj(&agent, exotic_to_prim);
     let test_value = ECMAScriptValue::from(test_obj);
 
-    let result = to_primitive(&mut agent, test_value.clone(), None).unwrap();
+    let result = to_primitive(&agent, test_value.clone(), None).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Saw default"));
-    let result = to_primitive(&mut agent, test_value.clone(), Some(ConversionHint::Number)).unwrap();
+    let result = to_primitive(&agent, test_value.clone(), Some(ConversionHint::Number)).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Saw number"));
-    let result = to_primitive(&mut agent, test_value, Some(ConversionHint::String)).unwrap();
+    let result = to_primitive(&agent, test_value, Some(ConversionHint::String)).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Saw string"));
 }
 fn exotic_returns_object(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -1538,15 +1535,15 @@ fn exotic_returns_object(
 }
 #[test]
 fn to_primitive_exotic_returns_object() {
-    let mut agent = test_agent();
-    let test_obj = make_toprimitive_obj(&mut agent, exotic_returns_object);
+    let agent = test_agent();
+    let test_obj = make_toprimitive_obj(&agent, exotic_returns_object);
     let test_value = ECMAScriptValue::from(test_obj);
 
-    let result = to_primitive(&mut agent, test_value, None).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Cannot convert object to primitive value");
+    let result = to_primitive(&agent, test_value, None).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Cannot convert object to primitive value");
 }
 fn exotic_throws(
-    agent: &mut Agent,
+    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -1555,23 +1552,23 @@ fn exotic_throws(
 }
 #[test]
 fn to_primitive_exotic_throws() {
-    let mut agent = test_agent();
-    let test_obj = make_toprimitive_obj(&mut agent, exotic_throws);
+    let agent = test_agent();
+    let test_obj = make_toprimitive_obj(&agent, exotic_throws);
     let test_value = ECMAScriptValue::from(test_obj);
 
-    let result = to_primitive(&mut agent, test_value, None).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Test Sentinel");
+    let result = to_primitive(&agent, test_value, None).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Test Sentinel");
 }
 #[test]
 fn to_primitive_exotic_getter_throws() {
-    let mut agent = test_agent();
+    let agent = test_agent();
     let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
-    let target = ordinary_object_create(&mut agent, Some(object_prototype), &[]);
+    let target = ordinary_object_create(&agent, Some(object_prototype), &[]);
     let key = PropertyKey::from(agent.wks(WksId::ToPrimitive));
     let toprim_getter = create_builtin_function(
-        &mut agent,
+        &agent,
         faux_errors,
         false,
         0_f64,
@@ -1582,7 +1579,7 @@ fn to_primitive_exotic_getter_throws() {
         Some(JSString::from("get")),
     );
     define_property_or_throw(
-        &mut agent,
+        &agent,
         &target,
         key,
         PotentialPropertyDescriptor {
@@ -1595,8 +1592,8 @@ fn to_primitive_exotic_getter_throws() {
     .unwrap();
     let test_value = ECMAScriptValue::from(target);
 
-    let result = to_primitive(&mut agent, test_value, None).unwrap_err();
-    assert_eq!(unwind_type_error(&mut agent, result), "Test Sentinel");
+    let result = to_primitive(&agent, test_value, None).unwrap_err();
+    assert_eq!(unwind_type_error(&agent, result), "Test Sentinel");
 }
 
 mod to_property_key {
@@ -1606,21 +1603,21 @@ mod to_property_key {
     #[test_case(|_| ECMAScriptValue::Undefined => Ok(PropertyKey::from("undefined")); "undefined")]
     #[test_case(|_| ECMAScriptValue::from("blue") => Ok(PropertyKey::from("blue")); "string")]
     #[test_case(|a| ECMAScriptValue::from(make_tostring_getter_error(a)) => Err("Test Sentinel".to_string()); "to_primitive error")]
-    fn simple(make_value: fn(&mut Agent) -> ECMAScriptValue) -> Result<PropertyKey, String> {
-        let mut agent = test_agent();
-        let arg = make_value(&mut agent);
-        match to_property_key(&mut agent, arg) {
+    fn simple(make_value: fn(&Agent) -> ECMAScriptValue) -> Result<PropertyKey, String> {
+        let agent = test_agent();
+        let arg = make_value(&agent);
+        match to_property_key(&agent, arg) {
             Ok(key) => Ok(key),
-            Err(err) => Err(unwind_type_error(&mut agent, err)),
+            Err(err) => Err(unwind_type_error(&agent, err)),
         }
     }
 
     #[test]
     fn symbol() {
-        let mut agent = test_agent();
-        let sym = Symbol::new(&mut agent, Some("test symbol".into()));
+        let agent = test_agent();
+        let sym = Symbol::new(&agent, Some("test symbol".into()));
         let argument = ECMAScriptValue::from(sym.clone());
-        assert_eq!(to_property_key(&mut agent, argument).unwrap(), PropertyKey::from(sym));
+        assert_eq!(to_property_key(&agent, argument).unwrap(), PropertyKey::from(sym));
     }
 }
 
@@ -1630,11 +1627,11 @@ mod to_property_key {
 #[test_case(|_| ECMAScriptValue::from(9007199254740991.0) => Ok(9007199254740991); "top edge")]
 #[test_case(|_| ECMAScriptValue::from(9007199254740992.0) => Ok(9007199254740991); "over")]
 #[test_case(|a| ECMAScriptValue::from(Symbol::new(a, Some("test".into()))) => Err("Symbol values cannot be converted to Number values".to_string()); "not a number")]
-fn to_length(make_arg: fn(&mut Agent) -> ECMAScriptValue) -> Result<i64, String> {
-    let mut agent = test_agent();
-    let arg = make_arg(&mut agent);
+fn to_length(make_arg: fn(&Agent) -> ECMAScriptValue) -> Result<i64, String> {
+    let agent = test_agent();
+    let arg = make_arg(&agent);
 
-    super::to_length(&mut agent, arg).map_err(|e| unwind_type_error(&mut agent, e))
+    super::to_length(&agent, arg).map_err(|e| unwind_type_error(&agent, e))
 }
 
 mod canonical_numeric_index_string {
@@ -1669,8 +1666,8 @@ mod to_index {
     #[test_case(ECMAScriptValue::from(-0.0) => Ok(0); "Negative zero")]
     #[test_case(ECMAScriptValue::from(BigInt::from(10_i32)) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "non-number")]
     fn f(arg: ECMAScriptValue) -> Result<i64, String> {
-        let mut agent = test_agent();
-        to_index(&mut agent, arg).map_err(|e| unwind_any_error(&mut agent, e))
+        let agent = test_agent();
+        to_index(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
     }
 }
 
@@ -1688,8 +1685,8 @@ mod to_int32 {
     #[test_case(-2147483648.0 => Ok(-2147483648); "lower limit")]
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<i32, String> {
-        let mut agent = test_agent();
-        to_int32(&mut agent, arg).map_err(|e| unwind_any_error(&mut agent, e))
+        let agent = test_agent();
+        to_int32(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
     }
 }
 
@@ -1707,8 +1704,8 @@ mod to_uint32 {
     #[test_case(-300.0 => Ok(4294966996); "negative inputs")]
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<u32, String> {
-        let mut agent = test_agent();
-        to_uint32(&mut agent, arg).map_err(|e| unwind_any_error(&mut agent, e))
+        let agent = test_agent();
+        to_uint32(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
     }
 }
 
@@ -1726,8 +1723,8 @@ mod to_int16 {
     #[test_case(-32768.0 => Ok(-32768); "lower limit")]
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<i16, String> {
-        let mut agent = test_agent();
-        to_int16(&mut agent, arg).map_err(|e| unwind_any_error(&mut agent, e))
+        let agent = test_agent();
+        to_int16(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
     }
 }
 
@@ -1745,8 +1742,8 @@ mod to_uint16 {
     #[test_case(-300.0 => Ok(65236); "negative inputs")]
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<u16, String> {
-        let mut agent = test_agent();
-        to_uint16(&mut agent, arg).map_err(|e| unwind_any_error(&mut agent, e))
+        let agent = test_agent();
+        to_uint16(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
     }
 }
 
@@ -1764,8 +1761,8 @@ mod to_int8 {
     #[test_case(-128.0 => Ok(-128); "lower limit")]
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<i8, String> {
-        let mut agent = test_agent();
-        to_int8(&mut agent, arg).map_err(|e| unwind_any_error(&mut agent, e))
+        let agent = test_agent();
+        to_int8(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
     }
 }
 
@@ -1783,8 +1780,8 @@ mod to_uint8 {
     #[test_case(-200.0 => Ok(56); "negative inputs")]
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<u8, String> {
-        let mut agent = test_agent();
-        to_uint8(&mut agent, arg).map_err(|e| unwind_any_error(&mut agent, e))
+        let agent = test_agent();
+        to_uint8(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
     }
 }
 
@@ -1842,9 +1839,9 @@ mod array_index {
         #[test_case(|_| "010".into() => Err("Invalid array index".to_string()); "leading zeroes")]
         #[test_case(|_| "72x".into() => Err("Invalid array index".to_string()); "parse fail")]
         #[test_case(|_| "4294967295".into() => Err("The maximum array index is 4294967294".to_string()); "convert fail")]
-        fn property_key(make_key: fn(&mut Agent) -> PropertyKey) -> Result<ArrayIndex, String> {
-            let mut agent = test_agent();
-            let key = make_key(&mut agent);
+        fn property_key(make_key: fn(&Agent) -> PropertyKey) -> Result<ArrayIndex, String> {
+            let agent = test_agent();
+            let key = make_key(&agent);
             ArrayIndex::try_from(&key).map_err(|e| e.into())
         }
     }
@@ -1921,7 +1918,7 @@ mod option_object {
     use super::*;
     use test_case::test_case;
 
-    fn object_with_marker(agent: &mut Agent) -> ECMAScriptValue {
+    fn object_with_marker(agent: &Agent) -> ECMAScriptValue {
         let obj = ordinary_object_create(agent, None, &[]);
         define_property_or_throw(agent, &obj, "marker", PotentialPropertyDescriptor::new().value("sentinel")).unwrap();
         ECMAScriptValue::Object(obj)
@@ -1936,9 +1933,9 @@ mod option_object {
     #[test_case(|_| ECMAScriptValue::Null => Ok(None); "null")]
     #[test_case(|_| ECMAScriptValue::Number(12.0) => serr("Bad type for Object/null"); "number")]
     #[test_case(object_with_marker => with validate_marker; "object")]
-    fn try_from(maker: fn(&mut Agent) -> ECMAScriptValue) -> Result<Option<Object>, String> {
-        let mut agent = test_agent();
-        let val = maker(&mut agent);
+    fn try_from(maker: fn(&Agent) -> ECMAScriptValue) -> Result<Option<Object>, String> {
+        let agent = test_agent();
+        let val = maker(&agent);
         let result: anyhow::Result<Option<Object>> = val.try_into();
         result.map_err(|e| e.to_string())
     }
@@ -1970,79 +1967,79 @@ mod agent {
     use super::*;
     use test_case::test_case;
 
-    type ValueMaker = fn(&mut Agent) -> ECMAScriptValue;
-    fn undef(_: &mut Agent) -> ECMAScriptValue {
+    type ValueMaker = fn(&Agent) -> ECMAScriptValue;
+    fn undef(_: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::Undefined
     }
-    fn null(_: &mut Agent) -> ECMAScriptValue {
+    fn null(_: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::Null
     }
-    fn string_a(_: &mut Agent) -> ECMAScriptValue {
+    fn string_a(_: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::from("A")
     }
-    fn string_b(_: &mut Agent) -> ECMAScriptValue {
+    fn string_b(_: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::from("B")
     }
-    fn string_10(_: &mut Agent) -> ECMAScriptValue {
+    fn string_10(_: &Agent) -> ECMAScriptValue {
         "10".into()
     }
-    fn bool_a(_: &mut Agent) -> ECMAScriptValue {
+    fn bool_a(_: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::from(true)
     }
-    fn bool_b(_: &mut Agent) -> ECMAScriptValue {
+    fn bool_b(_: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::from(false)
     }
-    fn symbol_a(agent: &mut Agent) -> ECMAScriptValue {
+    fn symbol_a(agent: &Agent) -> ECMAScriptValue {
         agent.wks(WksId::ToPrimitive).into()
     }
-    fn symbol_b(agent: &mut Agent) -> ECMAScriptValue {
+    fn symbol_b(agent: &Agent) -> ECMAScriptValue {
         agent.wks(WksId::HasInstance).into()
     }
-    fn object_a(agent: &mut Agent) -> ECMAScriptValue {
+    fn object_a(agent: &Agent) -> ECMAScriptValue {
         agent.intrinsic(IntrinsicId::FunctionPrototype).into()
     }
-    fn object_b(agent: &mut Agent) -> ECMAScriptValue {
+    fn object_b(agent: &Agent) -> ECMAScriptValue {
         agent.intrinsic(IntrinsicId::ObjectPrototype).into()
     }
-    fn number_10(_: &mut Agent) -> ECMAScriptValue {
+    fn number_10(_: &Agent) -> ECMAScriptValue {
         10.into()
     }
-    fn number_100(_: &mut Agent) -> ECMAScriptValue {
+    fn number_100(_: &Agent) -> ECMAScriptValue {
         100.into()
     }
-    fn number_zero(_: &mut Agent) -> ECMAScriptValue {
+    fn number_zero(_: &Agent) -> ECMAScriptValue {
         0.into()
     }
-    fn number_neg_zero(_: &mut Agent) -> ECMAScriptValue {
+    fn number_neg_zero(_: &Agent) -> ECMAScriptValue {
         (-0.0).into()
     }
-    fn number_nan(_: &mut Agent) -> ECMAScriptValue {
+    fn number_nan(_: &Agent) -> ECMAScriptValue {
         f64::NAN.into()
     }
-    fn number_inf(_: &mut Agent) -> ECMAScriptValue {
+    fn number_inf(_: &Agent) -> ECMAScriptValue {
         f64::INFINITY.into()
     }
-    fn number_neg_inf(_: &mut Agent) -> ECMAScriptValue {
+    fn number_neg_inf(_: &Agent) -> ECMAScriptValue {
         f64::NEG_INFINITY.into()
     }
-    fn bigint_a(_: &mut Agent) -> ECMAScriptValue {
+    fn bigint_a(_: &Agent) -> ECMAScriptValue {
         BigInt::from(10).into()
     }
-    fn bigint_b(_: &mut Agent) -> ECMAScriptValue {
+    fn bigint_b(_: &Agent) -> ECMAScriptValue {
         BigInt::from(-1097631).into()
     }
-    fn dead_object(agent: &mut Agent) -> ECMAScriptValue {
+    fn dead_object(agent: &Agent) -> ECMAScriptValue {
         DeadObject::object(agent).into()
     }
     fn returns_10(
-        _: &mut Agent,
+        _: &Agent,
         _: ECMAScriptValue,
         _: Option<&Object>,
         _: &[ECMAScriptValue],
     ) -> Completion<ECMAScriptValue> {
         Ok(10.into())
     }
-    fn object_10(agent: &mut Agent) -> ECMAScriptValue {
+    fn object_10(agent: &Agent) -> ECMAScriptValue {
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let object = ordinary_object_create(agent, Some(object_prototype), &[]);
         let to_primitive = agent.wks(WksId::ToPrimitive);
@@ -2093,10 +2090,10 @@ mod agent {
     #[test_case(bigint_a, number_nan => Ok(false); "number nan right")]
     #[test_case(null, symbol_a => Ok(false); "Null & symbol")]
     fn is_loosely_equal(make_x: ValueMaker, make_y: ValueMaker) -> Result<bool, String> {
-        let mut agent = test_agent();
-        let x = make_x(&mut agent);
-        let y = make_y(&mut agent);
+        let agent = test_agent();
+        let x = make_x(&agent);
+        let y = make_y(&agent);
 
-        agent.is_loosely_equal(&x, &y).map_err(|e| unwind_any_error(&mut agent, e))
+        agent.is_loosely_equal(&x, &y).map_err(|e| unwind_any_error(&agent, e))
     }
 }


### PR DESCRIPTION
The needs of a few generators outweigh the needs of the many.

If generators work, it means that we can no longer pass around a single
&mut reference to the agent, as it would be need to be stashed in the
"paused execution" of a generator (and thus generating two mutable
references).

So we pass around a shared reference instead, which means we need to
switch to iterior mutability for the agent.

Also wrapped in an Rc, since the lifetime of any generator object
will outlive anything that creates it, and so passing around the agent
lifetimes as well will otherwise become a bit too onerous.