### PR TITLE
Move Agent structure to thread-local data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ test-case = "2.0"
 [profile.coverage]
 inherits = "dev"
 #rustflags = [ "-Cinstrument-coverage" ]
+
+[profile.bacon]
+inherits = "dev"

--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,62 @@
+# This is a configuration file for the bacon tool
+# More info at https://github.com/Canop/bacon
+
+default_job = "check"
+
+[jobs]
+
+[jobs.check]
+command = ["cargo", "check", "--tests", "--color", "always", "--profile", "bacon"]
+need_stdout = false
+watch = ["tests"]
+
+[jobs.check-all]
+command = ["cargo", "check", "--all-targets", "--color", "always", "--profile", "bacon"]
+need_stdout = false
+watch = ["tests", "benches", "examples"]
+
+[jobs.clippy]
+command = ["cargo", "clippy", "--color", "always", "--profile", "bacon"]
+need_stdout = false
+watch = ["tests"]
+
+[jobs.clippy-all]
+command = ["cargo", "clippy", "--all-targets", "--color", "always", "--profile", "bacon"]
+need_stdout = false
+watch = ["tests", "benches", "examples"]
+
+[jobs.test]
+command = ["cargo", "test", "--color", "always", "--profile", "bacon"]
+need_stdout = true
+watch = ["tests"]
+
+[jobs.doc]
+command = ["cargo", "doc", "--color", "always", "--no-deps"]
+need_stdout = false
+
+# if the doc compiles, then it opens in your browser and bacon switches
+# to the previous job
+[jobs.doc-open]
+command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
+need_stdout = false
+on_success = "back" # so that we don't open the browser at each change
+
+# You can run your application and have the result displayed in bacon,
+# *if* it makes sense for this crate. You can run an example the same
+# way. Don't forget the `--color always` part or the errors won't be
+# properly parsed.
+[jobs.run]
+command = ["cargo", "run", "--color", "always"]
+need_stdout = true
+
+# You may define here keybindings that would be specific to
+# a project, for example a shortcut to launch a specific job.
+# Shortcuts to internal functions (scrolling, toggling, etc.)
+# should go in your personal prefs.toml file instead.
+[keybindings]
+a = "job:check-all"
+i = "job:initial"
+c = "job:clippy"
+d = "job:doc-open"
+t = "job:test"
+r = "job:run"

--- a/bacon.toml
+++ b/bacon.toml
@@ -16,7 +16,7 @@ need_stdout = false
 watch = ["tests", "benches", "examples"]
 
 [jobs.clippy]
-command = ["cargo", "clippy", "--color", "always", "--profile", "bacon"]
+command = ["cargo", "clippy", "--tests", "--color", "always", "--profile", "bacon"]
 need_stdout = false
 watch = ["tests"]
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -40,6 +40,12 @@ thread_local! {
     pub static AGENT: Agent = Agent::new();
 }
 
+impl Default for Agent {
+    fn default() -> Self {
+        Agent::new()
+    }
+}
+
 impl Agent {
     pub fn new() -> Self {
         Agent {

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -94,6 +94,13 @@ impl Agent {
             gsr: RefCell::new(None),
         }
     }
+
+    pub fn reset(&self) {
+        self.obj_id.set(1);
+        self.execution_context_stack.borrow_mut().clear();
+        self.symbol_id.set(14);
+        self.gsr.borrow_mut().take();
+    }
 }
 
 pub fn active_function_object() -> Option<Object> {

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -186,7 +186,7 @@ mod agent {
     fn void_operator(make_expr: fn() -> FullCompletion) -> Result<NormalCompletion, String> {
         setup_test_agent();
         let expr = make_expr();
-        super::void_operator(expr).map_err(|ac| unwind_any_error(ac))
+        super::void_operator(expr).map_err(unwind_any_error)
     }
 
     #[test_case(|| Ok(NormalCompletion::from(Reference::new(Base::Unresolvable, "not_here", true, None))) => Ok(NormalCompletion::from("undefined")); "unresolvable ref")]
@@ -213,7 +213,7 @@ mod agent {
     fn typeof_operator(make_expr: fn() -> FullCompletion) -> Result<NormalCompletion, String> {
         setup_test_agent();
         let expr = make_expr();
-        super::typeof_operator(expr).map_err(|ac| unwind_any_error(ac))
+        super::typeof_operator(expr).map_err(unwind_any_error)
     }
 
     fn superproperty() -> FullCompletion {
@@ -271,7 +271,7 @@ mod agent {
     fn delete_ref(make_expr: fn() -> FullCompletion) -> Result<NormalCompletion, String> {
         setup_test_agent();
         let expr = make_expr();
-        super::delete_ref(expr).map_err(|ac| unwind_any_error(ac))
+        super::delete_ref(expr).map_err(unwind_any_error)
     }
 
     #[test_case(|| ECMAScriptValue::from("left "),
@@ -450,7 +450,7 @@ mod agent {
         setup_test_agent();
         let lval = make_lval();
         let rval = make_rval();
-        super::apply_string_or_numeric_binary_operator(lval, rval, op).map_err(|ac| unwind_any_error(ac))
+        super::apply_string_or_numeric_binary_operator(lval, rval, op).map_err(unwind_any_error)
     }
 
     #[test_case(WksId::AsyncIterator => "Symbol.asyncIterator"; "Symbol.asyncIterator")]
@@ -546,7 +546,7 @@ mod agent {
         setup_test_agent();
         let x = make_x();
         let y = make_y();
-        super::is_less_than(x, y, left_first).map_err(|completion| unwind_any_error(completion))
+        super::is_less_than(x, y, left_first).map_err(unwind_any_error)
     }
 
     type ValueMaker = fn() -> ECMAScriptValue;
@@ -622,9 +622,7 @@ mod agent {
         let v = make_v();
         let target = make_target();
 
-        super::instanceof_operator(v, target)
-            .map_err(|completion| unwind_any_error(completion))
-            .map(|nc| nc.try_into().unwrap())
+        super::instanceof_operator(v, target).map_err(unwind_any_error).map(|nc| nc.try_into().unwrap())
     }
 
     mod create_unmapped_arguments_object {
@@ -1190,7 +1188,7 @@ mod global_declaration_instantiation {
 
         let result = super::global_declaration_instantiation(script, global_env.clone(), false, src);
 
-        result.map_err(|err| unwind_any_error(err)).map(|_| {
+        result.map_err(unwind_any_error).map(|_| {
             let after_vardecl = global_env.var_decls().into_iter().collect::<AHashSet<_>>();
             let after_lexdecl = global_env.lex_decls().into_iter().collect::<AHashSet<_>>();
 
@@ -1213,7 +1211,7 @@ mod script_evaluation {
         let realm = current_realm_record().unwrap();
         let script_record = parse_script(src, realm).unwrap();
 
-        super::script_evaluation(script_record).map_err(|err| unwind_any_error(err))
+        super::script_evaluation(script_record).map_err(unwind_any_error)
     }
 }
 

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -893,7 +893,7 @@ mod well_known_symbols {
     #[test]
     fn debug() {
         setup_test_agent();
-        let s = format!("{:?}", agent.0.symbols);
+        let s = AGENT.with(|agent| format!("{:?}", agent.0.symbols));
         assert_ne!(s, "");
     }
 }

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -482,9 +482,7 @@ mod agent {
     fn two_values() {
         let agent = test_agent();
         let index = agent.execution_context_stack.borrow().len() - 1;
-        agent.execution_context_stack.borrow_mut()[index]
-            .stack
-            .push(Ok(NormalCompletion::from(ECMAScriptValue::Null)));
+        agent.execution_context_stack.borrow_mut()[index].stack.push(Ok(NormalCompletion::from(ECMAScriptValue::Null)));
         agent.execution_context_stack.borrow_mut()[index]
             .stack
             .push(Ok(NormalCompletion::from(ECMAScriptValue::from("test"))));

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -25,36 +25,33 @@ mod agent {
 
         // All well-known symbols initialized, and different from one another.
         let symbols = vec![
-            agent.wks(WksId::AsyncIterator),
-            agent.wks(WksId::HasInstance),
-            agent.wks(WksId::IsConcatSpreadable),
-            agent.wks(WksId::Iterator),
-            agent.wks(WksId::Match),
-            agent.wks(WksId::MatchAll),
-            agent.wks(WksId::Replace),
-            agent.wks(WksId::Search),
-            agent.wks(WksId::Species),
-            agent.wks(WksId::Split),
-            agent.wks(WksId::ToPrimitive),
-            agent.wks(WksId::ToStringTag),
-            agent.wks(WksId::Unscopables),
+            agent.symbols.async_iterator_,
+            agent.symbols.has_instance_,
+            agent.symbols.is_concat_spreadable_,
+            agent.symbols.iterator_,
+            agent.symbols.match_,
+            agent.symbols.match_all_,
+            agent.symbols.replace_,
+            agent.symbols.search_,
+            agent.symbols.species_,
+            agent.symbols.split_,
+            agent.symbols.to_primitive_,
+            agent.symbols.to_string_tag_,
+            agent.symbols.unscopables_,
         ];
         let num_symbols = symbols.len();
-        let mut symbol_set = AHashSet::new();
-        for sym in symbols.iter() {
-            symbol_set.insert(sym);
-        }
+        let symbol_set = symbols.iter().collect::<AHashSet<_>>();
         assert_eq!(num_symbols, symbol_set.len());
 
         // ID trackers at reasonable spots
-        assert_eq!(agent.0.obj_id.get(), 1);
-        assert_eq!(agent.0.symbol_id.get(), num_symbols + 1);
+        assert_eq!(agent.obj_id.get(), 1);
+        assert_eq!(agent.symbol_id.get(), num_symbols + 1);
     }
 
     #[test]
     fn pop_execution_context() {
         setup_test_agent();
-        let realm_ref = agent.current_realm_record().unwrap();
+        let realm_ref = current_realm_record().unwrap();
         // build a new EC, and add it to the EC stack
         let sr = ScriptRecord {
             realm: realm_ref.clone(),
@@ -73,7 +70,7 @@ mod agent {
     #[test]
     fn push_execution_context() {
         setup_test_agent();
-        let realm_ref = agent.current_realm_record().unwrap();
+        let realm_ref = current_realm_record().unwrap();
         let prior_length = agent.execution_context_stack.borrow().len();
         // build a new EC, and add it to the EC stack
         let sr = ScriptRecord {
@@ -102,8 +99,8 @@ mod agent {
         assert!(afo.is_none());
 
         // Create a new EC that _does_ have a function object; push it, and then check the active function.
-        let fo = agent.intrinsic(IntrinsicId::ThrowTypeError);
-        let realm = agent.current_realm_record().unwrap();
+        let fo = intrinsic(IntrinsicId::ThrowTypeError);
+        let realm = current_realm_record().unwrap();
         let function_ec = ExecutionContext::new(Some(fo.clone()), realm, None);
         agent.push_execution_context(function_ec);
 
@@ -148,70 +145,71 @@ mod agent {
         #[test]
         fn empty_ec_stack() {
             let agent = Agent::new();
-            assert!(agent.current_realm_record().is_none());
+            assert!(current_realm_record().is_none());
         }
 
         #[test]
         fn stacked() {
-            let a = Agent::new();
-            let first_realm = create_named_realm(&a, "first");
+            setup_test_agent();
+
+            let first_realm = create_named_realm("first");
             let first_context = ExecutionContext::new(None, first_realm, None);
             a.push_execution_context(first_context);
 
-            let second_realm = create_named_realm(&a, "second");
+            let second_realm = create_named_realm("second");
             let second_context = ExecutionContext::new(None, second_realm, None);
             a.push_execution_context(second_context);
 
-            let current = a.current_realm_record().unwrap();
-            assert_eq!(get_realm_name(&a, &current.borrow()), "second");
+            let current = current_realm_record().unwrap();
+            assert_eq!(get_realm_name(&current.borrow()), "second");
 
-            a.pop_execution_context();
+            pop_execution_context();
 
-            let current = a.current_realm_record().unwrap();
-            assert_eq!(get_realm_name(&a, &current.borrow()), "first");
+            let current = current_realm_record().unwrap();
+            assert_eq!(get_realm_name(&current.borrow()), "first");
         }
     }
 
-    #[test_case(|_| Ok(NormalCompletion::from(10)) => Ok(NormalCompletion::from(ECMAScriptValue::Undefined)); "value")]
-    #[test_case(|agent| Err(create_type_error(agent, "Test Sentinel")) => serr("TypeError: Test Sentinel"); "pending type error")]
-    #[test_case(|agent| {
-            let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+    #[test_case(|| Ok(NormalCompletion::from(10)) => Ok(NormalCompletion::from(ECMAScriptValue::Undefined)); "value")]
+    #[test_case(|| Err(create_type_error("Test Sentinel")) => serr("TypeError: Test Sentinel"); "pending type error")]
+    #[test_case(|| {
+            let env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
             Ok(NormalCompletion::from(Reference::new(Base::Environment(env), "debug_token", true, None)))
         } => Ok(NormalCompletion::from(ECMAScriptValue::Undefined)); "valid ref")]
-    fn void_operator(make_expr: fn(&Agent) -> FullCompletion) -> Result<NormalCompletion, String> {
+    fn void_operator(make_expr: fn() -> FullCompletion) -> Result<NormalCompletion, String> {
         setup_test_agent();
-        let expr = make_expr(&agent);
-        agent.void_operator(expr).map_err(|ac| unwind_any_error(&agent, ac))
+        let expr = make_expr();
+        agent.void_operator(expr).map_err(|ac| unwind_any_error(ac))
     }
 
-    #[test_case(|_| Ok(NormalCompletion::from(Reference::new(Base::Unresolvable, "not_here", true, None))) => Ok(NormalCompletion::from("undefined")); "unresolvable ref")]
-    #[test_case(|agent| Err(create_type_error(agent, "Test Sentinel")) => serr("TypeError: Test Sentinel"); "pending type error")]
-    #[test_case(|_| Ok(NormalCompletion::from(ECMAScriptValue::Undefined)) => Ok(NormalCompletion::from("undefined")); "undefined value")]
-    #[test_case(|_| Ok(NormalCompletion::from(ECMAScriptValue::Null)) => Ok(NormalCompletion::from("object")); "null value")]
-    #[test_case(|_| Ok(NormalCompletion::from(true)) => Ok(NormalCompletion::from("boolean")); "bool value")]
-    #[test_case(|_| Ok(NormalCompletion::from("just a string")) => Ok(NormalCompletion::from("string")); "string value")]
-    #[test_case(|_| Ok(NormalCompletion::from(227)) => Ok(NormalCompletion::from("number")); "number value")]
-    #[test_case(|_| Ok(NormalCompletion::from(BigInt::from(102))) => Ok(NormalCompletion::from("bigint")); "bigint value")]
-    #[test_case(|agent| {
-        let symbol_constructor = agent.intrinsic(IntrinsicId::Symbol);
+    #[test_case(|| Ok(NormalCompletion::from(Reference::new(Base::Unresolvable, "not_here", true, None))) => Ok(NormalCompletion::from("undefined")); "unresolvable ref")]
+    #[test_case(|| Err(create_type_error("Test Sentinel")) => serr("TypeError: Test Sentinel"); "pending type error")]
+    #[test_case(|| Ok(NormalCompletion::from(ECMAScriptValue::Undefined)) => Ok(NormalCompletion::from("undefined")); "undefined value")]
+    #[test_case(|| Ok(NormalCompletion::from(ECMAScriptValue::Null)) => Ok(NormalCompletion::from("object")); "null value")]
+    #[test_case(|| Ok(NormalCompletion::from(true)) => Ok(NormalCompletion::from("boolean")); "bool value")]
+    #[test_case(|| Ok(NormalCompletion::from("just a string")) => Ok(NormalCompletion::from("string")); "string value")]
+    #[test_case(|| Ok(NormalCompletion::from(227)) => Ok(NormalCompletion::from("number")); "number value")]
+    #[test_case(|| Ok(NormalCompletion::from(BigInt::from(102))) => Ok(NormalCompletion::from("bigint")); "bigint value")]
+    #[test_case(|| {
+        let symbol_constructor = intrinsic(IntrinsicId::Symbol);
         let reference = Reference::new(Base::Value(ECMAScriptValue::from(symbol_constructor)), "species", true, None);
         Ok(NormalCompletion::from(reference))
     } => Ok(NormalCompletion::from("symbol")); "typeof Symbol.species")]
-    #[test_case(|agent| {
-        let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+    #[test_case(|| {
+        let env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         Ok(NormalCompletion::from(Reference::new(Base::Environment(env), "Boolean", true, None)))
     } => Ok(NormalCompletion::from("function")); "typeof Boolean")]
-    #[test_case(|agent| {
-        let bool_proto = agent.intrinsic(IntrinsicId::BooleanPrototype);
+    #[test_case(|| {
+        let bool_proto = intrinsic(IntrinsicId::BooleanPrototype);
         Ok(NormalCompletion::from(bool_proto))
     } => Ok(NormalCompletion::from("object")); "typeof Boolean.prototype")]
-    fn typeof_operator(make_expr: fn(&Agent) -> FullCompletion) -> Result<NormalCompletion, String> {
+    fn typeof_operator(make_expr: fn() -> FullCompletion) -> Result<NormalCompletion, String> {
         setup_test_agent();
-        let expr = make_expr(&agent);
-        agent.typeof_operator(expr).map_err(|ac| unwind_any_error(&agent, ac))
+        let expr = make_expr();
+        typeof_operator(expr).map_err(|ac| unwind_any_error(ac))
     }
 
-    fn superproperty(agent: &Agent) -> FullCompletion {
+    fn superproperty() -> FullCompletion {
         // For example: ({method() { delete super.test_property; }}).method()
         // 1. Let F be OrdinaryFunctionCreate(intrinsics.[[%FunctionPrototype%]], source_text, ParameterList, Body, thisMode, env, privateenv).
         // 2. Let homeObject be OrdinaryObjectCreate(intrinsics.[[%ObjectPrototype%]]).
@@ -219,233 +217,233 @@ mod agent {
         // 3. Let fenv be NewFunctionEnvironment(F, undefined).
         // 4. Let actualThis be fenv.GetThisBinding().
         // 5. Return MakeSuperPropertyReference(actualThis, "test_property", true)
-        let obj = ordinary_object_create(agent, None, &[]);
+        let obj = ordinary_object_create(None, &[]);
         let copy = obj.clone();
         let myref = Reference::new(Base::Value(obj.into()), "item", true, Some(copy.into()));
         Ok(NormalCompletion::from(myref))
     }
 
-    fn bool_proto_ref(agent: &Agent, strict: bool) -> FullCompletion {
-        let bool_obj = agent.intrinsic(IntrinsicId::Boolean);
+    fn bool_proto_ref(strict: bool) -> FullCompletion {
+        let bool_obj = intrinsic(IntrinsicId::Boolean);
         let myref = Reference::new(Base::Value(bool_obj.into()), "prototype", strict, None);
         Ok(NormalCompletion::from(myref))
     }
-    fn strict_proto_ref(agent: &Agent) -> FullCompletion {
-        bool_proto_ref(agent, true)
+    fn strict_proto_ref() -> FullCompletion {
+        bool_proto_ref(true)
     }
-    fn nonstrict_proto_ref(agent: &Agent) -> FullCompletion {
-        bool_proto_ref(agent, false)
+    fn nonstrict_proto_ref() -> FullCompletion {
+        bool_proto_ref(false)
     }
-    fn dead_ref(agent: &Agent) -> FullCompletion {
-        let dead = DeadObject::object(agent);
+    fn dead_ref() -> FullCompletion {
+        let dead = DeadObject::object();
         Ok(NormalCompletion::from(Reference::new(Base::Value(dead.into()), "anything", true, None)))
     }
-    fn ref_to_undefined(agent: &Agent) -> FullCompletion {
-        let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+    fn ref_to_undefined() -> FullCompletion {
+        let env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         Ok(NormalCompletion::from(Reference::new(Base::Environment(env), "undefined", true, None)))
     }
-    fn dead_env(agent: &Agent) -> FullCompletion {
-        let outer = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
-        let dead = DeadObject::object(agent);
+    fn dead_env() -> FullCompletion {
+        let outer = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+        let dead = DeadObject::object();
         let obj_env = Rc::new(ObjectEnvironmentRecord::new(dead, false, Some(outer), "dead"));
         Ok(NormalCompletion::from(Reference::new(Base::Environment(obj_env), "anything", true, None)))
     }
 
-    #[test_case(|_| Ok(NormalCompletion::Empty) => Ok(NormalCompletion::from(true)); "empty -> true")]
-    #[test_case(|_| Ok(NormalCompletion::from("test sentinel")) => Ok(NormalCompletion::from(true)); "value -> true")]
-    #[test_case(|agent| Err(create_type_error(agent, "Test Sentinel")) => serr("TypeError: Test Sentinel"); "pending type error")]
-    #[test_case(|_| Ok(NormalCompletion::from(Reference::new(Base::Unresolvable, "not_here", true, None))) => Ok(NormalCompletion::from(true)); "unresolvable ref")]
+    #[test_case(|| Ok(NormalCompletion::Empty) => Ok(NormalCompletion::from(true)); "empty -> true")]
+    #[test_case(|| Ok(NormalCompletion::from("test sentinel")) => Ok(NormalCompletion::from(true)); "value -> true")]
+    #[test_case(|| Err(create_type_error("Test Sentinel")) => serr("TypeError: Test Sentinel"); "pending type error")]
+    #[test_case(|| Ok(NormalCompletion::from(Reference::new(Base::Unresolvable, "not_here", true, None))) => Ok(NormalCompletion::from(true)); "unresolvable ref")]
     #[test_case(superproperty => serr("ReferenceError: super properties not deletable"); "super prop")]
-    #[test_case(|_| Ok(NormalCompletion::from(Reference::new(Base::Value(ECMAScriptValue::Undefined), "x", true, None))) => serr("TypeError: Undefined and null cannot be converted to objects"); "Non-object ref base")]
-    #[test_case(|_| Ok(NormalCompletion::from(Reference::new(Base::Value(true.into()), "x", true, None))) => Ok(NormalCompletion::from(true)); "delete nonexistent")]
+    #[test_case(|| Ok(NormalCompletion::from(Reference::new(Base::Value(ECMAScriptValue::Undefined), "x", true, None))) => serr("TypeError: Undefined and null cannot be converted to objects"); "Non-object ref base")]
+    #[test_case(|| Ok(NormalCompletion::from(Reference::new(Base::Value(true.into()), "x", true, None))) => Ok(NormalCompletion::from(true)); "delete nonexistent")]
     #[test_case(strict_proto_ref => serr("TypeError: property not deletable"); "permanent property; strict")]
     #[test_case(nonstrict_proto_ref => Ok(NormalCompletion::from(false)); "permanent property; nonstrict")]
     #[test_case(dead_ref => serr("TypeError: delete called on DeadObject"); "property ref delete errs")]
     #[test_case(ref_to_undefined => Ok(NormalCompletion::from(false)); "undefined ref")]
     #[test_case(dead_env => serr("TypeError: delete called on DeadObject"); "env ref delete errors")]
-    fn delete_ref(make_expr: fn(&Agent) -> FullCompletion) -> Result<NormalCompletion, String> {
+    fn delete_ref(make_expr: fn() -> FullCompletion) -> Result<NormalCompletion, String> {
         setup_test_agent();
-        let expr = make_expr(&agent);
-        agent.delete_ref(expr).map_err(|ac| unwind_any_error(&agent, ac))
+        let expr = make_expr();
+        delete_ref(expr).map_err(|ac| unwind_any_error(ac))
     }
 
-    #[test_case(|_| ECMAScriptValue::from("left "),
-                |_| ECMAScriptValue::from("right"),
+    #[test_case(|| ECMAScriptValue::from("left "),
+                || ECMAScriptValue::from("right"),
                 BinOp::Add
                 => Ok(NormalCompletion::from("left right")); "string catentation")]
     #[test_case(|agent| ECMAScriptValue::from(make_toprimitive_throw_obj(agent)),
-                |_| ECMAScriptValue::from("a"),
+                || ECMAScriptValue::from("a"),
                 BinOp::Add
                 => serr("TypeError: Test Sentinel"); "left toPrimitive error")]
-    #[test_case(|_| ECMAScriptValue::from("a"),
+    #[test_case(|| ECMAScriptValue::from("a"),
                 |agent| ECMAScriptValue::from(make_toprimitive_throw_obj(agent)),
                 BinOp::Add
                 => serr("TypeError: Test Sentinel"); "right toPrimitive error")]
-    #[test_case(|_| ECMAScriptValue::from(10),
-                |_| ECMAScriptValue::from("a"),
+    #[test_case(|| ECMAScriptValue::from(10),
+                || ECMAScriptValue::from("a"),
                 BinOp::Add
                 => Ok(NormalCompletion::from("10a")); "stringify from right")]
-    #[test_case(|_| ECMAScriptValue::from("a"),
-                |_| ECMAScriptValue::from(10),
+    #[test_case(|| ECMAScriptValue::from("a"),
+                || ECMAScriptValue::from(10),
                 BinOp::Add
                 => Ok(NormalCompletion::from("a10")); "stringify from left")]
-    #[test_case(|agent| ECMAScriptValue::from(agent.wks(WksId::ToPrimitive)),
-                |_| ECMAScriptValue::from("a"),
+    #[test_case(|| ECMAScriptValue::from(wks(WksId::ToPrimitive)),
+                || ECMAScriptValue::from("a"),
                 BinOp::Add
                 => serr("TypeError: Symbols may not be converted to strings"); "left tostring errs")]
-    #[test_case(|_| ECMAScriptValue::from("a"),
-                |agent| ECMAScriptValue::from(agent.wks(WksId::ToPrimitive)),
+    #[test_case(|| ECMAScriptValue::from("a"),
+                || ECMAScriptValue::from(wks(WksId::ToPrimitive)),
                 BinOp::Add
                 => serr("TypeError: Symbols may not be converted to strings"); "right tostring errs")]
-    #[test_case(|agent| ECMAScriptValue::from(agent.wks(WksId::ToPrimitive)),
-                |_| ECMAScriptValue::from(10),
+    #[test_case(|| ECMAScriptValue::from(wks(WksId::ToPrimitive)),
+                || ECMAScriptValue::from(10),
                 BinOp::Add
                 => serr("TypeError: Symbol values cannot be converted to Number values"); "left tonumeric errs")]
-    #[test_case(|_| ECMAScriptValue::from(10),
-                |agent| ECMAScriptValue::from(agent.wks(WksId::ToPrimitive)),
+    #[test_case(|| ECMAScriptValue::from(10),
+                || ECMAScriptValue::from(wks(WksId::ToPrimitive)),
                 BinOp::Add
                 => serr("TypeError: Symbol values cannot be converted to Number values"); "right tonumeric errs")]
-    #[test_case(|_| ECMAScriptValue::from(2.0),
-                |_| ECMAScriptValue::from(3.0),
+    #[test_case(|| ECMAScriptValue::from(2.0),
+                || ECMAScriptValue::from(3.0),
                 BinOp::Exponentiate
                 => Ok(NormalCompletion::from(8)); "exponentiation")]
-    #[test_case(|_| ECMAScriptValue::from(2.0),
-                |_| ECMAScriptValue::from(3.0),
+    #[test_case(|| ECMAScriptValue::from(2.0),
+                || ECMAScriptValue::from(3.0),
                 BinOp::Multiply
                 => Ok(NormalCompletion::from(6)); "multiplication")]
-    #[test_case(|_| ECMAScriptValue::from(12.0),
-                |_| ECMAScriptValue::from(3.0),
+    #[test_case(|| ECMAScriptValue::from(12.0),
+                || ECMAScriptValue::from(3.0),
                 BinOp::Divide
                 => Ok(NormalCompletion::from(4)); "division")]
-    #[test_case(|_| ECMAScriptValue::from(26.0),
-                |_| ECMAScriptValue::from(7.0),
+    #[test_case(|| ECMAScriptValue::from(26.0),
+                || ECMAScriptValue::from(7.0),
                 BinOp::Remainder
                 => Ok(NormalCompletion::from(5)); "remainder")]
-    #[test_case(|_| ECMAScriptValue::from(2.0),
-                |_| ECMAScriptValue::from(3.0),
+    #[test_case(|| ECMAScriptValue::from(2.0),
+                || ECMAScriptValue::from(3.0),
                 BinOp::Add
                 => Ok(NormalCompletion::from(5)); "addition")]
-    #[test_case(|_| ECMAScriptValue::from(2.0),
-                |_| ECMAScriptValue::from(3.0),
+    #[test_case(|| ECMAScriptValue::from(2.0),
+                || ECMAScriptValue::from(3.0),
                 BinOp::Subtract
                 => Ok(NormalCompletion::from(-1)); "subtraction")]
-    #[test_case(|_| ECMAScriptValue::from(2.0),
-                |_| ECMAScriptValue::from(3.0),
+    #[test_case(|| ECMAScriptValue::from(2.0),
+                || ECMAScriptValue::from(3.0),
                 BinOp::LeftShift
                 => Ok(NormalCompletion::from(16.0)); "left shift")]
-    #[test_case(|_| ECMAScriptValue::from(16.0),
-                |_| ECMAScriptValue::from(3.0),
+    #[test_case(|| ECMAScriptValue::from(16.0),
+                || ECMAScriptValue::from(3.0),
                 BinOp::SignedRightShift
                 => Ok(NormalCompletion::from(2)); "signed right shift")]
-    #[test_case(|_| ECMAScriptValue::from(-16.0),
-                |_| ECMAScriptValue::from(3.0),
+    #[test_case(|| ECMAScriptValue::from(-16.0),
+                || ECMAScriptValue::from(3.0),
                 BinOp::SignedRightShift
                 => Ok(NormalCompletion::from(-2)); "signed right shift (negative)")]
-    #[test_case(|_| ECMAScriptValue::from(16.0),
-                |_| ECMAScriptValue::from(3.0),
+    #[test_case(|| ECMAScriptValue::from(16.0),
+                || ECMAScriptValue::from(3.0),
                 BinOp::UnsignedRightShift
                 => Ok(NormalCompletion::from(2)); "unsigned right shift")]
-    #[test_case(|_| ECMAScriptValue::from(-16.0),
-                |_| ECMAScriptValue::from(3.0),
+    #[test_case(|| ECMAScriptValue::from(-16.0),
+                || ECMAScriptValue::from(3.0),
                 BinOp::UnsignedRightShift
                 => Ok(NormalCompletion::from(536870910)); "unsigned right shift (negative)")]
-    #[test_case(|_| ECMAScriptValue::from(2.0),
-                |_| ECMAScriptValue::from(3.0),
+    #[test_case(|| ECMAScriptValue::from(2.0),
+                || ECMAScriptValue::from(3.0),
                 BinOp::BitwiseAnd
                 => Ok(NormalCompletion::from(2)); "bitwise and")]
-    #[test_case(|_| ECMAScriptValue::from(2.0),
-                |_| ECMAScriptValue::from(3.0),
+    #[test_case(|| ECMAScriptValue::from(2.0),
+                || ECMAScriptValue::from(3.0),
                 BinOp::BitwiseOr
                 => Ok(NormalCompletion::from(3)); "bitwise or")]
-    #[test_case(|_| ECMAScriptValue::from(2.0),
-                |_| ECMAScriptValue::from(3.0),
+    #[test_case(|| ECMAScriptValue::from(2.0),
+                || ECMAScriptValue::from(3.0),
                 BinOp::BitwiseXor
                 => Ok(NormalCompletion::from(1)); "bitwise xor")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(2)),
-                |_| ECMAScriptValue::from(BigInt::from(3)),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(2)),
+                || ECMAScriptValue::from(BigInt::from(3)),
                 BinOp::Exponentiate
                 => Ok(NormalCompletion::from(BigInt::from(8))); "exponentiation (bigint)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(2)),
-                |_| ECMAScriptValue::from(BigInt::from(-3)),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(2)),
+                || ECMAScriptValue::from(BigInt::from(-3)),
                 BinOp::Exponentiate
                 => serr("RangeError: Exponent must be positive"); "bad exponentiation (bigint)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(2)),
-                |_| ECMAScriptValue::from(BigInt::from(3)),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(2)),
+                || ECMAScriptValue::from(BigInt::from(3)),
                 BinOp::Multiply
                 => Ok(NormalCompletion::from(BigInt::from(6))); "multiplication (bigint)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(12)),
-                |_| ECMAScriptValue::from(BigInt::from(3)),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(12)),
+                || ECMAScriptValue::from(BigInt::from(3)),
                 BinOp::Divide
                 => Ok(NormalCompletion::from(BigInt::from(4))); "division (bigint)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(12)),
-                |_| ECMAScriptValue::from(BigInt::from(0)),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(12)),
+                || ECMAScriptValue::from(BigInt::from(0)),
                 BinOp::Divide
                 =>serr("RangeError: Division by zero"); "zero division (bigint)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(26)),
-                |_| ECMAScriptValue::from(BigInt::from(7)),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(26)),
+                || ECMAScriptValue::from(BigInt::from(7)),
                 BinOp::Remainder
                 => Ok(NormalCompletion::from(BigInt::from(5))); "remainder (bigint)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(12)),
-                |_| ECMAScriptValue::from(BigInt::from(0)),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(12)),
+                || ECMAScriptValue::from(BigInt::from(0)),
                 BinOp::Remainder
                 =>serr("RangeError: Division by zero"); "zero remainder (bigint)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(2)),
-                |_| ECMAScriptValue::from(BigInt::from(3)),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(2)),
+                || ECMAScriptValue::from(BigInt::from(3)),
                 BinOp::Add
                 => Ok(NormalCompletion::from(BigInt::from(5))); "addition (bigint)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(2)),
-                |_| ECMAScriptValue::from(BigInt::from(3)),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(2)),
+                || ECMAScriptValue::from(BigInt::from(3)),
                 BinOp::Subtract
                 => Ok(NormalCompletion::from(BigInt::from(-1))); "subtraction (bigint)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(2)),
-                |_| ECMAScriptValue::from(BigInt::from(3)),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(2)),
+                || ECMAScriptValue::from(BigInt::from(3)),
                 BinOp::LeftShift
                 => Ok(NormalCompletion::from(BigInt::from(16))); "left shift (bigint)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(2)),
-                |_| ECMAScriptValue::from(BigInt::from_str("689674891678594267895287496789").unwrap()),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(2)),
+                || ECMAScriptValue::from(BigInt::from_str("689674891678594267895287496789").unwrap()),
                 BinOp::LeftShift
                 => serr("RangeError: out of range conversion regarding big integer attempted"); "left shift (bigint) (too big)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(16)),
-                |_| ECMAScriptValue::from(BigInt::from(3)),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(16)),
+                || ECMAScriptValue::from(BigInt::from(3)),
                 BinOp::SignedRightShift
                 => Ok(NormalCompletion::from(BigInt::from(2))); "signed right shift (bigint)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(16)),
-                |_| ECMAScriptValue::from(BigInt::from_str("-3267891568973452345").unwrap()),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(16)),
+                || ECMAScriptValue::from(BigInt::from_str("-3267891568973452345").unwrap()),
                 BinOp::SignedRightShift
                 => serr("RangeError: out of range conversion regarding big integer attempted"); "signed right shift (bigint) (too big)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(8)),
-                |_| ECMAScriptValue::from(BigInt::from(3)),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(8)),
+                || ECMAScriptValue::from(BigInt::from(3)),
                 BinOp::UnsignedRightShift
                 => serr("TypeError: BigInts have no unsigned right shift, use >> instead"); "unsigned right shift (bigint)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(2)),
-                |_| ECMAScriptValue::from(BigInt::from(3)),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(2)),
+                || ECMAScriptValue::from(BigInt::from(3)),
                 BinOp::BitwiseAnd
                 => Ok(NormalCompletion::from(ECMAScriptValue::from(BigInt::from(2)))); "bitwise and (bigint)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(2)),
-                |_| ECMAScriptValue::from(BigInt::from(3)),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(2)),
+                || ECMAScriptValue::from(BigInt::from(3)),
                 BinOp::BitwiseOr
                 => Ok(NormalCompletion::from(ECMAScriptValue::from(BigInt::from(3)))); "bitwise or (bigint)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(2)),
-                |_| ECMAScriptValue::from(BigInt::from(3)),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(2)),
+                || ECMAScriptValue::from(BigInt::from(3)),
                 BinOp::BitwiseXor
                 => Ok(NormalCompletion::from(ECMAScriptValue::from(BigInt::from(1)))); "bitwise xor (bigint)")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(12)),
-                |_| ECMAScriptValue::from(3),
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(12)),
+                || ECMAScriptValue::from(3),
                 BinOp::Remainder
                 =>serr("TypeError: Cannot mix BigInt and other types, use explicit conversions"); "bigint type mix (left)")]
-    #[test_case(|_| ECMAScriptValue::from(12),
-                |_| ECMAScriptValue::from(BigInt::from(1)),
+    #[test_case(|| ECMAScriptValue::from(12),
+                || ECMAScriptValue::from(BigInt::from(1)),
                 BinOp::Remainder
                 =>serr("TypeError: Cannot mix BigInt and other types, use explicit conversions"); "bigint type mix (right)")]
     fn apply_string_or_numeric_binary_operator(
-        make_lval: fn(&Agent) -> ECMAScriptValue,
-        make_rval: fn(&Agent) -> ECMAScriptValue,
+        make_lval: fn() -> ECMAScriptValue,
+        make_rval: fn() -> ECMAScriptValue,
         op: BinOp,
     ) -> Result<NormalCompletion, String> {
         setup_test_agent();
-        let lval = make_lval(&agent);
-        let rval = make_rval(&agent);
-        agent.apply_string_or_numeric_binary_operator(lval, rval, op).map_err(|ac| unwind_any_error(&agent, ac))
+        let lval = make_lval();
+        let rval = make_rval();
+        apply_string_or_numeric_binary_operator(lval, rval, op).map_err(|ac| unwind_any_error(ac))
     }
 
     #[test_case(WksId::AsyncIterator => "Symbol.asyncIterator"; "Symbol.asyncIterator")]
@@ -463,7 +461,7 @@ mod agent {
     #[test_case(WksId::Unscopables => "Symbol.unscopables"; "Symbol.unscopables")]
     fn wks(id: WksId) -> String {
         setup_test_agent();
-        String::from(agent.wks(id).description().unwrap())
+        String::from(wks(id).description().unwrap())
     }
 
     #[test]
@@ -471,11 +469,13 @@ mod agent {
         setup_test_agent();
         let chunk = Rc::new(Chunk::new("test sentinel"));
 
-        agent.prepare_for_execution(0, Rc::clone(&chunk));
+        super::prepare_for_execution(0, Rc::clone(&chunk));
 
-        assert_eq!(agent.execution_context_stack.borrow()[0].pc, 0);
-        assert!(agent.execution_context_stack.borrow()[0].stack.is_empty());
-        assert_eq!(agent.execution_context_stack.borrow()[0].chunk.as_ref().unwrap().name, "test sentinel");
+        AGENT.with(|agent| {
+            assert_eq!(agent.execution_context_stack.borrow()[0].pc, 0);
+            assert!(agent.execution_context_stack.borrow()[0].stack.is_empty());
+            assert_eq!(agent.execution_context_stack.borrow()[0].chunk.as_ref().unwrap().name, "test sentinel");
+        })
     }
 
     #[test]
@@ -491,60 +491,60 @@ mod agent {
         assert_eq!(right, ECMAScriptValue::from("test"));
     }
 
-    fn no_primitive_val(agent: &Agent) -> ECMAScriptValue {
+    fn no_primitive_val() -> ECMAScriptValue {
         make_test_obj_uncallable(agent).into()
     }
-    fn make_symbol(agent: &Agent) -> ECMAScriptValue {
+    fn make_symbol() -> ECMAScriptValue {
         Symbol::new(agent, None).into()
     }
-    #[test_case(no_primitive_val, |_| ECMAScriptValue::from(10), true => serr("TypeError: Cannot convert object to primitive value"); "lf:true; first errs")]
-    #[test_case(|_| ECMAScriptValue::from(10), no_primitive_val, true => serr("TypeError: Cannot convert object to primitive value"); "lf:true; second errs")]
-    #[test_case(no_primitive_val, |_| ECMAScriptValue::from(10), false => serr("TypeError: Cannot convert object to primitive value"); "lf:false; second errs")]
-    #[test_case(|_| ECMAScriptValue::from(10), no_primitive_val, false => serr("TypeError: Cannot convert object to primitive value"); "lf:false; first errs")]
-    #[test_case(|_| ECMAScriptValue::from("first"), |_| ECMAScriptValue::from("second"), true => Ok(Some(true)); "two strings; left first; true")]
-    #[test_case(|_| ECMAScriptValue::from("zfirst"), |_| ECMAScriptValue::from("second"), true => Ok(Some(false)); "two strings; left first; false")]
-    #[test_case(|_| ECMAScriptValue::from("10"), |_| ECMAScriptValue::from(BigInt::from(100)), true => Ok(Some(true)); "left string; right bigint; true")]
-    #[test_case(|_| ECMAScriptValue::from("1000"), |_| ECMAScriptValue::from(BigInt::from(100)), true => Ok(Some(false)); "left string; right bigint; false")]
-    #[test_case(|_| ECMAScriptValue::from("anchor"), |_| ECMAScriptValue::from(BigInt::from(100)), true => Ok(None); "left string; right bigint; none")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(100)), |_| ECMAScriptValue::from("10"), true => Ok(Some(false)); "left bigint; right string; false")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(100)), |_| ECMAScriptValue::from("1000"), true => Ok(Some(true)); "left bigint; right string; true")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(100)), |_| ECMAScriptValue::from("anchor"), true => Ok(None); "left bigint; right string; none")]
-    #[test_case(make_symbol, |_| ECMAScriptValue::Undefined, true => serr("TypeError: Symbol values cannot be converted to Number values"); "left symbol")]
-    #[test_case(|_| ECMAScriptValue::Undefined, make_symbol, true => serr("TypeError: Symbol values cannot be converted to Number values"); "right symbol")]
-    #[test_case(|_| ECMAScriptValue::from(0), |_| ECMAScriptValue::Undefined, true => Ok(None); "right NaN")]
-    #[test_case(|_| ECMAScriptValue::Undefined, |_| ECMAScriptValue::from(0), true => Ok(None); "left NaN")]
-    #[test_case(|_| ECMAScriptValue::from(100), |_| ECMAScriptValue::from(0), false => Ok(Some(false)); "numbers: left bigger")]
-    #[test_case(|_| ECMAScriptValue::from(100), |_| ECMAScriptValue::from(7880), true => Ok(Some(true)); "numbers: left smaller")]
-    #[test_case(|_| ECMAScriptValue::Undefined, |_| ECMAScriptValue::from(BigInt::from(10)), true => Ok(None); "left NaN vs Bigint")]
-    #[test_case(|_| ECMAScriptValue::from(f64::NEG_INFINITY), |_| ECMAScriptValue::from(BigInt::from(10)), true => Ok(Some(true)); "left neg inf vs Bigint")]
-    #[test_case(|_| ECMAScriptValue::from(f64::INFINITY), |_| ECMAScriptValue::from(BigInt::from(10)), true => Ok(Some(false)); "left pos inf vs Bigint")]
-    #[test_case(|_| ECMAScriptValue::from(2.3e87), |_| ECMAScriptValue::from(BigInt::from(388)), true => Ok(Some(false)); "left big vs BigInt")]
-    #[test_case(|_| ECMAScriptValue::from(-2.3e87), |_| ECMAScriptValue::from(BigInt::from(388)), true => Ok(Some(true)); "left small vs BigInt")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(10)), |_| ECMAScriptValue::Undefined, true => Ok(None); "right NaN vs Bigint")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(10)), |_| ECMAScriptValue::from(f64::NEG_INFINITY), true => Ok(Some(false)); "right neg inf vs Bigint")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(10)), |_| ECMAScriptValue::from(f64::INFINITY), true => Ok(Some(true)); "right pos inf vs Bigint")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(388)), |_| ECMAScriptValue::from(2.3e87), true => Ok(Some(true)); "right big vs BigInt")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(388)), |_| ECMAScriptValue::from(-2.3e87), true => Ok(Some(false)); "right small vs BigInt")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(100)), |_| ECMAScriptValue::from(BigInt::from(7880)), true => Ok(Some(true)); "bigints: left smaller")]
-    #[test_case(|_| ECMAScriptValue::from(BigInt::from(100999)), |_| ECMAScriptValue::from(BigInt::from(7880)), true => Ok(Some(false)); "bigints: right smaller")]
+    #[test_case(no_primitive_val, || ECMAScriptValue::from(10), true => serr("TypeError: Cannot convert object to primitive value"); "lf:true; first errs")]
+    #[test_case(|| ECMAScriptValue::from(10), no_primitive_val, true => serr("TypeError: Cannot convert object to primitive value"); "lf:true; second errs")]
+    #[test_case(no_primitive_val, || ECMAScriptValue::from(10), false => serr("TypeError: Cannot convert object to primitive value"); "lf:false; second errs")]
+    #[test_case(|| ECMAScriptValue::from(10), no_primitive_val, false => serr("TypeError: Cannot convert object to primitive value"); "lf:false; first errs")]
+    #[test_case(|| ECMAScriptValue::from("first"), || ECMAScriptValue::from("second"), true => Ok(Some(true)); "two strings; left first; true")]
+    #[test_case(|| ECMAScriptValue::from("zfirst"), || ECMAScriptValue::from("second"), true => Ok(Some(false)); "two strings; left first; false")]
+    #[test_case(|| ECMAScriptValue::from("10"), || ECMAScriptValue::from(BigInt::from(100)), true => Ok(Some(true)); "left string; right bigint; true")]
+    #[test_case(|| ECMAScriptValue::from("1000"), || ECMAScriptValue::from(BigInt::from(100)), true => Ok(Some(false)); "left string; right bigint; false")]
+    #[test_case(|| ECMAScriptValue::from("anchor"), || ECMAScriptValue::from(BigInt::from(100)), true => Ok(None); "left string; right bigint; none")]
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(100)), || ECMAScriptValue::from("10"), true => Ok(Some(false)); "left bigint; right string; false")]
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(100)), || ECMAScriptValue::from("1000"), true => Ok(Some(true)); "left bigint; right string; true")]
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(100)), || ECMAScriptValue::from("anchor"), true => Ok(None); "left bigint; right string; none")]
+    #[test_case(make_symbol, || ECMAScriptValue::Undefined, true => serr("TypeError: Symbol values cannot be converted to Number values"); "left symbol")]
+    #[test_case(|| ECMAScriptValue::Undefined, make_symbol, true => serr("TypeError: Symbol values cannot be converted to Number values"); "right symbol")]
+    #[test_case(|| ECMAScriptValue::from(0), || ECMAScriptValue::Undefined, true => Ok(None); "right NaN")]
+    #[test_case(|| ECMAScriptValue::Undefined, || ECMAScriptValue::from(0), true => Ok(None); "left NaN")]
+    #[test_case(|| ECMAScriptValue::from(100), || ECMAScriptValue::from(0), false => Ok(Some(false)); "numbers: left bigger")]
+    #[test_case(|| ECMAScriptValue::from(100), || ECMAScriptValue::from(7880), true => Ok(Some(true)); "numbers: left smaller")]
+    #[test_case(|| ECMAScriptValue::Undefined, || ECMAScriptValue::from(BigInt::from(10)), true => Ok(None); "left NaN vs Bigint")]
+    #[test_case(|| ECMAScriptValue::from(f64::NEG_INFINITY), || ECMAScriptValue::from(BigInt::from(10)), true => Ok(Some(true)); "left neg inf vs Bigint")]
+    #[test_case(|| ECMAScriptValue::from(f64::INFINITY), || ECMAScriptValue::from(BigInt::from(10)), true => Ok(Some(false)); "left pos inf vs Bigint")]
+    #[test_case(|| ECMAScriptValue::from(2.3e87), || ECMAScriptValue::from(BigInt::from(388)), true => Ok(Some(false)); "left big vs BigInt")]
+    #[test_case(|| ECMAScriptValue::from(-2.3e87), || ECMAScriptValue::from(BigInt::from(388)), true => Ok(Some(true)); "left small vs BigInt")]
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(10)), || ECMAScriptValue::Undefined, true => Ok(None); "right NaN vs Bigint")]
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(10)), || ECMAScriptValue::from(f64::NEG_INFINITY), true => Ok(Some(false)); "right neg inf vs Bigint")]
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(10)), || ECMAScriptValue::from(f64::INFINITY), true => Ok(Some(true)); "right pos inf vs Bigint")]
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(388)), || ECMAScriptValue::from(2.3e87), true => Ok(Some(true)); "right big vs BigInt")]
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(388)), || ECMAScriptValue::from(-2.3e87), true => Ok(Some(false)); "right small vs BigInt")]
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(100)), || ECMAScriptValue::from(BigInt::from(7880)), true => Ok(Some(true)); "bigints: left smaller")]
+    #[test_case(|| ECMAScriptValue::from(BigInt::from(100999)), || ECMAScriptValue::from(BigInt::from(7880)), true => Ok(Some(false)); "bigints: right smaller")]
     fn is_less_than(
-        make_x: fn(&Agent) -> ECMAScriptValue,
-        make_y: fn(&Agent) -> ECMAScriptValue,
+        make_x: fn() -> ECMAScriptValue,
+        make_y: fn() -> ECMAScriptValue,
         left_first: bool,
     ) -> Result<Option<bool>, String> {
         setup_test_agent();
         let x = make_x(&agent);
         let y = make_y(&agent);
-        agent.is_less_than(x, y, left_first).map_err(|completion| unwind_any_error(&agent, completion))
+        agent.is_less_than(x, y, left_first).map_err(|completion| unwind_any_error(completion))
     }
 
-    type ValueMaker = fn(&Agent) -> ECMAScriptValue;
-    fn empty_object(agent: &Agent) -> ECMAScriptValue {
-        let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
+    type ValueMaker = fn() -> ECMAScriptValue;
+    fn empty_object() -> ECMAScriptValue {
+        let obj_proto = intrinsic(IntrinsicId::ObjectPrototype);
         ECMAScriptValue::from(ordinary_object_create(agent, Some(obj_proto), &[]))
     }
-    fn bool_class(agent: &Agent) -> ECMAScriptValue {
-        let boolean = agent.intrinsic(IntrinsicId::Boolean);
+    fn bool_class() -> ECMAScriptValue {
+        let boolean = intrinsic(IntrinsicId::Boolean);
         ECMAScriptValue::from(boolean)
     }
     fn undef(_: &Agent) -> ECMAScriptValue {
@@ -556,8 +556,8 @@ mod agent {
     fn string(_: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::from("Test Sentinel")
     }
-    fn dead_object(agent: &Agent) -> ECMAScriptValue {
-        ECMAScriptValue::from(DeadObject::object(agent))
+    fn dead_object() -> ECMAScriptValue {
+        ECMAScriptValue::from(DeadObject::object())
     }
     fn test_has_instance(
         agent: &Agent,
@@ -571,15 +571,15 @@ mod agent {
         // But that strings are a type error
         match thing_to_check {
             ECMAScriptValue::Number(_) => Ok(true.into()),
-            ECMAScriptValue::String(s) => Err(create_type_error(agent, s)),
+            ECMAScriptValue::String(s) => Err(create_type_error(s)),
             _ => Ok(false.into()),
         }
     }
-    fn faux_class(agent: &Agent) -> ECMAScriptValue {
-        let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
+    fn faux_class() -> ECMAScriptValue {
+        let obj_proto = intrinsic(IntrinsicId::ObjectPrototype);
         let obj = ordinary_object_create(agent, Some(obj_proto), &[]);
-        let realm = agent.current_realm_record();
-        let function_prototype = agent.intrinsic(IntrinsicId::FunctionPrototype);
+        let realm = current_realm_record();
+        let function_prototype = intrinsic(IntrinsicId::FunctionPrototype);
         let has_instance = create_builtin_function(
             agent,
             test_has_instance,
@@ -591,7 +591,7 @@ mod agent {
             Some(function_prototype),
             None,
         );
-        let hi = agent.wks(WksId::HasInstance);
+        let hi = wks(WksId::HasInstance);
         define_property_or_throw(
             agent,
             &obj,
@@ -616,7 +616,7 @@ mod agent {
 
         agent
             .instanceof_operator(v, target)
-            .map_err(|completion| unwind_any_error(&agent, completion))
+            .map_err(|completion| unwind_any_error(completion))
             .map(|nc| nc.try_into().unwrap())
     }
 
@@ -662,9 +662,9 @@ mod agent {
             for (idx, val) in values.iter().enumerate() {
                 assert_eq!(&get(&agent, &ao, &idx.into()).unwrap(), val);
             }
-            let args_iterator = agent.intrinsic(IntrinsicId::ArrayPrototypeValues);
-            let type_error_generator = agent.intrinsic(IntrinsicId::ThrowTypeError);
-            let iterator_sym = agent.wks(WksId::Iterator);
+            let args_iterator = intrinsic(IntrinsicId::ArrayPrototypeValues);
+            let type_error_generator = intrinsic(IntrinsicId::ThrowTypeError);
+            let iterator_sym = wks(WksId::Iterator);
             assert_eq!(get(&agent, &ao, &iterator_sym.into()).unwrap(), ECMAScriptValue::from(args_iterator));
             let callee = ao.o.get_own_property(&agent, &"callee".into()).unwrap().unwrap();
             assert_eq!(
@@ -710,7 +710,7 @@ mod agent {
         #[test_case(&[10.into(), 20.into()]; "multiple")]
         fn normal(values: &[ECMAScriptValue]) {
             setup_test_agent();
-            let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+            let env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
             let lexenv = Rc::new(DeclarativeEnvironmentRecord::new(Some(env), "create_mapped_arguments_object test"));
             agent.set_lexical_environment(Some(lexenv as Rc<dyn EnvironmentRecord>));
 
@@ -753,8 +753,8 @@ mod agent {
             for (idx, val) in values.iter().enumerate() {
                 assert_eq!(&get(&agent, &ao, &idx.into()).unwrap(), val);
             }
-            let args_iterator = agent.intrinsic(IntrinsicId::ArrayPrototypeValues);
-            let iterator_sym = agent.wks(WksId::Iterator);
+            let args_iterator = intrinsic(IntrinsicId::ArrayPrototypeValues);
+            let iterator_sym = wks(WksId::Iterator);
             assert_eq!(get(&agent, &ao, &iterator_sym.into()).unwrap(), ECMAScriptValue::from(args_iterator));
             assert_eq!(get(&agent, &ao, &"callee".into()).unwrap(), ECMAScriptValue::from(func_obj));
         }
@@ -788,7 +788,7 @@ mod agent {
         #[test_case(&[10.into(), "blue".into(), true.into()], &["number".into(), "string".into(), "boolean".into()]; "typical")]
         fn normal(values: &[ECMAScriptValue], names: &[JSString]) {
             setup_test_agent();
-            let realm = agent.current_realm_record().unwrap();
+            let realm = current_realm_record().unwrap();
             let ge = realm.borrow().global_env.as_ref().unwrap().clone();
             let lex = Rc::new(DeclarativeEnvironmentRecord::new(Some(ge), "test lex"));
             let num_values = values.len() as u32;
@@ -882,7 +882,7 @@ mod parse_script {
     fn happy() {
         setup_test_agent();
         let src = "/* hello! */ 'hello world';";
-        let starting_realm = agent.current_realm_record().unwrap();
+        let starting_realm = current_realm_record().unwrap();
         let ScriptRecord { realm, ecmascript_code, compiled, text } =
             super::parse_script(&agent, src, starting_realm.clone()).unwrap();
         assert!(Rc::ptr_eq(&realm, &starting_realm));
@@ -899,7 +899,7 @@ mod parse_script {
     #[test_case("break lbl;" => sset(&["undefined break target detected"]); "early error syntax")]
     fn parse_error(src: &str) -> AHashSet<String> {
         setup_test_agent();
-        let starting_realm = agent.current_realm_record().unwrap();
+        let starting_realm = current_realm_record().unwrap();
         let errs = super::parse_script(&agent, src, starting_realm).unwrap_err();
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
     }
@@ -1078,7 +1078,7 @@ mod fcn_def {
     fn instantiate_function_object(part: (FcnDef, String)) -> Result<String, String> {
         let (part, src) = part;
         setup_test_agent();
-        let global_env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+        let global_env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let env = global_env as Rc<dyn EnvironmentRecord>;
 
         part.instantiate_function_object(&agent, env, None, true, &src)
@@ -1154,7 +1154,7 @@ mod global_declaration_instantiation {
     fn global_declaration_instantiation(src: &str) -> Result<(AHashSet<String>, AHashSet<String>), String> {
         setup_test_agent();
         let script = Maker::new(src).script();
-        let global_env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+        let global_env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         global_env.create_global_var_binding(&agent, "already_var_declared".into(), false).unwrap();
         global_env.create_mutable_binding(&agent, "existing_mutable".into(), false).unwrap();
 
@@ -1163,7 +1163,7 @@ mod global_declaration_instantiation {
 
         let result = super::global_declaration_instantiation(&agent, script, global_env.clone(), false, src);
 
-        result.map_err(|err| unwind_any_error(&agent, err)).map(|_| {
+        result.map_err(|err| unwind_any_error(err)).map(|| {
             let after_vardecl = global_env.var_decls().into_iter().collect::<AHashSet<_>>();
             let after_lexdecl = global_env.lex_decls().into_iter().collect::<AHashSet<_>>();
 
@@ -1183,10 +1183,10 @@ mod script_evaluation {
     #[test_case("" => Ok(ECMAScriptValue::Undefined); "empty")]
     fn script_evaluation(src: &str) -> Result<ECMAScriptValue, String> {
         setup_test_agent();
-        let realm = agent.current_realm_record().unwrap();
+        let realm = current_realm_record().unwrap();
         let script_record = parse_script(&agent, src, realm).unwrap();
 
-        super::script_evaluation(&agent, script_record).map_err(|err| unwind_any_error(&agent, err))
+        super::script_evaluation(&agent, script_record).map_err(|err| unwind_any_error(err))
     }
 }
 
@@ -1204,7 +1204,7 @@ mod process_error {
         ProcessError::InternalError { reason: "blue".into() }
     }
 
-    fn runtime_err_obj(agent: &Agent) -> ProcessError {
+    fn runtime_err_obj() -> ProcessError {
         let err = create_type_error_object(agent, "test sentinel");
         ProcessError::RuntimeError { error: err.into() }
     }
@@ -1212,7 +1212,7 @@ mod process_error {
         let error = "test sentinel".into();
         ProcessError::RuntimeError { error }
     }
-    fn runtime_err_non_err_obj(agent: &Agent) -> ProcessError {
+    fn runtime_err_non_err_obj() -> ProcessError {
         let error = ordinary_object_create(agent, None, &[]).into();
         ProcessError::RuntimeError { error }
     }
@@ -1222,7 +1222,7 @@ mod process_error {
         }
         assert!(MATCH.is_match(&s));
     }
-    fn compiler_objs(agent: &Agent) -> ProcessError {
+    fn compiler_objs() -> ProcessError {
         ProcessError::CompileErrors {
             values: vec![
                 create_syntax_error_object(agent, "Trouble in Paradise", None),
@@ -1235,7 +1235,7 @@ mod process_error {
     #[test_case(runtime_err_value => "Thrown: test sentinel"; "error value runtime")]
     #[test_case(runtime_err_non_err_obj => using matches_object; "error obj but not error")]
     #[test_case(compiler_objs => "During compilation:\nSyntaxError: Trouble in Paradise\nReferenceError: yeah, compiler errs are only syntax...\n"; "compiler err list")]
-    fn display(make_error: fn(&Agent) -> ProcessError) -> String {
+    fn display(make_error: fn() -> ProcessError) -> String {
         setup_test_agent();
         let err = make_error(&agent);
         format!("{err}")

--- a/src/arguments_object/tests.rs
+++ b/src/arguments_object/tests.rs
@@ -285,7 +285,7 @@ mod arguments_object {
         let obj = make_object();
         let receiver = ECMAScriptValue::from(obj.clone());
 
-        obj.o.get(&propname.into(), &receiver).map_err(|err| unwind_any_error(err))
+        obj.o.get(&propname.into(), &receiver).map_err(unwind_any_error)
     }
 
     #[test_case(test_ao, "0", ECMAScriptValue::from(99), &["0", "1", "2", "from", "the", "test"] => Ok((true, vec![
@@ -320,7 +320,7 @@ mod arguments_object {
             .unwrap_or_else(|| current_realm_record().unwrap().borrow().global_env.clone().unwrap());
         let receiver = ECMAScriptValue::from(obj.clone());
 
-        let result = obj.o.set(propname.into(), val, &receiver).map_err(|err| unwind_any_error(err))?;
+        let result = obj.o.set(propname.into(), val, &receiver).map_err(unwind_any_error)?;
 
         let values = to_check
             .iter()
@@ -387,7 +387,7 @@ mod arguments_object {
             .unwrap_or_else(|| current_realm_record().unwrap().borrow().global_env.clone().unwrap());
         let receiver = ECMAScriptValue::from(obj.clone());
 
-        let result = obj.o.delete(&name.into()).map_err(|err| unwind_any_error(err))?;
+        let result = obj.o.delete(&name.into()).map_err(unwind_any_error)?;
 
         let values = to_check
             .iter()
@@ -541,7 +541,7 @@ mod arguments_object {
         let obj = make_object();
         let env = current_lexical_environment().unwrap();
 
-        let result = obj.o.define_own_property(name.into(), desc).map_err(|e| unwind_any_error(e))?;
+        let result = obj.o.define_own_property(name.into(), desc).map_err(unwind_any_error)?;
 
         let object_keys = obj.o.own_property_keys().unwrap();
         let items =

--- a/src/arguments_object/tests.rs
+++ b/src/arguments_object/tests.rs
@@ -545,10 +545,8 @@ mod arguments_object {
         let result = obj.o.define_own_property(name.into(), desc).map_err(|e| unwind_any_error(e))?;
 
         let object_keys = obj.o.own_property_keys().unwrap();
-        let items = object_keys
-            .iter()
-            .map(|key| (key.to_string(), super::get(&obj, key).unwrap()))
-            .collect::<AHashMap<_, _>>();
+        let items =
+            object_keys.iter().map(|key| (key.to_string(), super::get(&obj, key).unwrap())).collect::<AHashMap<_, _>>();
 
         let env_items = env
             .binding_names()

--- a/src/arguments_object/tests.rs
+++ b/src/arguments_object/tests.rs
@@ -8,7 +8,7 @@ mod parameter_map {
 
     #[test]
     fn debug() {
-        let agent = test_agent();
+        setup_test_agent();
         let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let pmap = ParameterMap { env, properties: vec![] };
 
@@ -17,7 +17,7 @@ mod parameter_map {
 
     #[test]
     fn new() {
-        let agent = test_agent();
+        setup_test_agent();
         let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
 
         let map = ParameterMap::new(env.clone());
@@ -33,7 +33,7 @@ mod parameter_map {
     #[test_case(|_| PropertyKey::from("83828") => Some(83828); "valid nonzero")]
     #[test_case(|a| PropertyKey::from(a.wks(WksId::Iterator)) => None; "symbol key")]
     fn idx_from_key(make_key: impl FnOnce(&Agent) -> PropertyKey) -> Option<usize> {
-        let agent = test_agent();
+        setup_test_agent();
         let actual_key = make_key(&agent);
         ParameterMap::idx_from_key(&actual_key)
     }
@@ -44,7 +44,7 @@ mod parameter_map {
     #[test_case("3" => Some(3); "three")]
     #[test_case("4" => None; "too large")]
     fn to_index(key: &str) -> Option<usize> {
-        let agent = test_agent();
+        setup_test_agent();
         let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
 
         let pmap = ParameterMap {
@@ -57,7 +57,7 @@ mod parameter_map {
     #[test_case("bob", 10 => ssome("bob"); "expand")]
     #[test_case("alice", 0 => ssome("alice"); "precede")]
     fn add_mapped_name(name: &str, loc: usize) -> Option<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let mut pmap = ParameterMap::new(env);
 
@@ -72,7 +72,7 @@ mod parameter_map {
     #[test_case(&[Some("first"), Some("second"), Some("third")], 4 => panics "index out of bounds: the len is 3 but the index is 4"; "delete past end")]
     #[test_case(&[Some("first"), None, Some("third")], 1 => vec![ssome("first"), None, ssome("third")]; "delete already deleted")]
     fn delete(before: &[Option<&str>], loc: usize) -> Vec<Option<String>> {
-        let agent = test_agent();
+        setup_test_agent();
         let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let mut pmap = ParameterMap { env, properties: before.iter().map(|os| os.map(JSString::from)).collect() };
 
@@ -84,7 +84,7 @@ mod parameter_map {
     #[test_case(&[Some("first"), Some("second"), Some("third")], 0 => ECMAScriptValue::from("first+0"); "typical")]
     #[test_case(&[Some("first"), None, Some("third")], 1 => panics "Get only used on existing values"; "get a deleted item")]
     fn get(before: &[Option<&str>], loc: usize) -> ECMAScriptValue {
-        let agent = test_agent();
+        setup_test_agent();
         let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let pmap =
             ParameterMap { env: env.clone(), properties: before.iter().map(|os| os.map(JSString::from)).collect() };
@@ -102,7 +102,7 @@ mod parameter_map {
     #[test_case(&[Some("first"), Some("second"), Some("third")], 0, ECMAScriptValue::from("sentinel") => ECMAScriptValue::from("sentinel"); "typical")]
     #[test_case(&[Some("first"), None, Some("third")], 1, ECMAScriptValue::from("sentinel") => panics "Set only used on existing values"; "set a deleted item")]
     fn set(before: &[Option<&str>], loc: usize, val: ECMAScriptValue) -> ECMAScriptValue {
-        let agent = test_agent();
+        setup_test_agent();
         let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let pmap =
             ParameterMap { env: env.clone(), properties: before.iter().map(|os| os.map(JSString::from)).collect() };
@@ -127,7 +127,7 @@ mod arguments_object {
 
     #[test]
     fn object() {
-        let agent = test_agent();
+        setup_test_agent();
         let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let pmap = ParameterMap {
             env: env.clone(),
@@ -201,76 +201,76 @@ mod arguments_object {
     #[test_case(|ao| ao.o.is_ordinary() => true; "is_ordinary")]
     #[test_case(|ao| ao.o.is_arguments_object() => true; "is_arguments_object")]
     fn bool_stub(op: impl FnOnce(&Object) -> bool) -> bool {
-        let agent = test_agent();
+        setup_test_agent();
         let ao = test_ao(&agent);
         op(&ao)
     }
 
     #[test]
     fn to_array_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let ao = test_ao(&agent);
         assert!(ao.o.to_array_object().is_none());
     }
 
     #[test]
     fn to_boolean_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let ao = test_ao(&agent);
         assert!(ao.o.to_boolean_obj().is_none());
     }
 
     #[test]
     fn to_error_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let ao = test_ao(&agent);
         assert!(ao.o.to_error_obj().is_none());
     }
     #[test]
     fn to_symbol_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let ao = test_ao(&agent);
         assert!(ao.o.to_symbol_obj().is_none());
     }
 
     #[test]
     fn to_number_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let ao = test_ao(&agent);
         assert!(ao.o.to_number_obj().is_none());
     }
 
     #[test]
     fn to_callable_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let ao = test_ao(&agent);
         assert!(ao.o.to_callable_obj().is_none());
     }
 
     #[test]
     fn to_constructable() {
-        let agent = test_agent();
+        setup_test_agent();
         let ao = test_ao(&agent);
         assert!(ao.o.to_constructable().is_none());
     }
 
     #[test]
     fn to_function_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let ao = test_ao(&agent);
         assert!(ao.o.to_function_obj().is_none());
     }
 
     #[test]
     fn to_builtin_function_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let ao = test_ao(&agent);
         assert!(ao.o.to_builtin_function_obj().is_none());
     }
 
     #[test]
     fn debug() {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = test_ao(&agent);
         let ao = obj.o.to_arguments_object().unwrap();
         assert_ne!(format!("{:?}", ao), "");
@@ -281,7 +281,7 @@ mod arguments_object {
     #[test_case(|a| { let ao = test_ao(a); ao.o.delete(a, &"1".into()).unwrap(); ao }, "1" => Ok(ECMAScriptValue::Undefined); "tried to get a deleted one")]
     #[test_case(|a| ArgumentsObject::object(a, None), "10" => Ok(ECMAScriptValue::Undefined); "unmapped")]
     fn get(make_object: impl FnOnce(&Agent) -> Object, propname: &str) -> Result<ECMAScriptValue, String> {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = make_object(&agent);
         let receiver = ECMAScriptValue::from(obj.clone());
 
@@ -314,7 +314,7 @@ mod arguments_object {
         val: ECMAScriptValue,
         to_check: &[&str],
     ) -> Result<(bool, Vec<(ECMAScriptValue, ECMAScriptValue)>), String> {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = make_object(&agent);
         let env = agent
             .current_lexical_environment()
@@ -382,7 +382,7 @@ mod arguments_object {
         obj
     }, "key", &["key"] => Ok((false, test_hm(&[("key", ECMAScriptValue::from(39), ECMAScriptValue::Undefined)]), None)); "undeletable")]
     fn delete(make_object: impl FnOnce(&Agent) -> Object, name: &str, to_check: &[&str]) -> TestResult {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = make_object(&agent);
         let env = agent
             .current_lexical_environment()
@@ -455,7 +455,7 @@ mod arguments_object {
     #[test_case(test_unmapped, "2" => using prop_checker(PotentialPropertyDescriptor::new().value("value of 'test'").writable(true).enumerable(true).configurable(true)); "unmapped obj")]
     #[test_case(test_unmapped, "200" => None; "property not present")]
     fn get_own_property(make_object: impl FnOnce(&Agent) -> Object, name: &str) -> Option<PropertyDescriptor> {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = make_object(&agent);
 
         obj.o.get_own_property(&agent, &name.into()).unwrap()
@@ -539,7 +539,7 @@ mod arguments_object {
         name: &str,
         desc: PotentialPropertyDescriptor,
     ) -> DefineOwnPropertyTestResult {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = make_object(&agent);
         let env = agent.current_lexical_environment().unwrap();
 
@@ -563,7 +563,7 @@ mod arguments_object {
     #[test_case(test_ao, "0" => true; "exists")]
     #[test_case(test_ao, "from" => false; "not in ao")]
     fn has_property(make_object: impl FnOnce(&Agent) -> Object, name: &str) -> bool {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = make_object(&agent);
 
         obj.o.has_property(&agent, &name.into()).unwrap()
@@ -571,7 +571,7 @@ mod arguments_object {
 
     #[test_case(test_ao => true; "typical")]
     fn set_prototype_of(make_object: impl FnOnce(&Agent) -> Object) -> bool {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = make_object(&agent);
 
         obj.o.set_prototype_of(&agent, None).unwrap()
@@ -579,7 +579,7 @@ mod arguments_object {
 
     #[test_case(test_ao => true; "typical")]
     fn prevent_extensions(make_object: impl FnOnce(&Agent) -> Object) -> bool {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = make_object(&agent);
 
         obj.o.prevent_extensions(&agent).unwrap()

--- a/src/arguments_object/tests.rs
+++ b/src/arguments_object/tests.rs
@@ -383,8 +383,7 @@ mod arguments_object {
     fn delete(make_object: impl FnOnce() -> Object, name: &str, to_check: &[&str]) -> TestResult {
         setup_test_agent();
         let obj = make_object();
-        let env = agent
-            .current_lexical_environment()
+        let env = current_lexical_environment()
             .unwrap_or_else(|| current_realm_record().unwrap().borrow().global_env.clone().unwrap());
         let receiver = ECMAScriptValue::from(obj.clone());
 

--- a/src/arguments_object/tests.rs
+++ b/src/arguments_object/tests.rs
@@ -9,7 +9,7 @@ mod parameter_map {
     #[test]
     fn debug() {
         setup_test_agent();
-        let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+        let env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let pmap = ParameterMap { env, properties: vec![] };
 
         assert_ne!(format!("{:?}", pmap), "");
@@ -18,7 +18,7 @@ mod parameter_map {
     #[test]
     fn new() {
         setup_test_agent();
-        let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+        let env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
 
         let map = ParameterMap::new(env.clone());
 
@@ -26,15 +26,15 @@ mod parameter_map {
         assert_eq!(map.env.name(), env.name())
     }
 
-    #[test_case(|_| PropertyKey::from("blue") => None; "Not a numeric key")]
-    #[test_case(|_| PropertyKey::from("0") => Some(0); "Zero")]
-    #[test_case(|_| PropertyKey::from("   10") => None; "invalid whitespace")]
-    #[test_case(|_| PropertyKey::from("-9932") => None; "negative numbers")]
-    #[test_case(|_| PropertyKey::from("83828") => Some(83828); "valid nonzero")]
-    #[test_case(|a| PropertyKey::from(a.wks(WksId::Iterator)) => None; "symbol key")]
-    fn idx_from_key(make_key: impl FnOnce(&Agent) -> PropertyKey) -> Option<usize> {
+    #[test_case(|| PropertyKey::from("blue") => None; "Not a numeric key")]
+    #[test_case(|| PropertyKey::from("0") => Some(0); "Zero")]
+    #[test_case(|| PropertyKey::from("   10") => None; "invalid whitespace")]
+    #[test_case(|| PropertyKey::from("-9932") => None; "negative numbers")]
+    #[test_case(|| PropertyKey::from("83828") => Some(83828); "valid nonzero")]
+    #[test_case(|| PropertyKey::from(wks(WksId::Iterator)) => None; "symbol key")]
+    fn idx_from_key(make_key: impl FnOnce() -> PropertyKey) -> Option<usize> {
         setup_test_agent();
-        let actual_key = make_key(&agent);
+        let actual_key = make_key();
         ParameterMap::idx_from_key(&actual_key)
     }
 
@@ -45,7 +45,7 @@ mod parameter_map {
     #[test_case("4" => None; "too large")]
     fn to_index(key: &str) -> Option<usize> {
         setup_test_agent();
-        let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+        let env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
 
         let pmap = ParameterMap {
             env,
@@ -58,7 +58,7 @@ mod parameter_map {
     #[test_case("alice", 0 => ssome("alice"); "precede")]
     fn add_mapped_name(name: &str, loc: usize) -> Option<String> {
         setup_test_agent();
-        let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+        let env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let mut pmap = ParameterMap::new(env);
 
         pmap.add_mapped_name("sentinel".into(), 5);
@@ -73,7 +73,7 @@ mod parameter_map {
     #[test_case(&[Some("first"), None, Some("third")], 1 => vec![ssome("first"), None, ssome("third")]; "delete already deleted")]
     fn delete(before: &[Option<&str>], loc: usize) -> Vec<Option<String>> {
         setup_test_agent();
-        let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+        let env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let mut pmap = ParameterMap { env, properties: before.iter().map(|os| os.map(JSString::from)).collect() };
 
         pmap.delete(loc);
@@ -85,38 +85,38 @@ mod parameter_map {
     #[test_case(&[Some("first"), None, Some("third")], 1 => panics "Get only used on existing values"; "get a deleted item")]
     fn get(before: &[Option<&str>], loc: usize) -> ECMAScriptValue {
         setup_test_agent();
-        let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+        let env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let pmap =
             ParameterMap { env: env.clone(), properties: before.iter().map(|os| os.map(JSString::from)).collect() };
         for (idx, name) in
             before.iter().enumerate().filter_map(|(idx, os)| os.as_ref().map(|&s| (idx, JSString::from(s))))
         {
             let value = ECMAScriptValue::from(format!("{}+{}", name, idx));
-            env.create_mutable_binding(&agent, name.clone(), false).unwrap();
-            env.initialize_binding(&agent, &name, value).unwrap();
+            env.create_mutable_binding(name.clone(), false).unwrap();
+            env.initialize_binding(&name, value).unwrap();
         }
 
-        pmap.get(&agent, loc).unwrap()
+        pmap.get(loc).unwrap()
     }
 
     #[test_case(&[Some("first"), Some("second"), Some("third")], 0, ECMAScriptValue::from("sentinel") => ECMAScriptValue::from("sentinel"); "typical")]
     #[test_case(&[Some("first"), None, Some("third")], 1, ECMAScriptValue::from("sentinel") => panics "Set only used on existing values"; "set a deleted item")]
     fn set(before: &[Option<&str>], loc: usize, val: ECMAScriptValue) -> ECMAScriptValue {
         setup_test_agent();
-        let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+        let env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let pmap =
             ParameterMap { env: env.clone(), properties: before.iter().map(|os| os.map(JSString::from)).collect() };
         for (idx, name) in
             before.iter().enumerate().filter_map(|(idx, os)| os.as_ref().map(|&s| (idx, JSString::from(s))))
         {
             let value = ECMAScriptValue::from(format!("{}+{}", name, idx));
-            env.create_mutable_binding(&agent, name.clone(), false).unwrap();
-            env.initialize_binding(&agent, &name, value).unwrap();
+            env.create_mutable_binding(name.clone(), false).unwrap();
+            env.initialize_binding(&name, value).unwrap();
         }
 
-        pmap.set(&agent, loc, val).unwrap();
+        pmap.set(loc, val).unwrap();
 
-        env.get_binding_value(&agent, pmap.properties[loc].as_ref().unwrap(), true).unwrap()
+        env.get_binding_value(pmap.properties[loc].as_ref().unwrap(), true).unwrap()
     }
 }
 
@@ -128,17 +128,17 @@ mod arguments_object {
     #[test]
     fn object() {
         setup_test_agent();
-        let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+        let env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let pmap = ParameterMap {
             env: env.clone(),
             properties: vec![Some("from".into()), Some("the".into()), Some("test".into())],
         };
 
-        let result = ArgumentsObject::object(&agent, Some(pmap));
+        let result = ArgumentsObject::object(Some(pmap));
 
         let d = result.o.common_object_data().borrow();
 
-        assert_eq!(d.prototype, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)));
+        assert_eq!(d.prototype, Some(intrinsic(IntrinsicId::ObjectPrototype)));
         assert!(d.extensible);
         assert_eq!(d.slots, ARGUMENTS_OBJECT_SLOTS);
         assert!(d.private_elements.is_empty());
@@ -151,38 +151,38 @@ mod arguments_object {
         assert_eq!(pmap.properties, vec![Some("from".into()), Some("the".into()), Some("test".into())]);
     }
 
-    fn test_ao(agent: &Agent) -> Object {
-        let env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+    fn test_ao() -> Object {
+        let env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let lexenv = Rc::new(DeclarativeEnvironmentRecord::new(Some(env), "test_ao"));
-        agent.set_lexical_environment(Some(lexenv.clone() as Rc<dyn EnvironmentRecord>));
+        set_lexical_environment(Some(lexenv.clone() as Rc<dyn EnvironmentRecord>));
         let pmap = ParameterMap {
             env: lexenv.clone(),
             properties: vec![Some("from".into()), Some("the".into()), Some("test".into())],
         };
 
-        lexenv.create_mutable_binding(agent, "from".into(), false).unwrap();
-        lexenv.create_mutable_binding(agent, "the".into(), false).unwrap();
-        lexenv.create_mutable_binding(agent, "test".into(), false).unwrap();
-        lexenv.initialize_binding(agent, &"from".into(), "value of 'from'".into()).unwrap();
-        lexenv.initialize_binding(agent, &"the".into(), "value of 'the'".into()).unwrap();
-        lexenv.initialize_binding(agent, &"test".into(), "value of 'test'".into()).unwrap();
+        lexenv.create_mutable_binding("from".into(), false).unwrap();
+        lexenv.create_mutable_binding("the".into(), false).unwrap();
+        lexenv.create_mutable_binding("test".into(), false).unwrap();
+        lexenv.initialize_binding(&"from".into(), "value of 'from'".into()).unwrap();
+        lexenv.initialize_binding(&"the".into(), "value of 'the'".into()).unwrap();
+        lexenv.initialize_binding(&"test".into(), "value of 'test'".into()).unwrap();
 
-        let obj = ArgumentsObject::object(agent, Some(pmap));
+        let obj = ArgumentsObject::object(Some(pmap));
 
-        create_data_property_or_throw(agent, &obj, 0, "value of 'from'").unwrap();
-        create_data_property_or_throw(agent, &obj, 1, "value of 'the'").unwrap();
-        create_data_property_or_throw(agent, &obj, 2, "value of 'test'").unwrap();
-        create_data_property_or_throw(agent, &obj, 100, "not in index").unwrap();
+        create_data_property_or_throw(&obj, 0, "value of 'from'").unwrap();
+        create_data_property_or_throw(&obj, 1, "value of 'the'").unwrap();
+        create_data_property_or_throw(&obj, 2, "value of 'test'").unwrap();
+        create_data_property_or_throw(&obj, 100, "not in index").unwrap();
 
         obj
     }
 
-    fn test_unmapped(agent: &Agent) -> Object {
-        let obj = ArgumentsObject::object(agent, None);
+    fn test_unmapped() -> Object {
+        let obj = ArgumentsObject::object(None);
 
-        super::set(agent, &obj, "0".into(), "value of 'from'".into(), false).unwrap();
-        super::set(agent, &obj, "1".into(), "value of 'the'".into(), false).unwrap();
-        super::set(agent, &obj, "2".into(), "value of 'test'".into(), false).unwrap();
+        super::set(&obj, "0".into(), "value of 'from'".into(), false).unwrap();
+        super::set(&obj, "1".into(), "value of 'the'".into(), false).unwrap();
+        super::set(&obj, "2".into(), "value of 'test'".into(), false).unwrap();
 
         obj
     }
@@ -202,90 +202,90 @@ mod arguments_object {
     #[test_case(|ao| ao.o.is_arguments_object() => true; "is_arguments_object")]
     fn bool_stub(op: impl FnOnce(&Object) -> bool) -> bool {
         setup_test_agent();
-        let ao = test_ao(&agent);
+        let ao = test_ao();
         op(&ao)
     }
 
     #[test]
     fn to_array_object() {
         setup_test_agent();
-        let ao = test_ao(&agent);
+        let ao = test_ao();
         assert!(ao.o.to_array_object().is_none());
     }
 
     #[test]
     fn to_boolean_obj() {
         setup_test_agent();
-        let ao = test_ao(&agent);
+        let ao = test_ao();
         assert!(ao.o.to_boolean_obj().is_none());
     }
 
     #[test]
     fn to_error_obj() {
         setup_test_agent();
-        let ao = test_ao(&agent);
+        let ao = test_ao();
         assert!(ao.o.to_error_obj().is_none());
     }
     #[test]
     fn to_symbol_obj() {
         setup_test_agent();
-        let ao = test_ao(&agent);
+        let ao = test_ao();
         assert!(ao.o.to_symbol_obj().is_none());
     }
 
     #[test]
     fn to_number_obj() {
         setup_test_agent();
-        let ao = test_ao(&agent);
+        let ao = test_ao();
         assert!(ao.o.to_number_obj().is_none());
     }
 
     #[test]
     fn to_callable_obj() {
         setup_test_agent();
-        let ao = test_ao(&agent);
+        let ao = test_ao();
         assert!(ao.o.to_callable_obj().is_none());
     }
 
     #[test]
     fn to_constructable() {
         setup_test_agent();
-        let ao = test_ao(&agent);
+        let ao = test_ao();
         assert!(ao.o.to_constructable().is_none());
     }
 
     #[test]
     fn to_function_obj() {
         setup_test_agent();
-        let ao = test_ao(&agent);
+        let ao = test_ao();
         assert!(ao.o.to_function_obj().is_none());
     }
 
     #[test]
     fn to_builtin_function_obj() {
         setup_test_agent();
-        let ao = test_ao(&agent);
+        let ao = test_ao();
         assert!(ao.o.to_builtin_function_obj().is_none());
     }
 
     #[test]
     fn debug() {
         setup_test_agent();
-        let obj = test_ao(&agent);
+        let obj = test_ao();
         let ao = obj.o.to_arguments_object().unwrap();
         assert_ne!(format!("{:?}", ao), "");
     }
 
     #[test_case(test_ao, "0" => Ok(ECMAScriptValue::from("value of 'from'")); "index was there")]
     #[test_case(test_ao, "not" => Ok(ECMAScriptValue::Undefined); "prop wasn't there")]
-    #[test_case(|a| { let ao = test_ao(a); ao.o.delete(a, &"1".into()).unwrap(); ao }, "1" => Ok(ECMAScriptValue::Undefined); "tried to get a deleted one")]
-    #[test_case(|a| ArgumentsObject::object(a, None), "10" => Ok(ECMAScriptValue::Undefined); "unmapped")]
-    fn get(make_object: impl FnOnce(&Agent) -> Object, propname: &str) -> Result<ECMAScriptValue, String> {
+    #[test_case(|| { let ao = test_ao(); ao.o.delete(&"1".into()).unwrap(); ao }, "1" => Ok(ECMAScriptValue::Undefined); "tried to get a deleted one")]
+    #[test_case(|| ArgumentsObject::object(None), "10" => Ok(ECMAScriptValue::Undefined); "unmapped")]
+    fn get(make_object: impl FnOnce() -> Object, propname: &str) -> Result<ECMAScriptValue, String> {
         setup_test_agent();
-        let obj = make_object(&agent);
+        let obj = make_object();
         let receiver = ECMAScriptValue::from(obj.clone());
 
-        obj.o.get(&agent, &propname.into(), &receiver).map_err(|err| unwind_any_error(&agent, err))
+        obj.o.get(&propname.into(), &receiver).map_err(|err| unwind_any_error(err))
     }
 
     #[test_case(test_ao, "0", ECMAScriptValue::from(99), &["0", "1", "2", "from", "the", "test"] => Ok((true, vec![
@@ -305,31 +305,30 @@ mod arguments_object {
         (ECMAScriptValue::Undefined, ECMAScriptValue::from("value of 'test'")),
         (ECMAScriptValue::from(99), ECMAScriptValue::Undefined),
     ])); "mapped, but not magic")]
-    #[test_case(|a| ArgumentsObject::object(a, None), "0", "sentinel".into(), &["0"] => Ok((true, vec![
+    #[test_case(|| ArgumentsObject::object(None), "0", "sentinel".into(), &["0"] => Ok((true, vec![
         (ECMAScriptValue::from("sentinel"), ECMAScriptValue::Undefined),
     ])); "unmapped")]
     fn set(
-        make_object: impl FnOnce(&Agent) -> Object,
+        make_object: impl FnOnce() -> Object,
         propname: &str,
         val: ECMAScriptValue,
         to_check: &[&str],
     ) -> Result<(bool, Vec<(ECMAScriptValue, ECMAScriptValue)>), String> {
         setup_test_agent();
-        let obj = make_object(&agent);
-        let env = agent
-            .current_lexical_environment()
-            .unwrap_or_else(|| agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap());
+        let obj = make_object();
+        let env = current_lexical_environment()
+            .unwrap_or_else(|| current_realm_record().unwrap().borrow().global_env.clone().unwrap());
         let receiver = ECMAScriptValue::from(obj.clone());
 
-        let result = obj.o.set(&agent, propname.into(), val, &receiver).map_err(|err| unwind_any_error(&agent, err))?;
+        let result = obj.o.set(propname.into(), val, &receiver).map_err(|err| unwind_any_error(err))?;
 
         let values = to_check
             .iter()
             .map(|&probe| {
                 (
-                    obj.o.get(&agent, &probe.into(), &receiver).unwrap(),
-                    if env.has_binding(&agent, &probe.into()).unwrap() {
-                        env.get_binding_value(&agent, &probe.into(), false).unwrap()
+                    obj.o.get(&probe.into(), &receiver).unwrap(),
+                    if env.has_binding(&probe.into()).unwrap() {
+                        env.get_binding_value(&probe.into(), false).unwrap()
                     } else {
                         ECMAScriptValue::Undefined
                     },
@@ -376,20 +375,20 @@ mod arguments_object {
         ("1", ECMAScriptValue::Undefined, ECMAScriptValue::Undefined),
         ("2", ECMAScriptValue::from("value of 'test'"), ECMAScriptValue::Undefined),
     ]), None)); "unmapped")]
-    #[test_case(|a| {
-        let obj = ArgumentsObject::object(a, None);
-        define_property_or_throw(a, &obj, "key", PotentialPropertyDescriptor::new().value(39).configurable(false)).unwrap();
+    #[test_case(|| {
+        let obj = ArgumentsObject::object(None);
+        define_property_or_throw(&obj, "key", PotentialPropertyDescriptor::new().value(39).configurable(false)).unwrap();
         obj
     }, "key", &["key"] => Ok((false, test_hm(&[("key", ECMAScriptValue::from(39), ECMAScriptValue::Undefined)]), None)); "undeletable")]
-    fn delete(make_object: impl FnOnce(&Agent) -> Object, name: &str, to_check: &[&str]) -> TestResult {
+    fn delete(make_object: impl FnOnce() -> Object, name: &str, to_check: &[&str]) -> TestResult {
         setup_test_agent();
-        let obj = make_object(&agent);
+        let obj = make_object();
         let env = agent
             .current_lexical_environment()
-            .unwrap_or_else(|| agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap());
+            .unwrap_or_else(|| current_realm_record().unwrap().borrow().global_env.clone().unwrap());
         let receiver = ECMAScriptValue::from(obj.clone());
 
-        let result = obj.o.delete(&agent, &name.into()).map_err(|err| unwind_any_error(&agent, err))?;
+        let result = obj.o.delete(&name.into()).map_err(|err| unwind_any_error(err))?;
 
         let values = to_check
             .iter()
@@ -397,9 +396,9 @@ mod arguments_object {
                 (
                     probe.to_string(),
                     (
-                        obj.o.get(&agent, &probe.into(), &receiver).unwrap(),
-                        if env.has_binding(&agent, &probe.into()).unwrap() {
-                            env.get_binding_value(&agent, &probe.into(), false).unwrap()
+                        obj.o.get(&probe.into(), &receiver).unwrap(),
+                        if env.has_binding(&probe.into()).unwrap() {
+                            env.get_binding_value(&probe.into(), false).unwrap()
                         } else {
                             ECMAScriptValue::Undefined
                         },
@@ -454,11 +453,11 @@ mod arguments_object {
     #[test_case(test_ao, "100" => using prop_checker(PotentialPropertyDescriptor::new().value("not in index").writable(true).enumerable(true).configurable(true)); "unmapped value")]
     #[test_case(test_unmapped, "2" => using prop_checker(PotentialPropertyDescriptor::new().value("value of 'test'").writable(true).enumerable(true).configurable(true)); "unmapped obj")]
     #[test_case(test_unmapped, "200" => None; "property not present")]
-    fn get_own_property(make_object: impl FnOnce(&Agent) -> Object, name: &str) -> Option<PropertyDescriptor> {
+    fn get_own_property(make_object: impl FnOnce() -> Object, name: &str) -> Option<PropertyDescriptor> {
         setup_test_agent();
-        let obj = make_object(&agent);
+        let obj = make_object();
 
-        obj.o.get_own_property(&agent, &name.into()).unwrap()
+        obj.o.get_own_property(&name.into()).unwrap()
     }
 
     type DefineOwnPropertyTestResult =
@@ -507,9 +506,9 @@ mod arguments_object {
         ("the", "value of 'the'".into()),
         ("test", "value of 'test'".into()),
     ]))); "adding enumerable")]
-    #[test_case(|a| {
-        let obj = test_ao(a);
-        obj.o.define_own_property(a, "own".into(), PotentialPropertyDescriptor::new().value(0).writable(false).enumerable(true).configurable(false)).unwrap();
+    #[test_case(|| {
+        let obj = test_ao();
+        obj.o.define_own_property("own".into(), PotentialPropertyDescriptor::new().value(0).writable(false).enumerable(true).configurable(false)).unwrap();
         obj
     }, "own", PotentialPropertyDescriptor::new().value(99).configurable(true) => Ok((false, hm(&[
         ("0", "value of 'from'".into()),
@@ -522,11 +521,11 @@ mod arguments_object {
         ("the", "value of 'the'".into()),
         ("test", "value of 'test'".into()),
     ]))); "failed define")]
-    #[test_case(|a| {
-        let obj = test_unmapped(a);
-        let env = a.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+    #[test_case(|| {
+        let obj = test_unmapped();
+        let env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let lexenv = Rc::new(DeclarativeEnvironmentRecord::new(Some(env), "test_unmapped"));
-        a.set_lexical_environment(Some(lexenv as Rc<dyn EnvironmentRecord>));
+        set_lexical_environment(Some(lexenv as Rc<dyn EnvironmentRecord>));
 
         obj
     }, "0", PotentialPropertyDescriptor::new().value(22) => Ok((true, hm(&[
@@ -535,26 +534,26 @@ mod arguments_object {
         ("2", "value of 'test'".into()),
     ]), hm(&[]))); "unmapped")]
     fn define_own_property(
-        make_object: impl FnOnce(&Agent) -> Object,
+        make_object: impl FnOnce() -> Object,
         name: &str,
         desc: PotentialPropertyDescriptor,
     ) -> DefineOwnPropertyTestResult {
         setup_test_agent();
-        let obj = make_object(&agent);
-        let env = agent.current_lexical_environment().unwrap();
+        let obj = make_object();
+        let env = current_lexical_environment().unwrap();
 
-        let result = obj.o.define_own_property(&agent, name.into(), desc).map_err(|e| unwind_any_error(&agent, e))?;
+        let result = obj.o.define_own_property(name.into(), desc).map_err(|e| unwind_any_error(e))?;
 
-        let object_keys = obj.o.own_property_keys(&agent).unwrap();
+        let object_keys = obj.o.own_property_keys().unwrap();
         let items = object_keys
             .iter()
-            .map(|key| (key.to_string(), super::get(&agent, &obj, key).unwrap()))
+            .map(|key| (key.to_string(), super::get(&obj, key).unwrap()))
             .collect::<AHashMap<_, _>>();
 
         let env_items = env
             .binding_names()
             .iter()
-            .map(|key| (key.to_string(), env.get_binding_value(&agent, key, false).unwrap()))
+            .map(|key| (key.to_string(), env.get_binding_value(key, false).unwrap()))
             .collect::<AHashMap<_, _>>();
 
         Ok((result, items, env_items))
@@ -562,26 +561,26 @@ mod arguments_object {
 
     #[test_case(test_ao, "0" => true; "exists")]
     #[test_case(test_ao, "from" => false; "not in ao")]
-    fn has_property(make_object: impl FnOnce(&Agent) -> Object, name: &str) -> bool {
+    fn has_property(make_object: impl FnOnce() -> Object, name: &str) -> bool {
         setup_test_agent();
-        let obj = make_object(&agent);
+        let obj = make_object();
 
-        obj.o.has_property(&agent, &name.into()).unwrap()
+        obj.o.has_property(&name.into()).unwrap()
     }
 
     #[test_case(test_ao => true; "typical")]
-    fn set_prototype_of(make_object: impl FnOnce(&Agent) -> Object) -> bool {
+    fn set_prototype_of(make_object: impl FnOnce() -> Object) -> bool {
         setup_test_agent();
-        let obj = make_object(&agent);
+        let obj = make_object();
 
-        obj.o.set_prototype_of(&agent, None).unwrap()
+        obj.o.set_prototype_of(None).unwrap()
     }
 
     #[test_case(test_ao => true; "typical")]
-    fn prevent_extensions(make_object: impl FnOnce(&Agent) -> Object) -> bool {
+    fn prevent_extensions(make_object: impl FnOnce() -> Object) -> bool {
         setup_test_agent();
-        let obj = make_object(&agent);
+        let obj = make_object();
 
-        obj.o.prevent_extensions(&agent).unwrap()
+        obj.o.prevent_extensions().unwrap()
     }
 }

--- a/src/arrays/tests.rs
+++ b/src/arrays/tests.rs
@@ -24,7 +24,7 @@ mod array_object {
                 Err(err) => Err(unwind_any_error(err)),
                 Ok(obj) => {
                     assert!(obj.is_array().unwrap());
-                    assert_eq!(obj.o.get_prototype_of().unwrap(), Some(agent.intrinsic(IntrinsicId::ArrayPrototype)));
+                    assert_eq!(obj.o.get_prototype_of().unwrap(), Some(intrinsic(IntrinsicId::ArrayPrototype)));
                     Ok(obj.o.common_object_data().borrow().propdump())
                 }
             }
@@ -33,7 +33,7 @@ mod array_object {
         #[test]
         fn proto_specified() {
             setup_test_agent();
-            let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
+            let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
 
             let obj = ArrayObject::create(600, Some(object_proto.clone())).unwrap();
             assert!(obj.is_array().unwrap());
@@ -60,14 +60,14 @@ mod array_object {
         setup_test_agent();
         let a = ArrayObject::create(0, None).unwrap();
         let a_proto = a.o.get_prototype_of().unwrap().unwrap();
-        assert_eq!(a_proto, agent.intrinsic(IntrinsicId::ArrayPrototype));
+        assert_eq!(a_proto, intrinsic(IntrinsicId::ArrayPrototype));
     }
 
     #[test]
     fn set_prototype_of() {
         setup_test_agent();
         let a = ArrayObject::create(0, None).unwrap();
-        let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
+        let obj_proto = intrinsic(IntrinsicId::ObjectPrototype);
         let success = a.o.set_prototype_of(Some(obj_proto.clone())).unwrap();
         assert!(success);
         assert_eq!(obj_proto, a.o.get_prototype_of().unwrap().unwrap());
@@ -281,7 +281,6 @@ mod array_object {
         use test_case::test_case;
 
         fn value_just_once(
-            agent: &Agent,
             this_value: ECMAScriptValue,
             _: Option<&Object>,
             _: &[ECMAScriptValue],
@@ -298,8 +297,8 @@ mod array_object {
             }
         }
         fn screwy_get_value() -> PotentialPropertyDescriptor {
-            let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let function_proto = agent.intrinsic(IntrinsicId::FunctionPrototype);
+            let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+            let function_proto = intrinsic(IntrinsicId::FunctionPrototype);
             let obj = ordinary_object_create(Some(object_proto), &[]);
             let value_of = create_builtin_function(
                 value_just_once,
@@ -325,29 +324,29 @@ mod array_object {
             .unwrap();
             PotentialPropertyDescriptor { value: Some(obj.into()), ..Default::default() }
         }
-        fn readonly(_: &Agent) -> PotentialPropertyDescriptor {
+        fn readonly() -> PotentialPropertyDescriptor {
             PotentialPropertyDescriptor { writable: Some(false), ..Default::default() }
         }
-        fn fraction(_: &Agent) -> PotentialPropertyDescriptor {
+        fn fraction() -> PotentialPropertyDescriptor {
             PotentialPropertyDescriptor { value: Some(1.5.into()), ..Default::default() }
         }
-        fn symbol(a: &Agent) -> PotentialPropertyDescriptor {
-            let sym = a.wks(WksId::Species);
+        fn symbol() -> PotentialPropertyDescriptor {
+            let sym = wks(WksId::Species);
             PotentialPropertyDescriptor { value: Some(sym.into()), ..Default::default() }
         }
-        fn bigger(_: &Agent) -> PotentialPropertyDescriptor {
+        fn bigger() -> PotentialPropertyDescriptor {
             PotentialPropertyDescriptor { value: Some(7000.into()), ..Default::default() }
         }
-        fn configurable_400(_: &Agent) -> PotentialPropertyDescriptor {
+        fn configurable_400() -> PotentialPropertyDescriptor {
             PotentialPropertyDescriptor { value: Some(400.into()), configurable: Some(true), ..Default::default() }
         }
-        fn writable_700(_: &Agent) -> PotentialPropertyDescriptor {
+        fn writable_700() -> PotentialPropertyDescriptor {
             PotentialPropertyDescriptor { value: Some(700.0.into()), writable: Some(true), ..Default::default() }
         }
-        fn readonly_0(_: &Agent) -> PotentialPropertyDescriptor {
+        fn readonly_0() -> PotentialPropertyDescriptor {
             PotentialPropertyDescriptor { value: Some(0.into()), writable: Some(false), ..Default::default() }
         }
-        fn fifty(_: &Agent) -> PotentialPropertyDescriptor {
+        fn fifty() -> PotentialPropertyDescriptor {
             PotentialPropertyDescriptor { value: Some(50.0.into()), ..Default::default() }
         }
 
@@ -557,7 +556,7 @@ mod array_object {
 #[test]
 fn array_create() {
     setup_test_agent();
-    let array_proto = agent.intrinsic(IntrinsicId::ArrayPrototype);
+    let array_proto = intrinsic(IntrinsicId::ArrayPrototype);
     let custom_proto = ordinary_object_create(Some(array_proto), &[]);
     let aobj = super::array_create(231, Some(custom_proto.clone())).unwrap();
     assert_eq!(aobj.o.get_prototype_of().unwrap(), Some(custom_proto));
@@ -566,7 +565,7 @@ fn array_create() {
 }
 
 fn make_ordinary_object() -> ECMAScriptValue {
-    let proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
+    let proto = intrinsic(IntrinsicId::ObjectPrototype);
     ordinary_object_create(Some(proto), &[]).into()
 }
 fn make_array_object() -> ECMAScriptValue {
@@ -590,13 +589,13 @@ mod array_species_create {
     use test_case::test_case;
 
     fn make_ordinary() -> Object {
-        let proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
+        let proto = intrinsic(IntrinsicId::ObjectPrototype);
         ordinary_object_create(Some(proto), &[])
     }
 
     fn make_throwing_constructor_prop() -> Object {
-        let proto = agent.intrinsic(IntrinsicId::ArrayPrototype);
-        let function_proto = agent.intrinsic(IntrinsicId::FunctionPrototype);
+        let proto = intrinsic(IntrinsicId::ArrayPrototype);
+        let function_proto = intrinsic(IntrinsicId::FunctionPrototype);
         let obj = super::super::array_create(0, Some(proto)).unwrap();
         let constructor_getter = create_builtin_function(
             faux_errors,
@@ -623,7 +622,7 @@ mod array_species_create {
         obj
     }
     fn make_undefined_constructor_prop() -> Object {
-        let proto = agent.intrinsic(IntrinsicId::ArrayPrototype);
+        let proto = intrinsic(IntrinsicId::ArrayPrototype);
         let obj = super::super::array_create(0, Some(proto)).unwrap();
         define_property_or_throw(
             &obj,
@@ -640,11 +639,11 @@ mod array_species_create {
         obj
     }
     fn make_plain_array() -> Object {
-        let proto = agent.intrinsic(IntrinsicId::ArrayPrototype);
+        let proto = intrinsic(IntrinsicId::ArrayPrototype);
         super::super::array_create(5, Some(proto)).unwrap()
     }
     fn make_primitive_constructor_prop() -> Object {
-        let proto = agent.intrinsic(IntrinsicId::ArrayPrototype);
+        let proto = intrinsic(IntrinsicId::ArrayPrototype);
         let obj = super::super::array_create(0, Some(proto)).unwrap();
         define_property_or_throw(
             &obj,

--- a/src/arrays/tests.rs
+++ b/src/arrays/tests.rs
@@ -573,10 +573,10 @@ fn make_array_object() -> ECMAScriptValue {
 }
 #[test_case(make_ordinary_object => Ok(false); "ordinary object")]
 #[test_case(make_array_object => Ok(true); "array object")]
-#[test_case(|_| ECMAScriptValue::Undefined => Ok(false); "undefined")]
-#[test_case(|_| ECMAScriptValue::Null => Ok(false); "null")]
-#[test_case(|_| ECMAScriptValue::from(true) => Ok(false); "boolean")]
-#[test_case(|_| ECMAScriptValue::from(33.2) => Ok(false); "number")]
+#[test_case(|| ECMAScriptValue::Undefined => Ok(false); "undefined")]
+#[test_case(|| ECMAScriptValue::Null => Ok(false); "null")]
+#[test_case(|| ECMAScriptValue::from(true) => Ok(false); "boolean")]
+#[test_case(|| ECMAScriptValue::from(33.2) => Ok(false); "number")]
 fn is_array(make_arg: fn() -> ECMAScriptValue) -> Result<bool, String> {
     setup_test_agent();
     let arg = make_arg();

--- a/src/arrays/tests.rs
+++ b/src/arrays/tests.rs
@@ -17,7 +17,7 @@ mod array_object {
         ]); "hundred length")]
         #[test_case(7294967295 => Err("RangeError: Array lengths greater than 4294967295 are not allowed".to_string()); "over limit")]
         fn normal(length: u64) -> Result<Vec<PropertyInfo>, String> {
-            let agent = test_agent();
+            setup_test_agent();
 
             let result = ArrayObject::create(&agent, length, None);
             match result {
@@ -35,7 +35,7 @@ mod array_object {
 
         #[test]
         fn proto_specified() {
-            let agent = test_agent();
+            setup_test_agent();
             let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
 
             let obj = ArrayObject::create(&agent, 600, Some(object_proto.clone())).unwrap();
@@ -46,21 +46,21 @@ mod array_object {
 
     #[test]
     fn debug() {
-        let agent = test_agent();
+        setup_test_agent();
         let a = ArrayObject::create(&agent, 0, None).unwrap();
         assert_ne!(format!("{:?}", a), "");
     }
 
     #[test]
     fn is_ordinary() {
-        let agent = test_agent();
+        setup_test_agent();
         let a = ArrayObject::create(&agent, 0, None).unwrap();
         assert_eq!(a.o.is_ordinary(), true);
     }
 
     #[test]
     fn get_prototype_of() {
-        let agent = test_agent();
+        setup_test_agent();
         let a = ArrayObject::create(&agent, 0, None).unwrap();
         let a_proto = a.o.get_prototype_of(&agent).unwrap().unwrap();
         assert_eq!(a_proto, agent.intrinsic(IntrinsicId::ArrayPrototype));
@@ -68,7 +68,7 @@ mod array_object {
 
     #[test]
     fn set_prototype_of() {
-        let agent = test_agent();
+        setup_test_agent();
         let a = ArrayObject::create(&agent, 0, None).unwrap();
         let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let success = a.o.set_prototype_of(&agent, Some(obj_proto.clone())).unwrap();
@@ -78,20 +78,20 @@ mod array_object {
 
     #[test]
     fn is_extensible() {
-        let agent = test_agent();
+        setup_test_agent();
         let a = ArrayObject::create(&agent, 0, None).unwrap();
         assert!(a.o.is_extensible(&agent).unwrap());
     }
     #[test]
     fn prevent_extensions() {
-        let agent = test_agent();
+        setup_test_agent();
         let a = ArrayObject::create(&agent, 0, None).unwrap();
         assert!(a.o.prevent_extensions(&agent).unwrap());
         assert!(!a.o.is_extensible(&agent).unwrap());
     }
     #[test]
     fn get_own_property() {
-        let agent = test_agent();
+        setup_test_agent();
         let a = ArrayObject::create(&agent, 0, None).unwrap();
         let desc: DataDescriptor = a.o.get_own_property(&agent, &"length".into()).unwrap().unwrap().try_into().unwrap();
 
@@ -127,7 +127,7 @@ mod array_object {
             enumerable: bool,
             configurable: bool,
         ) -> Result<(bool, Vec<PropertyInfo>), String> {
-            let agent = test_agent();
+            setup_test_agent();
             let a = ArrayObject::create(&agent, 0, None).unwrap();
             let result = a.o.define_own_property(
                 &agent,
@@ -160,7 +160,7 @@ mod array_object {
             enumerable: bool,
             configurable: bool,
         ) -> Result<(bool, Vec<PropertyInfo>), String> {
-            let agent = test_agent();
+            setup_test_agent();
             let a = ArrayObject::create(&agent, 100, None).unwrap();
             // Make the length property read-only
             a.o.define_own_property(
@@ -189,7 +189,7 @@ mod array_object {
 
         #[test]
         fn read_only_elem() {
-            let agent = test_agent();
+            setup_test_agent();
             let a = ArrayObject::create(&agent, 100, None).unwrap();
             // Make a read-only property with an array index
             a.o.define_own_property(
@@ -242,13 +242,13 @@ mod array_object {
 
     #[test]
     fn has_property() {
-        let agent = test_agent();
+        setup_test_agent();
         let a = ArrayObject::create(&agent, 0, None).unwrap();
         assert!(a.o.has_property(&agent, &"length".into()).unwrap());
     }
     #[test]
     fn get() {
-        let agent = test_agent();
+        setup_test_agent();
         let a = ArrayObject::create(&agent, 0, None).unwrap();
         let receiver: ECMAScriptValue = a.clone().into();
         let val = a.o.get(&agent, &"length".into(), &receiver).unwrap();
@@ -256,7 +256,7 @@ mod array_object {
     }
     #[test]
     fn set_() {
-        let agent = test_agent();
+        setup_test_agent();
         let a = ArrayObject::create(&agent, 0, None).unwrap();
         let receiver: ECMAScriptValue = a.clone().into();
         let success = a.o.set(&agent, "length".into(), 100.into(), &receiver).unwrap();
@@ -265,21 +265,21 @@ mod array_object {
     }
     #[test]
     fn delete() {
-        let agent = test_agent();
+        setup_test_agent();
         let a = ArrayObject::create(&agent, 0, None).unwrap();
         let success = a.o.delete(&agent, &"length".into()).unwrap();
         assert!(!success);
     }
     #[test]
     fn own_property_keys() {
-        let agent = test_agent();
+        setup_test_agent();
         let a = ArrayObject::create(&agent, 0, None).unwrap();
         let list = a.o.own_property_keys(&agent).unwrap();
         assert_eq!(list, vec!["length".into()]);
     }
     #[test]
     fn is_array_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let a = ArrayObject::create(&agent, 0, None).unwrap();
         assert!(a.o.is_array_object());
     }
@@ -385,7 +385,7 @@ mod array_object {
         fn zero_elements(
             make_desc: fn(&Agent) -> PotentialPropertyDescriptor,
         ) -> Result<(bool, Vec<PropertyInfo>), String> {
-            let agent = test_agent();
+            setup_test_agent();
             let aobj = ArrayObject::create(&agent, 0, None).unwrap();
             let a = aobj.o.to_array_object().unwrap();
             let desc = make_desc(&agent);
@@ -397,7 +397,7 @@ mod array_object {
 
         #[test]
         fn readonly_length() {
-            let agent = test_agent();
+            setup_test_agent();
             let aobj = ArrayObject::create(&agent, 9000, None).unwrap();
             define_property_or_throw(
                 &agent,
@@ -489,7 +489,7 @@ mod array_object {
         fn three_elements(
             make_desc: fn(&Agent) -> PotentialPropertyDescriptor,
         ) -> Result<(bool, Vec<PropertyInfo>), String> {
-            let agent = test_agent();
+            setup_test_agent();
             let aobj = ArrayObject::create(&agent, 9000, None).unwrap();
             set(&agent, &aobj, "0".into(), "blue".into(), true).unwrap();
             set(&agent, &aobj, "100".into(), "green".into(), true).unwrap();
@@ -545,7 +545,7 @@ mod array_object {
         fn frozen_middle(
             make_desc: fn(&Agent) -> PotentialPropertyDescriptor,
         ) -> Result<(bool, Vec<PropertyInfo>), String> {
-            let agent = test_agent();
+            setup_test_agent();
             let aobj = ArrayObject::create(&agent, 9000, None).unwrap();
             set(&agent, &aobj, "0".into(), "blue".into(), true).unwrap();
             define_property_or_throw(
@@ -574,7 +574,7 @@ mod array_object {
 
 #[test]
 fn array_create() {
-    let agent = test_agent();
+    setup_test_agent();
     let array_proto = agent.intrinsic(IntrinsicId::ArrayPrototype);
     let custom_proto = ordinary_object_create(&agent, Some(array_proto), &[]);
     let aobj = super::array_create(&agent, 231, Some(custom_proto.clone())).unwrap();
@@ -597,7 +597,7 @@ fn make_array_object(agent: &Agent) -> ECMAScriptValue {
 #[test_case(|_| ECMAScriptValue::from(true) => Ok(false); "boolean")]
 #[test_case(|_| ECMAScriptValue::from(33.2) => Ok(false); "number")]
 fn is_array(make_arg: fn(&Agent) -> ECMAScriptValue) -> Result<bool, String> {
-    let agent = test_agent();
+    setup_test_agent();
     let arg = make_arg(&agent);
 
     super::is_array(&agent, &arg).map_err(|err| unwind_any_error(&agent, err))
@@ -712,7 +712,7 @@ mod array_species_create {
     ]); "plain array")]
     #[test_case(make_primitive_constructor_prop, 10 => Err("TypeError: Array species constructor invalid".to_string()); "primitive in constructor")]
     fn f(make_original: fn(&Agent) -> Object, length: u64) -> Result<Vec<PropertyInfo>, String> {
-        let agent = test_agent();
+        setup_test_agent();
         let original = make_original(&agent);
         array_species_create(&agent, &original, length)
             .map(|val| Object::try_from(val).unwrap().o.common_object_data().borrow().propdump())
@@ -730,7 +730,7 @@ mod array_species_create {
 fn defaults() {
     // These don't really test anything except the default implementations, but it does clear a fair few instantiations
     // out of the "uncovered" set.
-    let agent = test_agent();
+    setup_test_agent();
     let a = super::array_create(&agent, 10, None).unwrap();
     assert_eq!(a.o.is_date_object(), false);
     assert!(a.o.to_function_obj().is_none());
@@ -787,6 +787,6 @@ fn defaults() {
 #[test_case(super::array_prototype_unshift => panics; "array_prototype_unshift")]
 #[test_case(super::array_prototype_values => panics; "array_prototype_values")]
 fn todo(f: fn(&Agent, ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion<ECMAScriptValue>) {
-    let agent = test_agent();
+    setup_test_agent();
     f(&agent, ECMAScriptValue::Undefined, None, &[]).unwrap();
 }

--- a/src/arrays/tests.rs
+++ b/src/arrays/tests.rs
@@ -377,9 +377,7 @@ mod array_object {
             let a = aobj.o.to_array_object().unwrap();
             let desc = make_desc();
 
-            a.set_length(desc)
-                .map(|success| (success, a.common.borrow().propdump()))
-                .map_err(|err| unwind_any_error(err))
+            a.set_length(desc).map(|success| (success, a.common.borrow().propdump())).map_err(unwind_any_error)
         }
 
         #[test]
@@ -397,7 +395,7 @@ mod array_object {
             let result = a
                 .set_length(PotentialPropertyDescriptor { value: Some(1000.0.into()), ..Default::default() })
                 .map(|success| (success, a.common.borrow().propdump()))
-                .map_err(|err| unwind_any_error(err));
+                .map_err(unwind_any_error);
             assert_eq!(
                 result,
                 Ok((
@@ -481,9 +479,7 @@ mod array_object {
             let a = aobj.o.to_array_object().unwrap();
             let desc = make_desc();
 
-            a.set_length(desc)
-                .map(|success| (success, a.common.borrow().propdump()))
-                .map_err(|err| unwind_any_error(err))
+            a.set_length(desc).map(|success| (success, a.common.borrow().propdump())).map_err(unwind_any_error)
         }
 
         #[test_case(fifty => Ok((false, vec![
@@ -546,9 +542,7 @@ mod array_object {
             let a = aobj.o.to_array_object().unwrap();
             let desc = make_desc();
 
-            a.set_length(desc)
-                .map(|success| (success, a.common.borrow().propdump()))
-                .map_err(|err| unwind_any_error(err))
+            a.set_length(desc).map(|success| (success, a.common.borrow().propdump())).map_err(unwind_any_error)
         }
     }
 }
@@ -581,7 +575,7 @@ fn is_array(make_arg: fn() -> ECMAScriptValue) -> Result<bool, String> {
     setup_test_agent();
     let arg = make_arg();
 
-    super::is_array(&arg).map_err(|err| unwind_any_error(err))
+    super::is_array(&arg).map_err(unwind_any_error)
 }
 
 mod array_species_create {
@@ -693,7 +687,7 @@ mod array_species_create {
         let original = make_original();
         array_species_create(&original, length)
             .map(|val| Object::try_from(val).unwrap().o.common_object_data().borrow().propdump())
-            .map_err(|err| unwind_any_error(err))
+            .map_err(unwind_any_error)
     }
 
     // todo!(): More tests want to be here to cover other code paths, but those code paths require:

--- a/src/bigint_object/mod.rs
+++ b/src/bigint_object/mod.rs
@@ -2,6 +2,6 @@ use super::*;
 use num::BigInt;
 use std::rc::Rc;
 
-pub fn create_bigint_object(_agent: &Agent, _b: Rc<BigInt>) -> Object {
+pub fn create_bigint_object(_b: Rc<BigInt>) -> Object {
     todo!()
 }

--- a/src/boolean_object/tests.rs
+++ b/src/boolean_object/tests.rs
@@ -4,7 +4,7 @@ use crate::tests::*;
 #[test]
 fn create_boolean_object_01() {
     setup_test_agent();
-    let result = create_boolean_object(&agent, true);
+    let result = create_boolean_object(true);
 
     let maybe_native = result.o.to_boolean_obj();
     assert!(maybe_native.is_some());
@@ -16,7 +16,7 @@ fn create_boolean_object_01() {
 #[test]
 fn create_boolean_object_02() {
     setup_test_agent();
-    let result = create_boolean_object(&agent, false);
+    let result = create_boolean_object(false);
 
     let maybe_native = result.o.to_boolean_obj();
     assert!(maybe_native.is_some());
@@ -28,38 +28,38 @@ fn create_boolean_object_02() {
 #[test]
 fn this_boolean_value_01() {
     setup_test_agent();
-    let result = this_boolean_value(&agent, &ECMAScriptValue::Boolean(true));
+    let result = this_boolean_value(&ECMAScriptValue::Boolean(true));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), true);
 }
 #[test]
 fn this_boolean_value_02() {
     setup_test_agent();
-    let result = this_boolean_value(&agent, &ECMAScriptValue::Boolean(false));
+    let result = this_boolean_value(&ECMAScriptValue::Boolean(false));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), false);
 }
 #[test]
 fn this_boolean_value_03() {
     setup_test_agent();
-    let result = this_boolean_value(&agent, &ECMAScriptValue::Null);
+    let result = this_boolean_value(&ECMAScriptValue::Null);
     assert!(result.is_err());
-    let msg = unwind_type_error(&agent, result.unwrap_err());
+    let msg = unwind_type_error(result.unwrap_err());
     assert_eq!(msg, "Value is not boolean");
 }
 #[test]
 fn this_boolean_value_04() {
     setup_test_agent();
-    let bool_obj = create_boolean_object(&agent, true);
-    let result = this_boolean_value(&agent, &ECMAScriptValue::Object(bool_obj));
+    let bool_obj = create_boolean_object(true);
+    let result = this_boolean_value(&ECMAScriptValue::Object(bool_obj));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), true);
 }
 #[test]
 fn this_boolean_value_05() {
     setup_test_agent();
-    let bool_obj = create_boolean_object(&agent, false);
-    let result = this_boolean_value(&agent, &ECMAScriptValue::Object(bool_obj));
+    let bool_obj = create_boolean_object(false);
+    let result = this_boolean_value(&ECMAScriptValue::Object(bool_obj));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), false);
 }
@@ -67,62 +67,61 @@ fn this_boolean_value_05() {
 #[test]
 fn this_boolean_value_06() {
     setup_test_agent();
-    let proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let other_obj = ordinary_object_create(&agent, Some(proto), &[]);
-    let result = this_boolean_value(&agent, &ECMAScriptValue::Object(other_obj));
+    let proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let other_obj = ordinary_object_create(Some(proto), &[]);
+    let result = this_boolean_value(&ECMAScriptValue::Object(other_obj));
     assert!(result.is_err());
-    let msg = unwind_type_error(&agent, result.unwrap_err());
+    let msg = unwind_type_error(result.unwrap_err());
     assert_eq!(msg, "Object has no boolean value");
 }
 
 #[test]
 fn get_prototype_of_01() {
     setup_test_agent();
-    let bool_obj = create_boolean_object(&agent, true);
-    let proto = bool_obj.o.get_prototype_of(&agent).unwrap().unwrap();
-    assert_eq!(proto, agent.intrinsic(IntrinsicId::BooleanPrototype));
+    let bool_obj = create_boolean_object(true);
+    let proto = bool_obj.o.get_prototype_of().unwrap().unwrap();
+    assert_eq!(proto, intrinsic(IntrinsicId::BooleanPrototype));
 }
 
 #[test]
 fn set_prototype_of_01() {
     setup_test_agent();
-    let bool_obj = create_boolean_object(&agent, true);
-    let res = bool_obj.o.set_prototype_of(&agent, None).unwrap();
+    let bool_obj = create_boolean_object(true);
+    let res = bool_obj.o.set_prototype_of(None).unwrap();
     assert!(res);
-    assert!(bool_obj.o.get_prototype_of(&agent).unwrap().is_none());
+    assert!(bool_obj.o.get_prototype_of().unwrap().is_none());
 }
 
 #[test]
 fn is_extensible_01() {
     setup_test_agent();
-    let bool_obj = create_boolean_object(&agent, true);
-    let res = bool_obj.o.is_extensible(&agent).unwrap();
+    let bool_obj = create_boolean_object(true);
+    let res = bool_obj.o.is_extensible().unwrap();
     assert!(res);
 }
 
 #[test]
 fn prevent_extensions_01() {
     setup_test_agent();
-    let bool_obj = create_boolean_object(&agent, true);
-    let res = bool_obj.o.prevent_extensions(&agent).unwrap();
+    let bool_obj = create_boolean_object(true);
+    let res = bool_obj.o.prevent_extensions().unwrap();
     assert!(res);
-    assert!(!bool_obj.o.is_extensible(&agent).unwrap());
+    assert!(!bool_obj.o.is_extensible().unwrap());
 }
 
 #[test]
 fn define_and_get_own_property_01() {
     setup_test_agent();
-    let bool_obj = create_boolean_object(&agent, true);
+    let bool_obj = create_boolean_object(true);
     let res = bool_obj
         .o
         .define_own_property(
-            &agent,
             PropertyKey::from("rust"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from("is awesome")), ..Default::default() },
         )
         .unwrap();
     assert!(res);
-    let val = bool_obj.o.get_own_property(&agent, &PropertyKey::from("rust")).unwrap().unwrap();
+    let val = bool_obj.o.get_own_property(&PropertyKey::from("rust")).unwrap().unwrap();
     assert_eq!(val.enumerable, false);
     assert_eq!(val.configurable, false);
     assert!(matches!(val.property, PropertyKind::Data(..)));
@@ -135,62 +134,62 @@ fn define_and_get_own_property_01() {
 #[test]
 fn has_property_01() {
     setup_test_agent();
-    let bool_obj = create_boolean_object(&agent, true);
-    let res = bool_obj.o.has_property(&agent, &PropertyKey::from("rust")).unwrap();
+    let bool_obj = create_boolean_object(true);
+    let res = bool_obj.o.has_property(&PropertyKey::from("rust")).unwrap();
     assert_eq!(res, false);
-    let res2 = bool_obj.o.has_property(&agent, &PropertyKey::from("constructor")).unwrap();
+    let res2 = bool_obj.o.has_property(&PropertyKey::from("constructor")).unwrap();
     assert_eq!(res2, true);
 }
 
 #[test]
 fn get_01() {
     setup_test_agent();
-    let bool_obj = create_boolean_object(&agent, true);
-    let res = bool_obj.o.get(&agent, &PropertyKey::from("rust"), &ECMAScriptValue::Undefined).unwrap();
+    let bool_obj = create_boolean_object(true);
+    let res = bool_obj.o.get(&PropertyKey::from("rust"), &ECMAScriptValue::Undefined).unwrap();
     assert_eq!(res, ECMAScriptValue::Undefined);
-    let res2 = bool_obj.o.get(&agent, &PropertyKey::from("constructor"), &ECMAScriptValue::Undefined).unwrap();
+    let res2 = bool_obj.o.get(&PropertyKey::from("constructor"), &ECMAScriptValue::Undefined).unwrap();
     assert!(matches!(res2, ECMAScriptValue::Object(..)));
     if let ECMAScriptValue::Object(obj) = res2 {
-        assert_eq!(obj, agent.intrinsic(IntrinsicId::Boolean));
+        assert_eq!(obj, intrinsic(IntrinsicId::Boolean));
     }
 }
 
 #[test]
 fn set_01() {
     setup_test_agent();
-    let bool_obj = create_boolean_object(&agent, true);
+    let bool_obj = create_boolean_object(true);
     let receiver = ECMAScriptValue::Object(bool_obj.clone());
-    let res = bool_obj.o.set(&agent, PropertyKey::from("rust"), ECMAScriptValue::Null, &receiver).unwrap();
+    let res = bool_obj.o.set(PropertyKey::from("rust"), ECMAScriptValue::Null, &receiver).unwrap();
     assert_eq!(res, true);
 }
 
 #[test]
 fn delete_01() {
     setup_test_agent();
-    let bool_obj = create_boolean_object(&agent, true);
-    let res = bool_obj.o.delete(&agent, &PropertyKey::from("rust")).unwrap();
+    let bool_obj = create_boolean_object(true);
+    let res = bool_obj.o.delete(&PropertyKey::from("rust")).unwrap();
     assert_eq!(res, true);
 }
 
 #[test]
 fn own_keys_01() {
     setup_test_agent();
-    let bool_obj = create_boolean_object(&agent, true);
-    let res = bool_obj.o.own_property_keys(&agent).unwrap();
+    let bool_obj = create_boolean_object(true);
+    let res = bool_obj.o.own_property_keys().unwrap();
     assert!(res.is_empty())
 }
 
 #[test]
 fn is_ordinary_01() {
     setup_test_agent();
-    let bool_obj = create_boolean_object(&agent, true);
+    let bool_obj = create_boolean_object(true);
     assert_eq!(bool_obj.o.is_ordinary(), true);
 }
 
 #[test]
 fn bool_object_checks() {
     setup_test_agent();
-    let bool_obj = create_boolean_object(&agent, true);
+    let bool_obj = create_boolean_object(true);
     assert_eq!(bool_obj.o.is_boolean_object(), true);
     assert_eq!(bool_obj.o.is_callable_obj(), false);
     assert_eq!(bool_obj.o.is_string_object(), false);
@@ -207,6 +206,6 @@ fn bool_object_checks() {
 #[test]
 fn bool_object_debug() {
     setup_test_agent();
-    let bool_obj = create_boolean_object(&agent, true);
+    let bool_obj = create_boolean_object(true);
     assert_ne!(format!("{:?}", bool_obj), "");
 }

--- a/src/boolean_object/tests.rs
+++ b/src/boolean_object/tests.rs
@@ -3,7 +3,7 @@ use crate::tests::*;
 
 #[test]
 fn create_boolean_object_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let result = create_boolean_object(&agent, true);
 
     let maybe_native = result.o.to_boolean_obj();
@@ -15,7 +15,7 @@ fn create_boolean_object_01() {
 
 #[test]
 fn create_boolean_object_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let result = create_boolean_object(&agent, false);
 
     let maybe_native = result.o.to_boolean_obj();
@@ -27,21 +27,21 @@ fn create_boolean_object_02() {
 
 #[test]
 fn this_boolean_value_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let result = this_boolean_value(&agent, &ECMAScriptValue::Boolean(true));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), true);
 }
 #[test]
 fn this_boolean_value_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let result = this_boolean_value(&agent, &ECMAScriptValue::Boolean(false));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), false);
 }
 #[test]
 fn this_boolean_value_03() {
-    let agent = test_agent();
+    setup_test_agent();
     let result = this_boolean_value(&agent, &ECMAScriptValue::Null);
     assert!(result.is_err());
     let msg = unwind_type_error(&agent, result.unwrap_err());
@@ -49,7 +49,7 @@ fn this_boolean_value_03() {
 }
 #[test]
 fn this_boolean_value_04() {
-    let agent = test_agent();
+    setup_test_agent();
     let bool_obj = create_boolean_object(&agent, true);
     let result = this_boolean_value(&agent, &ECMAScriptValue::Object(bool_obj));
     assert!(result.is_ok());
@@ -57,7 +57,7 @@ fn this_boolean_value_04() {
 }
 #[test]
 fn this_boolean_value_05() {
-    let agent = test_agent();
+    setup_test_agent();
     let bool_obj = create_boolean_object(&agent, false);
     let result = this_boolean_value(&agent, &ECMAScriptValue::Object(bool_obj));
     assert!(result.is_ok());
@@ -66,7 +66,7 @@ fn this_boolean_value_05() {
 
 #[test]
 fn this_boolean_value_06() {
-    let agent = test_agent();
+    setup_test_agent();
     let proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let other_obj = ordinary_object_create(&agent, Some(proto), &[]);
     let result = this_boolean_value(&agent, &ECMAScriptValue::Object(other_obj));
@@ -77,7 +77,7 @@ fn this_boolean_value_06() {
 
 #[test]
 fn get_prototype_of_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let bool_obj = create_boolean_object(&agent, true);
     let proto = bool_obj.o.get_prototype_of(&agent).unwrap().unwrap();
     assert_eq!(proto, agent.intrinsic(IntrinsicId::BooleanPrototype));
@@ -85,7 +85,7 @@ fn get_prototype_of_01() {
 
 #[test]
 fn set_prototype_of_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let bool_obj = create_boolean_object(&agent, true);
     let res = bool_obj.o.set_prototype_of(&agent, None).unwrap();
     assert!(res);
@@ -94,7 +94,7 @@ fn set_prototype_of_01() {
 
 #[test]
 fn is_extensible_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let bool_obj = create_boolean_object(&agent, true);
     let res = bool_obj.o.is_extensible(&agent).unwrap();
     assert!(res);
@@ -102,7 +102,7 @@ fn is_extensible_01() {
 
 #[test]
 fn prevent_extensions_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let bool_obj = create_boolean_object(&agent, true);
     let res = bool_obj.o.prevent_extensions(&agent).unwrap();
     assert!(res);
@@ -111,7 +111,7 @@ fn prevent_extensions_01() {
 
 #[test]
 fn define_and_get_own_property_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let bool_obj = create_boolean_object(&agent, true);
     let res = bool_obj
         .o
@@ -134,7 +134,7 @@ fn define_and_get_own_property_01() {
 
 #[test]
 fn has_property_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let bool_obj = create_boolean_object(&agent, true);
     let res = bool_obj.o.has_property(&agent, &PropertyKey::from("rust")).unwrap();
     assert_eq!(res, false);
@@ -144,7 +144,7 @@ fn has_property_01() {
 
 #[test]
 fn get_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let bool_obj = create_boolean_object(&agent, true);
     let res = bool_obj.o.get(&agent, &PropertyKey::from("rust"), &ECMAScriptValue::Undefined).unwrap();
     assert_eq!(res, ECMAScriptValue::Undefined);
@@ -157,7 +157,7 @@ fn get_01() {
 
 #[test]
 fn set_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let bool_obj = create_boolean_object(&agent, true);
     let receiver = ECMAScriptValue::Object(bool_obj.clone());
     let res = bool_obj.o.set(&agent, PropertyKey::from("rust"), ECMAScriptValue::Null, &receiver).unwrap();
@@ -166,7 +166,7 @@ fn set_01() {
 
 #[test]
 fn delete_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let bool_obj = create_boolean_object(&agent, true);
     let res = bool_obj.o.delete(&agent, &PropertyKey::from("rust")).unwrap();
     assert_eq!(res, true);
@@ -174,7 +174,7 @@ fn delete_01() {
 
 #[test]
 fn own_keys_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let bool_obj = create_boolean_object(&agent, true);
     let res = bool_obj.o.own_property_keys(&agent).unwrap();
     assert!(res.is_empty())
@@ -182,14 +182,14 @@ fn own_keys_01() {
 
 #[test]
 fn is_ordinary_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let bool_obj = create_boolean_object(&agent, true);
     assert_eq!(bool_obj.o.is_ordinary(), true);
 }
 
 #[test]
 fn bool_object_checks() {
-    let agent = test_agent();
+    setup_test_agent();
     let bool_obj = create_boolean_object(&agent, true);
     assert_eq!(bool_obj.o.is_boolean_object(), true);
     assert_eq!(bool_obj.o.is_callable_obj(), false);
@@ -206,7 +206,7 @@ fn bool_object_checks() {
 }
 #[test]
 fn bool_object_debug() {
-    let agent = test_agent();
+    setup_test_agent();
     let bool_obj = create_boolean_object(&agent, true);
     assert_ne!(format!("{:?}", bool_obj), "");
 }

--- a/src/comparison/mod.rs
+++ b/src/comparison/mod.rs
@@ -26,10 +26,10 @@ use super::*;
 // +---------------+------------------------------+
 //
 // https://tc39.es/ecma262/#sec-requireobjectcoercible
-pub fn require_object_coercible(agent: &Agent, argument: &ECMAScriptValue) -> Completion<()> {
+pub fn require_object_coercible(argument: &ECMAScriptValue) -> Completion<()> {
     match argument {
         ECMAScriptValue::Undefined | ECMAScriptValue::Null => {
-            Err(create_type_error(agent, "Undefined and null are not allowed in this context"))
+            Err(create_type_error("Undefined and null are not allowed in this context"))
         }
         _ => Ok(()),
     }
@@ -43,11 +43,11 @@ pub fn require_object_coercible(agent: &Agent, argument: &ECMAScriptValue) -> Co
 //
 //  1. Assert: Type(O) is Object.
 //  2. Return ? O.[[IsExtensible]]().
-pub fn is_extensible<'a, T>(agent: &Agent, obj: T) -> Completion<bool>
+pub fn is_extensible<'a, T>(obj: T) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
-    obj.into().is_extensible(agent)
+    obj.into().is_extensible()
 }
 
 // IsIntegralNumber ( argument )

--- a/src/comparison/tests.rs
+++ b/src/comparison/tests.rs
@@ -23,7 +23,7 @@ mod require_object_coercible {
     #[test_case(|_| BigInt::from(10).into() => Ok(()); "bigint")]
     #[test_case(|a| ordinary_object_create(a, None, &[]).into() => Ok(()); "object")]
     fn roc(make_arg: fn(&Agent) -> ECMAScriptValue) -> Result<(), String> {
-        let agent = test_agent();
+        setup_test_agent();
         let arg = make_arg(&agent);
 
         require_object_coercible(&agent, &arg).map_err(|err| unwind_any_error(&agent, err))

--- a/src/comparison/tests.rs
+++ b/src/comparison/tests.rs
@@ -23,5 +23,5 @@ fn require_object_coercible(make_arg: fn() -> ECMAScriptValue) -> Result<(), Str
     setup_test_agent();
     let arg = make_arg();
 
-    super::require_object_coercible(&arg).map_err(|err| unwind_any_error(err))
+    super::require_object_coercible(&arg).map_err(unwind_any_error)
 }

--- a/src/comparison/tests.rs
+++ b/src/comparison/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::tests::*;
 use num::bigint::BigInt;
+use test_case::test_case;
 
 #[test]
 fn is_integral_number_test() {
@@ -10,22 +11,17 @@ fn is_integral_number_test() {
     assert!(!is_integral_number(&ECMAScriptValue::from(f64::INFINITY)));
 }
 
-mod require_object_coercible {
-    use super::*;
-    use test_case::test_case;
+#[test_case(|| ECMAScriptValue::Undefined => Err("TypeError: Undefined and null are not allowed in this context".to_string()); "undefined")]
+#[test_case(|| ECMAScriptValue::Null => Err("TypeError: Undefined and null are not allowed in this context".to_string()); "null")]
+#[test_case(|| true.into() => Ok(()); "boolean")]
+#[test_case(|| 200.2.into() => Ok(()); "number")]
+#[test_case(|| "green".into() => Ok(()); "string")]
+#[test_case(|| wks(WksId::Species).into() => Ok(()); "symbol")]
+#[test_case(|| BigInt::from(10).into() => Ok(()); "bigint")]
+#[test_case(|| ordinary_object_create(None, &[]).into() => Ok(()); "object")]
+fn require_object_coercible(make_arg: fn() -> ECMAScriptValue) -> Result<(), String> {
+    setup_test_agent();
+    let arg = make_arg();
 
-    #[test_case(|_| ECMAScriptValue::Undefined => Err("TypeError: Undefined and null are not allowed in this context".to_string()); "undefined")]
-    #[test_case(|_| ECMAScriptValue::Null => Err("TypeError: Undefined and null are not allowed in this context".to_string()); "null")]
-    #[test_case(|_| true.into() => Ok(()); "boolean")]
-    #[test_case(|_| 200.2.into() => Ok(()); "number")]
-    #[test_case(|_| "green".into() => Ok(()); "string")]
-    #[test_case(|a| a.wks(WksId::Species).into() => Ok(()); "symbol")]
-    #[test_case(|_| BigInt::from(10).into() => Ok(()); "bigint")]
-    #[test_case(|a| ordinary_object_create(a, None, &[]).into() => Ok(()); "object")]
-    fn roc(make_arg: fn(&Agent) -> ECMAScriptValue) -> Result<(), String> {
-        setup_test_agent();
-        let arg = make_arg(&agent);
-
-        require_object_coercible(&agent, &arg).map_err(|err| unwind_any_error(&agent, err))
-    }
+    super::require_object_coercible(&arg).map_err(|err| unwind_any_error(err))
 }

--- a/src/control_abstraction/mod.rs
+++ b/src/control_abstraction/mod.rs
@@ -3,219 +3,208 @@ use std::cell::RefCell;
 use std::error::Error;
 use std::fmt;
 
-impl Agent {
-    pub fn provision_iterator_prototype(&self, realm: &Rc<RefCell<Realm>>) {
-        let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
-        let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
+pub fn provision_iterator_prototype(realm: &Rc<RefCell<Realm>>) {
+    let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
+    let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
-        // The %IteratorPrototype% Object
-        //
-        // The %IteratorPrototype% object:
-        //
-        //  * has a [[Prototype]] internal slot whose value is %Object.prototype%.
-        //  * is an ordinary object.
-        //
-        // NOTE All objects defined in this specification that implement the Iterator interface also inherit
-        // from %IteratorPrototype%. ECMAScript code may also define objects that inherit from
-        // %IteratorPrototype%. The %IteratorPrototype% object provides a place where additional methods that
-        // are applicable to all iterator objects may be added.
-        //
-        // The following expression is one way that ECMAScript code can access the %IteratorPrototype% object:
-        //
-        //      Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()))
+    // The %IteratorPrototype% Object
+    //
+    // The %IteratorPrototype% object:
+    //
+    //  * has a [[Prototype]] internal slot whose value is %Object.prototype%.
+    //  * is an ordinary object.
+    //
+    // NOTE All objects defined in this specification that implement the Iterator interface also inherit
+    // from %IteratorPrototype%. ECMAScript code may also define objects that inherit from
+    // %IteratorPrototype%. The %IteratorPrototype% object provides a place where additional methods that
+    // are applicable to all iterator objects may be added.
+    //
+    // The following expression is one way that ECMAScript code can access the %IteratorPrototype% object:
+    //
+    //      Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()))
 
-        let iterator_prototype = ordinary_object_create(self, Some(object_prototype), &[]);
+    let iterator_prototype = ordinary_object_create(Some(object_prototype), &[]);
 
-        // Prototype Function Properties
-        macro_rules! prototype_function {
-            ( $steps:expr, $name:expr, $length:expr ) => {
-                let key = PropertyKey::from($name);
-                let function_object = create_builtin_function(
-                    self,
-                    $steps,
-                    false,
-                    $length,
-                    key.clone(),
-                    BUILTIN_FUNCTION_SLOTS,
-                    Some(realm.clone()),
-                    Some(function_prototype.clone()),
-                    None,
-                );
-                define_property_or_throw(
-                    self,
-                    &iterator_prototype,
-                    key,
-                    PotentialPropertyDescriptor::new()
-                        .value(function_object)
-                        .writable(true)
-                        .enumerable(false)
-                        .configurable(true),
-                )
-                .unwrap();
-            };
-        }
-        prototype_function!(iterator_prototype_iterator, self.wks(WksId::Iterator), 0.0);
+    // Prototype Function Properties
+    macro_rules! prototype_function {
+        ( $steps:expr, $name:expr, $length:expr ) => {
+            let key = PropertyKey::from($name);
+            let function_object = create_builtin_function(
+                $steps,
+                false,
+                $length,
+                key.clone(),
+                BUILTIN_FUNCTION_SLOTS,
+                Some(realm.clone()),
+                Some(function_prototype.clone()),
+                None,
+            );
+            define_property_or_throw(
+                &iterator_prototype,
+                key,
+                PotentialPropertyDescriptor::new()
+                    .value(function_object)
+                    .writable(true)
+                    .enumerable(false)
+                    .configurable(true),
+            )
+            .unwrap();
+        };
+    }
+    prototype_function!(iterator_prototype_iterator, wks(WksId::Iterator), 0.0);
 
-        realm.borrow_mut().intrinsics.iterator_prototype = iterator_prototype;
+    realm.borrow_mut().intrinsics.iterator_prototype = iterator_prototype;
+}
+
+pub fn provision_generator_function_intrinsics(realm: &Rc<RefCell<Realm>>) {
+    let function = realm.borrow().intrinsics.function.clone();
+    let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
+    let iterator_prototype = realm.borrow().intrinsics.iterator_prototype.clone();
+
+    // The GeneratorFunction Constructor
+    //
+    // The GeneratorFunction constructor:
+    //
+    //  * is %GeneratorFunction%.
+    //  * is a subclass of Function.
+    //  * creates and initializes a new GeneratorFunction when called as a function rather than as a
+    //    constructor. Thus the function call GeneratorFunction (…) is equivalent to the object creation
+    //    expression new GeneratorFunction (…) with the same arguments.
+    //  * may be used as the value of an extends clause of a class definition. Subclass constructors that
+    //    intend to inherit the specified GeneratorFunction behaviour must include a super call to the
+    //    GeneratorFunction constructor to create and initialize subclass instances with the internal
+    //    slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for
+    //    defining generator function objects create direct instances of GeneratorFunction. There is no
+    //    syntactic means to create instances of GeneratorFunction subclasses.
+
+    // Properties of the GeneratorFunction Constructor
+    //
+    // The GeneratorFunction constructor:
+    //
+    //  * is a standard built-in function object that inherits from the Function constructor.
+    //  * has a [[Prototype]] internal slot whose value is %Function%.
+    //  * has a "name" property whose value is "GeneratorFunction".
+    let generator_function_constructor = create_builtin_function(
+        generator_function,
+        true,
+        1.0,
+        "GeneratorFunction".into(),
+        BUILTIN_FUNCTION_SLOTS,
+        Some(realm.clone()),
+        Some(function),
+        None,
+    );
+
+    macro_rules! constructor_data {
+        ( $name:expr, $value:expr, $writable:expr, $enumerable:expr, $configurable:expr ) => {
+            define_property_or_throw(
+                &generator_function_constructor,
+                $name,
+                PotentialPropertyDescriptor::new()
+                    .value(ECMAScriptValue::from($value))
+                    .writable($writable)
+                    .enumerable($enumerable)
+                    .configurable($configurable),
+            )
+            .unwrap();
+        };
     }
 
-    pub fn provision_generator_function_intrinsics(&self, realm: &Rc<RefCell<Realm>>) {
-        let function = realm.borrow().intrinsics.function.clone();
-        let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
-        let iterator_prototype = realm.borrow().intrinsics.iterator_prototype.clone();
+    // Properties of the GeneratorFunction Prototype Object
+    //
+    // The GeneratorFunction prototype object:
+    //
+    //  * is %GeneratorFunction.prototype% (see Figure 6).
+    //  * is an ordinary object.
+    //  * is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of
+    //    the internal slots listed in Table 33 or Table 86.
+    //  * has a [[Prototype]] internal slot whose value is %Function.prototype%.
+    let generator_function_prototype = ordinary_object_create(Some(function_prototype.clone()), &[]);
 
-        // The GeneratorFunction Constructor
-        //
-        // The GeneratorFunction constructor:
-        //
-        //  * is %GeneratorFunction%.
-        //  * is a subclass of Function.
-        //  * creates and initializes a new GeneratorFunction when called as a function rather than as a
-        //    constructor. Thus the function call GeneratorFunction (…) is equivalent to the object creation
-        //    expression new GeneratorFunction (…) with the same arguments.
-        //  * may be used as the value of an extends clause of a class definition. Subclass constructors that
-        //    intend to inherit the specified GeneratorFunction behaviour must include a super call to the
-        //    GeneratorFunction constructor to create and initialize subclass instances with the internal
-        //    slots necessary for built-in GeneratorFunction behaviour. All ECMAScript syntactic forms for
-        //    defining generator function objects create direct instances of GeneratorFunction. There is no
-        //    syntactic means to create instances of GeneratorFunction subclasses.
-
-        // Properties of the GeneratorFunction Constructor
-        //
-        // The GeneratorFunction constructor:
-        //
-        //  * is a standard built-in function object that inherits from the Function constructor.
-        //  * has a [[Prototype]] internal slot whose value is %Function%.
-        //  * has a "name" property whose value is "GeneratorFunction".
-        let generator_function_constructor = create_builtin_function(
-            self,
-            generator_function,
-            true,
-            1.0,
-            "GeneratorFunction".into(),
-            BUILTIN_FUNCTION_SLOTS,
-            Some(realm.clone()),
-            Some(function),
-            None,
-        );
-
-        macro_rules! constructor_data {
-            ( $name:expr, $value:expr, $writable:expr, $enumerable:expr, $configurable:expr ) => {
-                define_property_or_throw(
-                    self,
-                    &generator_function_constructor,
-                    $name,
-                    PotentialPropertyDescriptor::new()
-                        .value(ECMAScriptValue::from($value))
-                        .writable($writable)
-                        .enumerable($enumerable)
-                        .configurable($configurable),
-                )
-                .unwrap();
-            };
-        }
-
-        // Properties of the GeneratorFunction Prototype Object
-        //
-        // The GeneratorFunction prototype object:
-        //
-        //  * is %GeneratorFunction.prototype% (see Figure 6).
-        //  * is an ordinary object.
-        //  * is not a function object and does not have an [[ECMAScriptCode]] internal slot or any other of
-        //    the internal slots listed in Table 33 or Table 86.
-        //  * has a [[Prototype]] internal slot whose value is %Function.prototype%.
-        let generator_function_prototype = ordinary_object_create(self, Some(function_prototype.clone()), &[]);
-
-        macro_rules! gf_prototype_data {
-            ( $name:expr, $value:expr, $writable:expr, $enumerable:expr, $configurable:expr ) => {
-                define_property_or_throw(
-                    self,
-                    &generator_function_prototype,
-                    $name,
-                    PotentialPropertyDescriptor::new()
-                        .value(ECMAScriptValue::from($value))
-                        .writable($writable)
-                        .enumerable($enumerable)
-                        .configurable($configurable),
-                )
-                .unwrap();
-            };
-        }
-        let to_string_tag = self.wks(WksId::ToStringTag);
-        gf_prototype_data!("constructor", generator_function_constructor.clone(), false, false, true);
-        gf_prototype_data!(to_string_tag.clone(), "GeneratorFunction", false, false, true);
-        constructor_data!("prototype", generator_function_prototype.clone(), false, false, false);
-
-        // Properties of the Generator Prototype Object
-        //
-        // The Generator prototype object:
-        //
-        //  * is %GeneratorFunction.prototype.prototype%.
-        //  * is an ordinary object.
-        //  * is not a Generator instance and does not have a [[GeneratorState]] internal slot.
-        //  * has a [[Prototype]] internal slot whose value is %IteratorPrototype%.
-        //  * has properties that are indirectly inherited by all Generator instances.
-        let generator_prototype = ordinary_object_create(self, Some(iterator_prototype), &[]);
-        gf_prototype_data!("prototype", generator_prototype.clone(), false, false, true);
-
-        macro_rules! gen_prototype_data {
-            ( $name:expr, $value:expr, $writable:expr, $enumerable:expr, $configurable:expr ) => {
-                define_property_or_throw(
-                    self,
-                    &generator_prototype,
-                    $name,
-                    PotentialPropertyDescriptor::new()
-                        .value(ECMAScriptValue::from($value))
-                        .writable($writable)
-                        .enumerable($enumerable)
-                        .configurable($configurable),
-                )
-                .unwrap();
-            };
-        }
-
-        gen_prototype_data!("constructor", generator_function_prototype.clone(), false, false, true);
-        gen_prototype_data!(to_string_tag, "Generator", false, false, true);
-
-        macro_rules! gen_prototype_function {
-            ( $steps:expr, $name:expr, $length:expr ) => {
-                let key = PropertyKey::from($name);
-                let function_object = create_builtin_function(
-                    self,
-                    $steps,
-                    false,
-                    $length,
-                    key.clone(),
-                    BUILTIN_FUNCTION_SLOTS,
-                    Some(realm.clone()),
-                    Some(function_prototype.clone()),
-                    None,
-                );
-                define_property_or_throw(
-                    self,
-                    &generator_prototype,
-                    key,
-                    PotentialPropertyDescriptor::new()
-                        .value(function_object)
-                        .writable(true)
-                        .enumerable(false)
-                        .configurable(true),
-                )
-                .unwrap();
-            };
-        }
-        gen_prototype_function!(generator_prototype_next, "next", 1.0);
-        gen_prototype_function!(generator_prototype_return, "return", 1.0);
-        gen_prototype_function!(generator_prototype_throw, "throw", 1.0);
-
-        realm.borrow_mut().intrinsics.generator_function = generator_function_constructor;
-        realm.borrow_mut().intrinsics.generator_function_prototype = generator_function_prototype;
-        realm.borrow_mut().intrinsics.generator_function_prototype_prototype = generator_prototype;
+    macro_rules! gf_prototype_data {
+        ( $name:expr, $value:expr, $writable:expr, $enumerable:expr, $configurable:expr ) => {
+            define_property_or_throw(
+                &generator_function_prototype,
+                $name,
+                PotentialPropertyDescriptor::new()
+                    .value(ECMAScriptValue::from($value))
+                    .writable($writable)
+                    .enumerable($enumerable)
+                    .configurable($configurable),
+            )
+            .unwrap();
+        };
     }
+    let to_string_tag = wks(WksId::ToStringTag);
+    gf_prototype_data!("constructor", generator_function_constructor.clone(), false, false, true);
+    gf_prototype_data!(to_string_tag.clone(), "GeneratorFunction", false, false, true);
+    constructor_data!("prototype", generator_function_prototype.clone(), false, false, false);
+
+    // Properties of the Generator Prototype Object
+    //
+    // The Generator prototype object:
+    //
+    //  * is %GeneratorFunction.prototype.prototype%.
+    //  * is an ordinary object.
+    //  * is not a Generator instance and does not have a [[GeneratorState]] internal slot.
+    //  * has a [[Prototype]] internal slot whose value is %IteratorPrototype%.
+    //  * has properties that are indirectly inherited by all Generator instances.
+    let generator_prototype = ordinary_object_create(Some(iterator_prototype), &[]);
+    gf_prototype_data!("prototype", generator_prototype.clone(), false, false, true);
+
+    macro_rules! gen_prototype_data {
+        ( $name:expr, $value:expr, $writable:expr, $enumerable:expr, $configurable:expr ) => {
+            define_property_or_throw(
+                &generator_prototype,
+                $name,
+                PotentialPropertyDescriptor::new()
+                    .value(ECMAScriptValue::from($value))
+                    .writable($writable)
+                    .enumerable($enumerable)
+                    .configurable($configurable),
+            )
+            .unwrap();
+        };
+    }
+
+    gen_prototype_data!("constructor", generator_function_prototype.clone(), false, false, true);
+    gen_prototype_data!(to_string_tag, "Generator", false, false, true);
+
+    macro_rules! gen_prototype_function {
+        ( $steps:expr, $name:expr, $length:expr ) => {
+            let key = PropertyKey::from($name);
+            let function_object = create_builtin_function(
+                $steps,
+                false,
+                $length,
+                key.clone(),
+                BUILTIN_FUNCTION_SLOTS,
+                Some(realm.clone()),
+                Some(function_prototype.clone()),
+                None,
+            );
+            define_property_or_throw(
+                &generator_prototype,
+                key,
+                PotentialPropertyDescriptor::new()
+                    .value(function_object)
+                    .writable(true)
+                    .enumerable(false)
+                    .configurable(true),
+            )
+            .unwrap();
+        };
+    }
+    gen_prototype_function!(generator_prototype_next, "next", 1.0);
+    gen_prototype_function!(generator_prototype_return, "return", 1.0);
+    gen_prototype_function!(generator_prototype_throw, "throw", 1.0);
+
+    realm.borrow_mut().intrinsics.generator_function = generator_function_constructor;
+    realm.borrow_mut().intrinsics.generator_function_prototype = generator_function_prototype;
+    realm.borrow_mut().intrinsics.generator_function_prototype_prototype = generator_prototype;
 }
 
 fn iterator_prototype_iterator(
-    _agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -229,7 +218,6 @@ fn iterator_prototype_iterator(
 }
 
 fn generator_function(
-    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -238,7 +226,6 @@ fn generator_function(
 }
 
 fn generator_prototype_next(
-    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -247,7 +234,6 @@ fn generator_prototype_next(
 }
 
 fn generator_prototype_return(
-    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -256,7 +242,6 @@ fn generator_prototype_return(
 }
 
 fn generator_prototype_throw(
-    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -264,25 +249,23 @@ fn generator_prototype_throw(
     todo!()
 }
 
-impl Agent {
-    fn create_iter_result_object(&self, value: ECMAScriptValue, done: bool) -> Object {
-        // CreateIterResultObject ( value, done )
-        //
-        // The abstract operation CreateIterResultObject takes arguments value (an ECMAScript language value)
-        // and done (a Boolean) and returns an Object that conforms to the IteratorResult interface. It
-        // creates an object that conforms to the IteratorResult interface. It performs the following steps
-        // when called:
-        //
-        //  1. Let obj be OrdinaryObjectCreate(%Object.prototype%).
-        //  2. Perform ! CreateDataPropertyOrThrow(obj, "value", value).
-        //  3. Perform ! CreateDataPropertyOrThrow(obj, "done", done).
-        //  4. Return obj.
-        let object_prototype = self.intrinsic(IntrinsicId::ObjectPrototype);
-        let obj = ordinary_object_create(self, Some(object_prototype), &[]);
-        create_data_property_or_throw(self, &obj, "value", value).unwrap();
-        create_data_property_or_throw(self, &obj, "done", done).unwrap();
-        obj
-    }
+fn create_iter_result_object(value: ECMAScriptValue, done: bool) -> Object {
+    // CreateIterResultObject ( value, done )
+    //
+    // The abstract operation CreateIterResultObject takes arguments value (an ECMAScript language value)
+    // and done (a Boolean) and returns an Object that conforms to the IteratorResult interface. It
+    // creates an object that conforms to the IteratorResult interface. It performs the following steps
+    // when called:
+    //
+    //  1. Let obj be OrdinaryObjectCreate(%Object.prototype%).
+    //  2. Perform ! CreateDataPropertyOrThrow(obj, "value", value).
+    //  3. Perform ! CreateDataPropertyOrThrow(obj, "done", done).
+    //  4. Return obj.
+    let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_prototype), &[]);
+    create_data_property_or_throw(&obj, "value", value).unwrap();
+    create_data_property_or_throw(&obj, "done", done).unwrap();
+    obj
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -327,7 +310,7 @@ impl ObjectInterface for GeneratorObject {
     fn to_generator_object(&self) -> Option<&GeneratorObject> {
         Some(self)
     }
-    fn get_prototype_of(&self, _agent: &Agent) -> Completion<Option<Object>> {
+    fn get_prototype_of(&self) -> Completion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
 
@@ -337,7 +320,7 @@ impl ObjectInterface for GeneratorObject {
     // the following steps when called:
     //
     //  1. Return ! OrdinarySetPrototypeOf(O, V).
-    fn set_prototype_of(&self, _agent: &Agent, obj: Option<Object>) -> Completion<bool> {
+    fn set_prototype_of(&self, obj: Option<Object>) -> Completion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
 
@@ -347,7 +330,7 @@ impl ObjectInterface for GeneratorObject {
     // when called:
     //
     //  1. Return ! OrdinaryIsExtensible(O).
-    fn is_extensible(&self, _agent: &Agent) -> Completion<bool> {
+    fn is_extensible(&self) -> Completion<bool> {
         Ok(ordinary_is_extensible(self))
     }
 
@@ -357,7 +340,7 @@ impl ObjectInterface for GeneratorObject {
     // steps when called:
     //
     //  1. Return ! OrdinaryPreventExtensions(O).
-    fn prevent_extensions(&self, _agent: &Agent) -> Completion<bool> {
+    fn prevent_extensions(&self) -> Completion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
 
@@ -367,7 +350,7 @@ impl ObjectInterface for GeneratorObject {
     // following steps when called:
     //
     //  1. Return ! OrdinaryGetOwnProperty(O, P).
-    fn get_own_property(&self, _agent: &Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(self, key))
     }
 
@@ -377,13 +360,8 @@ impl ObjectInterface for GeneratorObject {
     // Property Descriptor). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
-    fn define_own_property(
-        &self,
-        agent: &Agent,
-        key: PropertyKey,
-        desc: PotentialPropertyDescriptor,
-    ) -> Completion<bool> {
-        ordinary_define_own_property(agent, self, key, desc)
+    fn define_own_property(&self, key: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool> {
+        ordinary_define_own_property(self, key, desc)
     }
 
     // [[HasProperty]] ( P )
@@ -392,8 +370,8 @@ impl ObjectInterface for GeneratorObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryHasProperty(O, P).
-    fn has_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
-        ordinary_has_property(agent, self, key)
+    fn has_property(&self, key: &PropertyKey) -> Completion<bool> {
+        ordinary_has_property(self, key)
     }
 
     // [[Get]] ( P, Receiver )
@@ -402,8 +380,8 @@ impl ObjectInterface for GeneratorObject {
     // ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryGet(O, P, Receiver).
-    fn get(&self, agent: &Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
-        ordinary_get(agent, self, key, receiver)
+    fn get(&self, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+        ordinary_get(self, key, receiver)
     }
 
     // [[Set]] ( P, V, Receiver )
@@ -412,8 +390,8 @@ impl ObjectInterface for GeneratorObject {
     // value), and Receiver (an ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinarySet(O, P, V, Receiver).
-    fn set(&self, agent: &Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
-        ordinary_set(agent, self, key, v, receiver)
+    fn set(&self, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
+        ordinary_set(self, key, v, receiver)
     }
 
     // [[Delete]] ( P )
@@ -422,8 +400,8 @@ impl ObjectInterface for GeneratorObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryDelete(O, P).
-    fn delete(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
-        ordinary_delete(agent, self, key)
+    fn delete(&self, key: &PropertyKey) -> Completion<bool> {
+        ordinary_delete(self, key)
     }
 
     // [[OwnPropertyKeys]] ( )
@@ -432,7 +410,7 @@ impl ObjectInterface for GeneratorObject {
     // steps when called:
     //
     // 1. Return ! OrdinaryOwnPropertyKeys(O).
-    fn own_property_keys(&self, _agent: &Agent) -> Completion<Vec<PropertyKey>> {
+    fn own_property_keys(&self) -> Completion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(self))
     }
 }
@@ -457,10 +435,10 @@ impl fmt::Display for GeneratorError {
 impl Error for GeneratorError {}
 
 impl GeneratorObject {
-    pub fn object(agent: &Agent, prototype: Option<Object>, state: GeneratorState, brand: &str) -> Object {
+    pub fn object(prototype: Option<Object>, state: GeneratorState, brand: &str) -> Object {
         Object {
             o: Rc::new(Self {
-                common: RefCell::new(CommonObjectData::new(agent, prototype, true, GENERATOR_OBJECT_SLOTS)),
+                common: RefCell::new(CommonObjectData::new(prototype, true, GENERATOR_OBJECT_SLOTS)),
                 generator_data: RefCell::new(GeneratorData {
                     generator_state: state,
                     generator_context: None,
@@ -498,31 +476,27 @@ impl GeneratorObject {
     }
 }
 
-impl Agent {
-    pub fn generator_validate(&self, generator: ECMAScriptValue, generator_brand: &str) -> Completion<GeneratorState> {
-        // GeneratorValidate ( generator, generatorBrand )
-        // The abstract operation GeneratorValidate takes arguments generator and generatorBrand and returns
-        // either a normal completion containing either suspendedStart, suspendedYield, or completed, or a
-        // throw completion. It performs the following steps when called:
-        //
-        //  1. Perform ? RequireInternalSlot(generator, [[GeneratorState]]).
-        //  2. Perform ? RequireInternalSlot(generator, [[GeneratorBrand]]).
-        //  3. If generator.[[GeneratorBrand]] is not the same value as generatorBrand, throw a TypeError
-        //     exception.
-        //  4. Assert: generator also has a [[GeneratorContext]] internal slot.
-        //  5. Let state be generator.[[GeneratorState]].
-        //  6. If state is executing, throw a TypeError exception.
-        //  7. Return state.
-        match generator {
-            ECMAScriptValue::Object(o) => {
-                o.o.to_generator_object()
-                    .ok_or(GeneratorError::NotAGenerator)
-                    .and_then(|gen| gen.validate(generator_brand))
-            }
-            _ => Err(GeneratorError::NotAGenerator),
+pub fn generator_validate(generator: ECMAScriptValue, generator_brand: &str) -> Completion<GeneratorState> {
+    // GeneratorValidate ( generator, generatorBrand )
+    // The abstract operation GeneratorValidate takes arguments generator and generatorBrand and returns
+    // either a normal completion containing either suspendedStart, suspendedYield, or completed, or a
+    // throw completion. It performs the following steps when called:
+    //
+    //  1. Perform ? RequireInternalSlot(generator, [[GeneratorState]]).
+    //  2. Perform ? RequireInternalSlot(generator, [[GeneratorBrand]]).
+    //  3. If generator.[[GeneratorBrand]] is not the same value as generatorBrand, throw a TypeError
+    //     exception.
+    //  4. Assert: generator also has a [[GeneratorContext]] internal slot.
+    //  5. Let state be generator.[[GeneratorState]].
+    //  6. If state is executing, throw a TypeError exception.
+    //  7. Return state.
+    match generator {
+        ECMAScriptValue::Object(o) => {
+            o.o.to_generator_object().ok_or(GeneratorError::NotAGenerator).and_then(|gen| gen.validate(generator_brand))
         }
-        .map_err(|e| create_type_error(self, e.to_string()))
+        _ => Err(GeneratorError::NotAGenerator),
     }
+    .map_err(|e| create_type_error(e.to_string()))
 }
 
 #[cfg(test)]

--- a/src/control_abstraction/tests.rs
+++ b/src/control_abstraction/tests.rs
@@ -49,10 +49,7 @@ mod agent {
                 function
             );
 
-            assert_eq!(
-                get(&generator_function, &"name".into()).unwrap(),
-                ECMAScriptValue::from("GeneratorFunction")
-            );
+            assert_eq!(get(&generator_function, &"name".into()).unwrap(), ECMAScriptValue::from("GeneratorFunction"));
             assert_eq!(get(&generator_function, &"length".into()).unwrap(), ECMAScriptValue::from(1));
             assert_eq!(
                 get(&generator_function, &"prototype".into()).unwrap(),
@@ -101,10 +98,7 @@ mod agent {
                 ECMAScriptValue::from(intrinsic(IntrinsicId::GeneratorFunctionPrototype))
             );
             let to_string_tag = wks(WksId::ToStringTag);
-            assert_eq!(
-                get(&generator_prototype, &to_string_tag.into()).unwrap(),
-                ECMAScriptValue::from("Generator")
-            );
+            assert_eq!(get(&generator_prototype, &to_string_tag.into()).unwrap(), ECMAScriptValue::from("Generator"));
         }
 
         #[test_case("next" => "next;1"; "next function")]
@@ -136,19 +130,19 @@ mod agent {
         assert_eq!(done_res, ECMAScriptValue::from(done));
     }
 
-    #[test_case(|_| ECMAScriptValue::Undefined, "" => serr("TypeError: Generator required"); "not an object")]
-    #[test_case(|a| a.create_string_object("blue".into()).into(), "" => serr("TypeError: Generator required"); "not a generator")]
-    #[test_case(|a| {
+    #[test_case(|| ECMAScriptValue::Undefined, "" => serr("TypeError: Generator required"); "not an object")]
+    #[test_case(|| create_string_object("blue".into()).into(), "" => serr("TypeError: Generator required"); "not a generator")]
+    #[test_case(|| {
         let proto = intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
-        GeneratorObject::object(a, Some(proto), GeneratorState::SuspendedStart, "TestingBrand").into()
+        GeneratorObject::object(Some(proto), GeneratorState::SuspendedStart, "TestingBrand").into()
     }, "TestingBrand" => Ok(GeneratorState::SuspendedStart); "valid")]
-    #[test_case(|a| {
+    #[test_case(|| {
         let proto = intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
-        GeneratorObject::object(a, Some(proto), GeneratorState::Executing, "TestingBrand").into()
+        GeneratorObject::object(Some(proto), GeneratorState::Executing, "TestingBrand").into()
     }, "TestingBrand" => serr("TypeError: Generator is already executing"); "already running")]
-    #[test_case(|a| {
+    #[test_case(|| {
         let proto = intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
-        GeneratorObject::object(a, Some(proto), GeneratorState::SuspendedStart, "TestingBrand").into()
+        GeneratorObject::object(Some(proto), GeneratorState::SuspendedStart, "TestingBrand").into()
     }, "OtherBrand" => serr("TypeError: Generator brand mismatch"); "brand mismatch")]
     fn generator_validate(
         make_value: impl FnOnce() -> ECMAScriptValue,
@@ -160,8 +154,8 @@ mod agent {
     }
 }
 
-#[test_case(|_| ECMAScriptValue::Undefined => Ok(ECMAScriptValue::Undefined); "pass-thru/undefined")]
-#[test_case(|_| ECMAScriptValue::from(67) => Ok(ECMAScriptValue::from(67)); "pass-thru/number")]
+#[test_case(|| ECMAScriptValue::Undefined => Ok(ECMAScriptValue::Undefined); "pass-thru/undefined")]
+#[test_case(|| ECMAScriptValue::from(67) => Ok(ECMAScriptValue::from(67)); "pass-thru/number")]
 fn iterator_prototype_iterator(make_params: impl FnOnce() -> ECMAScriptValue) -> Result<ECMAScriptValue, String> {
     setup_test_agent();
     let this_value = make_params();

--- a/src/control_abstraction/tests.rs
+++ b/src/control_abstraction/tests.rs
@@ -9,7 +9,7 @@ mod agent {
 
     #[test]
     fn provision_iterator_prototype() {
-        let agent = test_agent();
+        setup_test_agent();
 
         let iterator_prototype = agent.intrinsic(IntrinsicId::IteratorPrototype);
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
@@ -39,7 +39,7 @@ mod agent {
 
         #[test]
         fn generator_function() {
-            let agent = test_agent();
+            setup_test_agent();
             let function = agent.intrinsic(IntrinsicId::Function);
             let generator_function = agent.intrinsic(IntrinsicId::GeneratorFunction);
 
@@ -62,7 +62,7 @@ mod agent {
 
         #[test]
         fn generator_function_prototype() {
-            let agent = test_agent();
+            setup_test_agent();
             let generator_function_prototype = agent.intrinsic(IntrinsicId::GeneratorFunctionPrototype);
             let function_prototype = agent.intrinsic(IntrinsicId::FunctionPrototype);
 
@@ -89,7 +89,7 @@ mod agent {
 
         #[test]
         fn generator_prototype() {
-            let agent = test_agent();
+            setup_test_agent();
             let generator_prototype = agent.intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
 
             assert_eq!(
@@ -111,7 +111,7 @@ mod agent {
         #[test_case("return" => "return;1"; "return function")]
         #[test_case("throw" => "throw;1"; "throw function")]
         fn generator_prototype_func(key: &str) -> String {
-            let agent = test_agent();
+            setup_test_agent();
             let key = PropertyKey::from(key);
             let proto = agent.intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
             let val = super::get(&agent, &proto, &key).unwrap();
@@ -127,7 +127,7 @@ mod agent {
     #[test_case("a value".into(), true; "is done")]
     #[test_case(ECMAScriptValue::Undefined, false; "not done")]
     fn create_iter_result_object(value: ECMAScriptValue, done: bool) {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = agent.create_iter_result_object(value.clone(), done);
         let value_res = get(&agent, &obj, &"value".into()).unwrap();
         let done_res = get(&agent, &obj, &"done".into()).unwrap();
@@ -154,7 +154,7 @@ mod agent {
         make_value: impl FnOnce(&Agent) -> ECMAScriptValue,
         desired_brand: &str,
     ) -> Result<GeneratorState, String> {
-        let agent = test_agent();
+        setup_test_agent();
         let value = make_value(&agent);
         agent.generator_validate(value, desired_brand).map_err(|e| unwind_any_error(&agent, e))
     }
@@ -163,7 +163,7 @@ mod agent {
 #[test_case(|_| ECMAScriptValue::Undefined => Ok(ECMAScriptValue::Undefined); "pass-thru/undefined")]
 #[test_case(|_| ECMAScriptValue::from(67) => Ok(ECMAScriptValue::from(67)); "pass-thru/number")]
 fn iterator_prototype_iterator(make_params: impl FnOnce(&Agent) -> ECMAScriptValue) -> Result<ECMAScriptValue, String> {
-    let agent = test_agent();
+    setup_test_agent();
     let this_value = make_params(&agent);
     super::iterator_prototype_iterator(&agent, this_value, None, &[]).map_err(|e| unwind_any_error(&agent, e))
 }
@@ -240,7 +240,7 @@ mod generator_object {
 
     #[test]
     fn object() {
-        let agent = test_agent();
+        setup_test_agent();
         let gp = agent.intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
         let o = GeneratorObject::object(&agent, Some(gp.clone()), GeneratorState::Undefined, "TestingBrand");
 
@@ -289,7 +289,7 @@ mod generator_object {
 
     #[test]
     fn debug() {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = make(&agent);
         let go = obj.o.to_generator_object().unwrap();
         assert_ne!(format!("{:?}", go), "");
@@ -297,7 +297,7 @@ mod generator_object {
 
     #[test]
     fn common_object_data() {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = make(&agent);
         super::set(&agent, &obj, "test".into(), "sentinel".into(), true).unwrap();
 
@@ -322,14 +322,14 @@ mod generator_object {
 
     #[test]
     fn is_generator_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = make(&agent);
         assert!(obj.o.is_generator_object());
     }
 
     #[test]
     fn to_generator_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = make(&agent);
         let go = obj.o.to_generator_object();
         assert!(go.is_some());
@@ -339,7 +339,7 @@ mod generator_object {
     #[test_case("OtherBrand", GeneratorState::SuspendedStart => Err(GeneratorError::BrandMismatch); "brand mismatch")]
     #[test_case("TestingBrand", GeneratorState::Executing => Err(GeneratorError::AlreadyActive); "already active")]
     fn validate(desired_brand: &str, generator_state: GeneratorState) -> Result<GeneratorState, GeneratorError> {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = make(&agent); // brand is "TestingBrand"
         let gen_obj = obj.o.to_generator_object().unwrap();
         gen_obj.generator_data.borrow_mut().generator_state = generator_state;

--- a/src/control_abstraction/tests.rs
+++ b/src/control_abstraction/tests.rs
@@ -150,7 +150,7 @@ mod agent {
     ) -> Result<GeneratorState, String> {
         setup_test_agent();
         let value = make_value();
-        super::generator_validate(value, desired_brand).map_err(|e| unwind_any_error(e))
+        super::generator_validate(value, desired_brand).map_err(unwind_any_error)
     }
 }
 
@@ -159,7 +159,7 @@ mod agent {
 fn iterator_prototype_iterator(make_params: impl FnOnce() -> ECMAScriptValue) -> Result<ECMAScriptValue, String> {
     setup_test_agent();
     let this_value = make_params();
-    super::iterator_prototype_iterator(this_value, None, &[]).map_err(|e| unwind_any_error(e))
+    super::iterator_prototype_iterator(this_value, None, &[]).map_err(unwind_any_error)
 }
 
 tbd_function!(generator_function);

--- a/src/control_abstraction/tests.rs
+++ b/src/control_abstraction/tests.rs
@@ -11,15 +11,15 @@ mod agent {
     fn provision_iterator_prototype() {
         setup_test_agent();
 
-        let iterator_prototype = agent.intrinsic(IntrinsicId::IteratorPrototype);
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
+        let iterator_prototype = intrinsic(IntrinsicId::IteratorPrototype);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
 
         let iter_proto_proto = iterator_prototype.o.common_object_data().borrow().prototype.as_ref().unwrap().clone();
         assert_eq!(iter_proto_proto, object_prototype);
 
-        let iterator_sym = agent.wks(WksId::Iterator);
+        let iterator_sym = wks(WksId::Iterator);
         let iterator_desc = IdealizedPropertyDescriptor::from(
-            iterator_prototype.o.get_own_property(&agent, &iterator_sym.into()).unwrap().unwrap(),
+            iterator_prototype.o.get_own_property(&iterator_sym.into()).unwrap().unwrap(),
         );
         assert_eq!(iterator_desc.configurable, true);
         assert_eq!(iterator_desc.enumerable, false);
@@ -40,8 +40,8 @@ mod agent {
         #[test]
         fn generator_function() {
             setup_test_agent();
-            let function = agent.intrinsic(IntrinsicId::Function);
-            let generator_function = agent.intrinsic(IntrinsicId::GeneratorFunction);
+            let function = intrinsic(IntrinsicId::Function);
+            let generator_function = intrinsic(IntrinsicId::GeneratorFunction);
 
             assert!(generator_function.o.to_builtin_function_obj().is_some());
             assert_eq!(
@@ -50,21 +50,21 @@ mod agent {
             );
 
             assert_eq!(
-                get(&agent, &generator_function, &"name".into()).unwrap(),
+                get(&generator_function, &"name".into()).unwrap(),
                 ECMAScriptValue::from("GeneratorFunction")
             );
-            assert_eq!(get(&agent, &generator_function, &"length".into()).unwrap(), ECMAScriptValue::from(1));
+            assert_eq!(get(&generator_function, &"length".into()).unwrap(), ECMAScriptValue::from(1));
             assert_eq!(
-                get(&agent, &generator_function, &"prototype".into()).unwrap(),
-                ECMAScriptValue::from(agent.intrinsic(IntrinsicId::GeneratorFunctionPrototype))
+                get(&generator_function, &"prototype".into()).unwrap(),
+                ECMAScriptValue::from(intrinsic(IntrinsicId::GeneratorFunctionPrototype))
             );
         }
 
         #[test]
         fn generator_function_prototype() {
             setup_test_agent();
-            let generator_function_prototype = agent.intrinsic(IntrinsicId::GeneratorFunctionPrototype);
-            let function_prototype = agent.intrinsic(IntrinsicId::FunctionPrototype);
+            let generator_function_prototype = intrinsic(IntrinsicId::GeneratorFunctionPrototype);
+            let function_prototype = intrinsic(IntrinsicId::FunctionPrototype);
 
             assert!(!generator_function_prototype.o.is_callable_obj());
             assert_eq!(
@@ -72,37 +72,37 @@ mod agent {
                 function_prototype
             );
 
-            let to_string_tag = agent.wks(WksId::ToStringTag);
+            let to_string_tag = wks(WksId::ToStringTag);
             assert_eq!(
-                get(&agent, &generator_function_prototype, &to_string_tag.into()).unwrap(),
+                get(&generator_function_prototype, &to_string_tag.into()).unwrap(),
                 ECMAScriptValue::from("GeneratorFunction")
             );
             assert_eq!(
-                get(&agent, &generator_function_prototype, &"constructor".into()).unwrap(),
-                ECMAScriptValue::from(agent.intrinsic(IntrinsicId::GeneratorFunction))
+                get(&generator_function_prototype, &"constructor".into()).unwrap(),
+                ECMAScriptValue::from(intrinsic(IntrinsicId::GeneratorFunction))
             );
             assert_eq!(
-                get(&agent, &generator_function_prototype, &"prototype".into()).unwrap(),
-                ECMAScriptValue::from(agent.intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype))
+                get(&generator_function_prototype, &"prototype".into()).unwrap(),
+                ECMAScriptValue::from(intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype))
             );
         }
 
         #[test]
         fn generator_prototype() {
             setup_test_agent();
-            let generator_prototype = agent.intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
+            let generator_prototype = intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
 
             assert_eq!(
                 generator_prototype.o.common_object_data().borrow().prototype.as_ref().unwrap().clone(),
-                agent.intrinsic(IntrinsicId::IteratorPrototype)
+                intrinsic(IntrinsicId::IteratorPrototype)
             );
             assert_eq!(
-                get(&agent, &generator_prototype, &"constructor".into()).unwrap(),
-                ECMAScriptValue::from(agent.intrinsic(IntrinsicId::GeneratorFunctionPrototype))
+                get(&generator_prototype, &"constructor".into()).unwrap(),
+                ECMAScriptValue::from(intrinsic(IntrinsicId::GeneratorFunctionPrototype))
             );
-            let to_string_tag = agent.wks(WksId::ToStringTag);
+            let to_string_tag = wks(WksId::ToStringTag);
             assert_eq!(
-                get(&agent, &generator_prototype, &to_string_tag.into()).unwrap(),
+                get(&generator_prototype, &to_string_tag.into()).unwrap(),
                 ECMAScriptValue::from("Generator")
             );
         }
@@ -113,13 +113,13 @@ mod agent {
         fn generator_prototype_func(key: &str) -> String {
             setup_test_agent();
             let key = PropertyKey::from(key);
-            let proto = agent.intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
-            let val = super::get(&agent, &proto, &key).unwrap();
+            let proto = intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
+            let val = super::get(&proto, &key).unwrap();
             assert!(is_callable(&val));
-            let name = getv(&agent, &val, &"name".into()).unwrap();
-            let name = to_string(&agent, name).unwrap();
-            let length = getv(&agent, &val, &"length".into()).unwrap();
-            let length = to_string(&agent, length).unwrap();
+            let name = getv(&val, &"name".into()).unwrap();
+            let name = to_string(name).unwrap();
+            let length = getv(&val, &"length".into()).unwrap();
+            let length = to_string(length).unwrap();
             format!("{};{}", String::from(name), length)
         }
     }
@@ -128,9 +128,9 @@ mod agent {
     #[test_case(ECMAScriptValue::Undefined, false; "not done")]
     fn create_iter_result_object(value: ECMAScriptValue, done: bool) {
         setup_test_agent();
-        let obj = agent.create_iter_result_object(value.clone(), done);
-        let value_res = get(&agent, &obj, &"value".into()).unwrap();
-        let done_res = get(&agent, &obj, &"done".into()).unwrap();
+        let obj = super::create_iter_result_object(value.clone(), done);
+        let value_res = get(&obj, &"value".into()).unwrap();
+        let done_res = get(&obj, &"done".into()).unwrap();
 
         assert_eq!(value_res, value);
         assert_eq!(done_res, ECMAScriptValue::from(done));
@@ -139,33 +139,33 @@ mod agent {
     #[test_case(|_| ECMAScriptValue::Undefined, "" => serr("TypeError: Generator required"); "not an object")]
     #[test_case(|a| a.create_string_object("blue".into()).into(), "" => serr("TypeError: Generator required"); "not a generator")]
     #[test_case(|a| {
-        let proto = a.intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
+        let proto = intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
         GeneratorObject::object(a, Some(proto), GeneratorState::SuspendedStart, "TestingBrand").into()
     }, "TestingBrand" => Ok(GeneratorState::SuspendedStart); "valid")]
     #[test_case(|a| {
-        let proto = a.intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
+        let proto = intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
         GeneratorObject::object(a, Some(proto), GeneratorState::Executing, "TestingBrand").into()
     }, "TestingBrand" => serr("TypeError: Generator is already executing"); "already running")]
     #[test_case(|a| {
-        let proto = a.intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
+        let proto = intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
         GeneratorObject::object(a, Some(proto), GeneratorState::SuspendedStart, "TestingBrand").into()
     }, "OtherBrand" => serr("TypeError: Generator brand mismatch"); "brand mismatch")]
     fn generator_validate(
-        make_value: impl FnOnce(&Agent) -> ECMAScriptValue,
+        make_value: impl FnOnce() -> ECMAScriptValue,
         desired_brand: &str,
     ) -> Result<GeneratorState, String> {
         setup_test_agent();
-        let value = make_value(&agent);
-        agent.generator_validate(value, desired_brand).map_err(|e| unwind_any_error(&agent, e))
+        let value = make_value();
+        super::generator_validate(value, desired_brand).map_err(|e| unwind_any_error(e))
     }
 }
 
 #[test_case(|_| ECMAScriptValue::Undefined => Ok(ECMAScriptValue::Undefined); "pass-thru/undefined")]
 #[test_case(|_| ECMAScriptValue::from(67) => Ok(ECMAScriptValue::from(67)); "pass-thru/number")]
-fn iterator_prototype_iterator(make_params: impl FnOnce(&Agent) -> ECMAScriptValue) -> Result<ECMAScriptValue, String> {
+fn iterator_prototype_iterator(make_params: impl FnOnce() -> ECMAScriptValue) -> Result<ECMAScriptValue, String> {
     setup_test_agent();
-    let this_value = make_params(&agent);
-    super::iterator_prototype_iterator(&agent, this_value, None, &[]).map_err(|e| unwind_any_error(&agent, e))
+    let this_value = make_params();
+    super::iterator_prototype_iterator(this_value, None, &[]).map_err(|e| unwind_any_error(e))
 }
 
 tbd_function!(generator_function);
@@ -241,8 +241,8 @@ mod generator_object {
     #[test]
     fn object() {
         setup_test_agent();
-        let gp = agent.intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
-        let o = GeneratorObject::object(&agent, Some(gp.clone()), GeneratorState::Undefined, "TestingBrand");
+        let gp = intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
+        let o = GeneratorObject::object(Some(gp.clone()), GeneratorState::Undefined, "TestingBrand");
 
         let go_data = o.o.to_generator_object().unwrap().generator_data.borrow();
 
@@ -258,9 +258,9 @@ mod generator_object {
         assert!(cod.private_elements.is_empty());
     }
 
-    fn make(agent: &Agent) -> Object {
-        let gp = agent.intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
-        GeneratorObject::object(agent, Some(gp), GeneratorState::Undefined, "TestingBrand")
+    fn make() -> Object {
+        let gp = intrinsic(IntrinsicId::GeneratorFunctionPrototypePrototype);
+        GeneratorObject::object(Some(gp), GeneratorState::Undefined, "TestingBrand")
     }
 
     false_function!(is_boolean_object);
@@ -290,7 +290,7 @@ mod generator_object {
     #[test]
     fn debug() {
         setup_test_agent();
-        let obj = make(&agent);
+        let obj = make();
         let go = obj.o.to_generator_object().unwrap();
         assert_ne!(format!("{:?}", go), "");
     }
@@ -298,8 +298,8 @@ mod generator_object {
     #[test]
     fn common_object_data() {
         setup_test_agent();
-        let obj = make(&agent);
-        super::set(&agent, &obj, "test".into(), "sentinel".into(), true).unwrap();
+        let obj = make();
+        super::set(&obj, "test".into(), "sentinel".into(), true).unwrap();
 
         let cod = obj.o.common_object_data().borrow();
         assert_eq!(cod.properties.len(), 1);
@@ -316,21 +316,21 @@ mod generator_object {
     default_is_ordinary_test!();
     default_get_own_property_test!();
     default_define_own_property_test!();
-    default_get_test!(|agent| agent.wks(WksId::ToStringTag).into(), ECMAScriptValue::from("Generator"));
+    default_get_test!(|| wks(WksId::ToStringTag).into(), ECMAScriptValue::from("Generator"));
     default_set_test!();
     default_own_property_keys_test!();
 
     #[test]
     fn is_generator_object() {
         setup_test_agent();
-        let obj = make(&agent);
+        let obj = make();
         assert!(obj.o.is_generator_object());
     }
 
     #[test]
     fn to_generator_object() {
         setup_test_agent();
-        let obj = make(&agent);
+        let obj = make();
         let go = obj.o.to_generator_object();
         assert!(go.is_some());
     }
@@ -340,7 +340,7 @@ mod generator_object {
     #[test_case("TestingBrand", GeneratorState::Executing => Err(GeneratorError::AlreadyActive); "already active")]
     fn validate(desired_brand: &str, generator_state: GeneratorState) -> Result<GeneratorState, GeneratorError> {
         setup_test_agent();
-        let obj = make(&agent); // brand is "TestingBrand"
+        let obj = make(); // brand is "TestingBrand"
         let gen_obj = obj.o.to_generator_object().unwrap();
         gen_obj.generator_data.borrow_mut().generator_state = generator_state;
 

--- a/src/cr/tests.rs
+++ b/src/cr/tests.rs
@@ -52,7 +52,7 @@ mod normal_completion {
 
         #[test]
         fn object() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = ordinary_object_create(&agent, None, &[]);
             let nc = NormalCompletion::from(obj.clone());
 
@@ -113,7 +113,7 @@ mod normal_completion {
 
             #[test]
             fn actual() {
-                let agent = test_agent();
+                setup_test_agent();
                 let obj = ordinary_object_create(&agent, None, &[]);
                 let val = ECMAScriptValue::from(obj.clone());
                 let nc = NormalCompletion::from(val);

--- a/src/cr/tests.rs
+++ b/src/cr/tests.rs
@@ -53,7 +53,7 @@ mod normal_completion {
         #[test]
         fn object() {
             setup_test_agent();
-            let obj = ordinary_object_create(&agent, None, &[]);
+            let obj = ordinary_object_create(None, &[]);
             let nc = NormalCompletion::from(obj.clone());
 
             if let NormalCompletion::Value(ECMAScriptValue::Object(result)) = nc {
@@ -100,8 +100,6 @@ mod normal_completion {
 
         mod object {
             use super::*;
-            use crate::object::ordinary_object_create;
-            use crate::tests::test_agent;
             use test_case::test_case;
 
             #[test_case(NormalCompletion::Empty => Err("Not a language value!".to_string()); "empty")]
@@ -114,7 +112,7 @@ mod normal_completion {
             #[test]
             fn actual() {
                 setup_test_agent();
-                let obj = ordinary_object_create(&agent, None, &[]);
+                let obj = ordinary_object_create(None, &[]);
                 let val = ECMAScriptValue::from(obj.clone());
                 let nc = NormalCompletion::from(val);
                 let extracted: Object = nc.try_into().unwrap();

--- a/src/environment_record/mod.rs
+++ b/src/environment_record/mod.rs
@@ -109,12 +109,7 @@ pub trait EnvironmentRecord: Debug {
     fn create_mutable_binding(&self, name: JSString, deletable: bool) -> Completion<()>;
     fn create_immutable_binding(&self, name: JSString, strict: bool) -> Completion<()>;
     fn initialize_binding(&self, name: &JSString, value: ECMAScriptValue) -> Completion<()>;
-    fn set_mutable_binding(
-        &self,
-        name: JSString,
-        value: ECMAScriptValue,
-        strict: bool,
-    ) -> Completion<()>;
+    fn set_mutable_binding(&self, name: JSString, value: ECMAScriptValue, strict: bool) -> Completion<()>;
     fn get_binding_value(&self, name: &JSString, strict: bool) -> Completion<ECMAScriptValue>;
     fn delete_binding(&self, name: &JSString) -> Completion<bool>;
     fn has_this_binding(&self) -> bool;
@@ -124,7 +119,7 @@ pub trait EnvironmentRecord: Debug {
     fn get_this_binding(&self) -> Completion<ECMAScriptValue> {
         unreachable!()
     }
-    fn bind_this_value(&self, _agent: &Agent, _val: ECMAScriptValue) -> Completion<ECMAScriptValue> {
+    fn bind_this_value(&self, _val: ECMAScriptValue) -> Completion<ECMAScriptValue> {
         unreachable!()
     }
     fn name(&self) -> String;
@@ -213,7 +208,7 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
     //
     // 1. If envRec has a binding for the name that is the value of N, return true.
     // 2. Return false.
-    fn has_binding(&self, _agent: &Agent, name: &JSString) -> Completion<bool> {
+    fn has_binding(&self, name: &JSString) -> Completion<bool> {
         Ok(self.bindings.borrow().contains_key(name))
     }
 
@@ -228,7 +223,7 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
     //  2. Create a mutable binding in envRec for N and record that it is uninitialized. If D is true, record that the
     //     newly created binding may be deleted by a subsequent DeleteBinding call.
     //  3. Return NormalCompletion(empty).
-    fn create_mutable_binding(&self, _agent: &Agent, name: JSString, deletable: bool) -> Completion<()> {
+    fn create_mutable_binding(&self, name: JSString, deletable: bool) -> Completion<()> {
         let removable = Removability::from(deletable);
         self.bindings.borrow_mut().insert(name, Binding { value: None, mutability: Mutability::Mutable(removable) });
         Ok(())
@@ -245,7 +240,7 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
     // 2. Create an immutable binding in envRec for N and record that it is uninitialized. If S is true, record that the
     //    newly created binding is a strict binding.
     // 3. Return NormalCompletion(empty).
-    fn create_immutable_binding(&self, _agent: &Agent, name: JSString, strict: bool) -> Completion<()> {
+    fn create_immutable_binding(&self, name: JSString, strict: bool) -> Completion<()> {
         let strictness = Strictness::from(strict);
         self.bindings.borrow_mut().insert(name, Binding { value: None, mutability: Mutability::Immutable(strictness) });
         Ok(())
@@ -262,7 +257,7 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
     // 2. Set the bound value for N in envRec to V.
     // 3. Record that the binding for N in envRec has been initialized.
     // 4. Return NormalCompletion(empty).
-    fn initialize_binding(&self, _agent: &Agent, name: &JSString, value: ECMAScriptValue) -> Completion<()> {
+    fn initialize_binding(&self, name: &JSString, value: ECMAScriptValue) -> Completion<()> {
         self.bindings.borrow_mut().get_mut(name).unwrap().value = Some(value);
         Ok(())
     }
@@ -290,19 +285,13 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
     //
     // NOTE     An example of ECMAScript code that results in a missing binding at step 1 is:
     //              function f() { eval("var x; x = (delete x, 0);"); }
-    fn set_mutable_binding(
-        &self,
-        agent: &Agent,
-        name: JSString,
-        value: ECMAScriptValue,
-        strict: bool,
-    ) -> Completion<()> {
+    fn set_mutable_binding(&self, name: JSString, value: ECMAScriptValue, strict: bool) -> Completion<()> {
         let mut bindings = self.bindings.borrow_mut();
         let maybe_item = bindings.get_mut(&name);
         match maybe_item {
             None => {
                 if strict {
-                    return Err(create_reference_error(agent, "Identifier not defined"));
+                    return Err(create_reference_error("Identifier not defined"));
                 }
                 bindings.insert(
                     name,
@@ -312,7 +301,7 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
             }
             Some(item) => match item.value {
                 None => {
-                    return Err(create_reference_error(agent, "Binding not initialized"));
+                    return Err(create_reference_error("Binding not initialized"));
                 }
                 Some(_) => match &item.mutability {
                     Mutability::Mutable(_) => {
@@ -320,7 +309,7 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
                     }
                     Mutability::Immutable(s) => {
                         if *s == Strictness::Strict || strict {
-                            return Err(create_type_error(agent, "Cannot change read-only value"));
+                            return Err(create_type_error("Cannot change read-only value"));
                         }
                     }
                 },
@@ -339,11 +328,11 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
     //  1. Assert: envRec has a binding for N.
     //  2. If the binding for N in envRec is an uninitialized binding, throw a ReferenceError exception.
     //  3. Return the value currently bound to N in envRec.
-    fn get_binding_value(&self, agent: &Agent, name: &JSString, _strict: bool) -> Completion<ECMAScriptValue> {
+    fn get_binding_value(&self, name: &JSString, _strict: bool) -> Completion<ECMAScriptValue> {
         let bindings = self.bindings.borrow();
         let maybe_value = &bindings.get(name).unwrap().value;
         match maybe_value {
-            None => Err(create_reference_error(agent, "Binding not initialized")),
+            None => Err(create_reference_error("Binding not initialized")),
             Some(v) => Ok(v.clone()),
         }
     }
@@ -358,7 +347,7 @@ impl EnvironmentRecord for DeclarativeEnvironmentRecord {
     //  2. If the binding for N in envRec cannot be deleted, return false.
     //  3. Remove the binding for N from envRec.
     //  4. Return true.
-    fn delete_binding(&self, _agent: &Agent, name: &JSString) -> Completion<bool> {
+    fn delete_binding(&self, name: &JSString) -> Completion<bool> {
         let mut bindings = self.bindings.borrow_mut();
         let item = bindings.get(name).unwrap();
         if item.mutability != Mutability::Mutable(Removability::Deletable) {
@@ -497,19 +486,19 @@ impl EnvironmentRecord for ObjectEnvironmentRecord {
     //      a. Let blocked be ! ToBoolean(? Get(unscopables, N)).
     //      b. If blocked is true, return false.
     //  7. Return true.
-    fn has_binding(&self, agent: &Agent, name: &JSString) -> Completion<bool> {
+    fn has_binding(&self, name: &JSString) -> Completion<bool> {
         let name_key = PropertyKey::from(name);
         let binding_object = &self.binding_object;
-        let found_binding = has_property(agent, binding_object, &name_key)?;
+        let found_binding = has_property(binding_object, &name_key)?;
         if !found_binding {
             Ok(false)
         } else if !self.is_with_environment {
             Ok(true)
         } else {
-            let unscopables = get(agent, binding_object, &PropertyKey::from(agent.wks(WksId::Unscopables)))?;
+            let unscopables = get(binding_object, &PropertyKey::from(wks(WksId::Unscopables)))?;
             match &unscopables {
                 ECMAScriptValue::Object(unscopables_obj) => {
-                    let blocked = to_boolean(get(agent, unscopables_obj, &name_key)?);
+                    let blocked = to_boolean(get(unscopables_obj, &name_key)?);
                     Ok(!blocked)
                 }
                 _ => Ok(true),
@@ -531,21 +520,21 @@ impl EnvironmentRecord for ObjectEnvironmentRecord {
     //
     // NOTE     Normally envRec will not have a binding for N but if it does, the semantics of DefinePropertyOrThrow may
     //          result in an existing binding being replaced or shadowed or cause an abrupt completion to be returned.
-    fn create_mutable_binding(&self, agent: &Agent, name: JSString, deletable: bool) -> Completion<()> {
+    fn create_mutable_binding(&self, name: JSString, deletable: bool) -> Completion<()> {
         let binding_object = &self.binding_object;
         let desc = PotentialPropertyDescriptor::new()
             .value(ECMAScriptValue::Undefined)
             .writable(true)
             .enumerable(true)
             .configurable(deletable);
-        define_property_or_throw(agent, binding_object, name, desc)
+        define_property_or_throw(binding_object, name, desc)
     }
 
     // CreateImmutableBinding ( N, S )
     //
     // The CreateImmutableBinding concrete method of an object Environment Record is never used within this
     // specification.
-    fn create_immutable_binding(&self, _agent: &Agent, _name: JSString, _strict: bool) -> Completion<()> {
+    fn create_immutable_binding(&self, _name: JSString, _strict: bool) -> Completion<()> {
         unreachable!()
     }
 
@@ -560,8 +549,8 @@ impl EnvironmentRecord for ObjectEnvironmentRecord {
     // NOTE     In this specification, all uses of CreateMutableBinding for object Environment Records are immediately
     //          followed by a call to InitializeBinding for the same name. Hence, this specification does not explicitly
     //          track the initialization state of bindings in object Environment Records.
-    fn initialize_binding(&self, agent: &Agent, name: &JSString, value: ECMAScriptValue) -> Completion<()> {
-        self.set_mutable_binding(agent, name.clone(), value, false)
+    fn initialize_binding(&self, name: &JSString, value: ECMAScriptValue) -> Completion<()> {
+        self.set_mutable_binding(name.clone(), value, false)
     }
 
     // SetMutableBinding ( N, V, S )
@@ -576,20 +565,14 @@ impl EnvironmentRecord for ObjectEnvironmentRecord {
     //  2. Let stillExists be ? HasProperty(bindingObject, N).
     //  3. If stillExists is false and S is true, throw a ReferenceError exception.
     //  4. Return ? Set(bindingObject, N, V, S).
-    fn set_mutable_binding(
-        &self,
-        agent: &Agent,
-        name: JSString,
-        value: ECMAScriptValue,
-        strict: bool,
-    ) -> Completion<()> {
+    fn set_mutable_binding(&self, name: JSString, value: ECMAScriptValue, strict: bool) -> Completion<()> {
         let name_key = PropertyKey::from(name);
         let binding_object = &self.binding_object;
-        let still_exists = has_property(agent, binding_object, &name_key)?;
+        let still_exists = has_property(binding_object, &name_key)?;
         if !still_exists && strict {
-            Err(create_reference_error(agent, "Reference no longer exists"))
+            Err(create_reference_error("Reference no longer exists"))
         } else {
-            set(agent, binding_object, name_key, value, strict)?;
+            set(binding_object, name_key, value, strict)?;
             Ok(())
         }
     }
@@ -606,18 +589,18 @@ impl EnvironmentRecord for ObjectEnvironmentRecord {
     //  3. If value is false, then
     //      a. If S is false, return the value undefined; otherwise throw a ReferenceError exception.
     //  4. Return ? Get(bindingObject, N).
-    fn get_binding_value(&self, agent: &Agent, name: &JSString, strict: bool) -> Completion<ECMAScriptValue> {
+    fn get_binding_value(&self, name: &JSString, strict: bool) -> Completion<ECMAScriptValue> {
         let name_key = PropertyKey::from(name);
         let binding_object = &self.binding_object;
-        let has_prop = has_property(agent, binding_object, &name_key)?;
+        let has_prop = has_property(binding_object, &name_key)?;
         if !has_prop {
             if !strict {
                 Ok(ECMAScriptValue::Undefined)
             } else {
-                Err(create_reference_error(agent, "Unresolvable reference"))
+                Err(create_reference_error("Unresolvable reference"))
             }
         } else {
-            get(agent, binding_object, &name_key)
+            get(binding_object, &name_key)
         }
     }
 
@@ -629,10 +612,10 @@ impl EnvironmentRecord for ObjectEnvironmentRecord {
     //
     //  1. Let bindingObject be envRec.[[BindingObject]].
     //  2. Return ? bindingObject.[[Delete]](N).
-    fn delete_binding(&self, agent: &Agent, name: &JSString) -> Completion<bool> {
+    fn delete_binding(&self, name: &JSString) -> Completion<bool> {
         let name_key = PropertyKey::from(name);
         let binding_object = &self.binding_object;
-        binding_object.o.delete(agent, &name_key)
+        binding_object.o.delete(&name_key)
     }
 
     // HasThisBinding ( )
@@ -777,32 +760,26 @@ impl fmt::Debug for FunctionEnvironmentRecord {
 impl EnvironmentRecord for FunctionEnvironmentRecord {
     // Function Environment Records support all of the declarative Environment Record methods listed in Table 17 and share
     // the same specifications for all of those methods except for HasThisBinding and HasSuperBinding.
-    fn has_binding(&self, agent: &Agent, name: &JSString) -> Completion<bool> {
-        self.base.has_binding(agent, name)
+    fn has_binding(&self, name: &JSString) -> Completion<bool> {
+        self.base.has_binding(name)
     }
-    fn create_mutable_binding(&self, agent: &Agent, name: JSString, deletable: bool) -> Completion<()> {
-        self.base.create_mutable_binding(agent, name, deletable)
+    fn create_mutable_binding(&self, name: JSString, deletable: bool) -> Completion<()> {
+        self.base.create_mutable_binding(name, deletable)
     }
-    fn create_immutable_binding(&self, agent: &Agent, name: JSString, strict: bool) -> Completion<()> {
-        self.base.create_immutable_binding(agent, name, strict)
+    fn create_immutable_binding(&self, name: JSString, strict: bool) -> Completion<()> {
+        self.base.create_immutable_binding(name, strict)
     }
-    fn initialize_binding(&self, agent: &Agent, name: &JSString, value: ECMAScriptValue) -> Completion<()> {
-        self.base.initialize_binding(agent, name, value)
+    fn initialize_binding(&self, name: &JSString, value: ECMAScriptValue) -> Completion<()> {
+        self.base.initialize_binding(name, value)
     }
-    fn set_mutable_binding(
-        &self,
-        agent: &Agent,
-        name: JSString,
-        value: ECMAScriptValue,
-        strict: bool,
-    ) -> Completion<()> {
-        self.base.set_mutable_binding(agent, name, value, strict)
+    fn set_mutable_binding(&self, name: JSString, value: ECMAScriptValue, strict: bool) -> Completion<()> {
+        self.base.set_mutable_binding(name, value, strict)
     }
-    fn get_binding_value(&self, agent: &Agent, name: &JSString, strict: bool) -> Completion<ECMAScriptValue> {
-        self.base.get_binding_value(agent, name, strict)
+    fn get_binding_value(&self, name: &JSString, strict: bool) -> Completion<ECMAScriptValue> {
+        self.base.get_binding_value(name, strict)
     }
-    fn delete_binding(&self, agent: &Agent, name: &JSString) -> Completion<bool> {
-        self.base.delete_binding(agent, name)
+    fn delete_binding(&self, name: &JSString) -> Completion<bool> {
+        self.base.delete_binding(name)
     }
     fn with_base_object(&self) -> Option<Object> {
         self.base.with_base_object()
@@ -864,10 +841,10 @@ impl EnvironmentRecord for FunctionEnvironmentRecord {
     //  3. Set envRec.[[ThisValue]] to V.
     //  4. Set envRec.[[ThisBindingStatus]] to initialized.
     //  5. Return V.
-    fn bind_this_value(&self, agent: &Agent, val: ECMAScriptValue) -> Completion<ECMAScriptValue> {
+    fn bind_this_value(&self, val: ECMAScriptValue) -> Completion<ECMAScriptValue> {
         assert_ne!(self.this_binding_status.get(), BindingStatus::Lexical);
         if self.this_binding_status.get() == BindingStatus::Initialized {
-            Err(create_reference_error(agent, "This value already bound"))
+            Err(create_reference_error("This value already bound"))
         } else {
             *self.this_value.borrow_mut() = val.clone();
             self.this_binding_status.set(BindingStatus::Initialized);
@@ -914,11 +891,11 @@ impl FunctionEnvironmentRecord {
     //  2. If home has the value undefined, return undefined.
     //  3. Assert: Type(home) is Object.
     //  4. Return ? home.[[GetPrototypeOf]]().
-    pub fn get_super_base(&self, agent: &Agent) -> Completion<Option<Object>> {
+    pub fn get_super_base(&self) -> Completion<Option<Object>> {
         let fo = self.function_object.o.to_function_obj().unwrap();
         let home = &fo.function_data().borrow().home_object;
         match home {
-            Some(obj) => obj.o.get_prototype_of(agent),
+            Some(obj) => obj.o.get_prototype_of(),
             None => Ok(None),
         }
     }
@@ -1087,8 +1064,8 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     //  2. If DclRec.HasBinding(N) is true, return true.
     //  3. Let ObjRec be envRec.[[ObjectRecord]].
     //  4. Return ? ObjRec.HasBinding(N).
-    fn has_binding(&self, agent: &Agent, name: &JSString) -> Completion<bool> {
-        Ok(self.declarative_record.has_binding(agent, name).unwrap() || self.object_record.has_binding(agent, name)?)
+    fn has_binding(&self, name: &JSString) -> Completion<bool> {
+        Ok(self.declarative_record.has_binding(name).unwrap() || self.object_record.has_binding(name)?)
     }
 
     // CreateMutableBinding ( N, D )
@@ -1101,11 +1078,11 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     //  1. Let DclRec be envRec.[[DeclarativeRecord]].
     //  2. If DclRec.HasBinding(N) is true, throw a TypeError exception.
     //  3. Return DclRec.CreateMutableBinding(N, D).
-    fn create_mutable_binding(&self, agent: &Agent, name: JSString, deletable: bool) -> Completion<()> {
-        if self.declarative_record.has_binding(agent, &name).unwrap() {
-            Err(create_type_error(agent, "Binding already exists"))
+    fn create_mutable_binding(&self, name: JSString, deletable: bool) -> Completion<()> {
+        if self.declarative_record.has_binding(&name).unwrap() {
+            Err(create_type_error("Binding already exists"))
         } else {
-            self.declarative_record.create_mutable_binding(agent, name, deletable)
+            self.declarative_record.create_mutable_binding(name, deletable)
         }
     }
 
@@ -1119,11 +1096,11 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     //  1. Let DclRec be envRec.[[DeclarativeRecord]].
     //  2. If DclRec.HasBinding(N) is true, throw a TypeError exception.
     //  3. Return DclRec.CreateImmutableBinding(N, S).
-    fn create_immutable_binding(&self, agent: &Agent, name: JSString, strict: bool) -> Completion<()> {
-        if self.declarative_record.has_binding(agent, &name).unwrap() {
-            Err(create_type_error(agent, "Binding already exists"))
+    fn create_immutable_binding(&self, name: JSString, strict: bool) -> Completion<()> {
+        if self.declarative_record.has_binding(&name).unwrap() {
+            Err(create_type_error("Binding already exists"))
         } else {
-            self.declarative_record.create_immutable_binding(agent, name, strict)
+            self.declarative_record.create_immutable_binding(name, strict)
         }
     }
 
@@ -1140,11 +1117,11 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     //  3. Assert: If the binding exists, it must be in the object Environment Record.
     //  4. Let ObjRec be envRec.[[ObjectRecord]].
     //  5. Return ? ObjRec.InitializeBinding(N, V).
-    fn initialize_binding(&self, agent: &Agent, name: &JSString, value: ECMAScriptValue) -> Completion<()> {
-        if self.declarative_record.has_binding(agent, name).unwrap() {
-            self.declarative_record.initialize_binding(agent, name, value)
+    fn initialize_binding(&self, name: &JSString, value: ECMAScriptValue) -> Completion<()> {
+        if self.declarative_record.has_binding(name).unwrap() {
+            self.declarative_record.initialize_binding(name, value)
         } else {
-            self.object_record.initialize_binding(agent, name, value)
+            self.object_record.initialize_binding(name, value)
         }
     }
 
@@ -1161,17 +1138,11 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     //      a. Return DclRec.SetMutableBinding(N, V, S).
     //  3. Let ObjRec be envRec.[[ObjectRecord]].
     //  4. Return ? ObjRec.SetMutableBinding(N, V, S).
-    fn set_mutable_binding(
-        &self,
-        agent: &Agent,
-        name: JSString,
-        value: ECMAScriptValue,
-        strict: bool,
-    ) -> Completion<()> {
-        if self.declarative_record.has_binding(agent, &name).unwrap() {
-            self.declarative_record.set_mutable_binding(agent, name, value, strict)
+    fn set_mutable_binding(&self, name: JSString, value: ECMAScriptValue, strict: bool) -> Completion<()> {
+        if self.declarative_record.has_binding(&name).unwrap() {
+            self.declarative_record.set_mutable_binding(name, value, strict)
         } else {
-            self.object_record.set_mutable_binding(agent, name, value, strict)
+            self.object_record.set_mutable_binding(name, value, strict)
         }
     }
 
@@ -1188,11 +1159,11 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     //      a. Return DclRec.GetBindingValue(N, S).
     //  3. Let ObjRec be envRec.[[ObjectRecord]].
     //  4. Return ? ObjRec.GetBindingValue(N, S).
-    fn get_binding_value(&self, agent: &Agent, name: &JSString, strict: bool) -> Completion<ECMAScriptValue> {
-        if self.declarative_record.has_binding(agent, name).unwrap() {
-            self.declarative_record.get_binding_value(agent, name, strict)
+    fn get_binding_value(&self, name: &JSString, strict: bool) -> Completion<ECMAScriptValue> {
+        if self.declarative_record.has_binding(name).unwrap() {
+            self.declarative_record.get_binding_value(name, strict)
         } else {
-            self.object_record.get_binding_value(agent, name, strict)
+            self.object_record.get_binding_value(name, strict)
         }
     }
 
@@ -1215,13 +1186,13 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     //          ii. If N is an element of varNames, remove that element from the varNames.
     //      c. Return status.
     //  7. Return true.
-    fn delete_binding(&self, agent: &Agent, name: &JSString) -> Completion<bool> {
-        if self.declarative_record.has_binding(agent, name).unwrap() {
-            self.declarative_record.delete_binding(agent, name)
+    fn delete_binding(&self, name: &JSString) -> Completion<bool> {
+        if self.declarative_record.has_binding(name).unwrap() {
+            self.declarative_record.delete_binding(name)
         } else {
             let global_object = &self.object_record.binding_object;
-            if has_own_property(agent, global_object, &name.clone().into())? {
-                let status = self.object_record.delete_binding(agent, name)?;
+            if has_own_property(global_object, &name.clone().into())? {
+                let status = self.object_record.delete_binding(name)?;
                 if status {
                     self.var_names.borrow_mut().remove(name);
                 }
@@ -1313,8 +1284,8 @@ impl GlobalEnvironmentRecord {
     //
     //  1. Let DclRec be envRec.[[DeclarativeRecord]].
     //  2. Return DclRec.HasBinding(N).
-    pub fn has_lexical_declaration(&self, agent: &Agent, name: &JSString) -> bool {
-        self.declarative_record.has_binding(agent, name).unwrap()
+    pub fn has_lexical_declaration(&self, name: &JSString) -> bool {
+        self.declarative_record.has_binding(name).unwrap()
     }
 
     // HasRestrictedGlobalProperty ( N )
@@ -1334,9 +1305,9 @@ impl GlobalEnvironmentRecord {
     //          var or function declaration. A global lexical binding may not be created that has the same name as a
     //          non-configurable property of the global object. The global property "undefined" is an example of such a
     //          property.
-    pub fn has_restricted_global_property(&self, agent: &Agent, name: &JSString) -> Completion<bool> {
+    pub fn has_restricted_global_property(&self, name: &JSString) -> Completion<bool> {
         let global_object = &self.object_record.binding_object;
-        let existing_prop = global_object.o.get_own_property(agent, &name.clone().into())?;
+        let existing_prop = global_object.o.get_own_property(&name.clone().into())?;
         match existing_prop {
             None => Ok(false),
             Some(prop) => Ok(!prop.configurable),
@@ -1355,9 +1326,9 @@ impl GlobalEnvironmentRecord {
     //  3. Let hasProperty be ? HasOwnProperty(globalObject, N).
     //  4. If hasProperty is true, return true.
     //  5. Return ? IsExtensible(globalObject).
-    pub fn can_declare_global_var(&self, agent: &Agent, name: &JSString) -> Completion<bool> {
+    pub fn can_declare_global_var(&self, name: &JSString) -> Completion<bool> {
         let global_object = &self.object_record.binding_object;
-        Ok(has_own_property(agent, global_object, &name.clone().into())? || is_extensible(agent, global_object)?)
+        Ok(has_own_property(global_object, &name.clone().into())? || is_extensible(global_object)?)
     }
 
     // CanDeclareGlobalFunction ( N )
@@ -1373,11 +1344,11 @@ impl GlobalEnvironmentRecord {
     //  5. If existingProp.[[Configurable]] is true, return true.
     //  6. If IsDataDescriptor(existingProp) is true and existingProp has attribute values { [[Writable]]: true, [[Enumerable]]: true }, return true.
     //  7. Return false.
-    pub fn can_declare_global_function(&self, agent: &Agent, name: &JSString) -> Completion<bool> {
+    pub fn can_declare_global_function(&self, name: &JSString) -> Completion<bool> {
         let global_object = &self.object_record.binding_object;
-        let existing_prop = global_object.o.get_own_property(agent, &name.clone().into())?;
+        let existing_prop = global_object.o.get_own_property(&name.clone().into())?;
         match existing_prop {
-            None => is_extensible(agent, global_object),
+            None => is_extensible(global_object),
             Some(prop) => {
                 Ok(prop.configurable
                     || (prop.is_data_descriptor() && prop.is_writable() == Some(true) && prop.enumerable))
@@ -1403,13 +1374,13 @@ impl GlobalEnvironmentRecord {
     //  7. If varDeclaredNames does not contain N, then
     //      a. Append N to varDeclaredNames.
     //  8. Return NormalCompletion(empty).
-    pub fn create_global_var_binding(&self, agent: &Agent, name: JSString, deletable: bool) -> Completion<()> {
+    pub fn create_global_var_binding(&self, name: JSString, deletable: bool) -> Completion<()> {
         let global_object = &self.object_record.binding_object;
-        let has_property = has_own_property(agent, global_object, &name.clone().into())?;
-        let extensible = is_extensible(agent, global_object)?;
+        let has_property = has_own_property(global_object, &name.clone().into())?;
+        let extensible = is_extensible(global_object)?;
         if !has_property && extensible {
-            self.object_record.create_mutable_binding(agent, name.clone(), deletable)?;
-            self.object_record.initialize_binding(agent, &name, ECMAScriptValue::Undefined)?;
+            self.object_record.create_mutable_binding(name.clone(), deletable)?;
+            self.object_record.initialize_binding(&name, ECMAScriptValue::Undefined)?;
         }
         self.var_names.borrow_mut().insert(name);
         Ok(())
@@ -1443,14 +1414,13 @@ impl GlobalEnvironmentRecord {
     //          will produce the same sequence of Proxy trap calls.
     pub fn create_global_function_binding(
         &self,
-        agent: &Agent,
         name: JSString,
         val: ECMAScriptValue,
         deletable: bool,
     ) -> Completion<()> {
         let global_object = &self.object_record.binding_object;
         let prop_key = PropertyKey::from(name.clone());
-        let existing_prop = global_object.o.get_own_property(agent, &prop_key)?;
+        let existing_prop = global_object.o.get_own_property(&prop_key)?;
         let full_pd =
             |v, d| PotentialPropertyDescriptor::new().value(v).writable(true).enumerable(true).configurable(d);
         let desc = match existing_prop {
@@ -1458,8 +1428,8 @@ impl GlobalEnvironmentRecord {
             Some(prop) if prop.configurable => full_pd(val.clone(), deletable),
             _ => PotentialPropertyDescriptor::new().value(val.clone()),
         };
-        define_property_or_throw(agent, global_object, prop_key.clone(), desc)?;
-        set(agent, global_object, prop_key, val, false)?;
+        define_property_or_throw(global_object, prop_key.clone(), desc)?;
+        set(global_object, prop_key, val, false)?;
         self.var_names.borrow_mut().insert(name);
         Ok(())
     }
@@ -1516,7 +1486,6 @@ impl GlobalEnvironmentRecord {
 //      a. Let outer be env.[[OuterEnv]].
 //      b. Return ? GetIdentifierReference(outer, name, strict).
 pub fn get_identifier_reference(
-    agent: &Agent,
     environment: Option<Rc<dyn EnvironmentRecord>>,
     name: JSString,
     strict: bool,
@@ -1524,12 +1493,12 @@ pub fn get_identifier_reference(
     match environment {
         None => Ok(Reference::new(Base::Unresolvable, name, strict, None)),
         Some(env) => {
-            let exists = env.has_binding(agent, &name)?;
+            let exists = env.has_binding(&name)?;
             if exists {
                 Ok(Reference::new(Base::Environment(env.clone()), name, strict, None))
             } else {
                 let outer = env.get_outer_env();
-                get_identifier_reference(agent, outer, name, strict)
+                get_identifier_reference(outer, name, strict)
             }
         }
     }

--- a/src/environment_record/mod.rs
+++ b/src/environment_record/mod.rs
@@ -105,24 +105,23 @@ use std::rc::Rc;
 // +------------------------------+------------------------------------------------------------------------------------+
 
 pub trait EnvironmentRecord: Debug {
-    fn has_binding(&self, agent: &Agent, name: &JSString) -> Completion<bool>;
-    fn create_mutable_binding(&self, agent: &Agent, name: JSString, deletable: bool) -> Completion<()>;
-    fn create_immutable_binding(&self, agent: &Agent, name: JSString, strict: bool) -> Completion<()>;
-    fn initialize_binding(&self, agent: &Agent, name: &JSString, value: ECMAScriptValue) -> Completion<()>;
+    fn has_binding(&self, name: &JSString) -> Completion<bool>;
+    fn create_mutable_binding(&self, name: JSString, deletable: bool) -> Completion<()>;
+    fn create_immutable_binding(&self, name: JSString, strict: bool) -> Completion<()>;
+    fn initialize_binding(&self, name: &JSString, value: ECMAScriptValue) -> Completion<()>;
     fn set_mutable_binding(
         &self,
-        agent: &Agent,
         name: JSString,
         value: ECMAScriptValue,
         strict: bool,
     ) -> Completion<()>;
-    fn get_binding_value(&self, agent: &Agent, name: &JSString, strict: bool) -> Completion<ECMAScriptValue>;
-    fn delete_binding(&self, agent: &Agent, name: &JSString) -> Completion<bool>;
+    fn get_binding_value(&self, name: &JSString, strict: bool) -> Completion<ECMAScriptValue>;
+    fn delete_binding(&self, name: &JSString) -> Completion<bool>;
     fn has_this_binding(&self) -> bool;
     fn has_super_binding(&self) -> bool;
     fn with_base_object(&self) -> Option<Object>;
     fn get_outer_env(&self) -> Option<Rc<dyn EnvironmentRecord>>;
-    fn get_this_binding(&self, _agent: &Agent) -> Completion<ECMAScriptValue> {
+    fn get_this_binding(&self) -> Completion<ECMAScriptValue> {
         unreachable!()
     }
     fn bind_this_value(&self, _agent: &Agent, _val: ECMAScriptValue) -> Completion<ECMAScriptValue> {
@@ -847,9 +846,9 @@ impl EnvironmentRecord for FunctionEnvironmentRecord {
     //  1. Assert: envRec.[[ThisBindingStatus]] is not lexical.
     //  2. If envRec.[[ThisBindingStatus]] is uninitialized, throw a ReferenceError exception.
     //  3. Return envRec.[[ThisValue]].
-    fn get_this_binding(&self, agent: &Agent) -> Completion<ECMAScriptValue> {
+    fn get_this_binding(&self) -> Completion<ECMAScriptValue> {
         if self.this_binding_status.get() == BindingStatus::Uninitialized {
-            Err(create_reference_error(agent, "This binding uninitialized"))
+            Err(create_reference_error("This binding uninitialized"))
         } else {
             Ok(self.this_value.borrow().clone())
         }
@@ -1277,7 +1276,7 @@ impl EnvironmentRecord for GlobalEnvironmentRecord {
     // following steps when called:
     //
     //  1. Return envRec.[[GlobalThisValue]].
-    fn get_this_binding(&self, _: &Agent) -> Completion<ECMAScriptValue> {
+    fn get_this_binding(&self) -> Completion<ECMAScriptValue> {
         Ok(ECMAScriptValue::from(self.global_this_value.clone()))
     }
 

--- a/src/environment_record/tests.rs
+++ b/src/environment_record/tests.rs
@@ -175,10 +175,10 @@ mod declarative_environment_record {
     fn has_binding() {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_mutable_binding(&agent, JSString::from("a"), true).unwrap();
+        der.create_mutable_binding(JSString::from("a"), true).unwrap();
 
-        assert_eq!(der.has_binding(&agent, &JSString::from("a")).unwrap(), true);
-        assert_eq!(der.has_binding(&agent, &JSString::from("b")).unwrap(), false);
+        assert_eq!(der.has_binding(&JSString::from("a")).unwrap(), true);
+        assert_eq!(der.has_binding(&JSString::from("b")).unwrap(), false);
     }
 
     #[test]
@@ -186,8 +186,8 @@ mod declarative_environment_record {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
 
-        der.create_mutable_binding(&agent, JSString::from("a"), true).unwrap();
-        der.create_mutable_binding(&agent, JSString::from("b"), false).unwrap();
+        der.create_mutable_binding(JSString::from("a"), true).unwrap();
+        der.create_mutable_binding(JSString::from("b"), false).unwrap();
 
         // Poke in the internals
         let bindings = der.bindings.borrow();
@@ -203,8 +203,8 @@ mod declarative_environment_record {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
 
-        der.create_immutable_binding(&agent, JSString::from("a"), true).unwrap();
-        der.create_immutable_binding(&agent, JSString::from("b"), false).unwrap();
+        der.create_immutable_binding(JSString::from("a"), true).unwrap();
+        der.create_immutable_binding(JSString::from("b"), false).unwrap();
 
         // Poke in the internals
         let bindings = der.bindings.borrow();
@@ -220,11 +220,11 @@ mod declarative_environment_record {
     fn initialize_binding() {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_immutable_binding(&agent, JSString::from("a"), true).unwrap();
-        der.create_mutable_binding(&agent, JSString::from("b"), true).unwrap();
+        der.create_immutable_binding(JSString::from("a"), true).unwrap();
+        der.create_mutable_binding(JSString::from("b"), true).unwrap();
 
-        der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from("value")).unwrap();
-        der.initialize_binding(&agent, &JSString::from("b"), ECMAScriptValue::from("other")).unwrap();
+        der.initialize_binding(&JSString::from("a"), ECMAScriptValue::from("value")).unwrap();
+        der.initialize_binding(&JSString::from("b"), ECMAScriptValue::from("other")).unwrap();
 
         let bindings = der.bindings.borrow();
         let binding = bindings.get(&JSString::from("a")).unwrap();
@@ -237,8 +237,8 @@ mod declarative_environment_record {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
 
-        let err = der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), true).unwrap_err();
-        let msg = unwind_reference_error(&agent, err);
+        let err = der.set_mutable_binding(JSString::from("a"), ECMAScriptValue::from(10), true).unwrap_err();
+        let msg = unwind_reference_error(err);
         assert_eq!(msg, "Identifier not defined");
     }
     #[test]
@@ -246,7 +246,7 @@ mod declarative_environment_record {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
 
-        der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap();
+        der.set_mutable_binding(JSString::from("a"), ECMAScriptValue::from(10), false).unwrap();
 
         let bindings = der.bindings.borrow();
         let binding = bindings.get(&JSString::from("a")).unwrap();
@@ -257,42 +257,42 @@ mod declarative_environment_record {
     fn set_mutable_binding_03() {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_immutable_binding(&agent, JSString::from("a"), true).unwrap();
+        der.create_immutable_binding(JSString::from("a"), true).unwrap();
 
-        let err = der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap_err();
-        let msg = unwind_reference_error(&agent, err);
+        let err = der.set_mutable_binding(JSString::from("a"), ECMAScriptValue::from(10), false).unwrap_err();
+        let msg = unwind_reference_error(err);
         assert_eq!(msg, "Binding not initialized");
     }
     #[test]
     fn set_mutable_binding_04() {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_immutable_binding(&agent, JSString::from("a"), true).unwrap();
-        der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
+        der.create_immutable_binding(JSString::from("a"), true).unwrap();
+        der.initialize_binding(&JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
 
-        let err = der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap_err();
-        let msg = unwind_type_error(&agent, err);
+        let err = der.set_mutable_binding(JSString::from("a"), ECMAScriptValue::from(10), false).unwrap_err();
+        let msg = unwind_type_error(err);
         assert_eq!(msg, "Cannot change read-only value");
     }
     #[test]
     fn set_mutable_binding_05() {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_immutable_binding(&agent, JSString::from("a"), false).unwrap();
-        der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
+        der.create_immutable_binding(JSString::from("a"), false).unwrap();
+        der.initialize_binding(&JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
 
-        let err = der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), true).unwrap_err();
-        let msg = unwind_type_error(&agent, err);
+        let err = der.set_mutable_binding(JSString::from("a"), ECMAScriptValue::from(10), true).unwrap_err();
+        let msg = unwind_type_error(err);
         assert_eq!(msg, "Cannot change read-only value");
     }
     #[test]
     fn set_mutable_binding_06() {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_immutable_binding(&agent, JSString::from("a"), false).unwrap();
-        der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
+        der.create_immutable_binding(JSString::from("a"), false).unwrap();
+        der.initialize_binding(&JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
 
-        der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap();
+        der.set_mutable_binding(JSString::from("a"), ECMAScriptValue::from(10), false).unwrap();
 
         let bindings = der.bindings.borrow();
         let binding = bindings.get(&JSString::from("a")).unwrap();
@@ -302,10 +302,10 @@ mod declarative_environment_record {
     fn set_mutable_binding_07() {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_mutable_binding(&agent, JSString::from("a"), false).unwrap();
-        der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
+        der.create_mutable_binding(JSString::from("a"), false).unwrap();
+        der.initialize_binding(&JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
 
-        der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap();
+        der.set_mutable_binding(JSString::from("a"), ECMAScriptValue::from(10), false).unwrap();
 
         let bindings = der.bindings.borrow();
         let binding = bindings.get(&JSString::from("a")).unwrap();
@@ -315,10 +315,10 @@ mod declarative_environment_record {
     fn get_binding_value_01() {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_mutable_binding(&agent, JSString::from("a"), false).unwrap();
-        der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
+        der.create_mutable_binding(JSString::from("a"), false).unwrap();
+        der.initialize_binding(&JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
 
-        let result = der.get_binding_value(&agent, &JSString::from("a"), false).unwrap();
+        let result = der.get_binding_value(&JSString::from("a"), false).unwrap();
 
         assert_eq!(result, ECMAScriptValue::from(1));
     }
@@ -326,10 +326,10 @@ mod declarative_environment_record {
     fn get_binding_value_02() {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_mutable_binding(&agent, JSString::from("a"), false).unwrap();
+        der.create_mutable_binding(JSString::from("a"), false).unwrap();
 
-        let result = der.get_binding_value(&agent, &JSString::from("a"), false).unwrap_err();
-        let msg = unwind_reference_error(&agent, result);
+        let result = der.get_binding_value(&JSString::from("a"), false).unwrap_err();
+        let msg = unwind_reference_error(result);
 
         assert_eq!(msg, "Binding not initialized");
     }
@@ -337,34 +337,34 @@ mod declarative_environment_record {
     fn delete_binding_01() {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_mutable_binding(&agent, JSString::from("permanent"), false).unwrap();
+        der.create_mutable_binding(JSString::from("permanent"), false).unwrap();
 
-        let result = der.delete_binding(&agent, &JSString::from("permanent")).unwrap();
+        let result = der.delete_binding(&JSString::from("permanent")).unwrap();
 
         assert_eq!(result, false);
-        assert!(der.has_binding(&agent, &JSString::from("permanent")).unwrap());
+        assert!(der.has_binding(&JSString::from("permanent")).unwrap());
     }
     #[test]
     fn delete_binding_02() {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_mutable_binding(&agent, JSString::from("deletable"), true).unwrap();
+        der.create_mutable_binding(JSString::from("deletable"), true).unwrap();
 
-        let result = der.delete_binding(&agent, &JSString::from("deletable")).unwrap();
+        let result = der.delete_binding(&JSString::from("deletable")).unwrap();
 
         assert_eq!(result, true);
-        assert!(!der.has_binding(&agent, &JSString::from("deletable")).unwrap());
+        assert!(!der.has_binding(&JSString::from("deletable")).unwrap());
     }
     #[test]
     fn delete_binding_03() {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_immutable_binding(&agent, JSString::from("immutable"), true).unwrap();
+        der.create_immutable_binding(JSString::from("immutable"), true).unwrap();
 
-        let result = der.delete_binding(&agent, &JSString::from("immutable")).unwrap();
+        let result = der.delete_binding(&JSString::from("immutable")).unwrap();
 
         assert_eq!(result, false);
-        assert!(der.has_binding(&agent, &JSString::from("immutable")).unwrap());
+        assert!(der.has_binding(&JSString::from("immutable")).unwrap());
     }
     #[test]
     fn has_this_binding() {
@@ -388,14 +388,13 @@ mod declarative_environment_record {
     fn get_outer_env() {
         setup_test_agent();
         let der = Rc::new(DeclarativeEnvironmentRecord::new(None, "test"));
-        der.create_immutable_binding(&agent, JSString::from("sentinel"), true).unwrap();
-        der.initialize_binding(&agent, &JSString::from("sentinel"), ECMAScriptValue::from("very unique string"))
-            .unwrap();
+        der.create_immutable_binding(JSString::from("sentinel"), true).unwrap();
+        der.initialize_binding(&JSString::from("sentinel"), ECMAScriptValue::from("very unique string")).unwrap();
         let der2 = DeclarativeEnvironmentRecord::new(Some(der), "inner");
 
         let outer = der2.get_outer_env().unwrap();
 
-        let val_from_outer = outer.get_binding_value(&agent, &JSString::from("sentinel"), true).unwrap();
+        let val_from_outer = outer.get_binding_value(&JSString::from("sentinel"), true).unwrap();
         assert_eq!(val_from_outer, ECMAScriptValue::from("very unique string"));
     }
 
@@ -404,7 +403,7 @@ mod declarative_environment_record {
     fn get_this_binding() {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.get_this_binding(&agent).unwrap();
+        der.get_this_binding().unwrap();
     }
 
     #[test]
@@ -412,15 +411,15 @@ mod declarative_environment_record {
     fn bind_this_value() {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.bind_this_value(&agent, ECMAScriptValue::Undefined).unwrap();
+        der.bind_this_value(ECMAScriptValue::Undefined).unwrap();
     }
 
     #[test]
     fn binding_names() {
         setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
-        der.create_mutable_binding(&agent, JSString::from("a"), true).unwrap();
-        der.create_mutable_binding(&agent, JSString::from("greasy"), true).unwrap();
+        der.create_mutable_binding(JSString::from("a"), true).unwrap();
+        der.create_mutable_binding(JSString::from("greasy"), true).unwrap();
 
         let mut names = der.binding_names();
         names.sort();
@@ -433,8 +432,8 @@ mod object_environment_record {
     #[test]
     fn debug() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, false, None, "test");
 
         assert_ne!(format!("{:#?}", oer), "");
@@ -443,20 +442,19 @@ mod object_environment_record {
     #[test]
     fn has_binding_01() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, false, None, "test");
 
-        let result = oer.has_binding(&agent, &JSString::from("not_here")).unwrap();
+        let result = oer.has_binding(&JSString::from("not_here")).unwrap();
         assert_eq!(result, false);
     }
     #[test]
     fn has_binding_02() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         define_property_or_throw(
-            &agent,
             &binding_object,
             "exists",
             PotentialPropertyDescriptor {
@@ -470,16 +468,15 @@ mod object_environment_record {
         .unwrap();
         let oer = ObjectEnvironmentRecord::new(binding_object, false, None, "test");
 
-        let result = oer.has_binding(&agent, &JSString::from("exists")).unwrap();
+        let result = oer.has_binding(&JSString::from("exists")).unwrap();
         assert_eq!(result, true);
     }
     #[test]
     fn has_binding_03() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         define_property_or_throw(
-            &agent,
             &binding_object,
             "exists",
             PotentialPropertyDescriptor {
@@ -493,21 +490,20 @@ mod object_environment_record {
         .unwrap();
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
-        let result = oer.has_binding(&agent, &JSString::from("exists")).unwrap();
+        let result = oer.has_binding(&JSString::from("exists")).unwrap();
 
         assert_eq!(result, true);
     }
     #[test]
     fn has_binding_04() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
         // unscopables_obj = {
         //    hidden: 10,
         //    visible: false
         // }
-        let unscopables_obj = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+        let unscopables_obj = ordinary_object_create(Some(object_prototype.clone()), &[]);
         define_property_or_throw(
-            &agent,
             &unscopables_obj,
             "hidden",
             PotentialPropertyDescriptor {
@@ -520,7 +516,6 @@ mod object_environment_record {
         )
         .unwrap();
         define_property_or_throw(
-            &agent,
             &unscopables_obj,
             "visible",
             PotentialPropertyDescriptor {
@@ -538,9 +533,8 @@ mod object_environment_record {
         //    hidden: "This name is not in the environment"
         //    also: "This one also visible"
         // }
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         define_property_or_throw(
-            &agent,
             &binding_object,
             "visible",
             PotentialPropertyDescriptor {
@@ -553,7 +547,6 @@ mod object_environment_record {
         )
         .unwrap();
         define_property_or_throw(
-            &agent,
             &binding_object,
             "hidden",
             PotentialPropertyDescriptor {
@@ -566,7 +559,6 @@ mod object_environment_record {
         )
         .unwrap();
         define_property_or_throw(
-            &agent,
             &binding_object,
             "also",
             PotentialPropertyDescriptor {
@@ -578,9 +570,8 @@ mod object_environment_record {
             },
         )
         .unwrap();
-        let unscopables_sym = agent.wks(WksId::Unscopables);
+        let unscopables_sym = wks(WksId::Unscopables);
         define_property_or_throw(
-            &agent,
             &binding_object,
             unscopables_sym,
             PotentialPropertyDescriptor {
@@ -594,40 +585,40 @@ mod object_environment_record {
         .unwrap();
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
-        assert!(oer.has_binding(&agent, &JSString::from("visible")).unwrap());
-        assert!(!oer.has_binding(&agent, &JSString::from("hidden")).unwrap());
-        assert!(oer.has_binding(&agent, &JSString::from("also")).unwrap());
+        assert!(oer.has_binding(&JSString::from("visible")).unwrap());
+        assert!(!oer.has_binding(&JSString::from("hidden")).unwrap());
+        assert!(oer.has_binding(&JSString::from("also")).unwrap());
     }
     #[test]
     fn has_binding_05() {
         // has_property returns an error
         setup_test_agent();
-        let binding_object = DeadObject::object(&agent);
+        let binding_object = DeadObject::object();
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
-        let err = oer.has_binding(&agent, &JSString::from("random")).unwrap_err();
-        let msg = unwind_type_error(&agent, err);
+        let err = oer.has_binding(&JSString::from("random")).unwrap_err();
+        let msg = unwind_type_error(err);
         assert_eq!(msg, "has_property called on DeadObject");
     }
     #[test]
     fn has_binding_06() {
         // binding_object.get(@@unscopables) fails
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         // binding_object = {
         //    get [Symbol.unscopables] = %ThrowTypeError%
         //    field: true
         // }
-        let tte = agent.intrinsic(IntrinsicId::ThrowTypeError);
-        let pk = PropertyKey::from(agent.wks(WksId::Unscopables));
+        let tte = intrinsic(IntrinsicId::ThrowTypeError);
+        let pk = PropertyKey::from(wks(WksId::Unscopables));
         let property = PotentialPropertyDescriptor {
             get: Some(ECMAScriptValue::from(tte)),
             enumerable: Some(true),
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(&agent, &binding_object, pk, property).unwrap();
+        define_property_or_throw(&binding_object, pk, property).unwrap();
         let pk = PropertyKey::from("field");
         let property = PotentialPropertyDescriptor {
             value: Some(ECMAScriptValue::from(true)),
@@ -636,28 +627,28 @@ mod object_environment_record {
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(&agent, &binding_object, pk, property).unwrap();
+        define_property_or_throw(&binding_object, pk, property).unwrap();
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
-        let err = oer.has_binding(&agent, &JSString::from("field")).unwrap_err();
+        let err = oer.has_binding(&JSString::from("field")).unwrap_err();
 
-        let msg = unwind_type_error(&agent, err);
+        let msg = unwind_type_error(err);
         assert_eq!(msg, "Generic TypeError");
     }
     #[test]
     fn has_binding_07() {
         // binding_object.@@unscopables.get(field) fails
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
         // binding_object = {
         //    [Symbol.unscopables] = {
         //        get field = %ThrowTypeError%
         //    }
         //    field: true
         // }
-        let unscopables_obj = ordinary_object_create(&agent, Some(object_prototype), &[]);
-        let tte = agent.intrinsic(IntrinsicId::ThrowTypeError);
+        let unscopables_obj = ordinary_object_create(Some(object_prototype), &[]);
+        let tte = intrinsic(IntrinsicId::ThrowTypeError);
         let pk = PropertyKey::from("field");
         let property = PotentialPropertyDescriptor {
             get: Some(ECMAScriptValue::from(tte)),
@@ -665,7 +656,7 @@ mod object_environment_record {
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(&agent, &unscopables_obj, pk.clone(), property).unwrap();
+        define_property_or_throw(&unscopables_obj, pk.clone(), property).unwrap();
         let property = PotentialPropertyDescriptor {
             value: Some(ECMAScriptValue::from(true)),
             writable: Some(true),
@@ -673,8 +664,8 @@ mod object_environment_record {
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(&agent, &binding_object, pk, property).unwrap();
-        let pk = PropertyKey::from(agent.wks(WksId::Unscopables));
+        define_property_or_throw(&binding_object, pk, property).unwrap();
+        let pk = PropertyKey::from(wks(WksId::Unscopables));
         let property = PotentialPropertyDescriptor {
             value: Some(ECMAScriptValue::from(unscopables_obj)),
             writable: Some(true),
@@ -682,27 +673,27 @@ mod object_environment_record {
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(&agent, &binding_object, pk, property).unwrap();
+        define_property_or_throw(&binding_object, pk, property).unwrap();
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
-        let err = oer.has_binding(&agent, &JSString::from("field")).unwrap_err();
+        let err = oer.has_binding(&JSString::from("field")).unwrap_err();
 
-        let msg = unwind_type_error(&agent, err);
+        let msg = unwind_type_error(err);
         assert_eq!(msg, "Generic TypeError");
     }
 
     #[test]
     fn create_mutable_binding() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object.clone(), true, None, "test");
 
-        oer.create_mutable_binding(&agent, JSString::from("can_delete"), true).unwrap();
-        oer.create_mutable_binding(&agent, JSString::from("permanent"), false).unwrap();
+        oer.create_mutable_binding(JSString::from("can_delete"), true).unwrap();
+        oer.create_mutable_binding(JSString::from("permanent"), false).unwrap();
 
         let can_delete_key = PropertyKey::from("can_delete");
-        let cd_desc = binding_object.o.get_own_property(&agent, &can_delete_key).unwrap().unwrap();
+        let cd_desc = binding_object.o.get_own_property(&can_delete_key).unwrap().unwrap();
         assert_eq!(cd_desc.enumerable, true);
         assert_eq!(cd_desc.configurable, true);
         assert!(cd_desc.is_data_descriptor());
@@ -712,7 +703,7 @@ mod object_environment_record {
         }
 
         let permanent_key = PropertyKey::from("permanent");
-        let perm_desc = binding_object.o.get_own_property(&agent, &permanent_key).unwrap().unwrap();
+        let perm_desc = binding_object.o.get_own_property(&permanent_key).unwrap().unwrap();
         assert_eq!(perm_desc.enumerable, true);
         assert_eq!(perm_desc.configurable, false);
         assert!(perm_desc.is_data_descriptor());
@@ -726,26 +717,26 @@ mod object_environment_record {
     #[should_panic(expected = "unreachable code")]
     fn create_immutable_binding() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
-        oer.create_immutable_binding(&agent, JSString::from("nothing"), true).unwrap();
+        oer.create_immutable_binding(JSString::from("nothing"), true).unwrap();
     }
 
     #[test]
     fn initialize_binding() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object.clone(), true, None, "test");
         let name = JSString::from("colorado");
-        oer.create_mutable_binding(&agent, name.clone(), true).unwrap();
+        oer.create_mutable_binding(name.clone(), true).unwrap();
 
-        oer.initialize_binding(&agent, &name, ECMAScriptValue::from(76)).unwrap();
+        oer.initialize_binding(&name, ECMAScriptValue::from(76)).unwrap();
 
         let key = PropertyKey::from(name);
-        let desc = binding_object.o.get_own_property(&agent, &key).unwrap().unwrap();
+        let desc = binding_object.o.get_own_property(&key).unwrap().unwrap();
         assert_eq!(desc.enumerable, true);
         assert_eq!(desc.configurable, true);
         assert!(desc.is_data_descriptor());
@@ -758,17 +749,17 @@ mod object_environment_record {
     #[test]
     fn set_mutable_binding_01() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object.clone(), true, None, "test");
         let name = JSString::from("vegetable");
-        oer.create_mutable_binding(&agent, name.clone(), true).unwrap();
-        oer.initialize_binding(&agent, &name, ECMAScriptValue::from(true)).unwrap();
+        oer.create_mutable_binding(name.clone(), true).unwrap();
+        oer.initialize_binding(&name, ECMAScriptValue::from(true)).unwrap();
 
-        oer.set_mutable_binding(&agent, name.clone(), ECMAScriptValue::from(false), true).unwrap();
+        oer.set_mutable_binding(name.clone(), ECMAScriptValue::from(false), true).unwrap();
 
         let key = PropertyKey::from(name);
-        let desc = binding_object.o.get_own_property(&agent, &key).unwrap().unwrap();
+        let desc = binding_object.o.get_own_property(&key).unwrap().unwrap();
         assert_eq!(desc.enumerable, true);
         assert_eq!(desc.configurable, true);
         assert!(desc.is_data_descriptor());
@@ -781,107 +772,107 @@ mod object_environment_record {
     fn set_mutable_binding_02() {
         // binding that's been deleted (or was never there)
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
         let name = JSString::from("vegetable");
 
-        let err = oer.set_mutable_binding(&agent, name, ECMAScriptValue::Undefined, true).unwrap_err();
+        let err = oer.set_mutable_binding(name, ECMAScriptValue::Undefined, true).unwrap_err();
 
-        let msg = unwind_reference_error(&agent, err);
+        let msg = unwind_reference_error(err);
         assert_eq!(msg, "Reference no longer exists");
     }
     #[test]
     fn set_mutable_binding_03() {
         // has_property throws
         setup_test_agent();
-        let binding_object = DeadObject::object(&agent);
+        let binding_object = DeadObject::object();
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
         let name = JSString::from("vegetable");
 
-        let err = oer.set_mutable_binding(&agent, name, ECMAScriptValue::Undefined, true).unwrap_err();
+        let err = oer.set_mutable_binding(name, ECMAScriptValue::Undefined, true).unwrap_err();
 
-        let msg = unwind_type_error(&agent, err);
+        let msg = unwind_type_error(err);
         assert_eq!(msg, "has_property called on DeadObject");
     }
     #[test]
     fn set_mutable_binding_04() {
         // set throws
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let name = JSString::from("vegetable");
         let key = PropertyKey::from(name.clone());
-        let tte = agent.intrinsic(IntrinsicId::ThrowTypeError);
+        let tte = intrinsic(IntrinsicId::ThrowTypeError);
         let property = PotentialPropertyDescriptor {
             set: Some(ECMAScriptValue::from(tte)),
             enumerable: Some(true),
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(&agent, &binding_object, key, property).unwrap();
+        define_property_or_throw(&binding_object, key, property).unwrap();
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
-        let err = oer.set_mutable_binding(&agent, name, ECMAScriptValue::Undefined, true).unwrap_err();
+        let err = oer.set_mutable_binding(name, ECMAScriptValue::Undefined, true).unwrap_err();
 
-        let msg = unwind_type_error(&agent, err);
+        let msg = unwind_type_error(err);
         assert_eq!(msg, "Generic TypeError");
     }
 
     #[test]
     fn get_binding_value_01() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
         let name = JSString::from("vegetable");
-        oer.create_mutable_binding(&agent, name.clone(), true).unwrap();
-        oer.initialize_binding(&agent, &name, ECMAScriptValue::from(true)).unwrap();
-        oer.set_mutable_binding(&agent, name.clone(), ECMAScriptValue::from("squirrel"), true).unwrap();
+        oer.create_mutable_binding(name.clone(), true).unwrap();
+        oer.initialize_binding(&name, ECMAScriptValue::from(true)).unwrap();
+        oer.set_mutable_binding(name.clone(), ECMAScriptValue::from("squirrel"), true).unwrap();
 
-        let result = oer.get_binding_value(&agent, &name, false).unwrap();
+        let result = oer.get_binding_value(&name, false).unwrap();
         assert_eq!(result, ECMAScriptValue::from("squirrel"));
 
-        let result = oer.get_binding_value(&agent, &JSString::from("nothere"), false).unwrap();
+        let result = oer.get_binding_value(&JSString::from("nothere"), false).unwrap();
         assert_eq!(result, ECMAScriptValue::Undefined);
 
-        let result = oer.get_binding_value(&agent, &JSString::from("a"), true).unwrap_err();
-        assert_eq!(unwind_reference_error(&agent, result), "Unresolvable reference");
+        let result = oer.get_binding_value(&JSString::from("a"), true).unwrap_err();
+        assert_eq!(unwind_reference_error(result), "Unresolvable reference");
     }
     #[test]
     fn get_binding_value_02() {
         // has_property throws
         setup_test_agent();
-        let binding_object = DeadObject::object(&agent);
+        let binding_object = DeadObject::object();
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
         let name = JSString::from("vegetable");
 
-        let err = oer.get_binding_value(&agent, &name, true).unwrap_err();
+        let err = oer.get_binding_value(&name, true).unwrap_err();
 
-        let msg = unwind_type_error(&agent, err);
+        let msg = unwind_type_error(err);
         assert_eq!(msg, "has_property called on DeadObject");
     }
 
     #[test]
     fn delete() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
         let name = JSString::from("vegetable");
-        oer.create_mutable_binding(&agent, name.clone(), true).unwrap();
-        oer.initialize_binding(&agent, &name, ECMAScriptValue::from(true)).unwrap();
-        oer.set_mutable_binding(&agent, name.clone(), ECMAScriptValue::from("squirrel"), true).unwrap();
+        oer.create_mutable_binding(name.clone(), true).unwrap();
+        oer.initialize_binding(&name, ECMAScriptValue::from(true)).unwrap();
+        oer.set_mutable_binding(name.clone(), ECMAScriptValue::from("squirrel"), true).unwrap();
 
-        oer.delete_binding(&agent, &name).unwrap();
-        assert!(!oer.has_binding(&agent, &name).unwrap());
+        oer.delete_binding(&name).unwrap();
+        assert!(!oer.has_binding(&name).unwrap());
     }
 
     #[test]
     fn object_environment_record_has_this_binding() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
         assert!(!oer.has_this_binding());
@@ -890,8 +881,8 @@ mod object_environment_record {
     #[test]
     fn object_environment_record_has_super_binding() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
         assert!(!oer.has_super_binding());
@@ -900,8 +891,8 @@ mod object_environment_record {
     #[test]
     fn object_environment_record_with_base_object_01() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object.clone(), true, None, "test");
 
         assert_eq!(oer.with_base_object(), Some(binding_object));
@@ -910,8 +901,8 @@ mod object_environment_record {
     #[test]
     fn object_environment_record_with_base_object_02() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, false, None, "test");
 
         assert!(oer.with_base_object().is_none());
@@ -921,16 +912,15 @@ mod object_environment_record {
     fn object_environment_record_get_outer_env() {
         setup_test_agent();
         let der = Rc::new(DeclarativeEnvironmentRecord::new(None, "test"));
-        der.create_immutable_binding(&agent, JSString::from("sentinel"), true).unwrap();
-        der.initialize_binding(&agent, &JSString::from("sentinel"), ECMAScriptValue::from("very unique string"))
-            .unwrap();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        der.create_immutable_binding(JSString::from("sentinel"), true).unwrap();
+        der.initialize_binding(&JSString::from("sentinel"), ECMAScriptValue::from("very unique string")).unwrap();
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, false, Some(der), "test");
 
         let outer = oer.get_outer_env().unwrap();
 
-        let val_from_outer = outer.get_binding_value(&agent, &JSString::from("sentinel"), true).unwrap();
+        let val_from_outer = outer.get_binding_value(&JSString::from("sentinel"), true).unwrap();
         assert_eq!(val_from_outer, ECMAScriptValue::from("very unique string"));
     }
 
@@ -938,27 +928,27 @@ mod object_environment_record {
     #[should_panic(expected = "unreachable")]
     fn get_this_binding() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
-        oer.get_this_binding(&agent).unwrap();
+        oer.get_this_binding().unwrap();
     }
 
     #[test]
     #[should_panic(expected = "unreachable")]
     fn bind_this_value() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
-        oer.bind_this_value(&agent, 29.into()).unwrap();
+        oer.bind_this_value(29.into()).unwrap();
     }
 
     #[test]
     fn name() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "sentinel");
         assert_eq!(oer.name(), "sentinel");
     }
@@ -966,11 +956,11 @@ mod object_environment_record {
     #[test]
     fn binding_names() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let binding_object = ordinary_object_create(Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "sentinel");
-        oer.create_mutable_binding(&agent, "bill".into(), true).unwrap();
-        oer.create_mutable_binding(&agent, "alice".into(), true).unwrap();
+        oer.create_mutable_binding("bill".into(), true).unwrap();
+        oer.create_mutable_binding("alice".into(), true).unwrap();
 
         let bindings = oer.binding_names();
         assert_eq!(bindings.len(), 2);
@@ -1012,7 +1002,7 @@ mod function_environment_record {
     use super::*;
     use test_case::test_case;
 
-    fn make_fer(agent: &Agent, src: &str, new_target: Option<Object>) -> (Object, FunctionEnvironmentRecord) {
+    fn make_fer(src: &str, new_target: Option<Object>) -> (Object, FunctionEnvironmentRecord) {
         let ae = Maker::new(src).assignment_expression();
         let this_mode = if ae.contains(ParseNodeKind::ArrowFunction) || ae.contains(ParseNodeKind::AsyncArrowFunction) {
             ThisLexicality::LexicalThis
@@ -1025,7 +1015,7 @@ mod function_environment_record {
 
         let realm = agent.current_realm_record().unwrap();
         let global_env = realm.borrow().global_env.clone().unwrap();
-        let function_prototype = agent.intrinsic(IntrinsicId::FunctionPrototype);
+        let function_prototype = intrinsic(IntrinsicId::FunctionPrototype);
         let chunk = Rc::new(Chunk::new("empty"));
         let closure = ordinary_function_create(
             agent,
@@ -1047,7 +1037,7 @@ mod function_environment_record {
     fn new(source: &str) -> BindingStatus {
         setup_test_agent();
 
-        let (closure, fer) = make_fer(&agent, source, None);
+        let (closure, fer) = make_fer(source, None);
 
         assert_eq!(fer.name, "environment_tag");
         assert!(fer.new_target.is_none());
@@ -1061,7 +1051,7 @@ mod function_environment_record {
     #[test]
     fn name() {
         setup_test_agent();
-        let (_, fer) = make_fer(&agent, "function a(){}", None);
+        let (_, fer) = make_fer("function a(){}", None);
 
         assert_eq!(fer.name(), "environment_tag");
     }
@@ -1069,15 +1059,15 @@ mod function_environment_record {
     #[test]
     fn create_immutable_binding() {
         setup_test_agent();
-        let (_, fer) = make_fer(&agent, "function a(){}", None);
+        let (_, fer) = make_fer("function a(){}", None);
 
-        fer.create_immutable_binding(&agent, "bob".into(), false).unwrap();
+        fer.create_immutable_binding("bob".into(), false).unwrap();
         assert_eq!(fer.binding_names(), &[JSString::from("bob")]);
 
         // But was it immutable?
-        fer.initialize_binding(&agent, &"bob".into(), "initialized".into()).unwrap();
-        fer.set_mutable_binding(&agent, "bob".into(), "illegal".into(), true).expect_err("Should be immutable");
-        let val = fer.get_binding_value(&agent, &"bob".into(), true).unwrap();
+        fer.initialize_binding(&"bob".into(), "initialized".into()).unwrap();
+        fer.set_mutable_binding("bob".into(), "illegal".into(), true).expect_err("Should be immutable");
+        let val = fer.get_binding_value(&"bob".into(), true).unwrap();
         assert_eq!(val, ECMAScriptValue::from("initialized"));
     }
 }
@@ -1086,31 +1076,31 @@ mod global_environment_record {
     use super::*;
     use test_case::test_case;
 
-    fn setup(agent: &Agent) -> GlobalEnvironmentRecord {
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(agent, Some(object_prototype), &[]);
+    fn setup() -> GlobalEnvironmentRecord {
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
         let ld = JSString::from("lexical_deletable");
         // mutable, deletable lexical binding, named "lexical_deletable"
-        ger.declarative_record.create_mutable_binding(agent, ld.clone(), true).unwrap();
-        ger.initialize_binding(agent, &ld, ECMAScriptValue::from("LEXICAL DELETABLE")).unwrap();
+        ger.declarative_record.create_mutable_binding(ld.clone(), true).unwrap();
+        ger.initialize_binding(&ld, ECMAScriptValue::from("LEXICAL DELETABLE")).unwrap();
         // mutable, permanent lexical binding, named "lexical_permanent"
         let lp = JSString::from("lexical_permanent");
-        ger.declarative_record.create_mutable_binding(agent, lp.clone(), false).unwrap();
-        ger.initialize_binding(agent, &lp, ECMAScriptValue::from("LEXICAL PERMANENT")).unwrap();
+        ger.declarative_record.create_mutable_binding(lp.clone(), false).unwrap();
+        ger.initialize_binding(&lp, ECMAScriptValue::from("LEXICAL PERMANENT")).unwrap();
         // immutable, strict lexical binding, named "lexical_strict"
         let ls = JSString::from("lexical_strict");
-        ger.declarative_record.create_immutable_binding(agent, ls.clone(), true).unwrap();
-        ger.initialize_binding(agent, &ls, ECMAScriptValue::from("LEXICAL STRICT")).unwrap();
+        ger.declarative_record.create_immutable_binding(ls.clone(), true).unwrap();
+        ger.initialize_binding(&ls, ECMAScriptValue::from("LEXICAL STRICT")).unwrap();
         // immutable, sloppy lexical binding, named "lexical_sloppy"
         let lslop = JSString::from("lexical_sloppy");
-        ger.declarative_record.create_immutable_binding(agent, lslop.clone(), false).unwrap();
-        ger.initialize_binding(agent, &lslop, ECMAScriptValue::from("LEXICAL SLOPPY")).unwrap();
+        ger.declarative_record.create_immutable_binding(lslop.clone(), false).unwrap();
+        ger.initialize_binding(&lslop, ECMAScriptValue::from("LEXICAL SLOPPY")).unwrap();
         // configurable global var (in varnames), deletable, named "normal_var"
-        ger.create_global_var_binding(agent, JSString::from("normal_var"), true).unwrap();
+        ger.create_global_var_binding(JSString::from("normal_var"), true).unwrap();
         ger.object_record
-            .set_mutable_binding(agent, JSString::from("normal_var"), ECMAScriptValue::from("NORMAL VAR"), true)
+            .set_mutable_binding(JSString::from("normal_var"), ECMAScriptValue::from("NORMAL VAR"), true)
             .unwrap();
         // param on global object that's not in varnames (like builtin props), named "non_config_var"
         let desc = PotentialPropertyDescriptor {
@@ -1120,11 +1110,7 @@ mod global_environment_record {
             configurable: Some(false),
             ..Default::default()
         };
-        ger.object_record
-            .binding_object
-            .o
-            .define_own_property(agent, JSString::from("non_config_var").into(), desc)
-            .unwrap();
+        ger.object_record.binding_object.o.define_own_property(JSString::from("non_config_var").into(), desc).unwrap();
         // Same thing, but not writable
         let desc = PotentialPropertyDescriptor {
             value: Some(ECMAScriptValue::from("CONST")),
@@ -1136,7 +1122,7 @@ mod global_environment_record {
         ger.object_record
             .binding_object
             .o
-            .define_own_property(agent, JSString::from("non_config_permanent").into(), desc)
+            .define_own_property(JSString::from("non_config_permanent").into(), desc)
             .unwrap();
         // Same thing, but not enumerable
         let desc = PotentialPropertyDescriptor {
@@ -1149,7 +1135,7 @@ mod global_environment_record {
         ger.object_record
             .binding_object
             .o
-            .define_own_property(agent, JSString::from("non_config_unlisted").into(), desc)
+            .define_own_property(JSString::from("non_config_unlisted").into(), desc)
             .unwrap();
         // Now a non-config accessor function
         let desc = PotentialPropertyDescriptor {
@@ -1162,7 +1148,7 @@ mod global_environment_record {
         ger.object_record
             .binding_object
             .o
-            .define_own_property(agent, JSString::from("non_config_accessor").into(), desc)
+            .define_own_property(JSString::from("non_config_accessor").into(), desc)
             .unwrap();
 
         ger
@@ -1171,9 +1157,9 @@ mod global_environment_record {
     #[test]
     fn debug() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
         assert_ne!(format!("{:?}", ger), "");
@@ -1182,9 +1168,9 @@ mod global_environment_record {
     #[test]
     fn fancy_debug() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
         assert_ne!(format!("{:#?}", ger), "");
@@ -1201,9 +1187,9 @@ mod global_environment_record {
             let nobody_name = JSString::from("nobody");
             let in_object_key = PropertyKey::from(in_object_name.clone());
 
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let in_object_property = PotentialPropertyDescriptor {
                 value: Some(ECMAScriptValue::from(0)),
                 writable: Some(true),
@@ -1211,25 +1197,25 @@ mod global_environment_record {
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(&agent, &global_object, in_object_key, in_object_property).unwrap();
+            define_property_or_throw(&global_object, in_object_key, in_object_property).unwrap();
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
-            ger.create_mutable_binding(&agent, in_decl_name.clone(), true).unwrap();
-            ger.initialize_binding(&agent, &in_decl_name, ECMAScriptValue::from(0)).unwrap();
+            ger.create_mutable_binding(in_decl_name.clone(), true).unwrap();
+            ger.initialize_binding(&in_decl_name, ECMAScriptValue::from(0)).unwrap();
 
-            assert!(ger.has_binding(&agent, &in_decl_name).unwrap());
-            assert!(ger.has_binding(&agent, &in_object_name).unwrap());
-            assert!(!ger.has_binding(&agent, &nobody_name).unwrap());
+            assert!(ger.has_binding(&in_decl_name).unwrap());
+            assert!(ger.has_binding(&in_object_name).unwrap());
+            assert!(!ger.has_binding(&nobody_name).unwrap());
         }
         #[test]
         fn error_path() {
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = DeadObject::object(&agent);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = DeadObject::object();
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
-            let err = ger.has_binding(&agent, &JSString::from("a")).unwrap_err();
-            let msg = unwind_type_error(&agent, err);
+            let err = ger.has_binding(&JSString::from("a")).unwrap_err();
+            let msg = unwind_type_error(err);
             assert_eq!(msg, "has_property called on DeadObject");
         }
     }
@@ -1243,14 +1229,14 @@ mod global_environment_record {
         fn happy(deletable: bool) {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
 
             // Exercise function
-            ger.create_mutable_binding(&agent, test_name.clone(), deletable).unwrap();
+            ger.create_mutable_binding(test_name.clone(), deletable).unwrap();
 
             // Validate results
             let bindings = ger.declarative_record.bindings.borrow();
@@ -1268,19 +1254,19 @@ mod global_environment_record {
         fn error() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
+            ger.create_mutable_binding(test_name.clone(), true).unwrap();
 
             // Exercise function
-            let result = ger.create_mutable_binding(&agent, test_name, true);
+            let result = ger.create_mutable_binding(test_name, true);
 
             // Validate result
             let err = result.unwrap_err();
-            let msg = unwind_type_error(&agent, err);
+            let msg = unwind_type_error(err);
             assert_eq!(msg, "Binding already exists");
         }
     }
@@ -1294,14 +1280,14 @@ mod global_environment_record {
         fn happy(strict: bool) {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
 
             // Exercise function
-            ger.create_immutable_binding(&agent, test_name.clone(), strict).unwrap();
+            ger.create_immutable_binding(test_name.clone(), strict).unwrap();
 
             // Validate
             let bindings = ger.declarative_record.bindings.borrow();
@@ -1319,19 +1305,19 @@ mod global_environment_record {
         fn error() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
+            ger.create_mutable_binding(test_name.clone(), true).unwrap();
 
             // Exercise function
-            let result = ger.create_immutable_binding(&agent, test_name, true);
+            let result = ger.create_immutable_binding(test_name, true);
 
             // Validate result
             let err = result.unwrap_err();
-            let msg = unwind_type_error(&agent, err);
+            let msg = unwind_type_error(err);
             assert_eq!(msg, "Binding already exists");
         }
     }
@@ -1343,15 +1329,15 @@ mod global_environment_record {
         fn decl() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
+            ger.create_mutable_binding(test_name.clone(), true).unwrap();
 
             // Exercise function
-            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.initialize_binding(&test_name, ECMAScriptValue::from(527)).unwrap();
 
             let bindings = ger.declarative_record.bindings.borrow();
             // 1. Binding is in declarative record portion
@@ -1363,18 +1349,18 @@ mod global_environment_record {
         fn object() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object.clone(), this_object, "test");
             let test_name = JSString::from("test");
-            ger.object_record.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
+            ger.object_record.create_mutable_binding(test_name.clone(), true).unwrap();
 
             // Excersize function
-            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(223)).unwrap();
+            ger.initialize_binding(&test_name, ECMAScriptValue::from(223)).unwrap();
 
             // Validate
-            let val = get(&agent, &global_object, &PropertyKey::from(test_name)).unwrap();
+            let val = get(&global_object, &PropertyKey::from(test_name)).unwrap();
             assert_eq!(val, ECMAScriptValue::from(223));
         }
     }
@@ -1385,43 +1371,43 @@ mod global_environment_record {
         fn decl() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
-            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.create_mutable_binding(test_name.clone(), true).unwrap();
+            ger.initialize_binding(&test_name, ECMAScriptValue::from(527)).unwrap();
 
             // Exercise function
-            ger.set_mutable_binding(&agent, test_name.clone(), ECMAScriptValue::from(10), false).unwrap();
+            ger.set_mutable_binding(test_name.clone(), ECMAScriptValue::from(10), false).unwrap();
 
             // Validate
-            let val = ger.get_binding_value(&agent, &test_name, false).unwrap();
+            let val = ger.get_binding_value(&test_name, false).unwrap();
             assert_eq!(val, ECMAScriptValue::from(10));
-            assert!(ger.declarative_record.has_binding(&agent, &test_name).unwrap());
-            assert!(!ger.object_record.has_binding(&agent, &test_name).unwrap());
+            assert!(ger.declarative_record.has_binding(&test_name).unwrap());
+            assert!(!ger.object_record.has_binding(&test_name).unwrap());
         }
         #[test]
         fn object() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.object_record.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
-            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.object_record.create_mutable_binding(test_name.clone(), true).unwrap();
+            ger.initialize_binding(&test_name, ECMAScriptValue::from(527)).unwrap();
 
             // Exercise function
-            ger.set_mutable_binding(&agent, test_name.clone(), ECMAScriptValue::from(9933), false).unwrap();
+            ger.set_mutable_binding(test_name.clone(), ECMAScriptValue::from(9933), false).unwrap();
 
             // Validate
-            let val = ger.get_binding_value(&agent, &test_name, false).unwrap();
+            let val = ger.get_binding_value(&test_name, false).unwrap();
             assert_eq!(val, ECMAScriptValue::from(9933));
-            assert!(!ger.declarative_record.has_binding(&agent, &test_name).unwrap());
-            assert!(ger.object_record.has_binding(&agent, &test_name).unwrap());
+            assert!(!ger.declarative_record.has_binding(&test_name).unwrap());
+            assert!(ger.object_record.has_binding(&test_name).unwrap());
         }
     }
 
@@ -1432,16 +1418,16 @@ mod global_environment_record {
         fn decl() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
-            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.create_mutable_binding(test_name.clone(), true).unwrap();
+            ger.initialize_binding(&test_name, ECMAScriptValue::from(527)).unwrap();
 
             // Exercise
-            let result = ger.get_binding_value(&agent, &test_name, true).unwrap();
+            let result = ger.get_binding_value(&test_name, true).unwrap();
 
             // Validate
             assert_eq!(result, ECMAScriptValue::from(527));
@@ -1450,16 +1436,16 @@ mod global_environment_record {
         fn object() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.object_record.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
-            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.object_record.create_mutable_binding(test_name.clone(), true).unwrap();
+            ger.initialize_binding(&test_name, ECMAScriptValue::from(527)).unwrap();
 
             // Exercise
-            let result = ger.get_binding_value(&agent, &test_name, true).unwrap();
+            let result = ger.get_binding_value(&test_name, true).unwrap();
 
             // Validate
             assert_eq!(result, ECMAScriptValue::from(527));
@@ -1468,14 +1454,14 @@ mod global_environment_record {
         fn missing_sloppy() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
 
             // Exercise
-            let result = ger.get_binding_value(&agent, &test_name, false).unwrap();
+            let result = ger.get_binding_value(&test_name, false).unwrap();
 
             // Validate
             assert_eq!(result, ECMAScriptValue::Undefined);
@@ -1484,18 +1470,18 @@ mod global_environment_record {
         fn missing_strict() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
 
             // Exercise
-            let result = ger.get_binding_value(&agent, &test_name, true);
+            let result = ger.get_binding_value(&test_name, true);
 
             // Validate
             let err = result.unwrap_err();
-            let msg = unwind_reference_error(&agent, err);
+            let msg = unwind_reference_error(err);
             assert_eq!(msg, "Unresolvable reference");
         }
     }
@@ -1507,96 +1493,96 @@ mod global_environment_record {
         fn decl() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
-            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.create_mutable_binding(test_name.clone(), true).unwrap();
+            ger.initialize_binding(&test_name, ECMAScriptValue::from(527)).unwrap();
 
             // Exercise function
-            let result = ger.delete_binding(&agent, &test_name);
+            let result = ger.delete_binding(&test_name);
 
             // Validate
             assert!(result.unwrap());
-            assert!(!ger.has_binding(&agent, &test_name).unwrap());
+            assert!(!ger.has_binding(&test_name).unwrap());
         }
 
         #[test]
         fn object_binding_in_varnames() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.object_record.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
-            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.object_record.create_mutable_binding(test_name.clone(), true).unwrap();
+            ger.initialize_binding(&test_name, ECMAScriptValue::from(527)).unwrap();
             ger.var_names.borrow_mut().insert(test_name.clone());
 
             // Exercise
-            let result = ger.delete_binding(&agent, &test_name);
+            let result = ger.delete_binding(&test_name);
 
             // Validate
             assert!(result.unwrap());
-            assert!(!ger.has_binding(&agent, &test_name).unwrap());
+            assert!(!ger.has_binding(&test_name).unwrap());
             assert!(!ger.var_names.borrow().contains(&test_name));
         }
         #[test]
         fn object_binding_not_in_vn() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.object_record.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
-            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.object_record.create_mutable_binding(test_name.clone(), true).unwrap();
+            ger.initialize_binding(&test_name, ECMAScriptValue::from(527)).unwrap();
 
             // Exercise
-            let result = ger.delete_binding(&agent, &test_name);
+            let result = ger.delete_binding(&test_name);
 
             // Validate
             assert!(result.unwrap());
-            assert!(!ger.has_binding(&agent, &test_name).unwrap());
+            assert!(!ger.has_binding(&test_name).unwrap());
             assert!(!ger.var_names.borrow().contains(&test_name));
         }
         #[test]
         fn object_binding_permanent() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.object_record.create_mutable_binding(&agent, test_name.clone(), false).unwrap();
-            ger.initialize_binding(&agent, &test_name, ECMAScriptValue::from(527)).unwrap();
+            ger.object_record.create_mutable_binding(test_name.clone(), false).unwrap();
+            ger.initialize_binding(&test_name, ECMAScriptValue::from(527)).unwrap();
             ger.var_names.borrow_mut().insert(test_name.clone());
 
             // Exercise
-            let result = ger.delete_binding(&agent, &test_name);
+            let result = ger.delete_binding(&test_name);
 
             // Validate
             assert!(!result.unwrap());
-            assert!(ger.has_binding(&agent, &test_name).unwrap());
+            assert!(ger.has_binding(&test_name).unwrap());
             assert!(ger.var_names.borrow().contains(&test_name));
         }
         #[test]
         fn no_binding() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
 
             // Exercise
-            let result = ger.delete_binding(&agent, &test_name);
+            let result = ger.delete_binding(&test_name);
 
             // Validate
             assert!(result.unwrap());
@@ -1604,33 +1590,33 @@ mod global_environment_record {
         #[test]
         fn has_property_error() {
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = DeadObject::object(&agent);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = DeadObject::object();
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
-            let err = ger.delete_binding(&agent, &JSString::from("a")).unwrap_err();
-            let msg = unwind_type_error(&agent, err);
+            let err = ger.delete_binding(&JSString::from("a")).unwrap_err();
+            let msg = unwind_type_error(err);
             assert_eq!(msg, "get_own_property called on DeadObject");
         }
         #[test]
         fn delete_error() {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = TestObject::object(&agent, &[FunctionId::Delete(None)]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = TestObject::object(&[FunctionId::Delete(None)]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
             let test_name = JSString::from("test");
-            ger.object_record.create_mutable_binding(&agent, test_name.clone(), true).unwrap();
-            ger.object_record.initialize_binding(&agent, &test_name, ECMAScriptValue::from(88)).unwrap();
+            ger.object_record.create_mutable_binding(test_name.clone(), true).unwrap();
+            ger.object_record.initialize_binding(&test_name, ECMAScriptValue::from(88)).unwrap();
 
             // Exercise
-            let result = ger.delete_binding(&agent, &test_name);
+            let result = ger.delete_binding(&test_name);
 
             // Validate
             let err = result.unwrap_err();
-            let msg = unwind_type_error(&agent, err);
+            let msg = unwind_type_error(err);
             assert_eq!(msg, "[[Delete]] called on TestObject");
         }
     }
@@ -1639,9 +1625,9 @@ mod global_environment_record {
     fn has_this_binding() {
         // Setup
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
         // Exercise
@@ -1654,9 +1640,9 @@ mod global_environment_record {
     fn has_super_binding() {
         // Setup
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
         // Exercise
@@ -1669,9 +1655,9 @@ mod global_environment_record {
     fn with_base_object() {
         // Setup
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
         // Exercise
@@ -1684,9 +1670,9 @@ mod global_environment_record {
     fn get_outer_env() {
         // Setup
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
         // Exercise
@@ -1700,13 +1686,13 @@ mod global_environment_record {
     fn get_this_binding() {
         // Setup
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object.clone(), "test");
 
         // Exercise function
-        let result = ger.get_this_binding(&agent).unwrap();
+        let result = ger.get_this_binding().unwrap();
 
         // Validate
         assert_eq!(result, ECMAScriptValue::from(this_object));
@@ -1717,15 +1703,15 @@ mod global_environment_record {
     fn has_var_declaration(prop_name: &str) -> bool {
         // Setup
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
         let var_name = JSString::from("varstyle");
-        ger.create_global_var_binding(&agent, var_name, true).unwrap();
+        ger.create_global_var_binding(var_name, true).unwrap();
         let lex_name = JSString::from("lexical");
-        ger.create_mutable_binding(&agent, lex_name.clone(), true).unwrap();
-        ger.initialize_binding(&agent, &lex_name, ECMAScriptValue::Undefined).unwrap();
+        ger.create_mutable_binding(lex_name.clone(), true).unwrap();
+        ger.initialize_binding(&lex_name, ECMAScriptValue::Undefined).unwrap();
 
         // Exercise
         ger.has_var_declaration(&JSString::from(prop_name))
@@ -1735,18 +1721,18 @@ mod global_environment_record {
     fn has_lexical_declaration(prop_name: &str) -> bool {
         // Setup
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
         let var_name = JSString::from("varstyle");
-        ger.create_global_var_binding(&agent, var_name, true).unwrap();
+        ger.create_global_var_binding(var_name, true).unwrap();
         let lex_name = JSString::from("lexical");
-        ger.create_mutable_binding(&agent, lex_name.clone(), true).unwrap();
-        ger.initialize_binding(&agent, &lex_name, ECMAScriptValue::Undefined).unwrap();
+        ger.create_mutable_binding(lex_name.clone(), true).unwrap();
+        ger.initialize_binding(&lex_name, ECMAScriptValue::Undefined).unwrap();
 
         // Exercise
-        ger.has_lexical_declaration(&agent, &JSString::from(prop_name))
+        ger.has_lexical_declaration(&JSString::from(prop_name))
     }
 
     mod has_restricted_global_property {
@@ -1758,20 +1744,20 @@ mod global_environment_record {
         #[test_case("non_config_var" => true; "non-configurable property on object")]
         fn happy(propname: &str) -> bool {
             setup_test_agent();
-            let ger = setup(&agent);
-            ger.has_restricted_global_property(&agent, &JSString::from(propname)).unwrap()
+            let ger = setup();
+            ger.has_restricted_global_property(&JSString::from(propname)).unwrap()
         }
 
         #[test]
         fn error() {
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = DeadObject::object(&agent);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = DeadObject::object();
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
-            let err = ger.has_restricted_global_property(&agent, &JSString::from("test")).unwrap_err();
-            let msg = unwind_type_error(&agent, err);
+            let err = ger.has_restricted_global_property(&JSString::from("test")).unwrap_err();
+            let msg = unwind_type_error(err);
             assert_eq!(msg, "get_own_property called on DeadObject");
         }
     }
@@ -1786,12 +1772,12 @@ mod global_environment_record {
         #[test_case("not_present", false => false; "not there, not extensible")]
         fn happy(name: &str, global_extensible: bool) -> bool {
             setup_test_agent();
-            let ger = setup(&agent);
+            let ger = setup();
             if !global_extensible {
-                ger.object_record.binding_object.o.prevent_extensions(&agent).unwrap();
+                ger.object_record.binding_object.o.prevent_extensions().unwrap();
             }
 
-            ger.can_declare_global_var(&agent, &JSString::from(name)).unwrap()
+            ger.can_declare_global_var(&JSString::from(name)).unwrap()
         }
 
         #[test_case(FunctionId::GetOwnProperty(None) => "[[GetOwnProperty]] called on TestObject"; "GetOwnProperty")]
@@ -1799,13 +1785,13 @@ mod global_environment_record {
         fn error(method: FunctionId) -> String {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = TestObject::object(&agent, &[method]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = TestObject::object(&[method]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
-            let err = ger.can_declare_global_var(&agent, &JSString::from("anything")).unwrap_err();
-            unwind_type_error(&agent, err)
+            let err = ger.can_declare_global_var(&JSString::from("anything")).unwrap_err();
+            unwind_type_error(err)
         }
     }
 
@@ -1821,10 +1807,10 @@ mod global_environment_record {
         #[test_case("non_config_accessor" => false)]
         fn happy_extensible(name: &str) -> bool {
             setup_test_agent();
-            let ger = setup(&agent);
+            let ger = setup();
             let test_name = JSString::from(name);
 
-            ger.can_declare_global_function(&agent, &test_name).unwrap()
+            ger.can_declare_global_function(&test_name).unwrap()
         }
         #[test_case("not_present" => false)]
         #[test_case("normal_var" => true)]
@@ -1834,24 +1820,24 @@ mod global_environment_record {
         #[test_case("non_config_accessor" => false)]
         fn happy_frozen(name: &str) -> bool {
             setup_test_agent();
-            let ger = setup(&agent);
-            ger.object_record.binding_object.o.prevent_extensions(&agent).unwrap();
+            let ger = setup();
+            ger.object_record.binding_object.o.prevent_extensions().unwrap();
             let test_name = JSString::from(name);
 
-            ger.can_declare_global_function(&agent, &test_name).unwrap()
+            ger.can_declare_global_function(&test_name).unwrap()
         }
         #[test_case(FunctionId::GetOwnProperty(None) => "[[GetOwnProperty]] called on TestObject"; "GetOwnProperty")]
         #[test_case(FunctionId::IsExtensible => "[[IsExtensible]] called on TestObject"; "IsExtensible")]
         fn error(method: FunctionId) -> String {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = TestObject::object(&agent, &[method]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = TestObject::object(&[method]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
-            let err = ger.can_declare_global_function(&agent, &JSString::from("anything")).unwrap_err();
-            unwind_type_error(&agent, err)
+            let err = ger.can_declare_global_function(&JSString::from("anything")).unwrap_err();
+            unwind_type_error(err)
         }
     }
 
@@ -1865,19 +1851,14 @@ mod global_environment_record {
         #[test_case("normal_var", false => (ECMAScriptValue::from("NORMAL VAR"), true); "existing prop; permanent")]
         fn happy_extensible(name: &str, deletable: bool) -> (ECMAScriptValue, bool) {
             setup_test_agent();
-            let ger = setup(&agent);
+            let ger = setup();
             let test_name = JSString::from(name);
 
-            ger.create_global_var_binding(&agent, test_name.clone(), deletable).unwrap();
+            ger.create_global_var_binding(test_name.clone(), deletable).unwrap();
 
             assert!(ger.var_names.borrow().contains(&test_name));
-            let desc = ger
-                .object_record
-                .binding_object
-                .o
-                .get_own_property(&agent, &PropertyKey::from(test_name))
-                .unwrap()
-                .unwrap();
+            let desc =
+                ger.object_record.binding_object.o.get_own_property(&PropertyKey::from(test_name)).unwrap().unwrap();
             assert!(matches!(desc.property, PropertyKind::Data(_)));
             if let PropertyKind::Data(data) = desc.property {
                 (data.value, desc.configurable)
@@ -1892,15 +1873,14 @@ mod global_environment_record {
         #[test_case("normal_var", false => Some((ECMAScriptValue::from("NORMAL VAR"), true)); "existing prop; permanent")]
         fn happy_frozen(name: &str, deletable: bool) -> Option<(ECMAScriptValue, bool)> {
             setup_test_agent();
-            let ger = setup(&agent);
-            ger.object_record.binding_object.o.prevent_extensions(&agent).unwrap();
+            let ger = setup();
+            ger.object_record.binding_object.o.prevent_extensions().unwrap();
             let test_name = JSString::from(name);
 
-            ger.create_global_var_binding(&agent, test_name.clone(), deletable).unwrap();
+            ger.create_global_var_binding(test_name.clone(), deletable).unwrap();
 
             assert!(ger.var_names.borrow().contains(&test_name));
-            let opt_desc =
-                ger.object_record.binding_object.o.get_own_property(&agent, &PropertyKey::from(test_name)).unwrap();
+            let opt_desc = ger.object_record.binding_object.o.get_own_property(&PropertyKey::from(test_name)).unwrap();
             match opt_desc {
                 None => None,
                 Some(desc) => {
@@ -1921,13 +1901,13 @@ mod global_environment_record {
         fn error(method: FunctionId) -> String {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = TestObject::object(&agent, &[method]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = TestObject::object(&[method]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
-            let err = ger.create_global_var_binding(&agent, JSString::from("anything"), true).unwrap_err();
-            unwind_type_error(&agent, err)
+            let err = ger.create_global_var_binding(JSString::from("anything"), true).unwrap_err();
+            unwind_type_error(err)
         }
     }
 
@@ -1943,15 +1923,13 @@ mod global_environment_record {
         #[test_case("non_config_var", false => Some((ECMAScriptValue::from("unique"), true, true, false)); "not cfgable; permanent")]
         fn happy(name: &str, deletable: bool) -> Option<(ECMAScriptValue, bool, bool, bool)> {
             setup_test_agent();
-            let ger = setup(&agent);
+            let ger = setup();
             let test_name = JSString::from(name);
 
-            ger.create_global_function_binding(&agent, test_name.clone(), ECMAScriptValue::from("unique"), deletable)
-                .unwrap();
+            ger.create_global_function_binding(test_name.clone(), ECMAScriptValue::from("unique"), deletable).unwrap();
 
             assert!(ger.var_names.borrow().contains(&test_name));
-            let opt_desc =
-                ger.object_record.binding_object.o.get_own_property(&agent, &PropertyKey::from(test_name)).unwrap();
+            let opt_desc = ger.object_record.binding_object.o.get_own_property(&PropertyKey::from(test_name)).unwrap();
             match opt_desc {
                 None => None,
                 Some(desc) => {
@@ -1970,24 +1948,24 @@ mod global_environment_record {
         fn error(method: FunctionId) -> String {
             // Setup
             setup_test_agent();
-            let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let global_object = TestObject::object(&agent, &[method]);
-            let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+            let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+            let global_object = TestObject::object(&[method]);
+            let this_object = ordinary_object_create(Some(object_prototype), &[]);
             let ger = GlobalEnvironmentRecord::new(global_object, this_object, "test");
 
             let err = ger
-                .create_global_function_binding(&agent, JSString::from("anything"), ECMAScriptValue::Undefined, true)
+                .create_global_function_binding(JSString::from("anything"), ECMAScriptValue::Undefined, true)
                 .unwrap_err();
-            unwind_type_error(&agent, err)
+            unwind_type_error(err)
         }
     }
 
     #[test]
     fn new() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
-        let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let global_object = ordinary_object_create(Some(object_prototype.clone()), &[]);
+        let this_object = ordinary_object_create(Some(object_prototype), &[]);
         let ger = GlobalEnvironmentRecord::new(global_object.clone(), this_object.clone(), "test");
 
         assert_eq!(ger.object_record.binding_object, global_object);
@@ -1999,21 +1977,21 @@ mod global_environment_record {
     #[should_panic(expected = "unreachable")]
     fn bind_this_value() {
         setup_test_agent();
-        let ger = setup(&agent);
-        ger.bind_this_value(&agent, ECMAScriptValue::Undefined).unwrap();
+        let ger = setup();
+        ger.bind_this_value(ECMAScriptValue::Undefined).unwrap();
     }
 
     #[test]
     fn name() {
         setup_test_agent();
-        let ger = setup(&agent);
+        let ger = setup();
         assert_eq!(ger.name(), "test");
     }
 
     #[test]
     fn var_decls() {
         setup_test_agent();
-        let ger = setup(&agent);
+        let ger = setup();
         let vd_list = ger.var_decls();
         assert_eq!(vd_list.len(), 1);
         assert!(vd_list.contains(&JSString::from("normal_var")));
@@ -2022,7 +2000,7 @@ mod global_environment_record {
     #[test]
     fn lex_decls() {
         setup_test_agent();
-        let ger = setup(&agent);
+        let ger = setup();
         let lex_list = ger.lex_decls();
         assert_eq!(lex_list.len(), 4);
         assert!(lex_list.contains(&JSString::from("lexical_sloppy")));
@@ -2034,7 +2012,7 @@ mod global_environment_record {
     #[test]
     fn binding_names() {
         setup_test_agent();
-        let ger = setup(&agent);
+        let ger = setup();
         let bindings = ger.binding_names();
         assert_eq!(bindings.len(), 5);
         assert!(bindings.contains(&JSString::from("lexical_sloppy")));
@@ -2053,7 +2031,7 @@ mod get_identifier_reference {
     #[test_case("bob", false => (true, ReferencedName::from("bob"), false, None); "sloppy")]
     fn no_env(name: &str, strict: bool) -> (bool, ReferencedName, bool, Option<ECMAScriptValue>) {
         setup_test_agent();
-        let reference = get_identifier_reference(&agent, None, JSString::from(name), strict).unwrap();
+        let reference = get_identifier_reference(None, JSString::from(name), strict).unwrap();
         (
             matches!(reference.base, Base::Unresolvable),
             reference.referenced_name,
@@ -2078,15 +2056,15 @@ mod get_identifier_reference {
     fn some_env(name: &str, strict: bool) -> (EnvResult, ReferencedName, bool, Option<ECMAScriptValue>) {
         setup_test_agent();
         let parent = DeclarativeEnvironmentRecord::new(None, "test");
-        parent.create_immutable_binding(&agent, JSString::from("parent"), true).unwrap();
-        parent.initialize_binding(&agent, &JSString::from("parent"), ECMAScriptValue::from("testing")).unwrap();
+        parent.create_immutable_binding(JSString::from("parent"), true).unwrap();
+        parent.initialize_binding(&JSString::from("parent"), ECMAScriptValue::from("testing")).unwrap();
         let rcparent: Rc<dyn EnvironmentRecord> = Rc::new(parent);
         let env = DeclarativeEnvironmentRecord::new(Some(Rc::clone(&rcparent)), "inner");
-        env.create_immutable_binding(&agent, JSString::from("present"), true).unwrap();
-        env.initialize_binding(&agent, &JSString::from("present"), ECMAScriptValue::from("testing")).unwrap();
+        env.create_immutable_binding(JSString::from("present"), true).unwrap();
+        env.initialize_binding(&JSString::from("present"), ECMAScriptValue::from("testing")).unwrap();
         let rcenv: Rc<dyn EnvironmentRecord> = Rc::new(env);
 
-        let result = get_identifier_reference(&agent, Some(Rc::clone(&rcenv)), JSString::from(name), strict).unwrap();
+        let result = get_identifier_reference(Some(Rc::clone(&rcenv)), JSString::from(name), strict).unwrap();
         (
             match &result.base {
                 Base::Unresolvable => EnvResult::Unresolvable,
@@ -2110,14 +2088,14 @@ mod get_identifier_reference {
     #[test]
     fn error() {
         setup_test_agent();
-        let binding_object = TestObject::object(&agent, &[FunctionId::HasProperty(None)]);
+        let binding_object = TestObject::object(&[FunctionId::HasProperty(None)]);
         let env = ObjectEnvironmentRecord::new(binding_object, false, None, "test");
         let rcenv: Rc<dyn EnvironmentRecord> = Rc::new(env);
 
-        let result = get_identifier_reference(&agent, Some(Rc::clone(&rcenv)), JSString::from("anything"), true);
+        let result = get_identifier_reference(Some(Rc::clone(&rcenv)), JSString::from("anything"), true);
 
         let err = result.unwrap_err();
-        let msg = unwind_type_error(&agent, err);
+        let msg = unwind_type_error(err);
         assert_eq!(msg, "[[HasProperty]] called on TestObject");
     }
 }

--- a/src/environment_record/tests.rs
+++ b/src/environment_record/tests.rs
@@ -1017,17 +1017,8 @@ mod function_environment_record {
         let global_env = realm.borrow().global_env.clone().unwrap();
         let function_prototype = intrinsic(IntrinsicId::FunctionPrototype);
         let chunk = Rc::new(Chunk::new("empty"));
-        let closure = ordinary_function_create(
-            function_prototype,
-            src,
-            params,
-            body,
-            this_mode,
-            global_env,
-            None,
-            true,
-            chunk,
-        );
+        let closure =
+            ordinary_function_create(function_prototype, src, params, body, this_mode, global_env, None, true, chunk);
         (closure.clone(), FunctionEnvironmentRecord::new(closure, new_target, "environment_tag".to_string()))
     }
 

--- a/src/environment_record/tests.rs
+++ b/src/environment_record/tests.rs
@@ -158,7 +158,7 @@ mod declarative_environment_record {
     fn new(name: impl Into<String> + Clone) {
         setup_test_agent();
         let name_dup: String = name.clone().into();
-        let global_env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
+        let global_env = current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let der = DeclarativeEnvironmentRecord::new(Some(global_env.clone()), name);
         assert_eq!(der.outer_env.unwrap().name(), global_env.name());
         assert_eq!(der.name, name_dup);
@@ -1013,12 +1013,11 @@ mod function_environment_record {
         let params = node.params();
         let body = node.body();
 
-        let realm = agent.current_realm_record().unwrap();
+        let realm = current_realm_record().unwrap();
         let global_env = realm.borrow().global_env.clone().unwrap();
         let function_prototype = intrinsic(IntrinsicId::FunctionPrototype);
         let chunk = Rc::new(Chunk::new("empty"));
         let closure = ordinary_function_create(
-            agent,
             function_prototype,
             src,
             params,

--- a/src/environment_record/tests.rs
+++ b/src/environment_record/tests.rs
@@ -156,7 +156,7 @@ mod declarative_environment_record {
     #[test_case("&str"; "string slice")]
     #[test_case(JSString::from("JSString"); "JSString")]
     fn new(name: impl Into<String> + Clone) {
-        let agent = test_agent();
+        setup_test_agent();
         let name_dup: String = name.clone().into();
         let global_env = agent.current_realm_record().unwrap().borrow().global_env.clone().unwrap();
         let der = DeclarativeEnvironmentRecord::new(Some(global_env.clone()), name);
@@ -173,7 +173,7 @@ mod declarative_environment_record {
 
     #[test]
     fn has_binding() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
         der.create_mutable_binding(&agent, JSString::from("a"), true).unwrap();
 
@@ -183,7 +183,7 @@ mod declarative_environment_record {
 
     #[test]
     fn create_mutable_binding() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
 
         der.create_mutable_binding(&agent, JSString::from("a"), true).unwrap();
@@ -200,7 +200,7 @@ mod declarative_environment_record {
     }
     #[test]
     fn create_immmutable_binding() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
 
         der.create_immutable_binding(&agent, JSString::from("a"), true).unwrap();
@@ -218,7 +218,7 @@ mod declarative_environment_record {
 
     #[test]
     fn initialize_binding() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
         der.create_immutable_binding(&agent, JSString::from("a"), true).unwrap();
         der.create_mutable_binding(&agent, JSString::from("b"), true).unwrap();
@@ -234,7 +234,7 @@ mod declarative_environment_record {
     }
     #[test]
     fn set_mutable_binding_01() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
 
         let err = der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), true).unwrap_err();
@@ -243,7 +243,7 @@ mod declarative_environment_record {
     }
     #[test]
     fn set_mutable_binding_02() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
 
         der.set_mutable_binding(&agent, JSString::from("a"), ECMAScriptValue::from(10), false).unwrap();
@@ -255,7 +255,7 @@ mod declarative_environment_record {
     }
     #[test]
     fn set_mutable_binding_03() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
         der.create_immutable_binding(&agent, JSString::from("a"), true).unwrap();
 
@@ -265,7 +265,7 @@ mod declarative_environment_record {
     }
     #[test]
     fn set_mutable_binding_04() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
         der.create_immutable_binding(&agent, JSString::from("a"), true).unwrap();
         der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
@@ -276,7 +276,7 @@ mod declarative_environment_record {
     }
     #[test]
     fn set_mutable_binding_05() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
         der.create_immutable_binding(&agent, JSString::from("a"), false).unwrap();
         der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
@@ -287,7 +287,7 @@ mod declarative_environment_record {
     }
     #[test]
     fn set_mutable_binding_06() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
         der.create_immutable_binding(&agent, JSString::from("a"), false).unwrap();
         der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
@@ -300,7 +300,7 @@ mod declarative_environment_record {
     }
     #[test]
     fn set_mutable_binding_07() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
         der.create_mutable_binding(&agent, JSString::from("a"), false).unwrap();
         der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
@@ -313,7 +313,7 @@ mod declarative_environment_record {
     }
     #[test]
     fn get_binding_value_01() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
         der.create_mutable_binding(&agent, JSString::from("a"), false).unwrap();
         der.initialize_binding(&agent, &JSString::from("a"), ECMAScriptValue::from(1)).unwrap();
@@ -324,7 +324,7 @@ mod declarative_environment_record {
     }
     #[test]
     fn get_binding_value_02() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
         der.create_mutable_binding(&agent, JSString::from("a"), false).unwrap();
 
@@ -335,7 +335,7 @@ mod declarative_environment_record {
     }
     #[test]
     fn delete_binding_01() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
         der.create_mutable_binding(&agent, JSString::from("permanent"), false).unwrap();
 
@@ -346,7 +346,7 @@ mod declarative_environment_record {
     }
     #[test]
     fn delete_binding_02() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
         der.create_mutable_binding(&agent, JSString::from("deletable"), true).unwrap();
 
@@ -357,7 +357,7 @@ mod declarative_environment_record {
     }
     #[test]
     fn delete_binding_03() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
         der.create_immutable_binding(&agent, JSString::from("immutable"), true).unwrap();
 
@@ -386,7 +386,7 @@ mod declarative_environment_record {
     }
     #[test]
     fn get_outer_env() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = Rc::new(DeclarativeEnvironmentRecord::new(None, "test"));
         der.create_immutable_binding(&agent, JSString::from("sentinel"), true).unwrap();
         der.initialize_binding(&agent, &JSString::from("sentinel"), ECMAScriptValue::from("very unique string"))
@@ -402,7 +402,7 @@ mod declarative_environment_record {
     #[test]
     #[should_panic(expected = "unreachable")]
     fn get_this_binding() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
         der.get_this_binding(&agent).unwrap();
     }
@@ -410,14 +410,14 @@ mod declarative_environment_record {
     #[test]
     #[should_panic(expected = "unreachable")]
     fn bind_this_value() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
         der.bind_this_value(&agent, ECMAScriptValue::Undefined).unwrap();
     }
 
     #[test]
     fn binding_names() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = DeclarativeEnvironmentRecord::new(None, "test");
         der.create_mutable_binding(&agent, JSString::from("a"), true).unwrap();
         der.create_mutable_binding(&agent, JSString::from("greasy"), true).unwrap();
@@ -432,7 +432,7 @@ mod object_environment_record {
     use super::*;
     #[test]
     fn debug() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, false, None, "test");
@@ -442,7 +442,7 @@ mod object_environment_record {
     }
     #[test]
     fn has_binding_01() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, false, None, "test");
@@ -452,7 +452,7 @@ mod object_environment_record {
     }
     #[test]
     fn has_binding_02() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         define_property_or_throw(
@@ -475,7 +475,7 @@ mod object_environment_record {
     }
     #[test]
     fn has_binding_03() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         define_property_or_throw(
@@ -499,7 +499,7 @@ mod object_environment_record {
     }
     #[test]
     fn has_binding_04() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         // unscopables_obj = {
         //    hidden: 10,
@@ -601,7 +601,7 @@ mod object_environment_record {
     #[test]
     fn has_binding_05() {
         // has_property returns an error
-        let agent = test_agent();
+        setup_test_agent();
         let binding_object = DeadObject::object(&agent);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
 
@@ -612,7 +612,7 @@ mod object_environment_record {
     #[test]
     fn has_binding_06() {
         // binding_object.get(@@unscopables) fails
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         // binding_object = {
@@ -647,7 +647,7 @@ mod object_environment_record {
     #[test]
     fn has_binding_07() {
         // binding_object.@@unscopables.get(field) fails
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
         // binding_object = {
@@ -693,7 +693,7 @@ mod object_environment_record {
 
     #[test]
     fn create_mutable_binding() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object.clone(), true, None, "test");
@@ -725,7 +725,7 @@ mod object_environment_record {
     #[test]
     #[should_panic(expected = "unreachable code")]
     fn create_immutable_binding() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
@@ -735,7 +735,7 @@ mod object_environment_record {
 
     #[test]
     fn initialize_binding() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object.clone(), true, None, "test");
@@ -757,7 +757,7 @@ mod object_environment_record {
 
     #[test]
     fn set_mutable_binding_01() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object.clone(), true, None, "test");
@@ -780,7 +780,7 @@ mod object_environment_record {
     #[test]
     fn set_mutable_binding_02() {
         // binding that's been deleted (or was never there)
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
@@ -794,7 +794,7 @@ mod object_environment_record {
     #[test]
     fn set_mutable_binding_03() {
         // has_property throws
-        let agent = test_agent();
+        setup_test_agent();
         let binding_object = DeadObject::object(&agent);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
         let name = JSString::from("vegetable");
@@ -807,7 +807,7 @@ mod object_environment_record {
     #[test]
     fn set_mutable_binding_04() {
         // set throws
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let name = JSString::from("vegetable");
@@ -830,7 +830,7 @@ mod object_environment_record {
 
     #[test]
     fn get_binding_value_01() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
@@ -851,7 +851,7 @@ mod object_environment_record {
     #[test]
     fn get_binding_value_02() {
         // has_property throws
-        let agent = test_agent();
+        setup_test_agent();
         let binding_object = DeadObject::object(&agent);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
         let name = JSString::from("vegetable");
@@ -864,7 +864,7 @@ mod object_environment_record {
 
     #[test]
     fn delete() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
@@ -879,7 +879,7 @@ mod object_environment_record {
 
     #[test]
     fn object_environment_record_has_this_binding() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
@@ -889,7 +889,7 @@ mod object_environment_record {
 
     #[test]
     fn object_environment_record_has_super_binding() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
@@ -899,7 +899,7 @@ mod object_environment_record {
 
     #[test]
     fn object_environment_record_with_base_object_01() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object.clone(), true, None, "test");
@@ -909,7 +909,7 @@ mod object_environment_record {
 
     #[test]
     fn object_environment_record_with_base_object_02() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, false, None, "test");
@@ -919,7 +919,7 @@ mod object_environment_record {
 
     #[test]
     fn object_environment_record_get_outer_env() {
-        let agent = test_agent();
+        setup_test_agent();
         let der = Rc::new(DeclarativeEnvironmentRecord::new(None, "test"));
         der.create_immutable_binding(&agent, JSString::from("sentinel"), true).unwrap();
         der.initialize_binding(&agent, &JSString::from("sentinel"), ECMAScriptValue::from("very unique string"))
@@ -937,7 +937,7 @@ mod object_environment_record {
     #[test]
     #[should_panic(expected = "unreachable")]
     fn get_this_binding() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
@@ -947,7 +947,7 @@ mod object_environment_record {
     #[test]
     #[should_panic(expected = "unreachable")]
     fn bind_this_value() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "test");
@@ -956,7 +956,7 @@ mod object_environment_record {
 
     #[test]
     fn name() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "sentinel");
@@ -965,7 +965,7 @@ mod object_environment_record {
 
     #[test]
     fn binding_names() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let binding_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
         let oer = ObjectEnvironmentRecord::new(binding_object, true, None, "sentinel");
@@ -1045,7 +1045,7 @@ mod function_environment_record {
     #[test_case("function foo(left, right) { return left * right; }" => BindingStatus::Uninitialized; "non-lexical")]
     #[test_case("(left, right) => { return left * right; }" => BindingStatus::Lexical; "lexical")]
     fn new(source: &str) -> BindingStatus {
-        let agent = test_agent();
+        setup_test_agent();
 
         let (closure, fer) = make_fer(&agent, source, None);
 
@@ -1060,7 +1060,7 @@ mod function_environment_record {
 
     #[test]
     fn name() {
-        let agent = test_agent();
+        setup_test_agent();
         let (_, fer) = make_fer(&agent, "function a(){}", None);
 
         assert_eq!(fer.name(), "environment_tag");
@@ -1068,7 +1068,7 @@ mod function_environment_record {
 
     #[test]
     fn create_immutable_binding() {
-        let agent = test_agent();
+        setup_test_agent();
         let (_, fer) = make_fer(&agent, "function a(){}", None);
 
         fer.create_immutable_binding(&agent, "bob".into(), false).unwrap();
@@ -1170,7 +1170,7 @@ mod global_environment_record {
 
     #[test]
     fn debug() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
         let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1181,7 +1181,7 @@ mod global_environment_record {
 
     #[test]
     fn fancy_debug() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
         let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1194,7 +1194,7 @@ mod global_environment_record {
         use super::*;
         #[test]
         fn happy_path() {
-            let agent = test_agent();
+            setup_test_agent();
 
             let in_object_name = JSString::from("in_object");
             let in_decl_name = JSString::from("in_decl");
@@ -1222,7 +1222,7 @@ mod global_environment_record {
         }
         #[test]
         fn error_path() {
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = DeadObject::object(&agent);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1242,7 +1242,7 @@ mod global_environment_record {
         #[test_case(false; "Permanent")]
         fn happy(deletable: bool) {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1267,7 +1267,7 @@ mod global_environment_record {
         #[test]
         fn error() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1293,7 +1293,7 @@ mod global_environment_record {
         #[test_case(false; "Sloppy")]
         fn happy(strict: bool) {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1318,7 +1318,7 @@ mod global_environment_record {
         #[test]
         fn error() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1342,7 +1342,7 @@ mod global_environment_record {
         #[test]
         fn decl() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1362,7 +1362,7 @@ mod global_environment_record {
         #[test]
         fn object() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1384,7 +1384,7 @@ mod global_environment_record {
         #[test]
         fn decl() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1405,7 +1405,7 @@ mod global_environment_record {
         #[test]
         fn object() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1431,7 +1431,7 @@ mod global_environment_record {
         #[test]
         fn decl() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1449,7 +1449,7 @@ mod global_environment_record {
         #[test]
         fn object() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1467,7 +1467,7 @@ mod global_environment_record {
         #[test]
         fn missing_sloppy() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1483,7 +1483,7 @@ mod global_environment_record {
         #[test]
         fn missing_strict() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1506,7 +1506,7 @@ mod global_environment_record {
         #[test]
         fn decl() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1526,7 +1526,7 @@ mod global_environment_record {
         #[test]
         fn object_binding_in_varnames() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1547,7 +1547,7 @@ mod global_environment_record {
         #[test]
         fn object_binding_not_in_vn() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1567,7 +1567,7 @@ mod global_environment_record {
         #[test]
         fn object_binding_permanent() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1588,7 +1588,7 @@ mod global_environment_record {
         #[test]
         fn no_binding() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1603,7 +1603,7 @@ mod global_environment_record {
         }
         #[test]
         fn has_property_error() {
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = DeadObject::object(&agent);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1616,7 +1616,7 @@ mod global_environment_record {
         #[test]
         fn delete_error() {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = TestObject::object(&agent, &[FunctionId::Delete(None)]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1638,7 +1638,7 @@ mod global_environment_record {
     #[test]
     fn has_this_binding() {
         // Setup
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
         let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1653,7 +1653,7 @@ mod global_environment_record {
     #[test]
     fn has_super_binding() {
         // Setup
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
         let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1668,7 +1668,7 @@ mod global_environment_record {
     #[test]
     fn with_base_object() {
         // Setup
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
         let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1683,7 +1683,7 @@ mod global_environment_record {
     #[test]
     fn get_outer_env() {
         // Setup
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
         let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1699,7 +1699,7 @@ mod global_environment_record {
     #[test]
     fn get_this_binding() {
         // Setup
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
         let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1716,7 +1716,7 @@ mod global_environment_record {
     #[test_case("lexical" => false; "lex")]
     fn has_var_declaration(prop_name: &str) -> bool {
         // Setup
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
         let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1734,7 +1734,7 @@ mod global_environment_record {
     #[test_case("lexical" => true; "lex")]
     fn has_lexical_declaration(prop_name: &str) -> bool {
         // Setup
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
         let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1757,14 +1757,14 @@ mod global_environment_record {
         #[test_case("normal_var" => false; "configurable var property")]
         #[test_case("non_config_var" => true; "non-configurable property on object")]
         fn happy(propname: &str) -> bool {
-            let agent = test_agent();
+            setup_test_agent();
             let ger = setup(&agent);
             ger.has_restricted_global_property(&agent, &JSString::from(propname)).unwrap()
         }
 
         #[test]
         fn error() {
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = DeadObject::object(&agent);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1785,7 +1785,7 @@ mod global_environment_record {
         #[test_case("normal_var", false => true; "normal, not extensible")]
         #[test_case("not_present", false => false; "not there, not extensible")]
         fn happy(name: &str, global_extensible: bool) -> bool {
-            let agent = test_agent();
+            setup_test_agent();
             let ger = setup(&agent);
             if !global_extensible {
                 ger.object_record.binding_object.o.prevent_extensions(&agent).unwrap();
@@ -1798,7 +1798,7 @@ mod global_environment_record {
         #[test_case(FunctionId::IsExtensible => "[[IsExtensible]] called on TestObject"; "IsExtensible")]
         fn error(method: FunctionId) -> String {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = TestObject::object(&agent, &[method]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1820,7 +1820,7 @@ mod global_environment_record {
         #[test_case("non_config_unlisted" => false)]
         #[test_case("non_config_accessor" => false)]
         fn happy_extensible(name: &str) -> bool {
-            let agent = test_agent();
+            setup_test_agent();
             let ger = setup(&agent);
             let test_name = JSString::from(name);
 
@@ -1833,7 +1833,7 @@ mod global_environment_record {
         #[test_case("non_config_unlisted" => false)]
         #[test_case("non_config_accessor" => false)]
         fn happy_frozen(name: &str) -> bool {
-            let agent = test_agent();
+            setup_test_agent();
             let ger = setup(&agent);
             ger.object_record.binding_object.o.prevent_extensions(&agent).unwrap();
             let test_name = JSString::from(name);
@@ -1844,7 +1844,7 @@ mod global_environment_record {
         #[test_case(FunctionId::IsExtensible => "[[IsExtensible]] called on TestObject"; "IsExtensible")]
         fn error(method: FunctionId) -> String {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = TestObject::object(&agent, &[method]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1864,7 +1864,7 @@ mod global_environment_record {
         #[test_case("normal_var", true => (ECMAScriptValue::from("NORMAL VAR"), true); "existing prop; deletable")]
         #[test_case("normal_var", false => (ECMAScriptValue::from("NORMAL VAR"), true); "existing prop; permanent")]
         fn happy_extensible(name: &str, deletable: bool) -> (ECMAScriptValue, bool) {
-            let agent = test_agent();
+            setup_test_agent();
             let ger = setup(&agent);
             let test_name = JSString::from(name);
 
@@ -1891,7 +1891,7 @@ mod global_environment_record {
         #[test_case("normal_var", true => Some((ECMAScriptValue::from("NORMAL VAR"), true)); "existing prop; deletable")]
         #[test_case("normal_var", false => Some((ECMAScriptValue::from("NORMAL VAR"), true)); "existing prop; permanent")]
         fn happy_frozen(name: &str, deletable: bool) -> Option<(ECMAScriptValue, bool)> {
-            let agent = test_agent();
+            setup_test_agent();
             let ger = setup(&agent);
             ger.object_record.binding_object.o.prevent_extensions(&agent).unwrap();
             let test_name = JSString::from(name);
@@ -1920,7 +1920,7 @@ mod global_environment_record {
         #[test_case(FunctionId::Set(None) => "[[Set]] called on TestObject"; "Set")]
         fn error(method: FunctionId) -> String {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = TestObject::object(&agent, &[method]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1942,7 +1942,7 @@ mod global_environment_record {
         #[test_case("non_config_var", true => Some((ECMAScriptValue::from("unique"), true, true, false)); "not cfgable; deletable")]
         #[test_case("non_config_var", false => Some((ECMAScriptValue::from("unique"), true, true, false)); "not cfgable; permanent")]
         fn happy(name: &str, deletable: bool) -> Option<(ECMAScriptValue, bool, bool, bool)> {
-            let agent = test_agent();
+            setup_test_agent();
             let ger = setup(&agent);
             let test_name = JSString::from(name);
 
@@ -1969,7 +1969,7 @@ mod global_environment_record {
         #[test_case(FunctionId::Set(None) => "[[Set]] called on TestObject"; "Set")]
         fn error(method: FunctionId) -> String {
             // Setup
-            let agent = test_agent();
+            setup_test_agent();
             let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let global_object = TestObject::object(&agent, &[method]);
             let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1984,7 +1984,7 @@ mod global_environment_record {
 
     #[test]
     fn new() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let global_object = ordinary_object_create(&agent, Some(object_prototype.clone()), &[]);
         let this_object = ordinary_object_create(&agent, Some(object_prototype), &[]);
@@ -1998,21 +1998,21 @@ mod global_environment_record {
     #[test]
     #[should_panic(expected = "unreachable")]
     fn bind_this_value() {
-        let agent = test_agent();
+        setup_test_agent();
         let ger = setup(&agent);
         ger.bind_this_value(&agent, ECMAScriptValue::Undefined).unwrap();
     }
 
     #[test]
     fn name() {
-        let agent = test_agent();
+        setup_test_agent();
         let ger = setup(&agent);
         assert_eq!(ger.name(), "test");
     }
 
     #[test]
     fn var_decls() {
-        let agent = test_agent();
+        setup_test_agent();
         let ger = setup(&agent);
         let vd_list = ger.var_decls();
         assert_eq!(vd_list.len(), 1);
@@ -2021,7 +2021,7 @@ mod global_environment_record {
 
     #[test]
     fn lex_decls() {
-        let agent = test_agent();
+        setup_test_agent();
         let ger = setup(&agent);
         let lex_list = ger.lex_decls();
         assert_eq!(lex_list.len(), 4);
@@ -2033,7 +2033,7 @@ mod global_environment_record {
 
     #[test]
     fn binding_names() {
-        let agent = test_agent();
+        setup_test_agent();
         let ger = setup(&agent);
         let bindings = ger.binding_names();
         assert_eq!(bindings.len(), 5);
@@ -2052,7 +2052,7 @@ mod get_identifier_reference {
     #[test_case("bob", true => (true, ReferencedName::from("bob"), true, None); "strict")]
     #[test_case("bob", false => (true, ReferencedName::from("bob"), false, None); "sloppy")]
     fn no_env(name: &str, strict: bool) -> (bool, ReferencedName, bool, Option<ECMAScriptValue>) {
-        let agent = test_agent();
+        setup_test_agent();
         let reference = get_identifier_reference(&agent, None, JSString::from(name), strict).unwrap();
         (
             matches!(reference.base, Base::Unresolvable),
@@ -2076,7 +2076,7 @@ mod get_identifier_reference {
     #[test_case("parent", true => (EnvResult::ParentEnv, ReferencedName::from("parent"), true, None); "parent; strict")]
     #[test_case("parent", false => (EnvResult::ParentEnv, ReferencedName::from("parent"), false, None); "parent; sloppy")]
     fn some_env(name: &str, strict: bool) -> (EnvResult, ReferencedName, bool, Option<ECMAScriptValue>) {
-        let agent = test_agent();
+        setup_test_agent();
         let parent = DeclarativeEnvironmentRecord::new(None, "test");
         parent.create_immutable_binding(&agent, JSString::from("parent"), true).unwrap();
         parent.initialize_binding(&agent, &JSString::from("parent"), ECMAScriptValue::from("testing")).unwrap();
@@ -2109,7 +2109,7 @@ mod get_identifier_reference {
 
     #[test]
     fn error() {
-        let agent = test_agent();
+        setup_test_agent();
         let binding_object = TestObject::object(&agent, &[FunctionId::HasProperty(None)]);
         let env = ObjectEnvironmentRecord::new(binding_object, false, None, "test");
         let rcenv: Rc<dyn EnvironmentRecord> = Rc::new(env);

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -3,43 +3,38 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 fn create_native_error_object(
-    agent: &Agent,
     message: impl Into<JSString>,
     error_constructor: Object,
     proto_id: IntrinsicId,
     location: Option<Location>,
 ) -> Object {
     let o =
-        ordinary_create_from_constructor(agent, &error_constructor, proto_id, &[InternalSlotName::ErrorData]).unwrap();
+        ordinary_create_from_constructor(&error_constructor, proto_id, &[InternalSlotName::ErrorData]).unwrap();
     let desc =
         PotentialPropertyDescriptor::new().value(message.into()).writable(true).enumerable(false).configurable(true);
-    define_property_or_throw(agent, &o, "message", desc).unwrap();
+    define_property_or_throw(&o, "message", desc).unwrap();
     if let Some(location) = location {
         let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let loc = ordinary_object_create(agent, Some(obj_proto), &[]);
+        let loc = ordinary_object_create(Some(obj_proto), &[]);
         define_property_or_throw(
-            agent,
             &loc,
             "line",
             PotentialPropertyDescriptor::new().value(location.starting_line).writable(true).configurable(true),
         )
         .unwrap();
         define_property_or_throw(
-            agent,
             &loc,
             "column",
             PotentialPropertyDescriptor::new().value(location.starting_column).writable(true).configurable(true),
         )
         .unwrap();
         define_property_or_throw(
-            agent,
             &loc,
             "byte_length",
             PotentialPropertyDescriptor::new().value(location.span.length as u32).writable(true).configurable(true),
         )
         .unwrap();
         define_property_or_throw(
-            agent,
             &o,
             "location",
             PotentialPropertyDescriptor::new().value(loc).writable(true).configurable(true),
@@ -49,27 +44,27 @@ fn create_native_error_object(
     o
 }
 
-pub fn create_type_error_object(agent: &Agent, message: impl Into<JSString>) -> Object {
+pub fn create_type_error_object(message: impl Into<JSString>) -> Object {
     let error_constructor = agent.intrinsic(IntrinsicId::TypeError);
-    create_native_error_object(agent, message, error_constructor, IntrinsicId::TypeErrorPrototype, None)
+    create_native_error_object(message, error_constructor, IntrinsicId::TypeErrorPrototype, None)
 }
 
-pub fn create_type_error(agent: &Agent, message: impl Into<JSString>) -> AbruptCompletion {
-    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_type_error_object(agent, message)) }
+pub fn create_type_error(message: impl Into<JSString>) -> AbruptCompletion {
+    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_type_error_object(message)) }
 }
 
-pub fn create_reference_error_object(agent: &Agent, message: impl Into<JSString>) -> Object {
+pub fn create_reference_error_object(message: impl Into<JSString>) -> Object {
     let cstr = agent.intrinsic(IntrinsicId::ReferenceError);
-    create_native_error_object(agent, message, cstr, IntrinsicId::ReferenceErrorPrototype, None)
+    create_native_error_object(message, cstr, IntrinsicId::ReferenceErrorPrototype, None)
 }
 
-pub fn create_reference_error(agent: &Agent, message: impl Into<JSString>) -> AbruptCompletion {
-    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_reference_error_object(agent, message)) }
+pub fn create_reference_error(message: impl Into<JSString>) -> AbruptCompletion {
+    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_reference_error_object(message)) }
 }
 
-pub fn create_syntax_error_object(agent: &Agent, message: impl Into<JSString>, location: Option<Location>) -> Object {
+pub fn create_syntax_error_object(message: impl Into<JSString>, location: Option<Location>) -> Object {
     let cstr = agent.intrinsic(IntrinsicId::SyntaxError);
-    create_native_error_object(agent, message, cstr, IntrinsicId::SyntaxErrorPrototype, location)
+    create_native_error_object(message, cstr, IntrinsicId::SyntaxErrorPrototype, location)
 }
 
 pub fn create_syntax_error(
@@ -77,34 +72,34 @@ pub fn create_syntax_error(
     message: impl Into<JSString>,
     location: Option<Location>,
 ) -> AbruptCompletion {
-    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_syntax_error_object(agent, message, location)) }
+    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_syntax_error_object(message, location)) }
 }
 
-pub fn create_range_error_object(agent: &Agent, message: impl Into<JSString>) -> Object {
+pub fn create_range_error_object(message: impl Into<JSString>) -> Object {
     let cstr = agent.intrinsic(IntrinsicId::RangeError);
-    create_native_error_object(agent, message, cstr, IntrinsicId::RangeErrorPrototype, None)
+    create_native_error_object(message, cstr, IntrinsicId::RangeErrorPrototype, None)
 }
 
-pub fn create_range_error(agent: &Agent, message: impl Into<JSString>) -> AbruptCompletion {
-    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_range_error_object(agent, message)) }
+pub fn create_range_error(message: impl Into<JSString>) -> AbruptCompletion {
+    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_range_error_object(message)) }
 }
 
-pub fn create_eval_error_object(agent: &Agent, message: impl Into<JSString>) -> Object {
+pub fn create_eval_error_object(message: impl Into<JSString>) -> Object {
     let cstr = agent.intrinsic(IntrinsicId::EvalError);
-    create_native_error_object(agent, message, cstr, IntrinsicId::EvalErrorPrototype, None)
+    create_native_error_object(message, cstr, IntrinsicId::EvalErrorPrototype, None)
 }
 
-pub fn create_eval_error(agent: &Agent, message: impl Into<JSString>) -> AbruptCompletion {
-    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_eval_error_object(agent, message)) }
+pub fn create_eval_error(message: impl Into<JSString>) -> AbruptCompletion {
+    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_eval_error_object(message)) }
 }
 
-pub fn create_uri_error_object(agent: &Agent, message: impl Into<JSString>) -> Object {
+pub fn create_uri_error_object(message: impl Into<JSString>) -> Object {
     let cstr = agent.intrinsic(IntrinsicId::URIError);
-    create_native_error_object(agent, message, cstr, IntrinsicId::URIErrorPrototype, None)
+    create_native_error_object(message, cstr, IntrinsicId::URIErrorPrototype, None)
 }
 
-pub fn create_uri_error(agent: &Agent, message: impl Into<JSString>) -> AbruptCompletion {
-    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_uri_error_object(agent, message)) }
+pub fn create_uri_error(message: impl Into<JSString>) -> AbruptCompletion {
+    AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_uri_error_object(message)) }
 }
 
 #[derive(Debug)]
@@ -113,10 +108,10 @@ pub struct ErrorObject {
 }
 
 impl ErrorObject {
-    pub fn object(agent: &Agent, prototype: Option<Object>) -> Object {
+    pub fn object(prototype: Option<Object>) -> Object {
         Object {
             o: Rc::new(Self {
-                common: RefCell::new(CommonObjectData::new(agent, prototype, true, ERROR_OBJECT_SLOTS)),
+                common: RefCell::new(CommonObjectData::new(prototype, true, ERROR_OBJECT_SLOTS)),
             }),
         }
     }
@@ -148,7 +143,7 @@ impl ObjectInterface for ErrorObject {
     fn get_prototype_of(&self, _agent: &Agent) -> Completion<Option<Object>> {
         Ok(ordinary_get_prototype_of(self))
     }
-    fn set_prototype_of(&self, _agent: &Agent, obj: Option<Object>) -> Completion<bool> {
+    fn set_prototype_of(&self, _obj: Option<Object>) -> Completion<bool> {
         Ok(ordinary_set_prototype_of(self, obj))
     }
     fn is_extensible(&self, _agent: &Agent) -> Completion<bool> {
@@ -157,7 +152,7 @@ impl ObjectInterface for ErrorObject {
     fn prevent_extensions(&self, _agent: &Agent) -> Completion<bool> {
         Ok(ordinary_prevent_extensions(self))
     }
-    fn get_own_property(&self, _agent: &Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, _key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         Ok(ordinary_get_own_property(self, key))
     }
     fn define_own_property(
@@ -166,26 +161,26 @@ impl ObjectInterface for ErrorObject {
         key: PropertyKey,
         desc: PotentialPropertyDescriptor,
     ) -> Completion<bool> {
-        ordinary_define_own_property(agent, self, key, desc)
+        ordinary_define_own_property(self, key, desc)
     }
-    fn has_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
-        ordinary_has_property(agent, self, key)
+    fn has_property(&self, key: &PropertyKey) -> Completion<bool> {
+        ordinary_has_property(self, key)
     }
-    fn get(&self, agent: &Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
-        ordinary_get(agent, self, key, receiver)
+    fn get(&self, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+        ordinary_get(self, key, receiver)
     }
-    fn set(&self, agent: &Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
-        ordinary_set(agent, self, key, v, receiver)
+    fn set(&self, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
+        ordinary_set(self, key, v, receiver)
     }
-    fn delete(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
-        ordinary_delete(agent, self, key)
+    fn delete(&self, key: &PropertyKey) -> Completion<bool> {
+        ordinary_delete(self, key)
     }
     fn own_property_keys(&self, _agent: &Agent) -> Completion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(self))
     }
 }
 
-pub fn provision_error_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -240,7 +235,7 @@ pub fn provision_error_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
     //    * is an ordinary object.
     //    * is not an Error instance and does not have an [[ErrorData]] internal slot.
     //    * has a [[Prototype]] internal slot whose value is %Object.prototype%.
-    let error_prototype = ordinary_object_create(agent, Some(object_prototype), &[]);
+    let error_prototype = ordinary_object_create(Some(object_prototype), &[]);
 
     // Error.prototype
     //
@@ -329,7 +324,7 @@ pub fn error_constructor_function(
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::Error)
+    native_error_constructor_function(this_value, new_target, arguments, IntrinsicId::Error)
 }
 
 // Error.prototype.toString ( )
@@ -352,10 +347,10 @@ pub fn error_prototype_tostring(
     _arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
     if let ECMAScriptValue::Object(o) = this_value {
-        let name_prop = get(agent, &o, &PropertyKey::from("name"))?;
-        let name = if name_prop.is_undefined() { JSString::from("Error") } else { to_string(agent, name_prop)? };
-        let msg_prop = get(agent, &o, &PropertyKey::from("message"))?;
-        let msg = if msg_prop.is_undefined() { JSString::from("") } else { to_string(agent, msg_prop)? };
+        let name_prop = get(&o, &PropertyKey::from("name"))?;
+        let name = if name_prop.is_undefined() { JSString::from("Error") } else { to_string(name_prop)? };
+        let msg_prop = get(&o, &PropertyKey::from("message"))?;
+        let msg = if msg_prop.is_undefined() { JSString::from("") } else { to_string(msg_prop)? };
         if name.is_empty() {
             Ok(ECMAScriptValue::from(msg))
         } else if msg.is_empty() {
@@ -364,7 +359,7 @@ pub fn error_prototype_tostring(
             Ok(ECMAScriptValue::from(name.concat(": ").concat(msg)))
         }
     } else {
-        Err(create_type_error(agent, "Error.prototype.toString called with non-object this value"))
+        Err(create_type_error("Error.prototype.toString called with non-object this value"))
     }
 }
 
@@ -431,7 +426,7 @@ fn provision_native_error_intrinsics(
     //    * is an ordinary object.
     //    * is not an Error instance and does not have an [[ErrorData]] internal slot.
     //    * has a [[Prototype]] internal slot whose value is %Error.prototype%.
-    let native_error_prototype = ordinary_object_create(agent, Some(error_prototype), &[]);
+    let native_error_prototype = ordinary_object_create(Some(error_prototype), &[]);
 
     // NativeError.prototype
     //
@@ -508,12 +503,12 @@ fn native_error_constructor_function(
             &afo
         }
     };
-    let o = ordinary_create_from_constructor(agent, nt, intrinsic_id, &[InternalSlotName::ErrorData])?;
+    let o = ordinary_create_from_constructor(nt, intrinsic_id, &[InternalSlotName::ErrorData])?;
     if !message.is_undefined() {
-        let msg = to_string(agent, message)?;
+        let msg = to_string(message)?;
         let msg_desc =
             PotentialPropertyDescriptor::new().value(msg).writable(true).enumerable(false).configurable(true);
-        define_property_or_throw(agent, &o, "message", msg_desc).unwrap();
+        define_property_or_throw(&o, "message", msg_desc).unwrap();
     }
     Ok(ECMAScriptValue::from(o))
 }
@@ -524,7 +519,7 @@ fn type_error_constructor_function(
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::TypeErrorPrototype)
+    native_error_constructor_function(this_value, new_target, arguments, IntrinsicId::TypeErrorPrototype)
 }
 fn eval_error_constructor_function(
     agent: &Agent,
@@ -532,7 +527,7 @@ fn eval_error_constructor_function(
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::EvalErrorPrototype)
+    native_error_constructor_function(this_value, new_target, arguments, IntrinsicId::EvalErrorPrototype)
 }
 fn range_error_constructor_function(
     agent: &Agent,
@@ -540,7 +535,7 @@ fn range_error_constructor_function(
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::RangeErrorPrototype)
+    native_error_constructor_function(this_value, new_target, arguments, IntrinsicId::RangeErrorPrototype)
 }
 fn reference_error_constructor_function(
     agent: &Agent,
@@ -548,7 +543,7 @@ fn reference_error_constructor_function(
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::ReferenceErrorPrototype)
+    native_error_constructor_function(this_value, new_target, arguments, IntrinsicId::ReferenceErrorPrototype)
 }
 fn syntax_error_constructor_function(
     agent: &Agent,
@@ -556,7 +551,7 @@ fn syntax_error_constructor_function(
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::SyntaxErrorPrototype)
+    native_error_constructor_function(this_value, new_target, arguments, IntrinsicId::SyntaxErrorPrototype)
 }
 fn uri_error_constructor_function(
     agent: &Agent,
@@ -564,55 +559,55 @@ fn uri_error_constructor_function(
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    native_error_constructor_function(agent, this_value, new_target, arguments, IntrinsicId::URIErrorPrototype)
+    native_error_constructor_function(this_value, new_target, arguments, IntrinsicId::URIErrorPrototype)
 }
 
-pub fn provision_type_error_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_type_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
-        provision_native_error_intrinsics(agent, realm, "TypeError", type_error_constructor_function);
+        provision_native_error_intrinsics(realm, "TypeError", type_error_constructor_function);
     realm.borrow_mut().intrinsics.type_error = constructor;
     realm.borrow_mut().intrinsics.type_error_prototype = prototype;
 }
-pub fn provision_eval_error_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_eval_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
-        provision_native_error_intrinsics(agent, realm, "EvalError", eval_error_constructor_function);
+        provision_native_error_intrinsics(realm, "EvalError", eval_error_constructor_function);
     realm.borrow_mut().intrinsics.eval_error = constructor;
     realm.borrow_mut().intrinsics.eval_error_prototype = prototype;
 }
-pub fn provision_range_error_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_range_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
-        provision_native_error_intrinsics(agent, realm, "RangeError", range_error_constructor_function);
+        provision_native_error_intrinsics(realm, "RangeError", range_error_constructor_function);
     realm.borrow_mut().intrinsics.range_error = constructor;
     realm.borrow_mut().intrinsics.range_error_prototype = prototype;
 }
-pub fn provision_reference_error_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_reference_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
-        provision_native_error_intrinsics(agent, realm, "ReferenceError", reference_error_constructor_function);
+        provision_native_error_intrinsics(realm, "ReferenceError", reference_error_constructor_function);
     realm.borrow_mut().intrinsics.reference_error = constructor;
     realm.borrow_mut().intrinsics.reference_error_prototype = prototype;
 }
-pub fn provision_syntax_error_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_syntax_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
-        provision_native_error_intrinsics(agent, realm, "SyntaxError", syntax_error_constructor_function);
+        provision_native_error_intrinsics(realm, "SyntaxError", syntax_error_constructor_function);
     realm.borrow_mut().intrinsics.syntax_error = constructor;
     realm.borrow_mut().intrinsics.syntax_error_prototype = prototype;
 }
-pub fn provision_uri_error_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_uri_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
-        provision_native_error_intrinsics(agent, realm, "URIError", uri_error_constructor_function);
+        provision_native_error_intrinsics(realm, "URIError", uri_error_constructor_function);
     realm.borrow_mut().intrinsics.uri_error = constructor;
     realm.borrow_mut().intrinsics.uri_error_prototype = prototype;
 }
 
 /// Transform an ECMAScript Error object into a Rust string
-pub fn unwind_any_error_value(agent: &Agent, err: ECMAScriptValue) -> String {
-    to_string(agent, err).unwrap().into()
+pub fn unwind_any_error_value(err: ECMAScriptValue) -> String {
+    to_string(err).unwrap().into()
 }
 
 /// Transform an ECMAScript Throw Completion into a Rust string
-pub fn unwind_any_error(agent: &Agent, completion: AbruptCompletion) -> String {
+pub fn unwind_any_error(completion: AbruptCompletion) -> String {
     match completion {
-        AbruptCompletion::Throw { value: err } => unwind_any_error_value(agent, err),
+        AbruptCompletion::Throw { value: err } => unwind_any_error_value(err),
         _ => panic!("Improper completion for error: {:?}", completion),
     }
 }

--- a/src/errors/tests.rs
+++ b/src/errors/tests.rs
@@ -4,7 +4,7 @@ use test_case::test_case;
 
 #[test]
 fn create_native_error_object_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let constructor = agent.intrinsic(IntrinsicId::RangeError);
     let message = "Great Googly Moogly!";
     let proto_id = IntrinsicId::RangeErrorPrototype;
@@ -20,7 +20,7 @@ fn create_native_error_object_01() {
 
 #[test]
 fn create_type_error_object_01() {
-    let agent = test_agent();
+    setup_test_agent();
 
     let result = create_type_error_object(&agent, "Happy Days");
 
@@ -31,7 +31,7 @@ fn create_type_error_object_01() {
 
 #[test]
 fn create_type_error_01() {
-    let agent = test_agent();
+    setup_test_agent();
 
     let result = create_type_error(&agent, "A");
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
@@ -47,7 +47,7 @@ fn create_type_error_01() {
 
 #[test]
 fn create_eval_error_object_01() {
-    let agent = test_agent();
+    setup_test_agent();
 
     let result = create_eval_error_object(&agent, "Happy Days");
 
@@ -58,7 +58,7 @@ fn create_eval_error_object_01() {
 
 #[test]
 fn create_eval_error_01() {
-    let agent = test_agent();
+    setup_test_agent();
 
     let result = create_eval_error(&agent, "A");
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
@@ -74,7 +74,7 @@ fn create_eval_error_01() {
 
 #[test]
 fn create_reference_error_object_01() {
-    let agent = test_agent();
+    setup_test_agent();
 
     let result = create_reference_error_object(&agent, "Happy Days");
 
@@ -85,7 +85,7 @@ fn create_reference_error_object_01() {
 
 #[test]
 fn create_reference_error_01() {
-    let agent = test_agent();
+    setup_test_agent();
 
     let result = create_reference_error(&agent, "A");
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
@@ -101,7 +101,7 @@ fn create_reference_error_01() {
 
 #[test]
 fn create_range_error_object_01() {
-    let agent = test_agent();
+    setup_test_agent();
 
     let result = create_range_error_object(&agent, "Happy Days");
 
@@ -112,7 +112,7 @@ fn create_range_error_object_01() {
 
 #[test]
 fn create_range_error_01() {
-    let agent = test_agent();
+    setup_test_agent();
 
     let result = create_range_error(&agent, "A");
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
@@ -128,7 +128,7 @@ fn create_range_error_01() {
 
 #[test]
 fn create_syntax_error_object_01() {
-    let agent = test_agent();
+    setup_test_agent();
 
     let result = create_syntax_error_object(
         &agent,
@@ -147,7 +147,7 @@ fn create_syntax_error_object_01() {
 
 #[test]
 fn create_syntax_error_01() {
-    let agent = test_agent();
+    setup_test_agent();
 
     let result = create_syntax_error(&agent, "A", None);
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
@@ -163,7 +163,7 @@ fn create_syntax_error_01() {
 
 #[test]
 fn create_uri_error_object_01() {
-    let agent = test_agent();
+    setup_test_agent();
 
     let result = create_uri_error_object(&agent, "Happy Days");
 
@@ -174,7 +174,7 @@ fn create_uri_error_object_01() {
 
 #[test]
 fn create_uri_error_01() {
-    let agent = test_agent();
+    setup_test_agent();
 
     let result = create_uri_error(&agent, "A");
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
@@ -190,14 +190,14 @@ fn create_uri_error_01() {
 
 #[test]
 fn error_object_debug() {
-    let agent = test_agent();
+    setup_test_agent();
     let eo = ErrorObject { common: RefCell::new(CommonObjectData::new(&agent, None, true, &[])) };
     assert_ne!(format!("{:?}", eo), "");
 }
 
 #[test]
 fn error_object_object() {
-    let agent = test_agent();
+    setup_test_agent();
     let eo = ErrorObject::object(&agent, None);
 
     assert!(eo.o.is_error_object());
@@ -210,7 +210,7 @@ fn create_error_object(agent: &Agent) -> Object {
 }
 #[test]
 fn error_object_common_object_data() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
     let error_prototype = agent.intrinsic(IntrinsicId::ErrorPrototype);
 
@@ -224,7 +224,7 @@ fn error_object_common_object_data() {
 }
 #[test]
 fn error_object_is_ordinary() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     let result = no.o.is_ordinary();
@@ -233,7 +233,7 @@ fn error_object_is_ordinary() {
 }
 #[test]
 fn error_object_id() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     // ... essentially, assert that it doesn't panic.
@@ -241,7 +241,7 @@ fn error_object_id() {
 }
 #[test]
 fn error_object_to_error_object() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     let result = no.o.to_error_obj();
@@ -249,7 +249,7 @@ fn error_object_to_error_object() {
 }
 #[test]
 fn error_object_is_error_object() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     let result = no.o.is_error_object();
@@ -258,7 +258,7 @@ fn error_object_is_error_object() {
 }
 #[test]
 fn error_object_get_prototype_of() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     let result = no.o.get_prototype_of(&agent).unwrap();
@@ -266,7 +266,7 @@ fn error_object_get_prototype_of() {
 }
 #[test]
 fn error_object_set_prototype_of() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     let result = no.o.set_prototype_of(&agent, None).unwrap();
@@ -274,7 +274,7 @@ fn error_object_set_prototype_of() {
 }
 #[test]
 fn error_object_is_extensible() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     let result = no.o.is_extensible(&agent).unwrap();
@@ -282,7 +282,7 @@ fn error_object_is_extensible() {
 }
 #[test]
 fn error_object_prevent_extensions() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     let result = no.o.prevent_extensions(&agent).unwrap();
@@ -290,7 +290,7 @@ fn error_object_prevent_extensions() {
 }
 #[test]
 fn error_object_get_own_property() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     let result = no.o.get_own_property(&agent, &PropertyKey::from("a")).unwrap();
@@ -298,7 +298,7 @@ fn error_object_get_own_property() {
 }
 #[test]
 fn error_object_define_own_property() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     let result =
@@ -312,7 +312,7 @@ fn error_object_define_own_property() {
 }
 #[test]
 fn error_object_has_property() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     let result = no.o.has_property(&agent, &PropertyKey::from("a")).unwrap();
@@ -320,7 +320,7 @@ fn error_object_has_property() {
 }
 #[test]
 fn error_object_get() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     let result = no.o.get(&agent, &PropertyKey::from("a"), &ECMAScriptValue::from(no.clone())).unwrap();
@@ -328,7 +328,7 @@ fn error_object_get() {
 }
 #[test]
 fn error_object_set() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     let result =
@@ -338,7 +338,7 @@ fn error_object_set() {
 }
 #[test]
 fn error_object_delete() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     let result = no.o.delete(&agent, &PropertyKey::from("a")).unwrap();
@@ -346,7 +346,7 @@ fn error_object_delete() {
 }
 #[test]
 fn error_object_own_property_keys() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     let result = no.o.own_property_keys(&agent).unwrap();
@@ -354,7 +354,7 @@ fn error_object_own_property_keys() {
 }
 #[test]
 fn error_object_other_automatic_functions() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_error_object(&agent);
 
     assert!(!no.o.is_number_object());
@@ -374,7 +374,7 @@ fn error_object_other_automatic_functions() {
 
 #[test]
 fn error_constructor_data_props() {
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
 
     let val = get(&agent, &error_constructor, &PropertyKey::from("prototype")).unwrap();
@@ -385,7 +385,7 @@ fn error_constructor_data_props() {
 #[test]
 fn error_constructor_function_01() {
     // Called as function, with argument.
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Error));
 
     let result = call(&agent, &error_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from("A")]).unwrap();
@@ -399,7 +399,7 @@ fn error_constructor_function_01() {
 #[test]
 fn error_constructor_function_02() {
     // Called as function, with no argument.
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Error));
 
     let result = call(&agent, &error_constructor, &ECMAScriptValue::Undefined, &[]).unwrap();
@@ -413,7 +413,7 @@ fn error_constructor_function_02() {
 #[test]
 fn error_constructor_function_03() {
     // Called as constructor
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
 
     let result = construct(&agent, &error_constructor, &[ECMAScriptValue::from("A")], None).unwrap();
@@ -428,7 +428,7 @@ fn error_constructor_function_03() {
 fn error_constructor_throws() {
     // ordinary_create_from_contructor throws.
     // This looks to be difficult to make happen, but I can imagine some class shenanigans that could do it.
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
 
     // This hack is to get around the "not configurable" characteristic of Error.prototype.
@@ -448,7 +448,7 @@ fn error_constructor_throws() {
 }
 #[test]
 fn error_constructor_to_string_throws() {
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
     let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
 
@@ -458,7 +458,7 @@ fn error_constructor_to_string_throws() {
 
 #[test]
 fn error_prototype_data_props() {
-    let agent = test_agent();
+    setup_test_agent();
     let error_prototype = agent.intrinsic(IntrinsicId::ErrorPrototype);
 
     let val = get(&agent, &error_prototype, &PropertyKey::from("constructor")).unwrap();
@@ -475,7 +475,7 @@ fn error_prototype_data_props() {
 use crate::object::{define_property_or_throw, invoke, set};
 #[test]
 fn error_prototype_tostring_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
     let errobj = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
 
@@ -484,7 +484,7 @@ fn error_prototype_tostring_01() {
 }
 #[test]
 fn error_prototype_tostring_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
     let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
     let errobj = to_object(&agent, errobjval.clone()).unwrap();
@@ -496,7 +496,7 @@ fn error_prototype_tostring_02() {
 }
 #[test]
 fn error_prototype_tostring_03() {
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
     let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
     let errobj = to_object(&agent, errobjval.clone()).unwrap();
@@ -508,7 +508,7 @@ fn error_prototype_tostring_03() {
 }
 #[test]
 fn error_prototype_tostring_04() {
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
     let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
     let errobj = to_object(&agent, errobjval.clone()).unwrap();
@@ -520,7 +520,7 @@ fn error_prototype_tostring_04() {
 }
 #[test]
 fn error_prototype_tostring_05() {
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
     let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
     let errobj = to_object(&agent, errobjval.clone()).unwrap();
@@ -532,7 +532,7 @@ fn error_prototype_tostring_05() {
 }
 #[test]
 fn error_prototype_tostring_06() {
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
     let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
     let errobj = to_object(&agent, errobjval.clone()).unwrap();
@@ -545,7 +545,7 @@ fn error_prototype_tostring_06() {
 #[test]
 fn error_prototype_tostring_07() {
     // getting property "name" throws
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
     let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
     let errobj = to_object(&agent, errobjval.clone()).unwrap();
@@ -561,7 +561,7 @@ fn error_prototype_tostring_07() {
 #[test]
 fn error_prototype_tostring_08() {
     // getting property "message" throws
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
     let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
     let errobj = to_object(&agent, errobjval.clone()).unwrap();
@@ -576,7 +576,7 @@ fn error_prototype_tostring_08() {
 }
 #[test]
 fn error_prototype_tostring_09() {
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
     let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
     let errobj = to_object(&agent, errobjval.clone()).unwrap();
@@ -588,7 +588,7 @@ fn error_prototype_tostring_09() {
 }
 #[test]
 fn error_prototype_tostring_10() {
-    let agent = test_agent();
+    setup_test_agent();
     let error_constructor = agent.intrinsic(IntrinsicId::Error);
     let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
     let errobj = to_object(&agent, errobjval.clone()).unwrap();
@@ -600,7 +600,7 @@ fn error_prototype_tostring_10() {
 }
 #[test]
 fn error_prototype_to_string_11() {
-    let agent = test_agent();
+    setup_test_agent();
     let error_prototype = agent.intrinsic(IntrinsicId::ErrorPrototype);
     let func = get(&agent, &error_prototype, &PropertyKey::from("toString")).unwrap();
 
@@ -609,7 +609,7 @@ fn error_prototype_to_string_11() {
 }
 
 fn native_error_constructor_properties(intrinsic: IntrinsicId, expected_name: &str) {
-    let agent = test_agent();
+    setup_test_agent();
     let constructor = agent.intrinsic(intrinsic);
 
     let proto = constructor.o.get_prototype_of(&agent).unwrap().unwrap();
@@ -644,7 +644,7 @@ fn uri_error_constructor_properties() {
 }
 
 fn native_error_prototype_properties(prototype: IntrinsicId, constructor: IntrinsicId, name: &str) {
-    let agent = test_agent();
+    setup_test_agent();
     let prototype = agent.intrinsic(prototype);
     let constructor = agent.intrinsic(constructor);
     let error_prototype = agent.intrinsic(IntrinsicId::ErrorPrototype);
@@ -693,7 +693,7 @@ fn uri_error_prototype_properties() {
 }
 
 fn test_error_constructor(const_id: IntrinsicId, proto_id: IntrinsicId, name: &str) {
-    let agent = test_agent();
+    setup_test_agent();
     let constructor = agent.intrinsic(const_id);
     let proto = agent.intrinsic(proto_id);
     let objval = construct(&agent, &constructor, &[ECMAScriptValue::from("test message")], None).unwrap();
@@ -733,7 +733,7 @@ fn test_uri_error_constructor() {
 #[test_case(|a: &Agent| create_type_error_object(a, "message 1") => "TypeError: message 1"; "type error")]
 #[test_case(|a: &Agent| create_syntax_error_object(a, "message 2", None) => "SyntaxError: message 2"; "syntax error")]
 fn unwind_any_error_value(maker: fn(&Agent) -> Object) -> String {
-    let agent = test_agent();
+    setup_test_agent();
     let errobj = maker(&agent);
     super::unwind_any_error_value(&agent, ECMAScriptValue::from(errobj))
 }
@@ -742,7 +742,7 @@ fn unwind_any_error_value(maker: fn(&Agent) -> Object) -> String {
 #[test_case(|a: &Agent| create_syntax_error(a, "ouch", None) => "SyntaxError: ouch"; "syntax error")]
 #[test_case(|_: &Agent| AbruptCompletion::Break{value: NormalCompletion::Empty, target: None} => panics "Improper completion for error: "; "not error")]
 fn unwind_any_error(maker: fn(&Agent) -> AbruptCompletion) -> String {
-    let agent = test_agent();
+    setup_test_agent();
     let completion = maker(&agent);
     super::unwind_any_error(&agent, completion)
 }

--- a/src/errors/tests.rs
+++ b/src/errors/tests.rs
@@ -5,16 +5,16 @@ use test_case::test_case;
 #[test]
 fn create_native_error_object_01() {
     setup_test_agent();
-    let constructor = agent.intrinsic(IntrinsicId::RangeError);
+    let constructor = intrinsic(IntrinsicId::RangeError);
     let message = "Great Googly Moogly!";
     let proto_id = IntrinsicId::RangeErrorPrototype;
 
-    let result = create_native_error_object(&agent, message, constructor, proto_id, None);
+    let result = create_native_error_object(message, constructor, proto_id, None);
 
     assert!(result.o.is_error_object());
-    let msg_val = get(&agent, &result, &PropertyKey::from("message")).unwrap();
+    let msg_val = get(&result, &PropertyKey::from("message")).unwrap();
     assert_eq!(msg_val, ECMAScriptValue::from(message));
-    let kind = get(&agent, &result, &PropertyKey::from("name")).unwrap();
+    let kind = get(&result, &PropertyKey::from("name")).unwrap();
     assert_eq!(kind, ECMAScriptValue::from("RangeError"));
 }
 
@@ -22,25 +22,25 @@ fn create_native_error_object_01() {
 fn create_type_error_object_01() {
     setup_test_agent();
 
-    let result = create_type_error_object(&agent, "Happy Days");
+    let result = create_type_error_object("Happy Days");
 
     assert!(result.o.is_error_object());
-    assert_eq!(get(&agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("TypeError"));
-    assert_eq!(get(&agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
+    assert_eq!(get(&result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("TypeError"));
+    assert_eq!(get(&result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
 }
 
 #[test]
 fn create_type_error_01() {
     setup_test_agent();
 
-    let result = create_type_error(&agent, "A");
+    let result = create_type_error("A");
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
     if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("TypeError"));
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+            assert_eq!(get(&obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("TypeError"));
+            assert_eq!(get(&obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
         }
     }
 }
@@ -49,25 +49,25 @@ fn create_type_error_01() {
 fn create_eval_error_object_01() {
     setup_test_agent();
 
-    let result = create_eval_error_object(&agent, "Happy Days");
+    let result = create_eval_error_object("Happy Days");
 
     assert!(result.o.is_error_object());
-    assert_eq!(get(&agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("EvalError"));
-    assert_eq!(get(&agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
+    assert_eq!(get(&result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("EvalError"));
+    assert_eq!(get(&result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
 }
 
 #[test]
 fn create_eval_error_01() {
     setup_test_agent();
 
-    let result = create_eval_error(&agent, "A");
+    let result = create_eval_error("A");
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
     if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("EvalError"));
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+            assert_eq!(get(&obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("EvalError"));
+            assert_eq!(get(&obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
         }
     }
 }
@@ -76,25 +76,25 @@ fn create_eval_error_01() {
 fn create_reference_error_object_01() {
     setup_test_agent();
 
-    let result = create_reference_error_object(&agent, "Happy Days");
+    let result = create_reference_error_object("Happy Days");
 
     assert!(result.o.is_error_object());
-    assert_eq!(get(&agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("ReferenceError"));
-    assert_eq!(get(&agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
+    assert_eq!(get(&result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("ReferenceError"));
+    assert_eq!(get(&result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
 }
 
 #[test]
 fn create_reference_error_01() {
     setup_test_agent();
 
-    let result = create_reference_error(&agent, "A");
+    let result = create_reference_error("A");
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
     if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("ReferenceError"));
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+            assert_eq!(get(&obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("ReferenceError"));
+            assert_eq!(get(&obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
         }
     }
 }
@@ -103,25 +103,25 @@ fn create_reference_error_01() {
 fn create_range_error_object_01() {
     setup_test_agent();
 
-    let result = create_range_error_object(&agent, "Happy Days");
+    let result = create_range_error_object("Happy Days");
 
     assert!(result.o.is_error_object());
-    assert_eq!(get(&agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("RangeError"));
-    assert_eq!(get(&agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
+    assert_eq!(get(&result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("RangeError"));
+    assert_eq!(get(&result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
 }
 
 #[test]
 fn create_range_error_01() {
     setup_test_agent();
 
-    let result = create_range_error(&agent, "A");
+    let result = create_range_error("A");
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
     if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("RangeError"));
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+            assert_eq!(get(&obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("RangeError"));
+            assert_eq!(get(&obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
         }
     }
 }
@@ -131,32 +131,31 @@ fn create_syntax_error_object_01() {
     setup_test_agent();
 
     let result = create_syntax_error_object(
-        &agent,
         "Happy Days",
         Some(Location { starting_line: 10, starting_column: 5, span: Span { starting_index: 232, length: 12 } }),
     );
 
     assert!(result.o.is_error_object());
-    assert_eq!(get(&agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("SyntaxError"));
-    assert_eq!(get(&agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
-    let loc_obj = Object::try_from(get(&agent, &result, &"location".into()).unwrap()).unwrap();
-    assert_eq!(get(&agent, &loc_obj, &"line".into()).unwrap(), ECMAScriptValue::from(10));
-    assert_eq!(get(&agent, &loc_obj, &"column".into()).unwrap(), ECMAScriptValue::from(5));
-    assert_eq!(get(&agent, &loc_obj, &"byte_length".into()).unwrap(), ECMAScriptValue::from(12));
+    assert_eq!(get(&result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("SyntaxError"));
+    assert_eq!(get(&result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
+    let loc_obj = Object::try_from(get(&result, &"location".into()).unwrap()).unwrap();
+    assert_eq!(get(&loc_obj, &"line".into()).unwrap(), ECMAScriptValue::from(10));
+    assert_eq!(get(&loc_obj, &"column".into()).unwrap(), ECMAScriptValue::from(5));
+    assert_eq!(get(&loc_obj, &"byte_length".into()).unwrap(), ECMAScriptValue::from(12));
 }
 
 #[test]
 fn create_syntax_error_01() {
     setup_test_agent();
 
-    let result = create_syntax_error(&agent, "A", None);
+    let result = create_syntax_error("A", None);
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
     if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("SyntaxError"));
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+            assert_eq!(get(&obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("SyntaxError"));
+            assert_eq!(get(&obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
         }
     }
 }
@@ -165,25 +164,25 @@ fn create_syntax_error_01() {
 fn create_uri_error_object_01() {
     setup_test_agent();
 
-    let result = create_uri_error_object(&agent, "Happy Days");
+    let result = create_uri_error_object("Happy Days");
 
     assert!(result.o.is_error_object());
-    assert_eq!(get(&agent, &result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("URIError"));
-    assert_eq!(get(&agent, &result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
+    assert_eq!(get(&result, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("URIError"));
+    assert_eq!(get(&result, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("Happy Days"));
 }
 
 #[test]
 fn create_uri_error_01() {
     setup_test_agent();
 
-    let result = create_uri_error(&agent, "A");
+    let result = create_uri_error("A");
     assert!(matches!(result, AbruptCompletion::Throw { .. }));
     if let AbruptCompletion::Throw { value: objval } = result {
         assert!(objval.is_object());
         if let ECMAScriptValue::Object(obj) = objval {
             assert!(obj.o.is_error_object());
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("URIError"));
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+            assert_eq!(get(&obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("URIError"));
+            assert_eq!(get(&obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
         }
     }
 }
@@ -191,28 +190,28 @@ fn create_uri_error_01() {
 #[test]
 fn error_object_debug() {
     setup_test_agent();
-    let eo = ErrorObject { common: RefCell::new(CommonObjectData::new(&agent, None, true, &[])) };
+    let eo = ErrorObject { common: RefCell::new(CommonObjectData::new(None, true, &[])) };
     assert_ne!(format!("{:?}", eo), "");
 }
 
 #[test]
 fn error_object_object() {
     setup_test_agent();
-    let eo = ErrorObject::object(&agent, None);
+    let eo = ErrorObject::object(None);
 
     assert!(eo.o.is_error_object());
-    assert!(eo.o.get_prototype_of(&agent).unwrap().is_none());
+    assert!(eo.o.get_prototype_of().unwrap().is_none());
 }
 
-fn create_error_object(agent: &Agent) -> Object {
-    let error_proto = agent.intrinsic(IntrinsicId::ErrorPrototype);
-    ErrorObject::object(agent, Some(error_proto))
+fn create_error_object() -> Object {
+    let error_proto = intrinsic(IntrinsicId::ErrorPrototype);
+    ErrorObject::object(Some(error_proto))
 }
 #[test]
 fn error_object_common_object_data() {
     setup_test_agent();
-    let no = create_error_object(&agent);
-    let error_prototype = agent.intrinsic(IntrinsicId::ErrorPrototype);
+    let no = create_error_object();
+    let error_prototype = intrinsic(IntrinsicId::ErrorPrototype);
 
     let cod = no.o.common_object_data();
 
@@ -225,7 +224,7 @@ fn error_object_common_object_data() {
 #[test]
 fn error_object_is_ordinary() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
     let result = no.o.is_ordinary();
 
@@ -234,7 +233,7 @@ fn error_object_is_ordinary() {
 #[test]
 fn error_object_id() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
     // ... essentially, assert that it doesn't panic.
     no.o.id();
@@ -242,7 +241,7 @@ fn error_object_id() {
 #[test]
 fn error_object_to_error_object() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
     let result = no.o.to_error_obj();
     assert!(result.is_some());
@@ -250,7 +249,7 @@ fn error_object_to_error_object() {
 #[test]
 fn error_object_is_error_object() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
     let result = no.o.is_error_object();
 
@@ -259,51 +258,50 @@ fn error_object_is_error_object() {
 #[test]
 fn error_object_get_prototype_of() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
-    let result = no.o.get_prototype_of(&agent).unwrap();
+    let result = no.o.get_prototype_of().unwrap();
     assert!(result.is_some());
 }
 #[test]
 fn error_object_set_prototype_of() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
-    let result = no.o.set_prototype_of(&agent, None).unwrap();
+    let result = no.o.set_prototype_of(None).unwrap();
     assert!(result);
 }
 #[test]
 fn error_object_is_extensible() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
-    let result = no.o.is_extensible(&agent).unwrap();
+    let result = no.o.is_extensible().unwrap();
     assert!(result);
 }
 #[test]
 fn error_object_prevent_extensions() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
-    let result = no.o.prevent_extensions(&agent).unwrap();
+    let result = no.o.prevent_extensions().unwrap();
     assert!(result);
 }
 #[test]
 fn error_object_get_own_property() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
-    let result = no.o.get_own_property(&agent, &PropertyKey::from("a")).unwrap();
+    let result = no.o.get_own_property(&PropertyKey::from("a")).unwrap();
     assert!(result.is_none());
 }
 #[test]
 fn error_object_define_own_property() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
     let result =
         no.o.define_own_property(
-            &agent,
             PropertyKey::from("a"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::Undefined), ..Default::default() },
         )
@@ -313,49 +311,49 @@ fn error_object_define_own_property() {
 #[test]
 fn error_object_has_property() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
-    let result = no.o.has_property(&agent, &PropertyKey::from("a")).unwrap();
+    let result = no.o.has_property(&PropertyKey::from("a")).unwrap();
     assert!(!result);
 }
 #[test]
 fn error_object_get() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
-    let result = no.o.get(&agent, &PropertyKey::from("a"), &ECMAScriptValue::from(no.clone())).unwrap();
+    let result = no.o.get(&PropertyKey::from("a"), &ECMAScriptValue::from(no.clone())).unwrap();
     assert_eq!(result, ECMAScriptValue::Undefined);
 }
 #[test]
 fn error_object_set() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
     let result =
-        no.o.set(&agent, PropertyKey::from("a"), ECMAScriptValue::from(88.0), &ECMAScriptValue::from(no.clone()))
+        no.o.set(PropertyKey::from("a"), ECMAScriptValue::from(88.0), &ECMAScriptValue::from(no.clone()))
             .unwrap();
     assert!(result);
 }
 #[test]
 fn error_object_delete() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
-    let result = no.o.delete(&agent, &PropertyKey::from("a")).unwrap();
+    let result = no.o.delete(&PropertyKey::from("a")).unwrap();
     assert!(result);
 }
 #[test]
 fn error_object_own_property_keys() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
-    let result = no.o.own_property_keys(&agent).unwrap();
+    let result = no.o.own_property_keys().unwrap();
     assert_eq!(result, &[]);
 }
 #[test]
 fn error_object_other_automatic_functions() {
     setup_test_agent();
-    let no = create_error_object(&agent);
+    let no = create_error_object();
 
     assert!(!no.o.is_number_object());
     assert!(no.o.to_function_obj().is_none());
@@ -375,10 +373,10 @@ fn error_object_other_automatic_functions() {
 #[test]
 fn error_constructor_data_props() {
     setup_test_agent();
-    let error_constructor = agent.intrinsic(IntrinsicId::Error);
+    let error_constructor = intrinsic(IntrinsicId::Error);
 
-    let val = get(&agent, &error_constructor, &PropertyKey::from("prototype")).unwrap();
-    let error_prototype = agent.intrinsic(IntrinsicId::ErrorPrototype);
+    let val = get(&error_constructor, &PropertyKey::from("prototype")).unwrap();
+    let error_prototype = intrinsic(IntrinsicId::ErrorPrototype);
     assert_eq!(val, ECMAScriptValue::from(error_prototype));
 }
 
@@ -386,42 +384,42 @@ fn error_constructor_data_props() {
 fn error_constructor_function_01() {
     // Called as function, with argument.
     setup_test_agent();
-    let error_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Error));
+    let error_constructor = ECMAScriptValue::from(intrinsic(IntrinsicId::Error));
 
-    let result = call(&agent, &error_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from("A")]).unwrap();
-    let obj = to_object(&agent, result).unwrap();
+    let result = call(&error_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from("A")]).unwrap();
+    let obj = to_object(result).unwrap();
 
     assert!(obj.o.is_error_object());
-    assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
-    assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("Error"));
+    assert_eq!(get(&obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+    assert_eq!(get(&obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("Error"));
 }
 
 #[test]
 fn error_constructor_function_02() {
     // Called as function, with no argument.
     setup_test_agent();
-    let error_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Error));
+    let error_constructor = ECMAScriptValue::from(intrinsic(IntrinsicId::Error));
 
-    let result = call(&agent, &error_constructor, &ECMAScriptValue::Undefined, &[]).unwrap();
-    let obj = to_object(&agent, result).unwrap();
+    let result = call(&error_constructor, &ECMAScriptValue::Undefined, &[]).unwrap();
+    let obj = to_object(result).unwrap();
 
     assert!(obj.o.is_error_object());
-    assert!(!has_own_property(&agent, &obj, &PropertyKey::from("message")).unwrap());
-    assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("Error"));
+    assert!(!has_own_property(&obj, &PropertyKey::from("message")).unwrap());
+    assert_eq!(get(&obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("Error"));
 }
 
 #[test]
 fn error_constructor_function_03() {
     // Called as constructor
     setup_test_agent();
-    let error_constructor = agent.intrinsic(IntrinsicId::Error);
+    let error_constructor = intrinsic(IntrinsicId::Error);
 
-    let result = construct(&agent, &error_constructor, &[ECMAScriptValue::from("A")], None).unwrap();
-    let obj = to_object(&agent, result).unwrap();
+    let result = construct(&error_constructor, &[ECMAScriptValue::from("A")], None).unwrap();
+    let obj = to_object(result).unwrap();
 
     assert!(obj.o.is_error_object());
-    assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
-    assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("Error"));
+    assert_eq!(get(&obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("A"));
+    assert_eq!(get(&obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from("Error"));
 }
 
 #[test]
@@ -429,12 +427,12 @@ fn error_constructor_throws() {
     // ordinary_create_from_contructor throws.
     // This looks to be difficult to make happen, but I can imagine some class shenanigans that could do it.
     setup_test_agent();
-    let error_constructor = agent.intrinsic(IntrinsicId::Error);
+    let error_constructor = intrinsic(IntrinsicId::Error);
 
     // This hack is to get around the "not configurable" characteristic of Error.prototype.
     // (It replaces Error.prototype (a data property) with an accessor property that throws when "prototype" is gotten.)
     let new_prop = PropertyKind::Accessor(AccessorProperty {
-        get: ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError)),
+        get: ECMAScriptValue::from(intrinsic(IntrinsicId::ThrowTypeError)),
         set: ECMAScriptValue::Undefined,
     });
     {
@@ -443,32 +441,32 @@ fn error_constructor_throws() {
         prop.property = new_prop;
     }
 
-    let result = construct(&agent, &error_constructor, &[], None).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Generic TypeError");
+    let result = construct(&error_constructor, &[], None).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Generic TypeError");
 }
 #[test]
 fn error_constructor_to_string_throws() {
     setup_test_agent();
-    let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
+    let error_constructor = intrinsic(IntrinsicId::Error);
+    let sym = ECMAScriptValue::from(Symbol::new(None));
 
-    let result = construct(&agent, &error_constructor, &[sym], None).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Symbols may not be converted to strings");
+    let result = construct(&error_constructor, &[sym], None).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Symbols may not be converted to strings");
 }
 
 #[test]
 fn error_prototype_data_props() {
     setup_test_agent();
-    let error_prototype = agent.intrinsic(IntrinsicId::ErrorPrototype);
+    let error_prototype = intrinsic(IntrinsicId::ErrorPrototype);
 
-    let val = get(&agent, &error_prototype, &PropertyKey::from("constructor")).unwrap();
-    let error_constructor = agent.intrinsic(IntrinsicId::Error);
+    let val = get(&error_prototype, &PropertyKey::from("constructor")).unwrap();
+    let error_constructor = intrinsic(IntrinsicId::Error);
     assert_eq!(val, ECMAScriptValue::from(error_constructor));
 
-    let val = get(&agent, &error_prototype, &PropertyKey::from("message")).unwrap();
+    let val = get(&error_prototype, &PropertyKey::from("message")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(""));
 
-    let val = get(&agent, &error_prototype, &PropertyKey::from("name")).unwrap();
+    let val = get(&error_prototype, &PropertyKey::from("name")).unwrap();
     assert_eq!(val, ECMAScriptValue::from("Error"));
 }
 
@@ -476,145 +474,145 @@ use crate::object::{define_property_or_throw, invoke, set};
 #[test]
 fn error_prototype_tostring_01() {
     setup_test_agent();
-    let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobj = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let error_constructor = intrinsic(IntrinsicId::Error);
+    let errobj = construct(&error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
 
-    let result = invoke(&agent, errobj, &PropertyKey::from("toString"), &[]).unwrap();
+    let result = invoke(errobj, &PropertyKey::from("toString"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Error: ErrorMessage"));
 }
 #[test]
 fn error_prototype_tostring_02() {
     setup_test_agent();
-    let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&agent, errobjval.clone()).unwrap();
-    set(&agent, &errobj, PropertyKey::from("name"), ECMAScriptValue::from("Bob"), false).unwrap();
-    set(&agent, &errobj, PropertyKey::from("message"), ECMAScriptValue::from("you have a phone call"), false).unwrap();
+    let error_constructor = intrinsic(IntrinsicId::Error);
+    let errobjval = construct(&error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(errobjval.clone()).unwrap();
+    set(&errobj, PropertyKey::from("name"), ECMAScriptValue::from("Bob"), false).unwrap();
+    set(&errobj, PropertyKey::from("message"), ECMAScriptValue::from("you have a phone call"), false).unwrap();
 
-    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap();
+    let result = invoke(errobjval, &PropertyKey::from("toString"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Bob: you have a phone call"));
 }
 #[test]
 fn error_prototype_tostring_03() {
     setup_test_agent();
-    let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&agent, errobjval.clone()).unwrap();
-    set(&agent, &errobj, PropertyKey::from("name"), ECMAScriptValue::Undefined, false).unwrap();
-    set(&agent, &errobj, PropertyKey::from("message"), ECMAScriptValue::Undefined, false).unwrap();
+    let error_constructor = intrinsic(IntrinsicId::Error);
+    let errobjval = construct(&error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(errobjval.clone()).unwrap();
+    set(&errobj, PropertyKey::from("name"), ECMAScriptValue::Undefined, false).unwrap();
+    set(&errobj, PropertyKey::from("message"), ECMAScriptValue::Undefined, false).unwrap();
 
-    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap();
+    let result = invoke(errobjval, &PropertyKey::from("toString"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Error"));
 }
 #[test]
 fn error_prototype_tostring_04() {
     setup_test_agent();
-    let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&agent, errobjval.clone()).unwrap();
-    set(&agent, &errobj, PropertyKey::from("name"), ECMAScriptValue::from("Bob"), false).unwrap();
-    set(&agent, &errobj, PropertyKey::from("message"), ECMAScriptValue::Undefined, false).unwrap();
+    let error_constructor = intrinsic(IntrinsicId::Error);
+    let errobjval = construct(&error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(errobjval.clone()).unwrap();
+    set(&errobj, PropertyKey::from("name"), ECMAScriptValue::from("Bob"), false).unwrap();
+    set(&errobj, PropertyKey::from("message"), ECMAScriptValue::Undefined, false).unwrap();
 
-    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap();
+    let result = invoke(errobjval, &PropertyKey::from("toString"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Bob"));
 }
 #[test]
 fn error_prototype_tostring_05() {
     setup_test_agent();
-    let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&agent, errobjval.clone()).unwrap();
-    set(&agent, &errobj, PropertyKey::from("name"), ECMAScriptValue::Undefined, false).unwrap();
-    set(&agent, &errobj, PropertyKey::from("message"), ECMAScriptValue::from("Message"), false).unwrap();
+    let error_constructor = intrinsic(IntrinsicId::Error);
+    let errobjval = construct(&error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(errobjval.clone()).unwrap();
+    set(&errobj, PropertyKey::from("name"), ECMAScriptValue::Undefined, false).unwrap();
+    set(&errobj, PropertyKey::from("message"), ECMAScriptValue::from("Message"), false).unwrap();
 
-    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap();
+    let result = invoke(errobjval, &PropertyKey::from("toString"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Error: Message"));
 }
 #[test]
 fn error_prototype_tostring_06() {
     setup_test_agent();
-    let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&agent, errobjval.clone()).unwrap();
-    set(&agent, &errobj, PropertyKey::from("name"), ECMAScriptValue::from(""), false).unwrap();
-    set(&agent, &errobj, PropertyKey::from("message"), ECMAScriptValue::from("Message"), false).unwrap();
+    let error_constructor = intrinsic(IntrinsicId::Error);
+    let errobjval = construct(&error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(errobjval.clone()).unwrap();
+    set(&errobj, PropertyKey::from("name"), ECMAScriptValue::from(""), false).unwrap();
+    set(&errobj, PropertyKey::from("message"), ECMAScriptValue::from("Message"), false).unwrap();
 
-    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap();
+    let result = invoke(errobjval, &PropertyKey::from("toString"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Message"));
 }
 #[test]
 fn error_prototype_tostring_07() {
     // getting property "name" throws
     setup_test_agent();
-    let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&agent, errobjval.clone()).unwrap();
+    let error_constructor = intrinsic(IntrinsicId::Error);
+    let errobjval = construct(&error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(errobjval.clone()).unwrap();
     let desc = PotentialPropertyDescriptor {
-        get: Some(ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError))),
+        get: Some(ECMAScriptValue::from(intrinsic(IntrinsicId::ThrowTypeError))),
         ..Default::default()
     };
-    define_property_or_throw(&agent, &errobj, PropertyKey::from("name"), desc).unwrap();
+    define_property_or_throw(&errobj, PropertyKey::from("name"), desc).unwrap();
 
-    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Generic TypeError");
+    let result = invoke(errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Generic TypeError");
 }
 #[test]
 fn error_prototype_tostring_08() {
     // getting property "message" throws
     setup_test_agent();
-    let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&agent, errobjval.clone()).unwrap();
+    let error_constructor = intrinsic(IntrinsicId::Error);
+    let errobjval = construct(&error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(errobjval.clone()).unwrap();
     let desc = PotentialPropertyDescriptor {
-        get: Some(ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError))),
+        get: Some(ECMAScriptValue::from(intrinsic(IntrinsicId::ThrowTypeError))),
         ..Default::default()
     };
-    define_property_or_throw(&agent, &errobj, PropertyKey::from("message"), desc).unwrap();
+    define_property_or_throw(&errobj, PropertyKey::from("message"), desc).unwrap();
 
-    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Generic TypeError");
+    let result = invoke(errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Generic TypeError");
 }
 #[test]
 fn error_prototype_tostring_09() {
     setup_test_agent();
-    let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&agent, errobjval.clone()).unwrap();
-    let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
-    set(&agent, &errobj, PropertyKey::from("name"), sym, false).unwrap();
+    let error_constructor = intrinsic(IntrinsicId::Error);
+    let errobjval = construct(&error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(errobjval.clone()).unwrap();
+    let sym = ECMAScriptValue::from(Symbol::new(None));
+    set(&errobj, PropertyKey::from("name"), sym, false).unwrap();
 
-    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Symbols may not be converted to strings");
+    let result = invoke(errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Symbols may not be converted to strings");
 }
 #[test]
 fn error_prototype_tostring_10() {
     setup_test_agent();
-    let error_constructor = agent.intrinsic(IntrinsicId::Error);
-    let errobjval = construct(&agent, &error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
-    let errobj = to_object(&agent, errobjval.clone()).unwrap();
-    let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
-    set(&agent, &errobj, PropertyKey::from("message"), sym, false).unwrap();
+    let error_constructor = intrinsic(IntrinsicId::Error);
+    let errobjval = construct(&error_constructor, &[ECMAScriptValue::from("ErrorMessage")], None).unwrap();
+    let errobj = to_object(errobjval.clone()).unwrap();
+    let sym = ECMAScriptValue::from(Symbol::new(None));
+    set(&errobj, PropertyKey::from("message"), sym, false).unwrap();
 
-    let result = invoke(&agent, errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Symbols may not be converted to strings");
+    let result = invoke(errobjval, &PropertyKey::from("toString"), &[]).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Symbols may not be converted to strings");
 }
 #[test]
 fn error_prototype_to_string_11() {
     setup_test_agent();
-    let error_prototype = agent.intrinsic(IntrinsicId::ErrorPrototype);
-    let func = get(&agent, &error_prototype, &PropertyKey::from("toString")).unwrap();
+    let error_prototype = intrinsic(IntrinsicId::ErrorPrototype);
+    let func = get(&error_prototype, &PropertyKey::from("toString")).unwrap();
 
-    let result = call(&agent, &func, &ECMAScriptValue::Undefined, &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Error.prototype.toString called with non-object this value");
+    let result = call(&func, &ECMAScriptValue::Undefined, &[]).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Error.prototype.toString called with non-object this value");
 }
 
 fn native_error_constructor_properties(intrinsic: IntrinsicId, expected_name: &str) {
     setup_test_agent();
-    let constructor = agent.intrinsic(intrinsic);
+    let constructor = intrinsic(intrinsic);
 
-    let proto = constructor.o.get_prototype_of(&agent).unwrap().unwrap();
-    assert_eq!(proto, agent.intrinsic(IntrinsicId::Error));
-    let name = get(&agent, &constructor, &PropertyKey::from("name")).unwrap();
+    let proto = constructor.o.get_prototype_of().unwrap().unwrap();
+    assert_eq!(proto, intrinsic(IntrinsicId::Error));
+    let name = get(&constructor, &PropertyKey::from("name")).unwrap();
     assert_eq!(name, ECMAScriptValue::from(expected_name));
 }
 
@@ -645,21 +643,21 @@ fn uri_error_constructor_properties() {
 
 fn native_error_prototype_properties(prototype: IntrinsicId, constructor: IntrinsicId, name: &str) {
     setup_test_agent();
-    let prototype = agent.intrinsic(prototype);
-    let constructor = agent.intrinsic(constructor);
-    let error_prototype = agent.intrinsic(IntrinsicId::ErrorPrototype);
+    let prototype = intrinsic(prototype);
+    let constructor = intrinsic(constructor);
+    let error_prototype = intrinsic(IntrinsicId::ErrorPrototype);
 
     assert!(!prototype.o.is_error_object());
-    let proto_proto = prototype.o.get_prototype_of(&agent).unwrap().unwrap();
+    let proto_proto = prototype.o.get_prototype_of().unwrap().unwrap();
     assert_eq!(proto_proto, error_prototype);
 
-    let cons = get(&agent, &prototype, &PropertyKey::from("constructor")).unwrap();
+    let cons = get(&prototype, &PropertyKey::from("constructor")).unwrap();
     assert_eq!(cons, ECMAScriptValue::from(constructor));
 
-    let msg = get(&agent, &prototype, &PropertyKey::from("message")).unwrap();
+    let msg = get(&prototype, &PropertyKey::from("message")).unwrap();
     assert_eq!(msg, ECMAScriptValue::from(""));
 
-    let myname = get(&agent, &prototype, &PropertyKey::from("name")).unwrap();
+    let myname = get(&prototype, &PropertyKey::from("name")).unwrap();
     assert_eq!(myname, ECMAScriptValue::from(name));
 }
 
@@ -694,15 +692,15 @@ fn uri_error_prototype_properties() {
 
 fn test_error_constructor(const_id: IntrinsicId, proto_id: IntrinsicId, name: &str) {
     setup_test_agent();
-    let constructor = agent.intrinsic(const_id);
-    let proto = agent.intrinsic(proto_id);
-    let objval = construct(&agent, &constructor, &[ECMAScriptValue::from("test message")], None).unwrap();
-    let obj = to_object(&agent, objval).unwrap();
+    let constructor = intrinsic(const_id);
+    let proto = intrinsic(proto_id);
+    let objval = construct(&constructor, &[ECMAScriptValue::from("test message")], None).unwrap();
+    let obj = to_object(objval).unwrap();
 
     assert!(obj.o.is_error_object());
-    assert_eq!(get(&agent, &obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from(name));
-    assert_eq!(get(&agent, &obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("test message"));
-    assert_eq!(obj.o.get_prototype_of(&agent).unwrap().unwrap(), proto);
+    assert_eq!(get(&obj, &PropertyKey::from("name")).unwrap(), ECMAScriptValue::from(name));
+    assert_eq!(get(&obj, &PropertyKey::from("message")).unwrap(), ECMAScriptValue::from("test message"));
+    assert_eq!(obj.o.get_prototype_of().unwrap().unwrap(), proto);
 }
 
 #[test]
@@ -730,19 +728,19 @@ fn test_uri_error_constructor() {
     test_error_constructor(IntrinsicId::URIError, IntrinsicId::URIErrorPrototype, "URIError");
 }
 
-#[test_case(|a: &Agent| create_type_error_object(a, "message 1") => "TypeError: message 1"; "type error")]
-#[test_case(|a: &Agent| create_syntax_error_object(a, "message 2", None) => "SyntaxError: message 2"; "syntax error")]
-fn unwind_any_error_value(maker: fn(&Agent) -> Object) -> String {
+#[test_case(|| create_type_error_object(a, "message 1") => "TypeError: message 1"; "type error")]
+#[test_case(|| create_syntax_error_object(a, "message 2", None) => "SyntaxError: message 2"; "syntax error")]
+fn unwind_any_error_value(maker: fn() -> Object) -> String {
     setup_test_agent();
-    let errobj = maker(&agent);
-    super::unwind_any_error_value(&agent, ECMAScriptValue::from(errobj))
+    let errobj = maker();
+    super::unwind_any_error_value(ECMAScriptValue::from(errobj))
 }
 
-#[test_case(|a: &Agent| create_type_error(a, "blue") => "TypeError: blue"; "type error")]
-#[test_case(|a: &Agent| create_syntax_error(a, "ouch", None) => "SyntaxError: ouch"; "syntax error")]
-#[test_case(|_: &Agent| AbruptCompletion::Break{value: NormalCompletion::Empty, target: None} => panics "Improper completion for error: "; "not error")]
-fn unwind_any_error(maker: fn(&Agent) -> AbruptCompletion) -> String {
+#[test_case(|| create_type_error(a, "blue") => "TypeError: blue"; "type error")]
+#[test_case(|| create_syntax_error(a, "ouch", None) => "SyntaxError: ouch"; "syntax error")]
+#[test_case(|| AbruptCompletion::Break{value: NormalCompletion::Empty, target: None} => panics "Improper completion for error: "; "not error")]
+fn unwind_any_error(maker: fn() -> AbruptCompletion) -> String {
     setup_test_agent();
-    let completion = maker(&agent);
-    super::unwind_any_error(&agent, completion)
+    let completion = maker();
+    super::unwind_any_error(completion)
 }

--- a/src/errors/tests.rs
+++ b/src/errors/tests.rs
@@ -330,8 +330,7 @@ fn error_object_set() {
     let no = create_error_object();
 
     let result =
-        no.o.set(PropertyKey::from("a"), ECMAScriptValue::from(88.0), &ECMAScriptValue::from(no.clone()))
-            .unwrap();
+        no.o.set(PropertyKey::from("a"), ECMAScriptValue::from(88.0), &ECMAScriptValue::from(no.clone())).unwrap();
     assert!(result);
 }
 #[test]
@@ -606,9 +605,9 @@ fn error_prototype_to_string_11() {
     assert_eq!(unwind_type_error(result), "Error.prototype.toString called with non-object this value");
 }
 
-fn native_error_constructor_properties(intrinsic: IntrinsicId, expected_name: &str) {
+fn native_error_constructor_properties(id: IntrinsicId, expected_name: &str) {
     setup_test_agent();
-    let constructor = intrinsic(intrinsic);
+    let constructor = intrinsic(id);
 
     let proto = constructor.o.get_prototype_of().unwrap().unwrap();
     assert_eq!(proto, intrinsic(IntrinsicId::Error));
@@ -728,16 +727,16 @@ fn test_uri_error_constructor() {
     test_error_constructor(IntrinsicId::URIError, IntrinsicId::URIErrorPrototype, "URIError");
 }
 
-#[test_case(|| create_type_error_object(a, "message 1") => "TypeError: message 1"; "type error")]
-#[test_case(|| create_syntax_error_object(a, "message 2", None) => "SyntaxError: message 2"; "syntax error")]
+#[test_case(|| create_type_error_object("message 1") => "TypeError: message 1"; "type error")]
+#[test_case(|| create_syntax_error_object("message 2", None) => "SyntaxError: message 2"; "syntax error")]
 fn unwind_any_error_value(maker: fn() -> Object) -> String {
     setup_test_agent();
     let errobj = maker();
     super::unwind_any_error_value(ECMAScriptValue::from(errobj))
 }
 
-#[test_case(|| create_type_error(a, "blue") => "TypeError: blue"; "type error")]
-#[test_case(|| create_syntax_error(a, "ouch", None) => "SyntaxError: ouch"; "syntax error")]
+#[test_case(|| create_type_error("blue") => "TypeError: blue"; "type error")]
+#[test_case(|| create_syntax_error("ouch", None) => "SyntaxError: ouch"; "syntax error")]
 #[test_case(|| AbruptCompletion::Break{value: NormalCompletion::Empty, target: None} => panics "Improper completion for error: "; "not error")]
 fn unwind_any_error(maker: fn() -> AbruptCompletion) -> String {
     setup_test_agent();

--- a/src/execution_context/mod.rs
+++ b/src/execution_context/mod.rs
@@ -78,33 +78,31 @@ pub fn get_global_object() -> Option<Object> {
     current_realm_record()?.borrow().global_object.clone()
 }
 
-impl Agent {
-    /// Finds the Environment Record that currently supplies the binding of the keyword this.
-    ///
-    /// See [GetThisEnvironment](https://tc39.es/ecma262/#sec-getthisenvironment) in ECMA-262.
-    pub fn get_this_environment(&self) -> Rc<dyn EnvironmentRecord> {
-        // The abstract operation GetThisEnvironment takes no arguments and returns an Environment Record. It finds the
-        // Environment Record that currently supplies the binding of the keyword this. It performs the following steps when
-        // called:
-        //
-        //  1. Let env be the running execution context's LexicalEnvironment.
-        //  2. Repeat,
-        //      a. Let exists be env.HasThisBinding().
-        //      b. If exists is true, return env.
-        //      c. Let outer be env.[[OuterEnv]].
-        //      d. Assert: outer is not null.
-        //      e. Set env to outer.
-        // NOTE |   The loop in step 2 will always terminate because the list of environments always ends with the global
-        //      |   environment which has a this binding.
-        let mut env = self.current_lexical_environment().unwrap();
-        loop {
-            let exists = env.has_this_binding();
-            if exists {
-                return env;
-            }
-            let outer = env.get_outer_env().unwrap().clone();
-            env = outer;
+/// Finds the Environment Record that currently supplies the binding of the keyword this.
+///
+/// See [GetThisEnvironment](https://tc39.es/ecma262/#sec-getthisenvironment) in ECMA-262.
+pub fn get_this_environment() -> Rc<dyn EnvironmentRecord> {
+    // The abstract operation GetThisEnvironment takes no arguments and returns an Environment Record. It finds the
+    // Environment Record that currently supplies the binding of the keyword this. It performs the following steps when
+    // called:
+    //
+    //  1. Let env be the running execution context's LexicalEnvironment.
+    //  2. Repeat,
+    //      a. Let exists be env.HasThisBinding().
+    //      b. If exists is true, return env.
+    //      c. Let outer be env.[[OuterEnv]].
+    //      d. Assert: outer is not null.
+    //      e. Set env to outer.
+    // NOTE |   The loop in step 2 will always terminate because the list of environments always ends with the global
+    //      |   environment which has a this binding.
+    let mut env = current_lexical_environment().unwrap();
+    loop {
+        let exists = env.has_this_binding();
+        if exists {
+            return env;
         }
+        let outer = env.get_outer_env().unwrap().clone();
+        env = outer;
     }
 }
 

--- a/src/execution_context/mod.rs
+++ b/src/execution_context/mod.rs
@@ -74,8 +74,8 @@ impl ExecutionContext {
 //
 //  1. Let currentRealm be the current Realm Record.
 //  2. Return currentRealm.[[GlobalObject]].
-pub fn get_global_object(agent: &Agent) -> Option<Object> {
-    agent.current_realm_record()?.borrow().global_object.clone()
+pub fn get_global_object() -> Option<Object> {
+    current_realm_record()?.borrow().global_object.clone()
 }
 
 impl Agent {
@@ -106,51 +106,46 @@ impl Agent {
             env = outer;
         }
     }
+}
 
-    /// Determine the binding of the "this" keyword (and return it)
-    ///
-    /// See [ResolveThisBinding](https://tc39.es/ecma262/#sec-resolvethisbinding) in ECMA-262.
-    pub fn resolve_this_binding(&self) -> Completion<ECMAScriptValue> {
-        // ResolveThisBinding ( )
-        //
-        // The abstract operation ResolveThisBinding takes no arguments and returns either a normal completion containing an
-        // ECMAScript language value or an abrupt completion. It determines the binding of the keyword this using the
-        // LexicalEnvironment of the running execution context. It performs the following steps when called:
-        //
-        // 1. Let envRec be GetThisEnvironment().
-        // 2. Return ? envRec.GetThisBinding().
-        let env_rec = self.get_this_environment();
-        env_rec.get_this_binding(self)
-    }
+/// Determine the binding of the "this" keyword (and return it)
+///
+/// See [ResolveThisBinding](https://tc39.es/ecma262/#sec-resolvethisbinding) in ECMA-262.
+pub fn resolve_this_binding() -> Completion<ECMAScriptValue> {
+    // ResolveThisBinding ( )
+    //
+    // The abstract operation ResolveThisBinding takes no arguments and returns either a normal completion containing an
+    // ECMAScript language value or an abrupt completion. It determines the binding of the keyword this using the
+    // LexicalEnvironment of the running execution context. It performs the following steps when called:
+    //
+    // 1. Let envRec be GetThisEnvironment().
+    // 2. Return ? envRec.GetThisBinding().
+    let env_rec = get_this_environment();
+    env_rec.get_this_binding()
+}
 
-    /// Constructs a Reference for the given name (and, potentially, environment)
-    ///
-    /// See [ResolveBinding](https://tc39.es/ecma262/#sec-resolvebinding) in ECMA-262.
-    pub fn resolve_binding(
-        &self,
-        name: &JSString,
-        env: Option<Rc<dyn EnvironmentRecord>>,
-        strict: bool,
-    ) -> FullCompletion {
-        // ResolveBinding ( name [ , env ] )
-        // The abstract operation ResolveBinding takes argument name (a String) and optional argument env (an
-        // Environment Record or undefined) and returns either a normal completion containing a Reference Record or an
-        // abrupt completion. It is used to determine the binding of name. env can be used to explicitly provide the
-        // Environment Record that is to be searched for the binding. It performs the following steps when called:
-        //
-        //  1. If env is not present or if env is undefined, then
-        //      a. Set env to the running execution context's LexicalEnvironment.
-        //  2. Assert: env is an Environment Record.
-        //  3. If the source text matched by the syntactic production that is being evaluated is contained in strict
-        //     mode code, let strict be true; else let strict be false.
-        //  4. Return ? GetIdentifierReference(env, name, strict).
-        // NOTE |   The result of ResolveBinding is always a Reference Record whose [[ReferencedName]] field is name.
-        let env = match env {
-            Some(e) => Some(e),
-            None => self.current_lexical_environment(),
-        };
-        get_identifier_reference(self, env, name.clone(), strict).map(NormalCompletion::from)
-    }
+/// Constructs a Reference for the given name (and, potentially, environment)
+///
+/// See [ResolveBinding](https://tc39.es/ecma262/#sec-resolvebinding) in ECMA-262.
+pub fn resolve_binding(name: &JSString, env: Option<Rc<dyn EnvironmentRecord>>, strict: bool) -> FullCompletion {
+    // ResolveBinding ( name [ , env ] )
+    // The abstract operation ResolveBinding takes argument name (a String) and optional argument env (an
+    // Environment Record or undefined) and returns either a normal completion containing a Reference Record or an
+    // abrupt completion. It is used to determine the binding of name. env can be used to explicitly provide the
+    // Environment Record that is to be searched for the binding. It performs the following steps when called:
+    //
+    //  1. If env is not present or if env is undefined, then
+    //      a. Set env to the running execution context's LexicalEnvironment.
+    //  2. Assert: env is an Environment Record.
+    //  3. If the source text matched by the syntactic production that is being evaluated is contained in strict
+    //     mode code, let strict be true; else let strict be false.
+    //  4. Return ? GetIdentifierReference(env, name, strict).
+    // NOTE |   The result of ResolveBinding is always a Reference Record whose [[ReferencedName]] field is name.
+    let env = match env {
+        Some(e) => Some(e),
+        None => current_lexical_environment(),
+    };
+    get_identifier_reference(env, name.clone(), strict).map(NormalCompletion::from)
 }
 
 #[cfg(test)]

--- a/src/execution_context/tests.rs
+++ b/src/execution_context/tests.rs
@@ -16,14 +16,14 @@ mod script_record {
     #[test]
     fn debug() {
         setup_test_agent();
-        let sr = ScriptRecord::new_empty(agent.current_realm_record().unwrap());
+        let sr = ScriptRecord::new_empty(current_realm_record().unwrap());
         assert_ne!(format!("{:?}", sr), "");
     }
 
     #[test]
     fn clone() {
         setup_test_agent();
-        let sr = ScriptRecord::new_empty(agent.current_realm_record().unwrap());
+        let sr = ScriptRecord::new_empty(current_realm_record().unwrap());
         let sr2 = sr.clone();
         assert!(Rc::ptr_eq(&sr.realm, &sr2.realm));
         assert!(Rc::ptr_eq(&sr.ecmascript_code, &sr2.ecmascript_code));
@@ -55,7 +55,7 @@ mod script_or_module {
     #[test]
     fn clone() {
         setup_test_agent();
-        let s1 = ScriptOrModule::Script(Rc::new(ScriptRecord::new_empty(agent.current_realm_record().unwrap())));
+        let s1 = ScriptOrModule::Script(Rc::new(ScriptRecord::new_empty(current_realm_record().unwrap())));
         let s2 = s1.clone();
 
         if let (ScriptOrModule::Script(original), ScriptOrModule::Script(duplicate)) = (s1, s2) {
@@ -65,15 +65,15 @@ mod script_or_module {
         }
     }
 
-    #[test_case(|agent| {
-        let mut sr = ScriptRecord::new_empty(agent.current_realm_record().unwrap());
+    #[test_case(|| {
+        let mut sr = ScriptRecord::new_empty(current_realm_record().unwrap());
         sr.text = String::from("I am a walrus");
         ScriptOrModule::Script(Rc::new(sr))
     } => "I am a walrus"; "Script")]
-    #[test_case(|_| ScriptOrModule::Module(Rc::new(ModuleRecord{})) => panics "not yet implemented"; "module")]
-    fn source_text(maker: impl FnOnce(&Agent) -> ScriptOrModule) -> String {
+    #[test_case(|| ScriptOrModule::Module(Rc::new(ModuleRecord{})) => panics "not yet implemented"; "module")]
+    fn source_text(maker: impl FnOnce() -> ScriptOrModule) -> String {
         setup_test_agent();
-        let som = maker(&agent);
+        let som = maker();
         let text = som.source_text();
         text.clone()
     }
@@ -86,22 +86,22 @@ mod execution_context {
     #[test]
     fn debug() {
         setup_test_agent();
-        let ec = ExecutionContext::new(None, agent.current_realm_record().unwrap(), None);
+        let ec = ExecutionContext::new(None, current_realm_record().unwrap(), None);
 
         assert_ne!(format!("{:?}", ec), "");
     }
 
-    #[test_case(|_| None; "SOM is None")]
-    #[test_case(|_| Some(ScriptOrModule::Module(Rc::new(ModuleRecord{}))) => panics "not yet implemented"; "SOM is module")]
-    #[test_case(|a| Some(ScriptOrModule::Script(Rc::new(ScriptRecord::new_empty(a.current_realm_record().unwrap())))); "SOM is script")]
-    fn new(maker: fn(&Agent) -> Option<ScriptOrModule>) {
+    #[test_case(|| None; "SOM is None")]
+    #[test_case(|| Some(ScriptOrModule::Module(Rc::new(ModuleRecord{}))) => panics "not yet implemented"; "SOM is module")]
+    #[test_case(|| Some(ScriptOrModule::Script(Rc::new(ScriptRecord::new_empty(current_realm_record().unwrap())))); "SOM is script")]
+    fn new(maker: fn() -> Option<ScriptOrModule>) {
         setup_test_agent();
-        let som = maker(&agent);
+        let som = maker();
         let original_was_none = som.is_none();
-        let func = Some(ordinary_object_create(&agent, None, &[]));
-        let ec = ExecutionContext::new(func.clone(), agent.current_realm_record().unwrap(), som);
+        let func = Some(ordinary_object_create(None, &[]));
+        let ec = ExecutionContext::new(func.clone(), current_realm_record().unwrap(), som);
         assert_eq!(&func, &ec.function);
-        assert!(Rc::ptr_eq(&ec.realm, &agent.current_realm_record().unwrap()));
+        assert!(Rc::ptr_eq(&ec.realm, &current_realm_record().unwrap()));
         assert!(ec.lexical_environment.is_none());
         assert!(ec.variable_environment.is_none());
         assert!(ec.private_environment.is_none());
@@ -112,15 +112,18 @@ mod execution_context {
     }
 }
 
-#[test_case(|| Agent::new() => None; "empty agent")]
-#[test_case(test_agent => Some("present".to_string()); "has global")]
-fn get_global_object(maker: fn() -> Agent) -> Option<String> {
-    let agent = maker();
-    let maybe_obj = super::get_global_object(&agent);
+#[test_case(true => None; "empty agent")]
+#[test_case(false => Some("present".to_string()); "has global")]
+fn get_global_object(reset: bool) -> Option<String> {
+    setup_test_agent();
+    if reset {
+        AGENT.with(|agent| agent.reset())
+    }
+    let maybe_obj = super::get_global_object();
 
     maybe_obj.map(|obj| {
-        let val = get(&agent, &obj, &"debug_token".into()).unwrap_or_else(|_| "missing".into());
-        to_string(&agent, val).unwrap().to_string()
+        let val = get(&obj, &"debug_token".into()).unwrap_or_else(|_| "missing".into());
+        to_string(val).unwrap().to_string()
     })
 }
 
@@ -137,16 +140,16 @@ mod agent {
 
             setup_test_agent();
             // Need to establish a lexical environment first.
-            let realm = agent.current_realm_record().unwrap();
+            let realm = current_realm_record().unwrap();
             let global_env = realm.borrow().global_env.clone();
             let mut script_context = ExecutionContext::new(None, Rc::clone(&realm), None);
             script_context.lexical_environment = global_env.clone().map(|g| g as Rc<dyn EnvironmentRecord>);
             script_context.variable_environment = global_env.map(|g| g as Rc<dyn EnvironmentRecord>);
-            agent.push_execution_context(script_context);
+            push_execution_context(script_context);
 
-            let env = agent.get_this_environment();
-            let val = env.get_binding_value(&agent, &"debug_token".into(), false).unwrap();
-            let repr = to_string(&agent, val).unwrap();
+            let env = get_this_environment();
+            let val = env.get_binding_value(&"debug_token".into(), false).unwrap();
+            let repr = to_string(val).unwrap();
 
             assert_eq!(repr.to_string(), "present");
         }
@@ -156,18 +159,18 @@ mod agent {
             // Where the we start from a child node without a this binding and work our way up.
             setup_test_agent();
             // Need to establish a lexical environment first.
-            let realm = agent.current_realm_record().unwrap();
+            let realm = current_realm_record().unwrap();
             let global_env = realm.borrow().global_env.clone().unwrap() as Rc<dyn EnvironmentRecord>;
             let mut script_context = ExecutionContext::new(None, Rc::clone(&realm), None);
             script_context.lexical_environment = Some(Rc::new(DeclarativeEnvironmentRecord::new(
                 Some(global_env),
                 "child",
             )) as Rc<dyn EnvironmentRecord>);
-            agent.push_execution_context(script_context);
+            push_execution_context(script_context);
 
-            let env = agent.get_this_environment();
-            let val = env.get_binding_value(&agent, &"debug_token".into(), false).unwrap();
-            let repr = to_string(&agent, val).unwrap();
+            let env = get_this_environment();
+            let val = env.get_binding_value(&"debug_token".into(), false).unwrap();
+            let repr = to_string(val).unwrap();
 
             assert_eq!(repr.to_string(), "present");
         }
@@ -177,47 +180,47 @@ mod agent {
     fn resolve_this_binding() {
         setup_test_agent();
         // Need to establish a lexical environment first.
-        let realm = agent.current_realm_record().unwrap();
+        let realm = current_realm_record().unwrap();
         let global_env = realm.borrow().global_env.clone().unwrap() as Rc<dyn EnvironmentRecord>;
         let mut script_context = ExecutionContext::new(None, Rc::clone(&realm), None);
         script_context.lexical_environment =
             Some(Rc::new(DeclarativeEnvironmentRecord::new(Some(global_env), "rtb")) as Rc<dyn EnvironmentRecord>);
-        agent.push_execution_context(script_context);
+        push_execution_context(script_context);
 
-        let this_binding_value = agent.resolve_this_binding().unwrap();
-        let this_binding = to_object(&agent, this_binding_value).unwrap();
-        let probe = get(&agent, &this_binding, &"debug_token".into()).unwrap();
-        let repr = to_string(&agent, probe).unwrap();
+        let this_binding_value = super::resolve_this_binding().unwrap();
+        let this_binding = to_object(this_binding_value).unwrap();
+        let probe = get(&this_binding, &"debug_token".into()).unwrap();
+        let repr = to_string(probe).unwrap();
         assert_eq!(repr.to_string(), "present");
     }
 
-    #[test_case("debug_token", |_| None, false => Ok(("Environment(GlobalEnvironmentRecord(realm-global))".to_string(), ReferencedName::from("debug_token"), false, None)) ; "global ref")]
-    #[test_case("notPresent", |_| None, true => Ok(("Unresolvable".to_string(), ReferencedName::from("notPresent"), true, None)); "unresolvable")]
-    #[test_case("marker", |a| {
-        let outer = a.current_lexical_environment().unwrap();
+    #[test_case("debug_token", || None, false => Ok(("Environment(GlobalEnvironmentRecord(realm-global))".to_string(), ReferencedName::from("debug_token"), false, None)) ; "global ref")]
+    #[test_case("notPresent", || None, true => Ok(("Unresolvable".to_string(), ReferencedName::from("notPresent"), true, None)); "unresolvable")]
+    #[test_case("marker", || {
+        let outer = current_lexical_environment().unwrap();
         let env = DeclarativeEnvironmentRecord::new(Some(outer), "test-decl-env");
-        env.create_mutable_binding(a, "marker".into(), false).unwrap();
-        env.initialize_binding(a, &"marker".into(), ECMAScriptValue::from(100)).unwrap();
+        env.create_mutable_binding("marker".into(), false).unwrap();
+        env.initialize_binding(&"marker".into(), ECMAScriptValue::from(100)).unwrap();
         Some(Rc::new(env) as Rc<dyn EnvironmentRecord>)
     }, false => Ok(("Environment(DeclarativeEnvironmentRecord(test-decl-env))".to_string(), ReferencedName::from("marker"), false, None)); "Other env")]
     fn resolve_binding(
         name: &str,
-        env_maker: fn(&Agent) -> Option<Rc<dyn EnvironmentRecord>>,
+        env_maker: fn() -> Option<Rc<dyn EnvironmentRecord>>,
         strict: bool,
     ) -> Result<(String, ReferencedName, bool, Option<ECMAScriptValue>), String> {
         setup_test_agent();
         // Need to establish a lexical environment first.
-        let realm = agent.current_realm_record().unwrap();
+        let realm = current_realm_record().unwrap();
         let global_env = realm.borrow().global_env.clone().unwrap() as Rc<dyn EnvironmentRecord>;
         let mut script_context = ExecutionContext::new(None, Rc::clone(&realm), None);
         script_context.lexical_environment =
             Some(Rc::new(DeclarativeEnvironmentRecord::new(Some(global_env), "script")) as Rc<dyn EnvironmentRecord>);
-        agent.push_execution_context(script_context);
+        push_execution_context(script_context);
 
-        let env = env_maker(&agent);
-        let result = agent.resolve_binding(&name.into(), env, strict);
+        let env = env_maker();
+        let result = super::resolve_binding(&name.into(), env, strict);
 
-        result.map_err(|err| unwind_any_error(&agent, err)).and_then(|nc| match nc {
+        result.map_err(|err| unwind_any_error(err)).and_then(|nc| match nc {
             NormalCompletion::Empty | NormalCompletion::Value(_) | NormalCompletion::Environment(_) => {
                 Err("improper completion".to_string())
             }

--- a/src/execution_context/tests.rs
+++ b/src/execution_context/tests.rs
@@ -112,7 +112,7 @@ mod execution_context {
     }
 }
 
-#[test_case(|| Agent::new(Rc::new(RefCell::new(SymbolRegistry::new()))) => None; "empty agent")]
+#[test_case(|| Agent::new() => None; "empty agent")]
 #[test_case(test_agent => Some("present".to_string()); "has global")]
 fn get_global_object(maker: fn() -> Agent) -> Option<String> {
     let agent = maker();

--- a/src/execution_context/tests.rs
+++ b/src/execution_context/tests.rs
@@ -220,7 +220,7 @@ mod agent {
         let env = env_maker();
         let result = super::resolve_binding(&name.into(), env, strict);
 
-        result.map_err(|err| unwind_any_error(err)).and_then(|nc| match nc {
+        result.map_err(unwind_any_error).and_then(|nc| match nc {
             NormalCompletion::Empty | NormalCompletion::Value(_) | NormalCompletion::Environment(_) => {
                 Err("improper completion".to_string())
             }

--- a/src/execution_context/tests.rs
+++ b/src/execution_context/tests.rs
@@ -15,14 +15,14 @@ mod script_record {
 
     #[test]
     fn debug() {
-        let agent = test_agent();
+        setup_test_agent();
         let sr = ScriptRecord::new_empty(agent.current_realm_record().unwrap());
         assert_ne!(format!("{:?}", sr), "");
     }
 
     #[test]
     fn clone() {
-        let agent = test_agent();
+        setup_test_agent();
         let sr = ScriptRecord::new_empty(agent.current_realm_record().unwrap());
         let sr2 = sr.clone();
         assert!(Rc::ptr_eq(&sr.realm, &sr2.realm));
@@ -54,7 +54,7 @@ mod script_or_module {
 
     #[test]
     fn clone() {
-        let agent = test_agent();
+        setup_test_agent();
         let s1 = ScriptOrModule::Script(Rc::new(ScriptRecord::new_empty(agent.current_realm_record().unwrap())));
         let s2 = s1.clone();
 
@@ -72,7 +72,7 @@ mod script_or_module {
     } => "I am a walrus"; "Script")]
     #[test_case(|_| ScriptOrModule::Module(Rc::new(ModuleRecord{})) => panics "not yet implemented"; "module")]
     fn source_text(maker: impl FnOnce(&Agent) -> ScriptOrModule) -> String {
-        let agent = test_agent();
+        setup_test_agent();
         let som = maker(&agent);
         let text = som.source_text();
         text.clone()
@@ -85,7 +85,7 @@ mod execution_context {
 
     #[test]
     fn debug() {
-        let agent = test_agent();
+        setup_test_agent();
         let ec = ExecutionContext::new(None, agent.current_realm_record().unwrap(), None);
 
         assert_ne!(format!("{:?}", ec), "");
@@ -95,7 +95,7 @@ mod execution_context {
     #[test_case(|_| Some(ScriptOrModule::Module(Rc::new(ModuleRecord{}))) => panics "not yet implemented"; "SOM is module")]
     #[test_case(|a| Some(ScriptOrModule::Script(Rc::new(ScriptRecord::new_empty(a.current_realm_record().unwrap())))); "SOM is script")]
     fn new(maker: fn(&Agent) -> Option<ScriptOrModule>) {
-        let agent = test_agent();
+        setup_test_agent();
         let som = maker(&agent);
         let original_was_none = som.is_none();
         let func = Some(ordinary_object_create(&agent, None, &[]));
@@ -135,7 +135,7 @@ mod agent {
         fn global() {
             // Where the "this object" is the global object.
 
-            let agent = test_agent();
+            setup_test_agent();
             // Need to establish a lexical environment first.
             let realm = agent.current_realm_record().unwrap();
             let global_env = realm.borrow().global_env.clone();
@@ -154,7 +154,7 @@ mod agent {
         #[test]
         fn child() {
             // Where the we start from a child node without a this binding and work our way up.
-            let agent = test_agent();
+            setup_test_agent();
             // Need to establish a lexical environment first.
             let realm = agent.current_realm_record().unwrap();
             let global_env = realm.borrow().global_env.clone().unwrap() as Rc<dyn EnvironmentRecord>;
@@ -175,7 +175,7 @@ mod agent {
 
     #[test]
     fn resolve_this_binding() {
-        let agent = test_agent();
+        setup_test_agent();
         // Need to establish a lexical environment first.
         let realm = agent.current_realm_record().unwrap();
         let global_env = realm.borrow().global_env.clone().unwrap() as Rc<dyn EnvironmentRecord>;
@@ -205,7 +205,7 @@ mod agent {
         env_maker: fn(&Agent) -> Option<Rc<dyn EnvironmentRecord>>,
         strict: bool,
     ) -> Result<(String, ReferencedName, bool, Option<ECMAScriptValue>), String> {
-        let agent = test_agent();
+        setup_test_agent();
         // Need to establish a lexical environment first.
         let realm = agent.current_realm_record().unwrap();
         let global_env = realm.borrow().global_env.clone().unwrap() as Rc<dyn EnvironmentRecord>;

--- a/src/function_object/mod.rs
+++ b/src/function_object/mod.rs
@@ -392,14 +392,13 @@ impl<'a> From<&'a FunctionObject> for &'a dyn ObjectInterface {
 pub trait CallableObject: ObjectInterface {
     fn call(
         &self,
-        agent: &Agent,
         self_object: &Object,
         this_argument: &ECMAScriptValue,
         arguments_list: &[ECMAScriptValue],
     );
-    fn construct(&self, agent: &Agent, self_object: &Object, arguments_list: &[ECMAScriptValue], new_target: &Object);
-    fn end_evaluation(&self, agent: &Agent, result: FullCompletion);
-    fn complete_call(&self, agent: &Agent) -> Completion<ECMAScriptValue>;
+    fn construct(&self, self_object: &Object, arguments_list: &[ECMAScriptValue], new_target: &Object);
+    fn end_evaluation(&self, result: FullCompletion);
+    fn complete_call(&self) -> Completion<ECMAScriptValue>;
 }
 
 impl ObjectInterface for FunctionObject {
@@ -917,7 +916,7 @@ pub fn nameify(src: &str, limit: usize) -> String {
 //              i. Optionally, set F.[[InitialName]] to name.
 //      6. Return ! DefinePropertyOrThrow(F, "name", PropertyDescriptor { [[Value]]: name, [[Writable]]: false,
 //         [[Enumerable]]: false, [[Configurable]]: true }).
-pub fn set_function_name(agent: &Agent, func: &Object, name: FunctionName, prefix: Option<JSString>) {
+pub fn set_function_name(func: &Object, name: FunctionName, prefix: Option<JSString>) {
     let name_before_prefix = match name {
         FunctionName::String(s) => s,
         FunctionName::PrivateName(pn) => pn.description,
@@ -1453,7 +1452,6 @@ impl AsyncGeneratorDeclaration {
 /// See [OrdinaryFunctionCreate](https://tc39.es/ecma262/#sec-ordinaryfunctioncreate) from ECMA-262.
 #[allow(clippy::too_many_arguments)]
 pub fn ordinary_function_create(
-    agent: &Agent,
     function_prototype: Object,
     source_text: &str,
     parameter_list: ParamSource,
@@ -1539,7 +1537,7 @@ pub fn ordinary_function_create(
 /// Transform a function object into a constructor
 ///
 /// See [MakeConstructor](https://tc39.es/ecma262/#sec-makeconstructor) from ECMA-262.
-pub fn make_constructor(agent: &Agent, func: &Object, args: Option<(bool, Object)>) {
+pub fn make_constructor(func: &Object, args: Option<(bool, Object)>) {
     // MakeConstructor ( F [ , writablePrototype [ , prototype ] ] )
     //
     // The abstract operation MakeConstructor takes argument F (an ECMAScript function object or a built-in function

--- a/src/function_object/tests.rs
+++ b/src/function_object/tests.rs
@@ -56,7 +56,7 @@ mod function_declaration {
         fn typical(name: &str) -> String {
             let src = format!("function {name}(){{}}");
             let fd = Maker::new(&src).function_declaration();
-            let agent = test_agent();
+            setup_test_agent();
             let realm_rc = agent.current_realm_record().unwrap();
             let global_env = realm_rc.borrow().global_env.as_ref().unwrap().clone() as Rc<dyn EnvironmentRecord>;
 
@@ -93,7 +93,7 @@ mod function_declaration {
         fn compile_error() {
             let src = "function a(){ if (true) { @@@; } return 3; }";
             let fd = Maker::new(src).function_declaration();
-            let agent = test_agent();
+            setup_test_agent();
             let realm_rc = agent.current_realm_record().unwrap();
             let global_env = realm_rc.borrow().global_env.as_ref().unwrap().clone() as Rc<dyn EnvironmentRecord>;
 
@@ -113,7 +113,7 @@ mod generator_declaration {
     fn instantiate_function_object() {
         let src = "function *a(){}";
         let fd = Maker::new(src).generator_declaration();
-        let agent = test_agent();
+        setup_test_agent();
         let global_env = {
             let realm_rc = agent.current_realm_record().unwrap();
             let realm = realm_rc.borrow();
@@ -131,7 +131,7 @@ mod async_function_declaration {
     fn instantiate_function_object() {
         let src = "async function a(){}";
         let fd = Maker::new(src).async_function_declaration();
-        let agent = test_agent();
+        setup_test_agent();
         let global_env = {
             let realm_rc = agent.current_realm_record().unwrap();
             let realm = realm_rc.borrow();
@@ -149,7 +149,7 @@ mod async_generator_declaration {
     fn instantiate_function_object() {
         let src = "async function *a(){}";
         let fd = Maker::new(src).async_generator_declaration();
-        let agent = test_agent();
+        setup_test_agent();
         let global_env = {
             let realm_rc = agent.current_realm_record().unwrap();
             let realm = realm_rc.borrow();
@@ -220,7 +220,7 @@ mod function_prototype_call {
         get_this: impl FnOnce(&Agent) -> ECMAScriptValue,
         args: &[ECMAScriptValue],
     ) -> Result<ECMAScriptValue, String> {
-        let agent = test_agent();
+        setup_test_agent();
         let this_value = get_this(&agent);
         super::function_prototype_call(&agent, this_value, None, args).map_err(|err| unwind_any_error(&agent, err))
     }

--- a/src/function_object/tests.rs
+++ b/src/function_object/tests.rs
@@ -220,6 +220,6 @@ mod function_prototype_call {
     ) -> Result<ECMAScriptValue, String> {
         setup_test_agent();
         let this_value = get_this();
-        super::function_prototype_call(this_value, None, args).map_err(|err| unwind_any_error(err))
+        super::function_prototype_call(this_value, None, args).map_err(unwind_any_error)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ impl VM {
         let sym_registry = Rc::new(RefCell::new(SymbolRegistry::new()));
         AGENT.with(|agent| {
             agent.set_global_symbol_registry(sym_registry.clone());
-            agent.initialize_host_defined_realm(false);
+            initialize_host_defined_realm(false);
         });
         VM { symbols: sym_registry }
     }
@@ -133,7 +133,7 @@ fn run_file(vm: &mut VM, fname: &str) {
         Err(e) => println!("{}", e),
         Ok(file_content) => {
             let script_source = String::from_utf8_lossy(&file_content);
-            match process_ecmascript(&vm.agent, &script_source) {
+            match process_ecmascript(&script_source) {
                 Ok(value) => println!("{:#?}", value),
                 Err(err) => println!("{}", err),
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ impl VM {
     }
 }
 
-fn interpret(vm: &mut VM, source: &str) -> Result<i32, String> {
+fn interpret(source: &str) -> Result<i32, String> {
     let parsed = parse_text(source, ParseGoal::Script);
     match parsed {
         ParsedText::Errors(errs) => {
@@ -105,7 +105,7 @@ fn interpret(vm: &mut VM, source: &str) -> Result<i32, String> {
     }
 }
 
-fn repl(vm: &mut VM) {
+fn repl() {
     loop {
         print!("> ");
         io::stdout().flush().unwrap();
@@ -119,14 +119,14 @@ fn repl(vm: &mut VM) {
         }
 
         println!("You entered the string {:?}", line);
-        match interpret(vm, &line) {
+        match interpret(&line) {
             Ok(value) => println!("{}", value),
             Err(err) => println!("{}", err),
         }
     }
 }
 
-fn run_file(vm: &mut VM, fname: &str) {
+fn run_file(fname: &str) {
     println!("Running from the file {}", fname);
     let potential_file_content = fs::read(fname);
     match potential_file_content {
@@ -150,11 +150,11 @@ fn run_app() -> Result<(), i32> {
     println!("sizeof(NormalCompletion): {}", std::mem::size_of::<NormalCompletion>());
     println!("sizeof(AbruptCompletion): {}", std::mem::size_of::<AbruptCompletion>());
 
-    let mut vm: VM = VM::new();
+    VM::new();
     let args: Vec<String> = env::args().collect();
     match args.len() {
-        1 => repl(&mut vm),
-        2 => run_file(&mut vm, &args[1]),
+        1 => repl(),
+        2 => run_file(&args[1]),
         _ => {
             eprintln!("Usage: {} [path]", &args[0]);
             return Err(2);

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,5 +171,14 @@ fn main() {
     });
 }
 
+use itertools::Itertools;
+fn example() {
+    let mydigits = "012345";
+
+    for z in mydigits.chars().chunks(2).into_iter().map(|chunk| format!("{:?}", chunk.collect::<Vec<_>>())) {
+        println!("{:?}", z);
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/number_object/mod.rs
+++ b/src/number_object/mod.rs
@@ -158,7 +158,7 @@ impl NumberObject {
     }
 }
 
-pub fn provision_number_intrinsic(agent: &Agent, realm: &Rc<RefCell<Realm>>) {
+pub fn provision_number_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 

--- a/src/number_object/tests.rs
+++ b/src/number_object/tests.rs
@@ -4,7 +4,7 @@ use num::BigInt;
 
 #[test]
 fn number_object_debug() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = NumberObject {
         common: RefCell::new(CommonObjectData::new(&agent, None, false, NUMBER_OBJECT_SLOTS)),
         number_data: RefCell::new(0.0),
@@ -16,7 +16,7 @@ fn number_object_debug() {
 #[test]
 #[allow(clippy::float_cmp)]
 fn number_object_object() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
     let no = NumberObject::object(&agent, Some(number_prototype.clone()));
 
@@ -27,7 +27,7 @@ fn number_object_object() {
 #[test]
 #[allow(clippy::float_cmp)]
 fn create_number_object_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
@@ -37,7 +37,7 @@ fn create_number_object_01() {
 
 #[test]
 fn number_object_common_object_data() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
     let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
 
@@ -51,7 +51,7 @@ fn number_object_common_object_data() {
 }
 #[test]
 fn number_object_is_ordinary() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     let result = no.o.is_ordinary();
@@ -60,7 +60,7 @@ fn number_object_is_ordinary() {
 }
 #[test]
 fn number_object_id() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     // ... essentially, assert that it doesn't panic.
@@ -68,7 +68,7 @@ fn number_object_id() {
 }
 #[test]
 fn number_object_to_number_object() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     let result = no.o.to_number_obj();
@@ -76,7 +76,7 @@ fn number_object_to_number_object() {
 }
 #[test]
 fn number_object_is_number_object() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     let result = no.o.is_number_object();
@@ -85,7 +85,7 @@ fn number_object_is_number_object() {
 }
 #[test]
 fn number_object_get_prototype_of() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     let result = no.o.get_prototype_of(&agent).unwrap();
@@ -93,7 +93,7 @@ fn number_object_get_prototype_of() {
 }
 #[test]
 fn number_object_set_prototype_of() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     let result = no.o.set_prototype_of(&agent, None).unwrap();
@@ -101,7 +101,7 @@ fn number_object_set_prototype_of() {
 }
 #[test]
 fn number_object_is_extensible() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     let result = no.o.is_extensible(&agent).unwrap();
@@ -109,7 +109,7 @@ fn number_object_is_extensible() {
 }
 #[test]
 fn number_object_prevent_extensions() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     let result = no.o.prevent_extensions(&agent).unwrap();
@@ -117,7 +117,7 @@ fn number_object_prevent_extensions() {
 }
 #[test]
 fn number_object_get_own_property() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     let result = no.o.get_own_property(&agent, &PropertyKey::from("a")).unwrap();
@@ -125,7 +125,7 @@ fn number_object_get_own_property() {
 }
 #[test]
 fn number_object_define_own_property() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     let result =
@@ -139,7 +139,7 @@ fn number_object_define_own_property() {
 }
 #[test]
 fn number_object_has_property() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     let result = no.o.has_property(&agent, &PropertyKey::from("a")).unwrap();
@@ -147,7 +147,7 @@ fn number_object_has_property() {
 }
 #[test]
 fn number_object_get() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     let result = no.o.get(&agent, &PropertyKey::from("a"), &ECMAScriptValue::from(no.clone())).unwrap();
@@ -155,7 +155,7 @@ fn number_object_get() {
 }
 #[test]
 fn number_object_set() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     let result =
@@ -165,7 +165,7 @@ fn number_object_set() {
 }
 #[test]
 fn number_object_delete() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     let result = no.o.delete(&agent, &PropertyKey::from("a")).unwrap();
@@ -173,7 +173,7 @@ fn number_object_delete() {
 }
 #[test]
 fn number_object_own_property_keys() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     let result = no.o.own_property_keys(&agent).unwrap();
@@ -181,7 +181,7 @@ fn number_object_own_property_keys() {
 }
 #[test]
 fn number_object_other_automatic_functions() {
-    let agent = test_agent();
+    setup_test_agent();
     let no = create_number_object(&agent, 100.0);
 
     assert!(!no.o.is_error_object());
@@ -201,7 +201,7 @@ fn number_object_other_automatic_functions() {
 
 #[test]
 fn number_constructor_data_props() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let val = get(&agent, &number_constructor, &PropertyKey::from("EPSILON")).unwrap();
@@ -241,7 +241,7 @@ fn number_constructor_called_as_function_01() {
     // No arguments passed:
     //   > Number()
     //   0
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Number));
 
     let result = call(&agent, &number_constructor, &ECMAScriptValue::Undefined, &[]).unwrap();
@@ -252,7 +252,7 @@ fn number_constructor_called_as_function_02() {
     // Argument with a "Number" result from ToNumeric.
     //   > Number(true)
     //   1
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Number));
 
     let result =
@@ -264,7 +264,7 @@ fn number_constructor_called_as_function_03() {
     // Argument with a "BigInt" result from ToNumeric.
     //   > Number(10n)
     //   10
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Number));
 
     let result =
@@ -278,7 +278,7 @@ fn number_constructor_called_as_function_04() {
     //   > Number(Symbol())
     //   Uncaught TypeError: Cannot convert a Symbol value to a number
     //       at Number (<anonymous>)
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Number));
 
     let sym = Symbol::new(&agent, None);
@@ -293,7 +293,7 @@ fn number_constructor_as_constructor_01() {
     // No arguments:
     //   > new Number()
     //   [Number: 0]
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let result = construct(&agent, &number_constructor, &[], None).unwrap();
@@ -311,7 +311,7 @@ fn number_constructor_as_constructor_02() {
     // Argument needing conversion:
     //   > new Number("0xbadfade")
     //   [Number: 195951326]
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let arg = ECMAScriptValue::from("0xbadfade");
 
@@ -328,7 +328,7 @@ fn number_constructor_as_constructor_02() {
 fn number_constructor_throws() {
     // ordinary_create_from_contructor throws.
     // This looks to be difficult to make happen, but I can imagine some class shenanigans that could do it.
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     // This hack is to get around the "not configurable" characteristic of Number.prototype.
@@ -352,7 +352,7 @@ fn number_is_finite_no_args() {
     // no args
     //    > Number.isFinite()
     //    false
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let is_finite = get(&agent, &number_constructor, &PropertyKey::from("isFinite")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
@@ -362,7 +362,7 @@ fn number_is_finite_no_args() {
 }
 #[test]
 fn number_is_finite_one_arg() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let is_finite = get(&agent, &number_constructor, &PropertyKey::from("isFinite")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
@@ -386,7 +386,7 @@ fn number_is_finite_one_arg() {
 
 #[test]
 fn number_is_integer_no_args() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let is_integer = get(&agent, &number_constructor, &PropertyKey::from("isInteger")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
@@ -396,7 +396,7 @@ fn number_is_integer_no_args() {
 }
 #[test]
 fn number_is_integer_one_arg() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let is_integer = get(&agent, &number_constructor, &PropertyKey::from("isInteger")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
@@ -422,7 +422,7 @@ fn number_is_integer_one_arg() {
 
 #[test]
 fn number_is_nan_no_args() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let is_nan = get(&agent, &number_constructor, &PropertyKey::from("isNaN")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
@@ -432,7 +432,7 @@ fn number_is_nan_no_args() {
 }
 #[test]
 fn number_is_nan_one_arg() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let is_nan = get(&agent, &number_constructor, &PropertyKey::from("isNaN")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
@@ -455,7 +455,7 @@ fn number_is_nan_one_arg() {
 
 #[test]
 fn number_is_safe_integer_no_args() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let is_safe_integer = get(&agent, &number_constructor, &PropertyKey::from("isSafeInteger")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
@@ -465,7 +465,7 @@ fn number_is_safe_integer_no_args() {
 }
 #[test]
 fn number_is_safe_integer_one_arg() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let is_safe_integer = get(&agent, &number_constructor, &PropertyKey::from("isSafeInteger")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
@@ -495,7 +495,7 @@ fn number_is_safe_integer_one_arg() {
 #[allow(clippy::float_cmp)]
 fn this_number_value_01() {
     // called with number object
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
@@ -506,7 +506,7 @@ fn this_number_value_01() {
 #[allow(clippy::float_cmp)]
 fn this_number_value_02() {
     // called with number value
-    let agent = test_agent();
+    setup_test_agent();
 
     let result = this_number_value(&agent, ECMAScriptValue::from(123)).unwrap();
     assert_eq!(result, 123.0);
@@ -514,7 +514,7 @@ fn this_number_value_02() {
 #[test]
 fn this_number_value_03() {
     // called with non-number object
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
 
     let result = this_number_value(&agent, ECMAScriptValue::from(obj)).unwrap_err();
@@ -523,7 +523,7 @@ fn this_number_value_03() {
 #[test]
 fn this_number_value_04() {
     // called with non-number, non-object value
-    let agent = test_agent();
+    setup_test_agent();
 
     let result = this_number_value(&agent, ECMAScriptValue::from(true)).unwrap_err();
     assert_eq!(unwind_type_error(&agent, result), "Number method called with non-number receiver");
@@ -531,7 +531,7 @@ fn this_number_value_04() {
 
 #[test]
 fn number_proto_to_string_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
@@ -541,7 +541,7 @@ fn number_proto_to_string_01() {
 }
 #[test]
 fn number_proto_to_string_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123.789)], None).unwrap();
 
@@ -552,7 +552,7 @@ fn number_proto_to_string_02() {
 
 #[test]
 fn number_proto_to_string_03() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123.789)], None).unwrap();
     let sym = Symbol::new(&agent, None);
@@ -563,7 +563,7 @@ fn number_proto_to_string_03() {
 }
 #[test]
 fn number_proto_to_string_04() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
@@ -573,7 +573,7 @@ fn number_proto_to_string_04() {
 }
 #[test]
 fn number_proto_to_string_05() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
@@ -583,7 +583,7 @@ fn number_proto_to_string_05() {
 }
 #[test]
 fn number_proto_to_string_06() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
@@ -593,7 +593,7 @@ fn number_proto_to_string_06() {
 }
 #[test]
 fn number_proto_to_string_07() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
@@ -604,7 +604,7 @@ fn number_proto_to_string_07() {
 #[test]
 fn number_proto_to_string_08() {
     // this_number_value is not actually a number
-    let agent = test_agent();
+    setup_test_agent();
     let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
     let to_string = get(&agent, &number_prototype, &PropertyKey::from("toString")).unwrap();
 
@@ -613,7 +613,7 @@ fn number_proto_to_string_08() {
 }
 #[test]
 fn number_proto_to_string_09() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(1.0e100)], None).unwrap();
 
@@ -630,7 +630,7 @@ fn double_to_radix_string_01() {
 }
 
 fn number_proto_to_precision_test(value: f64, precision: u32, expected: &str) {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(value)], None).unwrap();
@@ -690,7 +690,7 @@ fn number_proto_to_precision_15() {
 #[test]
 fn number_proto_to_precision_12() {
     // this_number_value is not actually a number
-    let agent = test_agent();
+    setup_test_agent();
     let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
     let func = get(&agent, &number_prototype, &PropertyKey::from("toPrecision")).unwrap();
 
@@ -700,7 +700,7 @@ fn number_proto_to_precision_12() {
 #[test]
 fn number_proto_to_precision_13() {
     // precision not present
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
@@ -710,7 +710,7 @@ fn number_proto_to_precision_13() {
 #[test]
 fn number_proto_to_precision_14() {
     // precision not convertable to number
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
 
@@ -721,7 +721,7 @@ fn number_proto_to_precision_14() {
 #[test]
 fn number_proto_to_precision_16() {
     // precision out of range
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
@@ -731,7 +731,7 @@ fn number_proto_to_precision_16() {
 #[test]
 fn number_proto_to_precision_17() {
     // precision out of range
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
@@ -741,7 +741,7 @@ fn number_proto_to_precision_17() {
 #[test]
 fn number_proto_to_precision_18() {
     // precision just in range
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
@@ -755,7 +755,7 @@ fn number_proto_to_precision_18() {
 }
 
 fn number_proto_to_exponent_test(value: f64, fraction_digits: u32, expected: &str) {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(value)], None).unwrap();
@@ -777,7 +777,7 @@ fn number_proto_to_exponential_02() {
 }
 #[test]
 fn number_proto_to_exponential_03() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
@@ -787,7 +787,7 @@ fn number_proto_to_exponential_03() {
 #[test]
 fn number_proto_to_exponential_04() {
     // this_number_value is not actually a number
-    let agent = test_agent();
+    setup_test_agent();
     let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
     let func = get(&agent, &number_prototype, &PropertyKey::from("toExponential")).unwrap();
 
@@ -797,7 +797,7 @@ fn number_proto_to_exponential_04() {
 #[test]
 fn number_proto_to_exponential_05() {
     // fractionDigits not convertable to number
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
 
@@ -812,7 +812,7 @@ fn number_proto_to_exponential_06() {
 #[test]
 fn number_proto_to_exponential_07() {
     // fractionDigits out of range
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
@@ -823,7 +823,7 @@ fn number_proto_to_exponential_07() {
 #[test]
 fn number_proto_to_exponential_08() {
     // fractionDigits out of range
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
@@ -836,7 +836,7 @@ fn number_proto_to_exponential_09() {
 }
 
 fn number_proto_to_fixed_test(value: f64, fraction_digits: u32, expected: &str) {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(value)], None).unwrap();
@@ -909,7 +909,7 @@ fn number_proto_to_fixed_15() {
 #[test]
 fn number_proto_to_fixed_16() {
     // empty arg list
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
@@ -919,7 +919,7 @@ fn number_proto_to_fixed_16() {
 #[test]
 fn number_proto_to_fixed_17() {
     // bad argument
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
     let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
 
@@ -930,7 +930,7 @@ fn number_proto_to_fixed_17() {
 #[test]
 fn number_proto_to_fixed_18() {
     // bad argument
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
@@ -940,7 +940,7 @@ fn number_proto_to_fixed_18() {
 #[test]
 fn number_proto_to_fixed_19() {
     // bad argument
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
@@ -959,7 +959,7 @@ fn number_proto_to_fixed_20() {
 #[test]
 fn number_proto_to_fixed_21() {
     // this_number_value is not actually a number
-    let agent = test_agent();
+    setup_test_agent();
     let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
     let func = get(&agent, &number_prototype, &PropertyKey::from("toFixed")).unwrap();
 
@@ -995,7 +995,7 @@ fn next_double_test() {
 fn number_proto_to_locale_string_01() {
     // Implementations of toLocaleString may not use the arguments for any use beyond their ECMA-402 specified uses. In
     // particular, if we defer to toString, the first argument must _not_ be used as the radix argument.
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(10)], None).unwrap();
@@ -1005,7 +1005,7 @@ fn number_proto_to_locale_string_01() {
 
 #[test]
 fn number_proto_value_of() {
-    let agent = test_agent();
+    setup_test_agent();
     let number_constructor = agent.intrinsic(IntrinsicId::Number);
 
     let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();

--- a/src/number_object/tests.rs
+++ b/src/number_object/tests.rs
@@ -6,7 +6,7 @@ use num::BigInt;
 fn number_object_debug() {
     setup_test_agent();
     let no = NumberObject {
-        common: RefCell::new(CommonObjectData::new(&agent, None, false, NUMBER_OBJECT_SLOTS)),
+        common: RefCell::new(CommonObjectData::new(None, false, NUMBER_OBJECT_SLOTS)),
         number_data: RefCell::new(0.0),
     };
 
@@ -17,8 +17,8 @@ fn number_object_debug() {
 #[allow(clippy::float_cmp)]
 fn number_object_object() {
     setup_test_agent();
-    let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
-    let no = NumberObject::object(&agent, Some(number_prototype.clone()));
+    let number_prototype = intrinsic(IntrinsicId::NumberPrototype);
+    let no = NumberObject::object(Some(number_prototype.clone()));
 
     assert_eq!(no.o.common_object_data().borrow().prototype, Some(number_prototype));
     assert_eq!(*no.o.to_number_obj().unwrap().number_data().borrow(), 0.0);
@@ -28,18 +28,18 @@ fn number_object_object() {
 #[allow(clippy::float_cmp)]
 fn create_number_object_01() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
-    let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
-    assert_eq!(no.o.get_prototype_of(&agent).unwrap(), Some(number_prototype));
+    let number_prototype = intrinsic(IntrinsicId::NumberPrototype);
+    assert_eq!(no.o.get_prototype_of().unwrap(), Some(number_prototype));
     assert_eq!(*no.o.to_number_obj().unwrap().number_data().borrow(), 100.0);
 }
 
 #[test]
 fn number_object_common_object_data() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
-    let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
+    let no = create_number_object(100.0);
+    let number_prototype = intrinsic(IntrinsicId::NumberPrototype);
 
     let cod = no.o.common_object_data();
 
@@ -52,7 +52,7 @@ fn number_object_common_object_data() {
 #[test]
 fn number_object_is_ordinary() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
     let result = no.o.is_ordinary();
 
@@ -61,7 +61,7 @@ fn number_object_is_ordinary() {
 #[test]
 fn number_object_id() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
     // ... essentially, assert that it doesn't panic.
     no.o.id();
@@ -69,7 +69,7 @@ fn number_object_id() {
 #[test]
 fn number_object_to_number_object() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
     let result = no.o.to_number_obj();
     assert!(result.is_some());
@@ -77,7 +77,7 @@ fn number_object_to_number_object() {
 #[test]
 fn number_object_is_number_object() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
     let result = no.o.is_number_object();
 
@@ -86,51 +86,50 @@ fn number_object_is_number_object() {
 #[test]
 fn number_object_get_prototype_of() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
-    let result = no.o.get_prototype_of(&agent).unwrap();
+    let result = no.o.get_prototype_of().unwrap();
     assert!(result.is_some());
 }
 #[test]
 fn number_object_set_prototype_of() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
-    let result = no.o.set_prototype_of(&agent, None).unwrap();
+    let result = no.o.set_prototype_of(None).unwrap();
     assert!(result);
 }
 #[test]
 fn number_object_is_extensible() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
-    let result = no.o.is_extensible(&agent).unwrap();
+    let result = no.o.is_extensible().unwrap();
     assert!(result);
 }
 #[test]
 fn number_object_prevent_extensions() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
-    let result = no.o.prevent_extensions(&agent).unwrap();
+    let result = no.o.prevent_extensions().unwrap();
     assert!(result);
 }
 #[test]
 fn number_object_get_own_property() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
-    let result = no.o.get_own_property(&agent, &PropertyKey::from("a")).unwrap();
+    let result = no.o.get_own_property(&PropertyKey::from("a")).unwrap();
     assert!(result.is_none());
 }
 #[test]
 fn number_object_define_own_property() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
     let result =
         no.o.define_own_property(
-            &agent,
             PropertyKey::from("a"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::Undefined), ..Default::default() },
         )
@@ -140,49 +139,48 @@ fn number_object_define_own_property() {
 #[test]
 fn number_object_has_property() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
-    let result = no.o.has_property(&agent, &PropertyKey::from("a")).unwrap();
+    let result = no.o.has_property(&PropertyKey::from("a")).unwrap();
     assert!(!result);
 }
 #[test]
 fn number_object_get() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
-    let result = no.o.get(&agent, &PropertyKey::from("a"), &ECMAScriptValue::from(no.clone())).unwrap();
+    let result = no.o.get(&PropertyKey::from("a"), &ECMAScriptValue::from(no.clone())).unwrap();
     assert_eq!(result, ECMAScriptValue::Undefined);
 }
 #[test]
 fn number_object_set() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
     let result =
-        no.o.set(&agent, PropertyKey::from("a"), ECMAScriptValue::from(88.0), &ECMAScriptValue::from(no.clone()))
-            .unwrap();
+        no.o.set(PropertyKey::from("a"), ECMAScriptValue::from(88.0), &ECMAScriptValue::from(no.clone())).unwrap();
     assert!(result);
 }
 #[test]
 fn number_object_delete() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
-    let result = no.o.delete(&agent, &PropertyKey::from("a")).unwrap();
+    let result = no.o.delete(&PropertyKey::from("a")).unwrap();
     assert!(result);
 }
 #[test]
 fn number_object_own_property_keys() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
-    let result = no.o.own_property_keys(&agent).unwrap();
+    let result = no.o.own_property_keys().unwrap();
     assert_eq!(result, &[]);
 }
 #[test]
 fn number_object_other_automatic_functions() {
     setup_test_agent();
-    let no = create_number_object(&agent, 100.0);
+    let no = create_number_object(100.0);
 
     assert!(!no.o.is_error_object());
     assert!(no.o.to_function_obj().is_none());
@@ -202,37 +200,37 @@ fn number_object_other_automatic_functions() {
 #[test]
 fn number_constructor_data_props() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let val = get(&agent, &number_constructor, &PropertyKey::from("EPSILON")).unwrap();
+    let val = get(&number_constructor, &PropertyKey::from("EPSILON")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(f64::EPSILON));
 
-    let val = get(&agent, &number_constructor, &PropertyKey::from("MAX_SAFE_INTEGER")).unwrap();
+    let val = get(&number_constructor, &PropertyKey::from("MAX_SAFE_INTEGER")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(9007199254740991.0));
 
-    let val = get(&agent, &number_constructor, &PropertyKey::from("MAX_VALUE")).unwrap();
+    let val = get(&number_constructor, &PropertyKey::from("MAX_VALUE")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(f64::MAX));
 
-    let val = get(&agent, &number_constructor, &PropertyKey::from("MIN_SAFE_INTEGER")).unwrap();
+    let val = get(&number_constructor, &PropertyKey::from("MIN_SAFE_INTEGER")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(-9007199254740991.0));
 
-    let val = get(&agent, &number_constructor, &PropertyKey::from("MIN_VALUE")).unwrap();
+    let val = get(&number_constructor, &PropertyKey::from("MIN_VALUE")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(5e-324));
 
-    let val = get(&agent, &number_constructor, &PropertyKey::from("NaN")).unwrap();
+    let val = get(&number_constructor, &PropertyKey::from("NaN")).unwrap();
     assert!(matches!(val, ECMAScriptValue::Number(_)));
     if let ECMAScriptValue::Number(n) = val {
         assert!(n.is_nan());
     }
 
-    let val = get(&agent, &number_constructor, &PropertyKey::from("NEGATIVE_INFINITY")).unwrap();
+    let val = get(&number_constructor, &PropertyKey::from("NEGATIVE_INFINITY")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(f64::NEG_INFINITY));
 
-    let val = get(&agent, &number_constructor, &PropertyKey::from("POSITIVE_INFINITY")).unwrap();
+    let val = get(&number_constructor, &PropertyKey::from("POSITIVE_INFINITY")).unwrap();
     assert_eq!(val, ECMAScriptValue::from(f64::INFINITY));
 
-    let val = get(&agent, &number_constructor, &PropertyKey::from("prototype")).unwrap();
-    let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
+    let val = get(&number_constructor, &PropertyKey::from("prototype")).unwrap();
+    let number_prototype = intrinsic(IntrinsicId::NumberPrototype);
     assert_eq!(val, ECMAScriptValue::from(number_prototype));
 }
 
@@ -242,9 +240,9 @@ fn number_constructor_called_as_function_01() {
     //   > Number()
     //   0
     setup_test_agent();
-    let number_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Number));
+    let number_constructor = ECMAScriptValue::from(intrinsic(IntrinsicId::Number));
 
-    let result = call(&agent, &number_constructor, &ECMAScriptValue::Undefined, &[]).unwrap();
+    let result = call(&number_constructor, &ECMAScriptValue::Undefined, &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(0));
 }
 #[test]
@@ -253,10 +251,9 @@ fn number_constructor_called_as_function_02() {
     //   > Number(true)
     //   1
     setup_test_agent();
-    let number_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Number));
+    let number_constructor = ECMAScriptValue::from(intrinsic(IntrinsicId::Number));
 
-    let result =
-        call(&agent, &number_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from(true)]).unwrap();
+    let result = call(&number_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from(true)]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(1));
 }
 #[test]
@@ -265,11 +262,10 @@ fn number_constructor_called_as_function_03() {
     //   > Number(10n)
     //   10
     setup_test_agent();
-    let number_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Number));
+    let number_constructor = ECMAScriptValue::from(intrinsic(IntrinsicId::Number));
 
     let result =
-        call(&agent, &number_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from(BigInt::from(10))])
-            .unwrap();
+        call(&number_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from(BigInt::from(10))]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(10));
 }
 #[test]
@@ -279,12 +275,11 @@ fn number_constructor_called_as_function_04() {
     //   Uncaught TypeError: Cannot convert a Symbol value to a number
     //       at Number (<anonymous>)
     setup_test_agent();
-    let number_constructor = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Number));
+    let number_constructor = ECMAScriptValue::from(intrinsic(IntrinsicId::Number));
 
-    let sym = Symbol::new(&agent, None);
-    let result =
-        call(&agent, &number_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from(sym)]).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
+    let sym = Symbol::new(None);
+    let result = call(&number_constructor, &ECMAScriptValue::Undefined, &[ECMAScriptValue::from(sym)]).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Symbol values cannot be converted to Number values");
 }
 
 #[test]
@@ -294,9 +289,9 @@ fn number_constructor_as_constructor_01() {
     //   > new Number()
     //   [Number: 0]
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let result = construct(&agent, &number_constructor, &[], None).unwrap();
+    let result = construct(&number_constructor, &[], None).unwrap();
 
     assert!(result.is_object());
     if let ECMAScriptValue::Object(o) = result {
@@ -312,10 +307,10 @@ fn number_constructor_as_constructor_02() {
     //   > new Number("0xbadfade")
     //   [Number: 195951326]
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
     let arg = ECMAScriptValue::from("0xbadfade");
 
-    let result = construct(&agent, &number_constructor, &[arg], None).unwrap();
+    let result = construct(&number_constructor, &[arg], None).unwrap();
 
     assert!(result.is_object());
     if let ECMAScriptValue::Object(o) = result {
@@ -329,12 +324,12 @@ fn number_constructor_throws() {
     // ordinary_create_from_contructor throws.
     // This looks to be difficult to make happen, but I can imagine some class shenanigans that could do it.
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
     // This hack is to get around the "not configurable" characteristic of Number.prototype.
     // (It replaces Number.prototype (a data property) with an accessor property that throws when "prototype" is gotten.)
     let new_prop = PropertyKind::Accessor(AccessorProperty {
-        get: ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError)),
+        get: ECMAScriptValue::from(intrinsic(IntrinsicId::ThrowTypeError)),
         set: ECMAScriptValue::Undefined,
     });
     {
@@ -343,8 +338,8 @@ fn number_constructor_throws() {
         prop.property = new_prop;
     }
 
-    let result = construct(&agent, &number_constructor, &[], None).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Generic TypeError");
+    let result = construct(&number_constructor, &[], None).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Generic TypeError");
 }
 
 #[test]
@@ -353,18 +348,18 @@ fn number_is_finite_no_args() {
     //    > Number.isFinite()
     //    false
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_finite = get(&agent, &number_constructor, &PropertyKey::from("isFinite")).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let is_finite = get(&number_constructor, &PropertyKey::from("isFinite")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
 
-    let result = call(&agent, &is_finite, &this_value, &[]).unwrap();
+    let result = call(&is_finite, &this_value, &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 #[test]
 fn number_is_finite_one_arg() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_finite = get(&agent, &number_constructor, &PropertyKey::from("isFinite")).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let is_finite = get(&number_constructor, &PropertyKey::from("isFinite")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
 
     for (arg, expected) in [
@@ -376,29 +371,29 @@ fn number_is_finite_one_arg() {
         (89.3, true),
         (-89.3, true),
     ] {
-        let result = call(&agent, &is_finite, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
+        let result = call(&is_finite, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
         assert_eq!(result, ECMAScriptValue::from(expected));
     }
 
-    let result = call(&agent, &is_finite, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
+    let result = call(&is_finite, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 
 #[test]
 fn number_is_integer_no_args() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_integer = get(&agent, &number_constructor, &PropertyKey::from("isInteger")).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let is_integer = get(&number_constructor, &PropertyKey::from("isInteger")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
 
-    let result = call(&agent, &is_integer, &this_value, &[]).unwrap();
+    let result = call(&is_integer, &this_value, &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 #[test]
 fn number_is_integer_one_arg() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_integer = get(&agent, &number_constructor, &PropertyKey::from("isInteger")).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let is_integer = get(&number_constructor, &PropertyKey::from("isInteger")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
 
     for (arg, expected) in [
@@ -412,29 +407,29 @@ fn number_is_integer_one_arg() {
         (10.0, true),
         (3.33e200, true),
     ] {
-        let result = call(&agent, &is_integer, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
+        let result = call(&is_integer, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
         assert_eq!(result, ECMAScriptValue::from(expected));
     }
 
-    let result = call(&agent, &is_integer, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
+    let result = call(&is_integer, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 
 #[test]
 fn number_is_nan_no_args() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_nan = get(&agent, &number_constructor, &PropertyKey::from("isNaN")).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let is_nan = get(&number_constructor, &PropertyKey::from("isNaN")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
 
-    let result = call(&agent, &is_nan, &this_value, &[]).unwrap();
+    let result = call(&is_nan, &this_value, &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 #[test]
 fn number_is_nan_one_arg() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_nan = get(&agent, &number_constructor, &PropertyKey::from("isNaN")).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let is_nan = get(&number_constructor, &PropertyKey::from("isNaN")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
 
     for (arg, expected) in [
@@ -445,29 +440,29 @@ fn number_is_nan_one_arg() {
         (-0.0, false),
         (89.3, false),
     ] {
-        let result = call(&agent, &is_nan, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
+        let result = call(&is_nan, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
         assert_eq!(result, ECMAScriptValue::from(expected));
     }
 
-    let result = call(&agent, &is_nan, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
+    let result = call(&is_nan, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 
 #[test]
 fn number_is_safe_integer_no_args() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_safe_integer = get(&agent, &number_constructor, &PropertyKey::from("isSafeInteger")).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let is_safe_integer = get(&number_constructor, &PropertyKey::from("isSafeInteger")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
 
-    let result = call(&agent, &is_safe_integer, &this_value, &[]).unwrap();
+    let result = call(&is_safe_integer, &this_value, &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 #[test]
 fn number_is_safe_integer_one_arg() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let is_safe_integer = get(&agent, &number_constructor, &PropertyKey::from("isSafeInteger")).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let is_safe_integer = get(&number_constructor, &PropertyKey::from("isSafeInteger")).unwrap();
     let this_value = ECMAScriptValue::from(number_constructor);
 
     for (arg, expected) in [
@@ -483,11 +478,11 @@ fn number_is_safe_integer_one_arg() {
         (-0x1fffffffffffff_i64 as f64, true),
         (-0x20000000000000_i64 as f64, false),
     ] {
-        let result = call(&agent, &is_safe_integer, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
+        let result = call(&is_safe_integer, &this_value, &[ECMAScriptValue::from(arg)]).unwrap();
         assert_eq!(result, ECMAScriptValue::from(expected), "Tried {}, should have been {:?}", arg, expected);
     }
 
-    let result = call(&agent, &is_safe_integer, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
+    let result = call(&is_safe_integer, &this_value, &[ECMAScriptValue::from("blue")]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(false));
 }
 
@@ -496,10 +491,10 @@ fn number_is_safe_integer_one_arg() {
 fn this_number_value_01() {
     // called with number object
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
-    let result = this_number_value(&agent, number).unwrap();
+    let result = this_number_value(number).unwrap();
     assert_eq!(result, 123.0);
 }
 #[test]
@@ -508,44 +503,44 @@ fn this_number_value_02() {
     // called with number value
     setup_test_agent();
 
-    let result = this_number_value(&agent, ECMAScriptValue::from(123)).unwrap();
+    let result = this_number_value(ECMAScriptValue::from(123)).unwrap();
     assert_eq!(result, 123.0);
 }
 #[test]
 fn this_number_value_03() {
     // called with non-number object
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
-    let result = this_number_value(&agent, ECMAScriptValue::from(obj)).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Number method called with non-number receiver");
+    let result = this_number_value(ECMAScriptValue::from(obj)).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Number method called with non-number receiver");
 }
 #[test]
 fn this_number_value_04() {
     // called with non-number, non-object value
     setup_test_agent();
 
-    let result = this_number_value(&agent, ECMAScriptValue::from(true)).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Number method called with non-number receiver");
+    let result = this_number_value(ECMAScriptValue::from(true)).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Number method called with non-number receiver");
 }
 
 #[test]
 fn number_proto_to_string_01() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
-    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[]).unwrap();
+    let result = invoke(number, &PropertyKey::from("toString"), &[]).unwrap();
 
     assert_eq!(result, ECMAScriptValue::from("123"));
 }
 #[test]
 fn number_proto_to_string_02() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123.789)], None).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(123.789)], None).unwrap();
 
-    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(25)]).unwrap();
+    let result = invoke(number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(25)]).unwrap();
 
     assert_eq!(result, ECMAScriptValue::from("4n.ji33333333"));
 }
@@ -553,71 +548,71 @@ fn number_proto_to_string_02() {
 #[test]
 fn number_proto_to_string_03() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123.789)], None).unwrap();
-    let sym = Symbol::new(&agent, None);
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(123.789)], None).unwrap();
+    let sym = Symbol::new(None);
 
-    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(sym)]).unwrap_err();
+    let result = invoke(number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(sym)]).unwrap_err();
 
-    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
+    assert_eq!(unwind_type_error(result), "Symbol values cannot be converted to Number values");
 }
 #[test]
 fn number_proto_to_string_04() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
-    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(2)]).unwrap();
+    let result = invoke(number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(2)]).unwrap();
 
     assert_eq!(result, ECMAScriptValue::from("1111011"));
 }
 #[test]
 fn number_proto_to_string_05() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
-    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(36)]).unwrap();
+    let result = invoke(number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(36)]).unwrap();
 
     assert_eq!(result, ECMAScriptValue::from("3f"));
 }
 #[test]
 fn number_proto_to_string_06() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
-    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(1)]).unwrap_err();
+    let result = invoke(number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(1)]).unwrap_err();
 
-    assert_eq!(unwind_range_error(&agent, result), "Radix 1 out of range (must be in 2..36)");
+    assert_eq!(unwind_range_error(result), "Radix 1 out of range (must be in 2..36)");
 }
 #[test]
 fn number_proto_to_string_07() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(123)], None).unwrap();
 
-    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(37)]).unwrap_err();
+    let result = invoke(number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(37)]).unwrap_err();
 
-    assert_eq!(unwind_range_error(&agent, result), "Radix 37 out of range (must be in 2..36)");
+    assert_eq!(unwind_range_error(result), "Radix 37 out of range (must be in 2..36)");
 }
 #[test]
 fn number_proto_to_string_08() {
     // this_number_value is not actually a number
     setup_test_agent();
-    let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
-    let to_string = get(&agent, &number_prototype, &PropertyKey::from("toString")).unwrap();
+    let number_prototype = intrinsic(IntrinsicId::NumberPrototype);
+    let to_string = get(&number_prototype, &PropertyKey::from("toString")).unwrap();
 
-    let result = call(&agent, &to_string, &ECMAScriptValue::Null, &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Number method called with non-number receiver");
+    let result = call(&to_string, &ECMAScriptValue::Null, &[]).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Number method called with non-number receiver");
 }
 #[test]
 fn number_proto_to_string_09() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(1.0e100)], None).unwrap();
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(1.0e100)], None).unwrap();
 
-    let result = invoke(&agent, number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(30)]).unwrap();
+    let result = invoke(number, &PropertyKey::from("toString"), &[ECMAScriptValue::from(30)]).unwrap();
 
     assert_eq!(result, ECMAScriptValue::from("anhmc58j7ljq00000000000000000000000000000000000000000000000000000000"));
 }
@@ -631,11 +626,10 @@ fn double_to_radix_string_01() {
 
 fn number_proto_to_precision_test(value: f64, precision: u32, expected: &str) {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(value)], None).unwrap();
-    let result =
-        invoke(&agent, number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(precision)]).unwrap();
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(value)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(precision)]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(expected));
 }
 #[test]
@@ -691,61 +685,61 @@ fn number_proto_to_precision_15() {
 fn number_proto_to_precision_12() {
     // this_number_value is not actually a number
     setup_test_agent();
-    let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
-    let func = get(&agent, &number_prototype, &PropertyKey::from("toPrecision")).unwrap();
+    let number_prototype = intrinsic(IntrinsicId::NumberPrototype);
+    let func = get(&number_prototype, &PropertyKey::from("toPrecision")).unwrap();
 
-    let result = call(&agent, &func, &ECMAScriptValue::Null, &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Number method called with non-number receiver");
+    let result = call(&func, &ECMAScriptValue::Null, &[]).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Number method called with non-number receiver");
 }
 #[test]
 fn number_proto_to_precision_13() {
     // precision not present
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
-    let result = invoke(&agent, number, &PropertyKey::from("toPrecision"), &[]).unwrap();
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toPrecision"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("548.333"));
 }
 #[test]
 fn number_proto_to_precision_14() {
     // precision not convertable to number
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let sym = ECMAScriptValue::from(Symbol::new(None));
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
-    let result = invoke(&agent, number, &PropertyKey::from("toPrecision"), &[sym]).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toPrecision"), &[sym]).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Symbol values cannot be converted to Number values");
 }
 #[test]
 fn number_proto_to_precision_16() {
     // precision out of range
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
-    let result = invoke(&agent, number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(0)]).unwrap_err();
-    assert_eq!(unwind_range_error(&agent, result), "Precision ‘0’ must lie within the range 1..100");
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(0)]).unwrap_err();
+    assert_eq!(unwind_range_error(result), "Precision ‘0’ must lie within the range 1..100");
 }
 #[test]
 fn number_proto_to_precision_17() {
     // precision out of range
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
-    let result = invoke(&agent, number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(101)]).unwrap_err();
-    assert_eq!(unwind_range_error(&agent, result), "Precision ‘101’ must lie within the range 1..100");
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(101)]).unwrap_err();
+    assert_eq!(unwind_range_error(result), "Precision ‘101’ must lie within the range 1..100");
 }
 #[test]
 fn number_proto_to_precision_18() {
     // precision just in range
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
-    let result = invoke(&agent, number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(100)]).unwrap();
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toPrecision"), &[ECMAScriptValue::from(100)]).unwrap();
     assert_eq!(
         result,
         ECMAScriptValue::from(
@@ -756,11 +750,11 @@ fn number_proto_to_precision_18() {
 
 fn number_proto_to_exponent_test(value: f64, fraction_digits: u32, expected: &str) {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(value)], None).unwrap();
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(value)], None).unwrap();
     let result =
-        invoke(&agent, number, &PropertyKey::from("toExponential"), &[ECMAScriptValue::from(fraction_digits)]).unwrap();
+        invoke(number, &PropertyKey::from("toExponential"), &[ECMAScriptValue::from(fraction_digits)]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(expected));
 }
 #[test]
@@ -778,32 +772,32 @@ fn number_proto_to_exponential_02() {
 #[test]
 fn number_proto_to_exponential_03() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
-    let result = invoke(&agent, number, &PropertyKey::from("toExponential"), &[]).unwrap();
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toExponential"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("1e-1"));
 }
 #[test]
 fn number_proto_to_exponential_04() {
     // this_number_value is not actually a number
     setup_test_agent();
-    let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
-    let func = get(&agent, &number_prototype, &PropertyKey::from("toExponential")).unwrap();
+    let number_prototype = intrinsic(IntrinsicId::NumberPrototype);
+    let func = get(&number_prototype, &PropertyKey::from("toExponential")).unwrap();
 
-    let result = call(&agent, &func, &ECMAScriptValue::Null, &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Number method called with non-number receiver");
+    let result = call(&func, &ECMAScriptValue::Null, &[]).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Number method called with non-number receiver");
 }
 #[test]
 fn number_proto_to_exponential_05() {
     // fractionDigits not convertable to number
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let sym = ECMAScriptValue::from(Symbol::new(None));
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
-    let result = invoke(&agent, number, &PropertyKey::from("toExponential"), &[sym]).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toExponential"), &[sym]).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Symbol values cannot be converted to Number values");
 }
 #[test]
 fn number_proto_to_exponential_06() {
@@ -813,22 +807,21 @@ fn number_proto_to_exponential_06() {
 fn number_proto_to_exponential_07() {
     // fractionDigits out of range
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
-    let result =
-        invoke(&agent, number, &PropertyKey::from("toExponential"), &[ECMAScriptValue::from(101)]).unwrap_err();
-    assert_eq!(unwind_range_error(&agent, result), "FractionDigits ‘101’ must lie within the range 0..100");
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toExponential"), &[ECMAScriptValue::from(101)]).unwrap_err();
+    assert_eq!(unwind_range_error(result), "FractionDigits ‘101’ must lie within the range 0..100");
 }
 #[test]
 fn number_proto_to_exponential_08() {
     // fractionDigits out of range
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
-    let result = invoke(&agent, number, &PropertyKey::from("toExponential"), &[ECMAScriptValue::from(-1)]).unwrap_err();
-    assert_eq!(unwind_range_error(&agent, result), "FractionDigits ‘-1’ must lie within the range 0..100");
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(548.333)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toExponential"), &[ECMAScriptValue::from(-1)]).unwrap_err();
+    assert_eq!(unwind_range_error(result), "FractionDigits ‘-1’ must lie within the range 0..100");
 }
 #[test]
 fn number_proto_to_exponential_09() {
@@ -837,11 +830,10 @@ fn number_proto_to_exponential_09() {
 
 fn number_proto_to_fixed_test(value: f64, fraction_digits: u32, expected: &str) {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(value)], None).unwrap();
-    let result =
-        invoke(&agent, number, &PropertyKey::from("toFixed"), &[ECMAScriptValue::from(fraction_digits)]).unwrap();
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(value)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toFixed"), &[ECMAScriptValue::from(fraction_digits)]).unwrap();
     assert_eq!(result, ECMAScriptValue::from(expected));
 }
 
@@ -910,42 +902,42 @@ fn number_proto_to_fixed_15() {
 fn number_proto_to_fixed_16() {
     // empty arg list
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
-    let result = invoke(&agent, number, &PropertyKey::from("toFixed"), &[]).unwrap();
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toFixed"), &[]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("0"));
 }
 #[test]
 fn number_proto_to_fixed_17() {
     // bad argument
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
-    let sym = ECMAScriptValue::from(Symbol::new(&agent, None));
+    let number_constructor = intrinsic(IntrinsicId::Number);
+    let sym = ECMAScriptValue::from(Symbol::new(None));
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
-    let result = invoke(&agent, number, &PropertyKey::from("toFixed"), &[sym]).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toFixed"), &[sym]).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Symbol values cannot be converted to Number values");
 }
 #[test]
 fn number_proto_to_fixed_18() {
     // bad argument
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
-    let result = invoke(&agent, number, &PropertyKey::from("toFixed"), &[ECMAScriptValue::from(-1)]).unwrap_err();
-    assert_eq!(unwind_range_error(&agent, result), "Argument for Number.toFixed must be in the range 0..100");
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toFixed"), &[ECMAScriptValue::from(-1)]).unwrap_err();
+    assert_eq!(unwind_range_error(result), "Argument for Number.toFixed must be in the range 0..100");
 }
 #[test]
 fn number_proto_to_fixed_19() {
     // bad argument
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
-    let result = invoke(&agent, number, &PropertyKey::from("toFixed"), &[ECMAScriptValue::from(101)]).unwrap_err();
-    assert_eq!(unwind_range_error(&agent, result), "Argument for Number.toFixed must be in the range 0..100");
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toFixed"), &[ECMAScriptValue::from(101)]).unwrap_err();
+    assert_eq!(unwind_range_error(result), "Argument for Number.toFixed must be in the range 0..100");
 }
 #[test]
 fn number_proto_to_fixed_20() {
@@ -960,11 +952,11 @@ fn number_proto_to_fixed_20() {
 fn number_proto_to_fixed_21() {
     // this_number_value is not actually a number
     setup_test_agent();
-    let number_prototype = agent.intrinsic(IntrinsicId::NumberPrototype);
-    let func = get(&agent, &number_prototype, &PropertyKey::from("toFixed")).unwrap();
+    let number_prototype = intrinsic(IntrinsicId::NumberPrototype);
+    let func = get(&number_prototype, &PropertyKey::from("toFixed")).unwrap();
 
-    let result = call(&agent, &func, &ECMAScriptValue::Null, &[]).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Number method called with non-number receiver");
+    let result = call(&func, &ECMAScriptValue::Null, &[]).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Number method called with non-number receiver");
 }
 
 #[test]
@@ -996,20 +988,20 @@ fn number_proto_to_locale_string_01() {
     // Implementations of toLocaleString may not use the arguments for any use beyond their ECMA-402 specified uses. In
     // particular, if we defer to toString, the first argument must _not_ be used as the radix argument.
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(10)], None).unwrap();
-    let result = invoke(&agent, number, &PropertyKey::from("toLocaleString"), &[ECMAScriptValue::from(16)]).unwrap();
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(10)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("toLocaleString"), &[ECMAScriptValue::from(16)]).unwrap();
     assert_eq!(result, ECMAScriptValue::from("10"));
 }
 
 #[test]
 fn number_proto_value_of() {
     setup_test_agent();
-    let number_constructor = agent.intrinsic(IntrinsicId::Number);
+    let number_constructor = intrinsic(IntrinsicId::Number);
 
-    let number = construct(&agent, &number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
-    let result = invoke(&agent, number, &PropertyKey::from("valueOf"), &[]).unwrap();
+    let number = construct(&number_constructor, &[ECMAScriptValue::from(0.1)], None).unwrap();
+    let result = invoke(number, &PropertyKey::from("valueOf"), &[]).unwrap();
 
     assert_eq!(result, ECMAScriptValue::from(0.1));
 }

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -245,22 +245,22 @@ where
 //  9. If Desc has a [[Configurable]] field, then
 //      a. Perform ! CreateDataPropertyOrThrow(obj, "configurable", Desc.[[Configurable]]).
 //  10. Return obj.
-pub fn from_property_descriptor(agent: &Agent, desc: Option<PropertyDescriptor>) -> Option<Object> {
+pub fn from_property_descriptor(desc: Option<PropertyDescriptor>) -> Option<Object> {
     match desc {
         Some(d) => {
-            let obj = ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+            let obj = ordinary_object_create(Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
             match &d.property {
                 PropertyKind::Data(DataProperty { value, writable }) => {
-                    create_data_property_or_throw(agent, &obj, "value", value.clone()).unwrap();
-                    create_data_property_or_throw(agent, &obj, "writable", *writable).unwrap();
+                    create_data_property_or_throw(&obj, "value", value.clone()).unwrap();
+                    create_data_property_or_throw(&obj, "writable", *writable).unwrap();
                 }
                 PropertyKind::Accessor(AccessorProperty { get, set }) => {
-                    create_data_property_or_throw(agent, &obj, "get", get.clone()).unwrap();
-                    create_data_property_or_throw(agent, &obj, "set", set.clone()).unwrap();
+                    create_data_property_or_throw(&obj, "get", get.clone()).unwrap();
+                    create_data_property_or_throw(&obj, "set", set.clone()).unwrap();
                 }
             }
-            create_data_property_or_throw(agent, &obj, "enumerable", d.enumerable).unwrap();
-            create_data_property_or_throw(agent, &obj, "configurable", d.configurable).unwrap();
+            create_data_property_or_throw(&obj, "enumerable", d.enumerable).unwrap();
+            create_data_property_or_throw(&obj, "configurable", d.configurable).unwrap();
             Some(obj)
         }
         None => None,
@@ -302,41 +302,41 @@ pub fn from_property_descriptor(agent: &Agent, desc: Option<PropertyDescriptor>)
 //  15. If desc.[[Get]] is present or desc.[[Set]] is present, then
 //      a. If desc.[[Value]] is present or desc.[[Writable]] is present, throw a TypeError exception.
 //  16. Return desc.
-fn get_pd_prop(agent: &Agent, obj: &Object, key: impl Into<PropertyKey>) -> Completion<Option<ECMAScriptValue>> {
+fn get_pd_prop(obj: &Object, key: impl Into<PropertyKey>) -> Completion<Option<ECMAScriptValue>> {
     Ok({
         let key = key.into();
-        if has_property(agent, obj, &key)? {
-            Some(get(agent, obj, &key)?)
+        if has_property(obj, &key)? {
+            Some(get(obj, &key)?)
         } else {
             None
         }
     })
 }
-fn get_pd_bool(agent: &Agent, obj: &Object, key: &str) -> Completion<Option<bool>> {
-    Ok(get_pd_prop(agent, obj, key)?.map(to_boolean))
+fn get_pd_bool(obj: &Object, key: &str) -> Completion<Option<bool>> {
+    Ok(get_pd_prop(obj, key)?.map(to_boolean))
 }
-pub fn to_property_descriptor(agent: &Agent, obj: &ECMAScriptValue) -> Completion<PotentialPropertyDescriptor> {
+pub fn to_property_descriptor(obj: &ECMAScriptValue) -> Completion<PotentialPropertyDescriptor> {
     match obj {
         ECMAScriptValue::Object(obj) => {
-            let enumerable = get_pd_bool(agent, obj, "enumerable")?;
-            let configurable = get_pd_bool(agent, obj, "configurable")?;
-            let value = get_pd_prop(agent, obj, "value")?;
-            let writable = get_pd_bool(agent, obj, "writable")?;
-            let get = get_pd_prop(agent, obj, "get")?;
+            let enumerable = get_pd_bool(obj, "enumerable")?;
+            let configurable = get_pd_bool(obj, "configurable")?;
+            let value = get_pd_prop(obj, "value")?;
+            let writable = get_pd_bool(obj, "writable")?;
+            let get = get_pd_prop(obj, "get")?;
             if let Some(getter) = &get {
                 if !getter.is_undefined() && !is_callable(getter) {
-                    return Err(create_type_error(agent, "Getter must be callable (or undefined)"));
+                    return Err(create_type_error("Getter must be callable (or undefined)"));
                 }
             }
-            let set = get_pd_prop(agent, obj, "set")?;
+            let set = get_pd_prop(obj, "set")?;
             if let Some(setter) = &set {
                 if !setter.is_undefined() && !is_callable(setter) {
-                    return Err(create_type_error(agent, "Setter must be callable (or undefined)"));
+                    return Err(create_type_error("Setter must be callable (or undefined)"));
                 }
             }
             Ok(PotentialPropertyDescriptor { enumerable, configurable, value, writable, get, set })
         }
-        _ => Err(create_type_error(agent, "Must be an object")),
+        _ => Err(create_type_error("Must be an object")),
     }
 }
 
@@ -474,7 +474,6 @@ where
 //  2. Let extensible be ? IsExtensible(O).
 //  3. Return ValidateAndApplyPropertyDescriptor(O, P, extensible, Desc, current).
 pub fn ordinary_define_own_property<'a, T>(
-    agent: &Agent,
     o: T,
     p: PropertyKey,
     desc: PotentialPropertyDescriptor,
@@ -483,8 +482,8 @@ where
     T: Into<&'a dyn ObjectInterface>,
 {
     let obj = o.into();
-    let current = obj.get_own_property(agent, &p)?;
-    let extensible = is_extensible(agent, obj)?;
+    let current = obj.get_own_property(&p)?;
+    let extensible = is_extensible(obj)?;
     Ok(validate_and_apply_property_descriptor(Some(obj), Some(p), extensible, desc, current.as_ref()))
 }
 
@@ -708,18 +707,18 @@ pub fn is_compatible_property_descriptor(
 //  5. If parent is not null, then
 //      a. Return ? parent.[[HasProperty]](P).
 //  6. Return false.
-pub fn ordinary_has_property<'a, T>(agent: &Agent, o: T, p: &PropertyKey) -> Completion<bool>
+pub fn ordinary_has_property<'a, T>(o: T, p: &PropertyKey) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
     let obj = o.into();
-    let has_own = obj.get_own_property(agent, p)?;
+    let has_own = obj.get_own_property(p)?;
     match has_own {
         Some(_) => Ok(true),
         None => {
             let pot_parent = obj.get_prototype_of(agent)?;
             match pot_parent {
-                Some(parent) => parent.o.has_property(agent, p),
+                Some(parent) => parent.o.has_property(p),
                 None => Ok(false),
             }
         }
@@ -743,7 +742,6 @@ where
 //  7. If getter is undefined, return undefined.
 //  8. Return ? Call(getter, Receiver).
 pub fn ordinary_get<'a, T>(
-    agent: &Agent,
     o: T,
     p: &PropertyKey,
     receiver: &ECMAScriptValue,
@@ -752,13 +750,13 @@ where
     T: Into<&'a dyn ObjectInterface>,
 {
     let obj = o.into();
-    let pot_desc = obj.get_own_property(agent, p)?;
+    let pot_desc = obj.get_own_property(p)?;
     match pot_desc {
         None => {
             let pot_parent = obj.get_prototype_of(agent)?;
             match pot_parent {
                 None => Ok(ECMAScriptValue::Undefined),
-                Some(parent) => parent.o.get(agent, p, receiver),
+                Some(parent) => parent.o.get(p, receiver),
             }
         }
         Some(desc) => match desc.property {
@@ -767,7 +765,7 @@ where
                 let pot_getter = acc_methods.get;
                 match pot_getter {
                     ECMAScriptValue::Undefined => Ok(ECMAScriptValue::Undefined),
-                    getter => call(agent, &getter, receiver, &[]),
+                    getter => call(&getter, receiver, &[]),
                 }
             }
         },
@@ -800,7 +798,6 @@ pub fn get_agentless(o: &Object, p: &PropertyKey) -> Option<ECMAScriptValue> {
 //  2. Let ownDesc be ? O.[[GetOwnProperty]](P).
 //  3. Return OrdinarySetWithOwnDescriptor(O, P, V, Receiver, ownDesc).
 pub fn ordinary_set<'a, T>(
-    agent: &Agent,
     o: T,
     p: PropertyKey,
     v: ECMAScriptValue,
@@ -810,8 +807,8 @@ where
     T: Into<&'a dyn ObjectInterface>,
 {
     let obj = o.into();
-    let own_desc = obj.get_own_property(agent, &p)?;
-    ordinary_set_with_own_descriptor(agent, obj, p, v, receiver, own_desc)
+    let own_desc = obj.get_own_property(&p)?;
+    ordinary_set_with_own_descriptor(obj, p, v, receiver, own_desc)
 }
 
 // OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )
@@ -845,7 +842,6 @@ where
 //  7. Perform ? Call(setter, Receiver, « V »).
 //  8. Return true.
 pub fn ordinary_set_with_own_descriptor<'a, T>(
-    agent: &Agent,
     o: T,
     p: PropertyKey,
     v: ECMAScriptValue,
@@ -861,7 +857,7 @@ where
             let pot_parent = obj.get_prototype_of(agent)?;
             match pot_parent {
                 Some(parent) => {
-                    return parent.o.set(agent, p, v, receiver);
+                    return parent.o.set(p, v, receiver);
                 }
                 None => PropertyDescriptor {
                     configurable: true,
@@ -878,7 +874,7 @@ where
             false => Ok(false),
             true => match receiver {
                 ECMAScriptValue::Object(receiver) => {
-                    let maybe_existing_descriptor = receiver.o.get_own_property(agent, &p)?;
+                    let maybe_existing_descriptor = receiver.o.get_own_property(&p)?;
                     match maybe_existing_descriptor {
                         Some(existing_descriptor) => match &existing_descriptor.property {
                             PropertyKind::Accessor(_) => Ok(false),
@@ -886,11 +882,11 @@ where
                                 false => Ok(false),
                                 true => {
                                     let value_desc = PotentialPropertyDescriptor::new().value(v);
-                                    receiver.o.define_own_property(agent, p, value_desc)
+                                    receiver.o.define_own_property(p, value_desc)
                                 }
                             },
                         },
-                        None => create_data_property(agent, receiver, p, v),
+                        None => create_data_property(receiver, p, v),
                     }
                 }
                 _ => Ok(false),
@@ -901,7 +897,7 @@ where
             match setter {
                 ECMAScriptValue::Undefined => Ok(false),
                 setter => {
-                    call(agent, setter, receiver, &[v])?;
+                    call(setter, receiver, &[v])?;
                     Ok(true)
                 }
             }
@@ -921,12 +917,12 @@ where
 //      a. Remove the own property with name P from O.
 //      b. Return true.
 //  5. Return false.
-pub fn ordinary_delete<'a, T>(agent: &Agent, o: T, p: &PropertyKey) -> Completion<bool>
+pub fn ordinary_delete<'a, T>(o: T, p: &PropertyKey) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
     let obj = o.into();
-    let desc = obj.get_own_property(agent, p)?;
+    let desc = obj.get_own_property(p)?;
     match desc {
         None => Ok(true),
         Some(desc) => match desc.configurable {
@@ -1076,28 +1072,26 @@ pub trait ObjectInterface: Debug {
         None
     }
 
-    fn get_prototype_of(&self, agent: &Agent) -> Completion<Option<Object>>;
-    fn set_prototype_of(&self, agent: &Agent, obj: Option<Object>) -> Completion<bool>;
-    fn is_extensible(&self, agent: &Agent) -> Completion<bool>;
-    fn prevent_extensions(&self, agent: &Agent) -> Completion<bool>;
-    fn get_own_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>>;
+    fn get_prototype_of(&self) -> Completion<Option<Object>>;
+    fn set_prototype_of(&self, obj: Option<Object>) -> Completion<bool>;
+    fn is_extensible(&self) -> Completion<bool>;
+    fn prevent_extensions(&self) -> Completion<bool>;
+    fn get_own_property(&self, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>>;
     fn define_own_property(
         &self,
-        agent: &Agent,
         key: PropertyKey,
         desc: PotentialPropertyDescriptor,
     ) -> Completion<bool>;
-    fn has_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool>;
-    fn get(&self, agent: &Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue>;
+    fn has_property(&self, key: &PropertyKey) -> Completion<bool>;
+    fn get(&self, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue>;
     fn set(
         &self,
-        agent: &Agent,
         key: PropertyKey,
         value: ECMAScriptValue,
         receiver: &ECMAScriptValue,
     ) -> Completion<bool>;
-    fn delete(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool>;
-    fn own_property_keys(&self, agent: &Agent) -> Completion<Vec<PropertyKey>>;
+    fn delete(&self, key: &PropertyKey) -> Completion<bool>;
+    fn own_property_keys(&self) -> Completion<Vec<PropertyKey>>;
 }
 
 pub trait FunctionInterface: CallableObject {
@@ -1129,7 +1123,7 @@ pub struct CommonObjectData {
 }
 
 impl CommonObjectData {
-    pub fn new(agent: &Agent, prototype: Option<Object>, extensible: bool, slots: &[InternalSlotName]) -> Self {
+    pub fn new(prototype: Option<Object>, extensible: bool, slots: &[InternalSlotName]) -> Self {
         Self {
             properties: Default::default(),
             prototype,
@@ -1306,11 +1300,10 @@ impl ObjectInterface for OrdinaryObject {
     //  1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
     fn define_own_property(
         &self,
-        agent: &Agent,
         key: PropertyKey,
         desc: PotentialPropertyDescriptor,
     ) -> Completion<bool> {
-        ordinary_define_own_property(agent, self, key, desc)
+        ordinary_define_own_property(self, key, desc)
     }
 
     // [[HasProperty]] ( P )
@@ -1319,8 +1312,8 @@ impl ObjectInterface for OrdinaryObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryHasProperty(O, P).
-    fn has_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
-        ordinary_has_property(agent, self, key)
+    fn has_property(&self, key: &PropertyKey) -> Completion<bool> {
+        ordinary_has_property(self, key)
     }
 
     // [[Get]] ( P, Receiver )
@@ -1329,8 +1322,8 @@ impl ObjectInterface for OrdinaryObject {
     // ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryGet(O, P, Receiver).
-    fn get(&self, agent: &Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
-        ordinary_get(agent, self, key, receiver)
+    fn get(&self, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+        ordinary_get(self, key, receiver)
     }
 
     // [[Set]] ( P, V, Receiver )
@@ -1339,8 +1332,8 @@ impl ObjectInterface for OrdinaryObject {
     // value), and Receiver (an ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinarySet(O, P, V, Receiver).
-    fn set(&self, agent: &Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
-        ordinary_set(agent, self, key, v, receiver)
+    fn set(&self, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
+        ordinary_set(self, key, v, receiver)
     }
 
     // [[Delete]] ( P )
@@ -1349,8 +1342,8 @@ impl ObjectInterface for OrdinaryObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryDelete(O, P).
-    fn delete(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
-        ordinary_delete(agent, self, key)
+    fn delete(&self, key: &PropertyKey) -> Completion<bool> {
+        ordinary_delete(self, key)
     }
 
     // [[OwnPropertyKeys]] ( )
@@ -1410,10 +1403,10 @@ impl fmt::Display for Object {
 }
 
 impl Object {
-    fn new(agent: &Agent, prototype: Option<Object>, extensible: bool) -> Self {
+    fn new(prototype: Option<Object>, extensible: bool) -> Self {
         Self {
             o: Rc::new(OrdinaryObject {
-                data: RefCell::new(CommonObjectData::new(agent, prototype, extensible, ORDINARY_OBJECT_SLOTS)),
+                data: RefCell::new(CommonObjectData::new(prototype, extensible, ORDINARY_OBJECT_SLOTS)),
             }),
         }
     }
@@ -1555,7 +1548,7 @@ pub fn slot_match(slot_list: &[InternalSlotName], slot_set: &AHashSet<&InternalS
     true
 }
 
-pub fn make_basic_object(agent: &Agent, internal_slots_list: &[InternalSlotName], prototype: Option<Object>) -> Object {
+pub fn make_basic_object(internal_slots_list: &[InternalSlotName], prototype: Option<Object>) -> Object {
     let mut slot_set = AHashSet::with_capacity(internal_slots_list.len());
     for slot in internal_slots_list.iter() {
         slot_set.insert(slot);
@@ -1563,19 +1556,19 @@ pub fn make_basic_object(agent: &Agent, internal_slots_list: &[InternalSlotName]
 
     if slot_match(ORDINARY_OBJECT_SLOTS, &slot_set) {
         // Ordinary Objects
-        Object::new(agent, prototype, true)
+        Object::new(prototype, true)
     } else if slot_match(BOOLEAN_OBJECT_SLOTS, &slot_set) {
-        BooleanObject::object(agent, prototype)
+        BooleanObject::object(prototype)
     } else if slot_match(ERROR_OBJECT_SLOTS, &slot_set) {
-        ErrorObject::object(agent, prototype)
+        ErrorObject::object(prototype)
     } else if slot_match(NUMBER_OBJECT_SLOTS, &slot_set) {
-        NumberObject::object(agent, prototype)
+        NumberObject::object(prototype)
     } else if slot_match(ARRAY_OBJECT_SLOTS, &slot_set) {
-        ArrayObject::object(agent, prototype)
+        ArrayObject::object(prototype)
     } else if slot_match(SYMBOL_OBJECT_SLOTS, &slot_set) {
-        SymbolObject::object(agent, prototype)
+        SymbolObject::object(prototype)
     } else if slot_match(FUNCTION_OBJECT_SLOTS, &slot_set) {
-        //FunctionObject::object(agent, prototype)
+        //FunctionObject::object(prototype)
         panic!("More items are needed for initialization. Use FunctionObject::object directly instead")
     } else if slot_match(ARGUMENTS_OBJECT_SLOTS, &slot_set) {
         panic!("Additional info needed for arguments object; use direct constructor");
@@ -1595,9 +1588,9 @@ pub fn make_basic_object(agent: &Agent, internal_slots_list: &[InternalSlotName]
 //  1. Assert: Type(O) is Object.
 //  2. Assert: IsPropertyKey(P) is true.
 //  3. Return ? O.[[Get]](P, O).
-pub fn get(agent: &Agent, obj: &Object, key: &PropertyKey) -> Completion<ECMAScriptValue> {
+pub fn get(obj: &Object, key: &PropertyKey) -> Completion<ECMAScriptValue> {
     let val = ECMAScriptValue::Object(obj.clone());
-    obj.o.get(agent, key, &val)
+    obj.o.get(key, &val)
 }
 
 // GetV ( V, P )
@@ -1610,9 +1603,9 @@ pub fn get(agent: &Agent, obj: &Object, key: &PropertyKey) -> Completion<ECMAScr
 //  1. Assert: IsPropertyKey(P) is true.
 //  2. Let O be ? ToObject(V).
 //  3. Return ? O.[[Get]](P, V).
-pub fn getv(agent: &Agent, v: &ECMAScriptValue, p: &PropertyKey) -> Completion<ECMAScriptValue> {
-    let o = to_object(agent, v.clone())?;
-    o.o.get(agent, p, v)
+pub fn getv(v: &ECMAScriptValue, p: &PropertyKey) -> Completion<ECMAScriptValue> {
+    let o = to_object(v.clone())?;
+    o.o.get(p, v)
 }
 
 // Set ( O, P, V, Throw )
@@ -1627,11 +1620,11 @@ pub fn getv(agent: &Agent, v: &ECMAScriptValue, p: &PropertyKey) -> Completion<E
 //  4. Let success be ? O.[[Set]](P, V, O).
 //  5. If success is false and Throw is true, throw a TypeError exception.
 //  6. Return success.
-pub fn set(agent: &Agent, obj: &Object, propkey: PropertyKey, value: ECMAScriptValue, throw: bool) -> Completion<bool> {
+pub fn set(obj: &Object, propkey: PropertyKey, value: ECMAScriptValue, throw: bool) -> Completion<bool> {
     let objval = ECMAScriptValue::Object(obj.clone());
-    let success = obj.o.set(agent, propkey, value, &objval)?;
+    let success = obj.o.set(propkey, value, &objval)?;
     if !success && throw {
-        Err(create_type_error(agent, "Cannot add property, for one of many different possible reasons"))
+        Err(create_type_error("Cannot add property, for one of many different possible reasons"))
     } else {
         Ok(success)
     }
@@ -1650,9 +1643,9 @@ pub fn set(agent: &Agent, obj: &Object, propkey: PropertyKey, value: ECMAScriptV
 // NOTE     This abstract operation creates a property whose attributes are set to the same defaults used for properties
 //          created by the ECMAScript language assignment operator. Normally, the property will not already exist. If it
 //          does exist and is not configurable or if O is not extensible, [[DefineOwnProperty]] will return false.
-pub fn create_data_property(agent: &Agent, obj: &Object, p: PropertyKey, v: ECMAScriptValue) -> Completion<bool> {
+pub fn create_data_property(obj: &Object, p: PropertyKey, v: ECMAScriptValue) -> Completion<bool> {
     let new_desc = PotentialPropertyDescriptor::new().value(v).writable(true).enumerable(true).configurable(true);
-    obj.o.define_own_property(agent, p, new_desc)
+    obj.o.define_own_property(p, new_desc)
 }
 
 // CreateDataPropertyOrThrow ( O, P, V )
@@ -1670,14 +1663,13 @@ pub fn create_data_property(agent: &Agent, obj: &Object, p: PropertyKey, v: ECMA
 //          | already exist. If it does exist and is not configurable or if O is not extensible, [[DefineOwnProperty]]
 //          | will return false causing this operation to throw a TypeError exception.
 pub fn create_data_property_or_throw(
-    agent: &Agent,
     obj: &Object,
     p: impl Into<PropertyKey>,
     v: impl Into<ECMAScriptValue>,
 ) -> Completion<()> {
-    let success = create_data_property(agent, obj, p.into(), v.into())?;
+    let success = create_data_property(obj, p.into(), v.into())?;
     if !success {
-        Err(create_type_error(agent, "Unable to create data property"))
+        Err(create_type_error("Unable to create data property"))
     } else {
         Ok(())
     }
@@ -1696,14 +1688,13 @@ pub fn create_data_property_or_throw(
 //  4. If success is false, throw a TypeError exception.
 //  5. Return success.
 pub fn define_property_or_throw(
-    agent: &Agent,
     obj: &Object,
     p: impl Into<PropertyKey>,
     desc: PotentialPropertyDescriptor,
 ) -> Completion<()> {
-    let success = obj.o.define_own_property(agent, p.into(), desc)?;
+    let success = obj.o.define_own_property(p.into(), desc)?;
     if !success {
-        Err(create_type_error(agent, "Property cannot be assigned to"))
+        Err(create_type_error("Property cannot be assigned to"))
     } else {
         Ok(())
     }
@@ -1720,12 +1711,12 @@ pub fn define_property_or_throw(
 //  3. If func is either undefined or null, return undefined.
 //  4. If IsCallable(func) is false, throw a TypeError exception.
 //  5. Return func.
-pub fn get_method(agent: &Agent, val: &ECMAScriptValue, key: &PropertyKey) -> Completion<ECMAScriptValue> {
-    let func = getv(agent, val, key)?;
+pub fn get_method(val: &ECMAScriptValue, key: &PropertyKey) -> Completion<ECMAScriptValue> {
+    let func = getv(val, key)?;
     if func.is_undefined() || func.is_null() {
         Ok(ECMAScriptValue::Undefined)
     } else if !is_callable(&func) {
-        Err(create_type_error(agent, "item is not callable"))
+        Err(create_type_error("item is not callable"))
     } else {
         Ok(func)
     }
@@ -1741,8 +1732,8 @@ pub fn get_method(agent: &Agent, val: &ECMAScriptValue, key: &PropertyKey) -> Co
 //  1. Assert: Type(O) is Object.
 //  2. Assert: IsPropertyKey(P) is true.
 //  3. Return ? O.[[HasProperty]](P).
-pub fn has_property(agent: &Agent, obj: &Object, p: &PropertyKey) -> Completion<bool> {
-    obj.o.has_property(agent, p)
+pub fn has_property(obj: &Object, p: &PropertyKey) -> Completion<bool> {
+    obj.o.has_property(p)
 }
 
 // HasOwnProperty ( O, P )
@@ -1756,8 +1747,8 @@ pub fn has_property(agent: &Agent, obj: &Object, p: &PropertyKey) -> Completion<
 //  3. Let desc be ? O.[[GetOwnProperty]](P).
 //  4. If desc is undefined, return false.
 //  5. Return true.
-pub fn has_own_property(agent: &Agent, obj: &Object, p: &PropertyKey) -> Completion<bool> {
-    Ok(obj.o.get_own_property(agent, p)?.is_some())
+pub fn has_own_property(obj: &Object, p: &PropertyKey) -> Completion<bool> {
+    Ok(obj.o.get_own_property(p)?.is_some())
 }
 
 // Call ( F, V [ , argumentsList ] )
@@ -1779,30 +1770,29 @@ pub fn to_callable(val: &ECMAScriptValue) -> Option<&dyn CallableObject> {
 }
 
 pub fn call(
-    agent: &Agent,
     func: &ECMAScriptValue,
     this_value: &ECMAScriptValue,
     args: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    initiate_call(agent, func, this_value, args);
-    complete_call(agent, func)
+    initiate_call(func, this_value, args);
+    complete_call(func)
 }
 
-pub fn initiate_call(agent: &Agent, func: &ECMAScriptValue, this_value: &ECMAScriptValue, args: &[ECMAScriptValue]) {
+pub fn initiate_call(func: &ECMAScriptValue, this_value: &ECMAScriptValue, args: &[ECMAScriptValue]) {
     let maybe_callable = to_callable(func);
     match maybe_callable {
         None => {
-            let err = Err(create_type_error(agent, "Value not callable"));
+            let err = Err(create_type_error("Value not callable"));
             agent.ec_push(err);
         }
         Some(callable) => {
-            let self_obj = to_object(agent, func.clone()).unwrap();
-            callable.call(agent, &self_obj, this_value, args);
+            let self_obj = to_object(func.clone()).unwrap();
+            callable.call(&self_obj, this_value, args);
         }
     }
 }
 
-pub fn complete_call(agent: &Agent, func: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+pub fn complete_call(func: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
     let callable = to_callable(func).unwrap();
     callable.complete_call(agent)
 }
@@ -1823,22 +1813,21 @@ pub fn complete_call(agent: &Agent, func: &ECMAScriptValue) -> Completion<ECMASc
 //
 // NOTE     If newTarget is not present, this operation is equivalent to: new F(...argumentsList)
 pub fn construct(
-    agent: &Agent,
     func: &Object,
     args: &[ECMAScriptValue],
     new_target: Option<&Object>,
 ) -> Completion<ECMAScriptValue> {
-    initiate_construct(agent, func, args, new_target);
+    initiate_construct(func, args, new_target);
     agent
         .ec_pop()
         .expect("Construct must return a completion")
         .map(|nc| ECMAScriptValue::try_from(nc).expect("Construct must return a language value"))
 }
 
-pub fn initiate_construct(agent: &Agent, func: &Object, args: &[ECMAScriptValue], new_target: Option<&Object>) {
+pub fn initiate_construct(func: &Object, args: &[ECMAScriptValue], new_target: Option<&Object>) {
     let nt = new_target.unwrap_or(func);
     let cstr = func.o.to_constructable().unwrap();
-    cstr.construct(agent, func, args, nt);
+    cstr.construct(func, args, nt);
 }
 
 pub fn to_constructor(val: &ECMAScriptValue) -> Option<&dyn CallableObject> {
@@ -1877,7 +1866,7 @@ pub enum IntegrityLevel {
     Sealed,
     Frozen,
 }
-pub fn set_integrity_level(agent: &Agent, o: &Object, level: IntegrityLevel) -> Completion<bool> {
+pub fn set_integrity_level(o: &Object, level: IntegrityLevel) -> Completion<bool> {
     let status = o.o.prevent_extensions(agent)?;
     if !status {
         return Ok(false);
@@ -1885,17 +1874,17 @@ pub fn set_integrity_level(agent: &Agent, o: &Object, level: IntegrityLevel) -> 
     let keys = o.o.own_property_keys(agent)?;
     if level == IntegrityLevel::Sealed {
         for k in keys {
-            define_property_or_throw(agent, o, k, PotentialPropertyDescriptor::new().configurable(false))?;
+            define_property_or_throw(o, k, PotentialPropertyDescriptor::new().configurable(false))?;
         }
     } else {
         for k in keys {
-            if let Some(current_desc) = o.o.get_own_property(agent, &k)? {
+            if let Some(current_desc) = o.o.get_own_property(&k)? {
                 let desc = if is_accessor_descriptor(&current_desc) {
                     PotentialPropertyDescriptor::new().configurable(false)
                 } else {
                     PotentialPropertyDescriptor::new().configurable(false).writable(false)
                 };
-                define_property_or_throw(agent, o, k, desc)?;
+                define_property_or_throw(o, k, desc)?;
             }
         }
     }
@@ -1913,11 +1902,11 @@ pub fn set_integrity_level(agent: &Agent, o: &Object, level: IntegrityLevel) -> 
 //      a. Perform ! CreateDataPropertyOrThrow(array, ! ToString(𝔽(n)), e).
 //      b. Set n to n + 1.
 //  4. Return array.
-pub fn create_array_from_list(agent: &Agent, elements: &[ECMAScriptValue]) -> Object {
-    let array = array_create(agent, 0, None).unwrap();
+pub fn create_array_from_list(elements: &[ECMAScriptValue]) -> Object {
+    let array = array_create(0, None).unwrap();
     for (n, e) in elements.iter().enumerate() {
-        let key = to_string(agent, u64::try_from(n).unwrap()).unwrap();
-        create_data_property_or_throw(agent, &array, key, e.clone()).unwrap();
+        let key = to_string(u64::try_from(n).unwrap()).unwrap();
+        create_data_property_or_throw(&array, key, e.clone()).unwrap();
     }
     array
 }
@@ -1935,13 +1924,12 @@ pub fn create_array_from_list(agent: &Agent, elements: &[ECMAScriptValue]) -> Ob
 //  3. Let func be ? GetV(V, P).
 //  4. Return ? Call(func, V, argumentsList).
 pub fn invoke(
-    agent: &Agent,
     v: ECMAScriptValue,
     p: &PropertyKey,
     arguments_list: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let func = getv(agent, &v, p)?;
-    call(agent, &func, &v, arguments_list)
+    let func = getv(&v, p)?;
+    call(&func, &v, arguments_list)
 }
 
 impl Agent {
@@ -2024,7 +2012,6 @@ pub enum EnumerationStyle {
     KeyPlusValue,
 }
 pub fn enumerable_own_property_names(
-    agent: &Agent,
     obj: &Object,
     kind: EnumerationStyle,
 ) -> Completion<Vec<ECMAScriptValue>> {
@@ -2032,16 +2019,16 @@ pub fn enumerable_own_property_names(
     let mut properties: Vec<ECMAScriptValue> = vec![];
     for key in own_keys.into_iter() {
         if matches!(key, PropertyKey::String(_)) {
-            if let Some(desc) = obj.o.get_own_property(agent, &key)? {
+            if let Some(desc) = obj.o.get_own_property(&key)? {
                 if desc.enumerable {
                     if kind == EnumerationStyle::Key {
                         properties.push(ECMAScriptValue::from(key));
                     } else {
-                        let value = get(agent, obj, &key)?;
+                        let value = get(obj, &key)?;
                         if kind == EnumerationStyle::Value {
                             properties.push(value);
                         } else {
-                            let entry = create_array_from_list(agent, &[key.into(), value]);
+                            let entry = create_array_from_list(&[key.into(), value]);
                             properties.push(entry.into());
                         }
                     }
@@ -2071,13 +2058,12 @@ pub fn enumerable_own_property_names(
 //          any algorithm that subsequently modifies the internal methods of the object in ways that would make the
 //          result non-ordinary. Operations that create exotic objects invoke MakeBasicObject directly.
 pub fn ordinary_object_create(
-    agent: &Agent,
     proto: Option<Object>,
     additional_internal_slots_list: &[InternalSlotName],
 ) -> Object {
     let mut slots = vec![InternalSlotName::Prototype, InternalSlotName::Extensible];
     slots.extend_from_slice(additional_internal_slots_list);
-    let o = make_basic_object(agent, slots.as_slice(), proto);
+    let o = make_basic_object(slots.as_slice(), proto);
     o
 }
 
@@ -2095,13 +2081,12 @@ pub fn ordinary_object_create(
 //  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
 //  3. Return ! OrdinaryObjectCreate(proto, internalSlotsList).
 pub fn ordinary_create_from_constructor(
-    agent: &Agent,
     constructor: &Object,
     intrinsic_default_proto: IntrinsicId,
     internal_slots_list: &[InternalSlotName],
 ) -> Completion<Object> {
-    let proto = get_prototype_from_constructor(agent, constructor, intrinsic_default_proto)?;
-    Ok(ordinary_object_create(agent, Some(proto), internal_slots_list))
+    let proto = get_prototype_from_constructor(constructor, intrinsic_default_proto)?;
+    Ok(ordinary_object_create(Some(proto), internal_slots_list))
 }
 
 // GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
@@ -2123,15 +2108,14 @@ pub fn ordinary_create_from_constructor(
 // NOTE     If constructor does not supply a [[Prototype]] value, the default value that is used is obtained from the
 //          realm of the constructor function rather than from the running execution context.
 pub fn get_prototype_from_constructor(
-    agent: &Agent,
     constructor: &Object,
     intrinsic_default_proto: IntrinsicId,
 ) -> Completion<Object> {
-    let proto = get(agent, constructor, &PropertyKey::from("prototype"))?;
+    let proto = get(constructor, &PropertyKey::from("prototype"))?;
     match proto {
         ECMAScriptValue::Object(obj) => Ok(obj),
         _ => {
-            let realm = get_function_realm(agent, constructor)?;
+            let realm = get_function_realm(constructor)?;
             let proto = realm.borrow().intrinsics.get(intrinsic_default_proto);
             Ok(proto)
         }
@@ -2153,49 +2137,47 @@ impl ObjectInterface for DeadObject {
         self.objid
     }
 
-    fn get_prototype_of(&self, agent: &Agent) -> Completion<Option<Object>> {
-        Err(create_type_error(agent, "get_prototype_of called on DeadObject"))
+    fn get_prototype_of(&self) -> Completion<Option<Object>> {
+        Err(create_type_error("get_prototype_of called on DeadObject"))
     }
-    fn set_prototype_of(&self, agent: &Agent, _obj: Option<Object>) -> Completion<bool> {
-        Err(create_type_error(agent, "set_prototype_of called on DeadObject"))
+    fn set_prototype_of(&self, _obj: Option<Object>) -> Completion<bool> {
+        Err(create_type_error("set_prototype_of called on DeadObject"))
     }
-    fn is_extensible(&self, agent: &Agent) -> Completion<bool> {
-        Err(create_type_error(agent, "is_extensible called on DeadObject"))
+    fn is_extensible(&self) -> Completion<bool> {
+        Err(create_type_error("is_extensible called on DeadObject"))
     }
-    fn prevent_extensions(&self, agent: &Agent) -> Completion<bool> {
-        Err(create_type_error(agent, "prevent_extensions called on DeadObject"))
+    fn prevent_extensions(&self) -> Completion<bool> {
+        Err(create_type_error("prevent_extensions called on DeadObject"))
     }
-    fn get_own_property(&self, agent: &Agent, _key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
-        Err(create_type_error(agent, "get_own_property called on DeadObject"))
+    fn get_own_property(&self, _key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
+        Err(create_type_error("get_own_property called on DeadObject"))
     }
     fn define_own_property(
         &self,
-        agent: &Agent,
         _key: PropertyKey,
         _desc: PotentialPropertyDescriptor,
     ) -> Completion<bool> {
-        Err(create_type_error(agent, "define_own_property called on DeadObject"))
+        Err(create_type_error("define_own_property called on DeadObject"))
     }
-    fn has_property(&self, agent: &Agent, _key: &PropertyKey) -> Completion<bool> {
-        Err(create_type_error(agent, "has_property called on DeadObject"))
+    fn has_property(&self, _key: &PropertyKey) -> Completion<bool> {
+        Err(create_type_error("has_property called on DeadObject"))
     }
-    fn get(&self, agent: &Agent, _key: &PropertyKey, _receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
-        Err(create_type_error(agent, "get called on DeadObject"))
+    fn get(&self, _key: &PropertyKey, _receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+        Err(create_type_error("get called on DeadObject"))
     }
     fn set(
         &self,
-        agent: &Agent,
         _key: PropertyKey,
         _value: ECMAScriptValue,
         _receiver: &ECMAScriptValue,
     ) -> Completion<bool> {
-        Err(create_type_error(agent, "set called on DeadObject"))
+        Err(create_type_error("set called on DeadObject"))
     }
-    fn delete(&self, agent: &Agent, _key: &PropertyKey) -> Completion<bool> {
-        Err(create_type_error(agent, "delete called on DeadObject"))
+    fn delete(&self, _key: &PropertyKey) -> Completion<bool> {
+        Err(create_type_error("delete called on DeadObject"))
     }
-    fn own_property_keys(&self, agent: &Agent) -> Completion<Vec<PropertyKey>> {
-        Err(create_type_error(agent, "own_property_keys called on DeadObject"))
+    fn own_property_keys(&self) -> Completion<Vec<PropertyKey>> {
+        Err(create_type_error("own_property_keys called on DeadObject"))
     }
 }
 
@@ -2214,7 +2196,7 @@ impl DeadObject {
 //  2. Let current be ? O.[[GetPrototypeOf]]().
 //  3. If SameValue(V, current) is true, return true.
 //  4. Return false.
-pub fn set_immutable_prototype<'a, T>(agent: &Agent, o: T, val: Option<Object>) -> Completion<bool>
+pub fn set_immutable_prototype<'a, T>(o: T, val: Option<Object>) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -2261,8 +2243,8 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // null). It performs the following steps when called:
     //
     //  1. Return ? SetImmutablePrototype(O, V).
-    fn set_prototype_of(&self, agent: &Agent, obj: Option<Object>) -> Completion<bool> {
-        set_immutable_prototype(agent, self, obj)
+    fn set_prototype_of(&self, obj: Option<Object>) -> Completion<bool> {
+        set_immutable_prototype(self, obj)
     }
 
     // [[IsExtensible]] ( )
@@ -2303,11 +2285,10 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     //  1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
     fn define_own_property(
         &self,
-        agent: &Agent,
         key: PropertyKey,
         desc: PotentialPropertyDescriptor,
     ) -> Completion<bool> {
-        ordinary_define_own_property(agent, self, key, desc)
+        ordinary_define_own_property(self, key, desc)
     }
 
     // [[HasProperty]] ( P )
@@ -2316,8 +2297,8 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryHasProperty(O, P).
-    fn has_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
-        ordinary_has_property(agent, self, key)
+    fn has_property(&self, key: &PropertyKey) -> Completion<bool> {
+        ordinary_has_property(self, key)
     }
 
     // [[Get]] ( P, Receiver )
@@ -2326,8 +2307,8 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinaryGet(O, P, Receiver).
-    fn get(&self, agent: &Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
-        ordinary_get(agent, self, key, receiver)
+    fn get(&self, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+        ordinary_get(self, key, receiver)
     }
 
     // [[Set]] ( P, V, Receiver )
@@ -2336,8 +2317,8 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // value), and Receiver (an ECMAScript language value). It performs the following steps when called:
     //
     //  1. Return ? OrdinarySet(O, P, V, Receiver).
-    fn set(&self, agent: &Agent, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
-        ordinary_set(agent, self, key, v, receiver)
+    fn set(&self, key: PropertyKey, v: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
+        ordinary_set(self, key, v, receiver)
     }
 
     // [[Delete]] ( P )
@@ -2346,8 +2327,8 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     // following steps when called:
     //
     //  1. Return ? OrdinaryDelete(O, P).
-    fn delete(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
-        ordinary_delete(agent, self, key)
+    fn delete(&self, key: &PropertyKey) -> Completion<bool> {
+        ordinary_delete(self, key)
     }
 
     // [[OwnPropertyKeys]] ( )
@@ -2361,10 +2342,10 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
     }
 }
 
-pub fn immutable_prototype_exotic_object_create(agent: &Agent, proto: Option<&Object>) -> Object {
+pub fn immutable_prototype_exotic_object_create(proto: Option<&Object>) -> Object {
     Object {
         o: Rc::new(ImmutablePrototypeExoticObject {
-            data: RefCell::new(CommonObjectData::new(agent, proto.cloned(), true, ORDINARY_OBJECT_SLOTS)),
+            data: RefCell::new(CommonObjectData::new(proto.cloned(), true, ORDINARY_OBJECT_SLOTS)),
         }),
     }
 }
@@ -2387,7 +2368,7 @@ pub fn immutable_prototype_exotic_object_create(agent: &Agent, proto: Option<&Ob
 //
 // NOTE     Step 5 will only be reached if obj is a non-standard function exotic object that does not have a [[Realm]]
 //          internal slot.
-pub fn get_function_realm(agent: &Agent, obj: &Object) -> Completion<Rc<RefCell<Realm>>> {
+pub fn get_function_realm(obj: &Object) -> Completion<Rc<RefCell<Realm>>> {
     if let Some(f) = obj.o.to_function_obj() {
         Ok(f.function_data().borrow().realm.clone())
     } else if let Some(b) = obj.o.to_builtin_function_obj() {
@@ -2428,10 +2409,10 @@ pub fn private_element_find(o: &Object, p: &PrivateName) -> Option<Rc<PrivateEle
 //  1. Let entry be ! PrivateElementFind(O, P).
 //  2. If entry is not empty, throw a TypeError exception.
 //  3. Append PrivateElement { [[Key]]: P, [[Kind]]: field, [[Value]]: value } to O.[[PrivateElements]].
-pub fn private_field_add(agent: &Agent, obj: &Object, p: PrivateName, value: ECMAScriptValue) -> Completion<()> {
+pub fn private_field_add(obj: &Object, p: PrivateName, value: ECMAScriptValue) -> Completion<()> {
     let entry = private_element_find(obj, &p);
     match entry {
-        Some(_) => Err(create_type_error(agent, "PrivateName already defined")),
+        Some(_) => Err(create_type_error("PrivateName already defined")),
         None => {
             let elements = &mut obj.o.common_object_data().borrow_mut().private_elements;
             elements.push(Rc::new(PrivateElement {
@@ -2455,9 +2436,9 @@ pub fn private_field_add(agent: &Agent, obj: &Object, p: PrivateName, value: ECM
 //
 // NOTE: The values for private methods and accessors are shared across instances. This step does not create a new copy
 // of the method or accessor.
-pub fn private_method_or_accessor_add(agent: &Agent, obj: &Object, method: Rc<PrivateElement>) -> Completion<()> {
+pub fn private_method_or_accessor_add(obj: &Object, method: Rc<PrivateElement>) -> Completion<()> {
     if private_element_find(obj, &method.key).is_some() {
-        Err(create_type_error(agent, "PrivateName already defined"))
+        Err(create_type_error("PrivateName already defined"))
     } else {
         obj.o.common_object_data().borrow_mut().private_elements.push(method);
         Ok(())
@@ -2465,7 +2446,7 @@ pub fn private_method_or_accessor_add(agent: &Agent, obj: &Object, method: Rc<Pr
 }
 
 #[allow(unused_variables)]
-pub fn define_field(agent: &Agent, obj: &Object, field: &ClassFieldDefinitionRecord) -> Completion<()> {
+pub fn define_field(obj: &Object, field: &ClassFieldDefinitionRecord) -> Completion<()> {
     todo!()
 }
 
@@ -2482,17 +2463,17 @@ pub fn define_field(agent: &Agent, obj: &Object, field: &ClassFieldDefinitionRec
 //  5. If entry.[[Get]] is undefined, throw a TypeError exception.
 //  6. Let getter be entry.[[Get]].
 //  7. Return ? Call(getter, O).
-pub fn private_get(agent: &Agent, obj: &Object, pn: &PrivateName) -> Completion<ECMAScriptValue> {
+pub fn private_get(obj: &Object, pn: &PrivateName) -> Completion<ECMAScriptValue> {
     match private_element_find(obj, pn) {
-        None => Err(create_type_error(agent, "PrivateName not defined")),
+        None => Err(create_type_error("PrivateName not defined")),
         Some(pe) => match &pe.kind {
             PrivateElementKind::Field { value } => Ok(value.borrow().clone()),
             PrivateElementKind::Method { value } => Ok(value.clone()),
             PrivateElementKind::Accessor { get: None, set: _ } => {
-                Err(create_type_error(agent, "PrivateName has no getter"))
+                Err(create_type_error("PrivateName has no getter"))
             }
             PrivateElementKind::Accessor { get: Some(getter), set: _ } => {
-                call(agent, &ECMAScriptValue::from(getter), &ECMAScriptValue::from(obj), &[])
+                call(&ECMAScriptValue::from(getter), &ECMAScriptValue::from(obj), &[])
             }
         },
     }
@@ -2514,22 +2495,22 @@ pub fn private_get(agent: &Agent, obj: &Object, pn: &PrivateName) -> Completion<
 //      b. If entry.[[Set]] is undefined, throw a TypeError exception.
 //      c. Let setter be entry.[[Set]].
 //      d. Perform ? Call(setter, O, « value »).
-pub fn private_set(agent: &Agent, obj: &Object, pn: &PrivateName, v: ECMAScriptValue) -> Completion<()> {
+pub fn private_set(obj: &Object, pn: &PrivateName, v: ECMAScriptValue) -> Completion<()> {
     match private_element_find(obj, pn) {
-        None => Err(create_type_error(agent, "PrivateName not defined")),
+        None => Err(create_type_error("PrivateName not defined")),
         Some(pe) => match &pe.kind {
             PrivateElementKind::Field { value } => {
                 *value.borrow_mut() = v;
                 Ok(())
             }
             PrivateElementKind::Method { value: _ } => {
-                Err(create_type_error(agent, "PrivateName method may not be assigned"))
+                Err(create_type_error("PrivateName method may not be assigned"))
             }
             PrivateElementKind::Accessor { get: _, set: None } => {
-                Err(create_type_error(agent, "PrivateName has no setter"))
+                Err(create_type_error("PrivateName has no setter"))
             }
             PrivateElementKind::Accessor { get: _, set: Some(setter) } => {
-                call(agent, &ECMAScriptValue::from(setter), &ECMAScriptValue::from(obj), &[v])?;
+                call(&ECMAScriptValue::from(setter), &ECMAScriptValue::from(obj), &[v])?;
                 Ok(())
             }
         },
@@ -2540,20 +2521,19 @@ pub fn private_set(agent: &Agent, obj: &Object, pn: &PrivateName, v: ECMAScriptV
 ///
 /// See [CopyDataProperties](https://tc39.es/ecma262/#sec-copydataproperties) in ECMA-262.
 pub fn copy_data_properties(
-    agent: &Agent,
     target: &Object,
     source: ECMAScriptValue,
     excluded: &[PropertyKey],
 ) -> Completion<()> {
     if !(source.is_undefined() || source.is_null()) {
-        let from = to_object(agent, source).unwrap();
+        let from = to_object(source).unwrap();
         let keys = from.o.own_property_keys(agent)?;
         for next_key in keys.iter().filter(|&k| !excluded.contains(k)) {
-            let desc = from.o.get_own_property(agent, next_key)?;
+            let desc = from.o.get_own_property(next_key)?;
             if let Some(desc) = desc {
                 if desc.enumerable {
-                    let prop_value = get(agent, &from, next_key)?;
-                    create_data_property_or_throw(agent, target, next_key.clone(), prop_value).unwrap();
+                    let prop_value = get(&from, next_key)?;
+                    create_data_property_or_throw(target, next_key.clone(), prop_value).unwrap();
                 }
             }
         }

--- a/src/object/tests.rs
+++ b/src/object/tests.rs
@@ -526,8 +526,8 @@ fn is_generic_descriptor_01() {
 #[test]
 fn ordinary_get_prototype_of_01() {
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto.clone()), &[]);
 
     let result = ordinary_get_prototype_of(&obj);
     assert_eq!(result, Some(object_proto));
@@ -536,9 +536,9 @@ fn ordinary_get_prototype_of_01() {
 #[test]
 fn ordinary_set_prototype_of_01() {
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let new_proto = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
-    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let new_proto = ordinary_object_create(Some(object_proto.clone()), &[]);
+    let obj = ordinary_object_create(Some(object_proto), &[]);
 
     let result = ordinary_set_prototype_of(&obj, Some(new_proto.clone()));
     assert!(result);
@@ -547,7 +547,7 @@ fn ordinary_set_prototype_of_01() {
 #[test]
 fn ordinary_set_prototype_of_02() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
     let result = ordinary_set_prototype_of(&obj, None);
     assert!(result);
@@ -556,8 +556,8 @@ fn ordinary_set_prototype_of_02() {
 #[test]
 fn ordinary_set_prototype_of_03() {
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto.clone()), &[]);
 
     let result = ordinary_set_prototype_of(&obj, Some(object_proto.clone()));
     assert!(result);
@@ -566,8 +566,8 @@ fn ordinary_set_prototype_of_03() {
 #[test]
 fn ordinary_set_prototype_of_04() {
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(None, &[]);
 
     let result = ordinary_set_prototype_of(&obj, Some(object_proto.clone()));
     assert!(result);
@@ -576,9 +576,9 @@ fn ordinary_set_prototype_of_04() {
 #[test]
 fn ordinary_set_prototype_of_05() {
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
-    obj.o.prevent_extensions(&agent).unwrap();
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto.clone()), &[]);
+    obj.o.prevent_extensions().unwrap();
 
     let result = ordinary_set_prototype_of(&obj, None);
     assert!(!result);
@@ -587,8 +587,8 @@ fn ordinary_set_prototype_of_05() {
 #[test]
 fn ordinary_set_prototype_of_06() {
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto.clone()), &[]);
 
     let result = ordinary_set_prototype_of(&obj, Some(obj.clone()));
     assert!(!result);
@@ -598,8 +598,8 @@ fn ordinary_set_prototype_of_06() {
 #[test]
 fn ordinary_is_extensible_01() {
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto), &[]);
 
     let result = ordinary_is_extensible(&obj);
     assert!(result);
@@ -612,8 +612,8 @@ fn ordinary_is_extensible_01() {
 #[test]
 fn ordinary_prevent_extensions_01() {
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto), &[]);
 
     let result = ordinary_prevent_extensions(&obj);
     assert!(result);
@@ -623,8 +623,8 @@ fn ordinary_prevent_extensions_01() {
 #[test]
 fn ordinary_get_own_property_01() {
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto), &[]);
     let key = PropertyKey::from("a");
 
     let result = ordinary_get_own_property(&obj, &key);
@@ -633,8 +633,8 @@ fn ordinary_get_own_property_01() {
 #[test]
 fn ordinary_get_own_property_02() {
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto), &[]);
     let key = PropertyKey::from("a");
     let ppd = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(10)),
@@ -643,7 +643,7 @@ fn ordinary_get_own_property_02() {
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&agent, &obj, key.clone(), ppd).unwrap();
+    define_property_or_throw(&obj, key.clone(), ppd).unwrap();
 
     let result = ordinary_get_own_property(&obj, &key).unwrap();
     assert_eq!(result.configurable, true);
@@ -659,8 +659,8 @@ fn ordinary_get_own_property_02() {
 fn ordinary_define_own_property_01() {
     // Add a new property, object is extensible (the default)
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto), &[]);
     let key = PropertyKey::from("a");
     let ppd = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(10)),
@@ -670,10 +670,10 @@ fn ordinary_define_own_property_01() {
         ..Default::default()
     };
 
-    let result = ordinary_define_own_property(&agent, &obj, key.clone(), ppd).unwrap();
+    let result = ordinary_define_own_property(&obj, key.clone(), ppd).unwrap();
 
     assert!(result);
-    let prop = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
+    let prop = obj.o.get_own_property(&key).unwrap().unwrap();
     assert_eq!(prop.configurable, true);
     assert_eq!(prop.enumerable, true);
     assert!(matches!(prop.property, PropertyKind::Data(..)));
@@ -686,8 +686,8 @@ fn ordinary_define_own_property_01() {
 fn ordinary_define_own_property_02() {
     // Add a new property, object is not extensible
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto), &[]);
     let key = PropertyKey::from("a");
     let ppd = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(10)),
@@ -696,9 +696,9 @@ fn ordinary_define_own_property_02() {
         configurable: Some(true),
         ..Default::default()
     };
-    obj.o.prevent_extensions(&agent).unwrap();
+    obj.o.prevent_extensions().unwrap();
 
-    let result = ordinary_define_own_property(&agent, &obj, key, ppd).unwrap();
+    let result = ordinary_define_own_property(&obj, key, ppd).unwrap();
 
     assert!(!result);
 }
@@ -706,8 +706,8 @@ fn ordinary_define_own_property_02() {
 fn ordinary_define_own_property_03() {
     // Change an existing property
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto), &[]);
     let key = PropertyKey::from("a");
     let initial = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(10)),
@@ -716,13 +716,13 @@ fn ordinary_define_own_property_03() {
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&agent, &obj, key.clone(), initial).unwrap();
+    define_property_or_throw(&obj, key.clone(), initial).unwrap();
     let ppd = PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from(0)), ..Default::default() };
 
-    let result = ordinary_define_own_property(&agent, &obj, key.clone(), ppd).unwrap();
+    let result = ordinary_define_own_property(&obj, key.clone(), ppd).unwrap();
 
     assert!(result);
-    let prop = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
+    let prop = obj.o.get_own_property(&key).unwrap().unwrap();
     assert_eq!(prop.configurable, true);
     assert_eq!(prop.enumerable, true);
     assert!(matches!(prop.property, PropertyKind::Data(..)));
@@ -735,7 +735,7 @@ fn ordinary_define_own_property_03() {
 fn ordinary_define_own_property_04() {
     // [[GetOwnProperty]] throws
     setup_test_agent();
-    let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
+    let obj = TestObject::object(&[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
     let ppd = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(10)),
@@ -745,16 +745,16 @@ fn ordinary_define_own_property_04() {
         ..Default::default()
     };
 
-    let result = ordinary_define_own_property(&agent, &obj, key, ppd).unwrap_err();
+    let result = ordinary_define_own_property(&obj, key, ppd).unwrap_err();
 
-    let msg = unwind_type_error(&agent, result);
+    let msg = unwind_type_error(result);
     assert_eq!(msg, "[[GetOwnProperty]] called on TestObject");
 }
 #[test]
 fn ordinary_define_own_property_05() {
     // [[IsExtensible]] throws
     setup_test_agent();
-    let obj = TestObject::object(&agent, &[FunctionId::IsExtensible]);
+    let obj = TestObject::object(&[FunctionId::IsExtensible]);
     let key = PropertyKey::from("a");
     let ppd = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(10)),
@@ -764,9 +764,9 @@ fn ordinary_define_own_property_05() {
         ..Default::default()
     };
 
-    let result = ordinary_define_own_property(&agent, &obj, key, ppd).unwrap_err();
+    let result = ordinary_define_own_property(&obj, key, ppd).unwrap_err();
 
-    let msg = unwind_type_error(&agent, result);
+    let msg = unwind_type_error(result);
     assert_eq!(msg, "[[IsExtensible]] called on TestObject");
 }
 
@@ -788,15 +788,15 @@ fn validate_and_apply_property_descriptor_02() {
 fn validate_and_apply_property_descriptor_03() {
     // current Undefined; empty descriptor
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto), &[]);
     let ppd = PotentialPropertyDescriptor { ..Default::default() };
     let key = PropertyKey::from("key");
 
     let result = validate_and_apply_property_descriptor(Some(&obj), Some(key.clone()), true, ppd, None);
 
     assert!(result);
-    let pd = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
+    let pd = obj.o.get_own_property(&key).unwrap().unwrap();
     assert_eq!(pd.configurable, false);
     assert_eq!(pd.enumerable, false);
     assert_eq!(pd.property, PropertyKind::Data(DataProperty { value: ECMAScriptValue::Undefined, writable: false }));
@@ -805,8 +805,8 @@ fn validate_and_apply_property_descriptor_03() {
 fn validate_and_apply_property_descriptor_04() {
     // current Undefined; overfull descriptor
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto), &[]);
     let ppd = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(true)),
         writable: Some(true),
@@ -820,7 +820,7 @@ fn validate_and_apply_property_descriptor_04() {
     let result = validate_and_apply_property_descriptor(Some(&obj), Some(key.clone()), true, ppd, None);
 
     assert!(result);
-    let pd = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
+    let pd = obj.o.get_own_property(&key).unwrap().unwrap();
     assert_eq!(pd.configurable, true);
     assert_eq!(pd.enumerable, true);
     assert_eq!(pd.property, PropertyKind::Data(DataProperty { value: ECMAScriptValue::from(true), writable: true }));
@@ -829,12 +829,12 @@ fn validate_and_apply_property_descriptor_04() {
 fn validate_and_apply_property_descriptor_05() {
     // current Undefined; accessor descriptor
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto), &[]);
     let ppd = PotentialPropertyDescriptor {
         enumerable: Some(true),
         configurable: Some(true),
-        get: Some(ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError))),
+        get: Some(ECMAScriptValue::from(intrinsic(IntrinsicId::ThrowTypeError))),
         set: Some(ECMAScriptValue::Undefined),
         ..Default::default()
     };
@@ -843,13 +843,13 @@ fn validate_and_apply_property_descriptor_05() {
     let result = validate_and_apply_property_descriptor(Some(&obj), Some(key.clone()), true, ppd, None);
 
     assert!(result);
-    let pd = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
+    let pd = obj.o.get_own_property(&key).unwrap().unwrap();
     assert_eq!(pd.configurable, true);
     assert_eq!(pd.enumerable, true);
     assert_eq!(
         pd.property,
         PropertyKind::Accessor(AccessorProperty {
-            get: ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError)),
+            get: ECMAScriptValue::from(intrinsic(IntrinsicId::ThrowTypeError)),
             set: ECMAScriptValue::Undefined
         })
     );
@@ -858,8 +858,8 @@ fn validate_and_apply_property_descriptor_05() {
 fn validate_and_apply_property_descriptor_06() {
     // object Undefined; current reasonable; any valid input
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto), &[]);
     let existing = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(99)),
         writable: Some(true),
@@ -868,15 +868,15 @@ fn validate_and_apply_property_descriptor_06() {
         ..Default::default()
     };
     let key = PropertyKey::from("key");
-    define_property_or_throw(&agent, &obj, key.clone(), existing).unwrap();
-    let current = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
+    define_property_or_throw(&obj, key.clone(), existing).unwrap();
+    let current = obj.o.get_own_property(&key).unwrap().unwrap();
 
     let ppd = PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from(10)), ..Default::default() };
 
     let result = validate_and_apply_property_descriptor::<&Object>(None, Some(key.clone()), true, ppd, Some(&current));
 
     assert!(result);
-    let pd = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
+    let pd = obj.o.get_own_property(&key).unwrap().unwrap();
     assert_eq!(pd.configurable, true);
     assert_eq!(pd.enumerable, true);
     assert_eq!(pd.property, PropertyKind::Data(DataProperty { value: ECMAScriptValue::from(99), writable: true }));
@@ -908,8 +908,8 @@ struct VAPDIter {
     tte: ECMAScriptValue,
 }
 impl VAPDIter {
-    fn new(agent: &Agent) -> Self {
-        VAPDIter { tte: ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError)), ..Default::default() }
+    fn new() -> Self {
+        VAPDIter { tte: ECMAScriptValue::from(intrinsic(IntrinsicId::ThrowTypeError)), ..Default::default() }
     }
     fn id_name(&self) -> String {
         format!(
@@ -1015,8 +1015,8 @@ struct VAPDCheck {
     done: bool,
 }
 impl VAPDCheck {
-    fn new(agent: &Agent) -> Self {
-        Self { tte: ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError)), ..Default::default() }
+    fn new() -> Self {
+        Self { tte: ECMAScriptValue::from(intrinsic(IntrinsicId::ThrowTypeError)), ..Default::default() }
     }
 }
 impl Iterator for VAPDCheck {
@@ -1204,19 +1204,19 @@ fn figure_expectation(
 #[test]
 fn validate_and_apply_property_descriptor_many() {
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
-    for (name, ppd) in VAPDIter::new(&agent) {
-        for (idx, _) in VAPDCheck::new(&agent).enumerate() {
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto), &[]);
+    for (name, ppd) in VAPDIter::new() {
+        for (idx, _) in VAPDCheck::new().enumerate() {
             let key = PropertyKey::from(format!("{}-{}", name, idx));
-            define_property_or_throw(&agent, &obj, key, ppd.clone()).unwrap();
+            define_property_or_throw(&obj, key, ppd.clone()).unwrap();
         }
     }
 
-    for (name, _) in VAPDIter::new(&agent) {
-        for (idx, check) in VAPDCheck::new(&agent).enumerate() {
+    for (name, _) in VAPDIter::new() {
+        for (idx, check) in VAPDCheck::new().enumerate() {
             let key = PropertyKey::from(format!("{}-{}", name, idx));
-            let current = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
+            let current = obj.o.get_own_property(&key).unwrap().unwrap();
             let expected_prop = figure_expectation(&current, &check);
 
             let result = validate_and_apply_property_descriptor(
@@ -1235,7 +1235,7 @@ fn validate_and_apply_property_descriptor_many() {
                 check,
                 expected_prop
             );
-            let after = obj.o.get_own_property(&agent, &key).unwrap().unwrap();
+            let after = obj.o.get_own_property(&key).unwrap().unwrap();
             assert_eq!(
                 &after,
                 expected_prop.as_ref().unwrap_or(&current),
@@ -1252,8 +1252,8 @@ fn validate_and_apply_property_descriptor_many() {
 #[test]
 fn ordinary_has_property_01() {
     setup_test_agent();
-    let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
+    let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_proto), &[]);
     let initial = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(true)),
         writable: Some(true),
@@ -1262,78 +1262,78 @@ fn ordinary_has_property_01() {
         ..Default::default()
     };
     let key = PropertyKey::from("a");
-    define_property_or_throw(&agent, &obj, key.clone(), initial).unwrap();
+    define_property_or_throw(&obj, key.clone(), initial).unwrap();
     let key2 = PropertyKey::from("b");
     let key3 = PropertyKey::from("toString");
 
     // own property
-    let result = ordinary_has_property(&agent, &obj, &key).unwrap();
+    let result = ordinary_has_property(&obj, &key).unwrap();
     assert!(result);
 
     // property not there
-    let result = ordinary_has_property(&agent, &obj, &key2).unwrap();
+    let result = ordinary_has_property(&obj, &key2).unwrap();
     assert!(!result);
 
     // parent property
-    let result = ordinary_has_property(&agent, &obj, &key3).unwrap();
+    let result = ordinary_has_property(&obj, &key3).unwrap();
     assert!(result);
 }
 #[test]
 fn ordinary_has_property_02() {
     // [[GetOwnProperty]] throws
     setup_test_agent();
-    let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
+    let obj = TestObject::object(&[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_has_property(&agent, &obj, &key).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "[[GetOwnProperty]] called on TestObject");
+    let result = ordinary_has_property(&obj, &key).unwrap_err();
+    assert_eq!(unwind_type_error(result), "[[GetOwnProperty]] called on TestObject");
 }
 #[test]
 fn ordinary_has_property_03() {
     // [GetPrototypeOf]] throws
     setup_test_agent();
-    let obj = TestObject::object(&agent, &[FunctionId::GetPrototypeOf]);
+    let obj = TestObject::object(&[FunctionId::GetPrototypeOf]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_has_property(&agent, &obj, &key).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "[[GetPrototypeOf]] called on TestObject");
+    let result = ordinary_has_property(&obj, &key).unwrap_err();
+    assert_eq!(unwind_type_error(result), "[[GetPrototypeOf]] called on TestObject");
 }
 
 #[test]
 fn ordinary_get_01() {
     // [[GetOwnProperty]] throws
     setup_test_agent();
-    let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
+    let obj = TestObject::object(&[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_get(&agent, &obj, &key, &ECMAScriptValue::Undefined).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "[[GetOwnProperty]] called on TestObject");
+    let result = ordinary_get(&obj, &key, &ECMAScriptValue::Undefined).unwrap_err();
+    assert_eq!(unwind_type_error(result), "[[GetOwnProperty]] called on TestObject");
 }
 #[test]
 fn ordinary_get_02() {
     // [[GetPrototypeOf]] throws
     setup_test_agent();
-    let obj = TestObject::object(&agent, &[FunctionId::GetPrototypeOf]);
+    let obj = TestObject::object(&[FunctionId::GetPrototypeOf]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_get(&agent, &obj, &key, &ECMAScriptValue::Undefined).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "[[GetPrototypeOf]] called on TestObject");
+    let result = ordinary_get(&obj, &key, &ECMAScriptValue::Undefined).unwrap_err();
+    assert_eq!(unwind_type_error(result), "[[GetPrototypeOf]] called on TestObject");
 }
 #[test]
 fn ordinary_get_03() {
     // Top of the prototype chain
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_get(&agent, &obj, &key, &ECMAScriptValue::Undefined).unwrap();
+    let result = ordinary_get(&obj, &key, &ECMAScriptValue::Undefined).unwrap();
     assert_eq!(result, ECMAScriptValue::Undefined);
 }
 #[test]
 fn ordinary_get_04() {
     // Normal data property
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
     let initial = PotentialPropertyDescriptor {
         value: Some(ECMAScriptValue::from(0)),
@@ -1342,49 +1342,38 @@ fn ordinary_get_04() {
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&agent, &obj, key.clone(), initial).unwrap();
+    define_property_or_throw(&obj, key.clone(), initial).unwrap();
 
-    let result = ordinary_get(&agent, &obj, &key, &ECMAScriptValue::Undefined).unwrap();
+    let result = ordinary_get(&obj, &key, &ECMAScriptValue::Undefined).unwrap();
     assert_eq!(result, ECMAScriptValue::from(0));
 }
 fn test_getter(
-    agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
     // This is a getter; it is essentially:
     // function() { return this.result; }
-    let obj = to_object(agent, this_value)?;
+    let obj = to_object(this_value)?;
     let key = PropertyKey::from("result");
-    get(agent, &obj, &key)
+    get(&obj, &key)
 }
 #[test]
 fn ordinary_get_05() {
     // Normal accessor property
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
-    let getter = create_builtin_function(
-        &agent,
-        test_getter,
-        false,
-        0_f64,
-        key.clone(),
-        &[],
-        None,
-        None,
-        Some(JSString::from("get")),
-    );
+    let getter =
+        create_builtin_function(test_getter, false, 0_f64, key.clone(), &[], None, None, Some(JSString::from("get")));
     let initial = PotentialPropertyDescriptor {
         get: Some(ECMAScriptValue::from(getter)),
         enumerable: Some(true),
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&agent, &obj, key.clone(), initial).unwrap();
+    define_property_or_throw(&obj, key.clone(), initial).unwrap();
     define_property_or_throw(
-        &agent,
         &obj,
         PropertyKey::from("result"),
         PotentialPropertyDescriptor {
@@ -1397,26 +1386,17 @@ fn ordinary_get_05() {
     )
     .unwrap();
 
-    let result = ordinary_get(&agent, &obj, &key, &ECMAScriptValue::from(obj.clone())).unwrap();
+    let result = ordinary_get(&obj, &key, &ECMAScriptValue::from(obj.clone())).unwrap();
     assert_eq!(result, ECMAScriptValue::from("sentinel value"));
 }
 #[test]
 fn ordinary_get_06() {
     // Accessor property on parent (this ensures we're passing "receiver" properly)
     setup_test_agent();
-    let parent = ordinary_object_create(&agent, None, &[]);
+    let parent = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
-    let getter = create_builtin_function(
-        &agent,
-        test_getter,
-        false,
-        0_f64,
-        key.clone(),
-        &[],
-        None,
-        None,
-        Some(JSString::from("get")),
-    );
+    let getter =
+        create_builtin_function(test_getter, false, 0_f64, key.clone(), &[], None, None, Some(JSString::from("get")));
     let initial = PotentialPropertyDescriptor {
         get: Some(ECMAScriptValue::from(getter)),
         enumerable: Some(true),
@@ -1424,11 +1404,10 @@ fn ordinary_get_06() {
         ..Default::default()
     };
     // GETTER ON PARENT
-    define_property_or_throw(&agent, &parent, key.clone(), initial).unwrap();
-    let child = ordinary_object_create(&agent, Some(parent), &[]);
+    define_property_or_throw(&parent, key.clone(), initial).unwrap();
+    let child = ordinary_object_create(Some(parent), &[]);
     // RESULT VALUE ON CHILD
     define_property_or_throw(
-        &agent,
         &child,
         PropertyKey::from("result"),
         PotentialPropertyDescriptor {
@@ -1443,14 +1422,14 @@ fn ordinary_get_06() {
 
     // THEREFORE:
     //    child.a == "sentinel value"
-    let result = ordinary_get(&agent, &child, &key, &ECMAScriptValue::from(child.clone())).unwrap();
+    let result = ordinary_get(&child, &key, &ECMAScriptValue::from(child.clone())).unwrap();
     assert_eq!(result, ECMAScriptValue::from("sentinel value"));
 }
 #[test]
 fn ordinary_get_07() {
     // Accessor properties undefined
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
     let initial = PotentialPropertyDescriptor {
         get: Some(ECMAScriptValue::Undefined),
@@ -1458,9 +1437,9 @@ fn ordinary_get_07() {
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&agent, &obj, key.clone(), initial).unwrap();
+    define_property_or_throw(&obj, key.clone(), initial).unwrap();
 
-    let result = ordinary_get(&agent, &obj, &key, &ECMAScriptValue::from(obj.clone())).unwrap();
+    let result = ordinary_get(&obj, &key, &ECMAScriptValue::from(obj.clone())).unwrap();
     assert_eq!(result, ECMAScriptValue::Undefined);
 }
 
@@ -1468,26 +1447,26 @@ fn ordinary_get_07() {
 fn ordinary_set_01() {
     // [[GetOwnProperty]] throws
     setup_test_agent();
-    let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
+    let obj = TestObject::object(&[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
     let receiver = ECMAScriptValue::from(obj.clone());
 
-    let result = ordinary_set(&agent, &obj, key, value, &receiver).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "[[GetOwnProperty]] called on TestObject");
+    let result = ordinary_set(&obj, key, value, &receiver).unwrap_err();
+    assert_eq!(unwind_type_error(result), "[[GetOwnProperty]] called on TestObject");
 }
 #[test]
 fn ordinary_set_02() {
     // success
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from("test sentinel");
     let receiver = ECMAScriptValue::from(obj.clone());
 
-    let result = ordinary_set(&agent, &obj, key.clone(), value.clone(), &receiver).unwrap();
+    let result = ordinary_set(&obj, key.clone(), value.clone(), &receiver).unwrap();
     assert!(result);
-    let item = get(&agent, &obj, &key).unwrap();
+    let item = get(&obj, &key).unwrap();
     assert_eq!(item, value);
 }
 
@@ -1495,32 +1474,30 @@ fn ordinary_set_02() {
 fn ordinary_set_with_own_descriptor_01() {
     // [[GetPrototypeOf]] throws
     setup_test_agent();
-    let obj = TestObject::object(&agent, &[FunctionId::GetPrototypeOf]);
+    let obj = TestObject::object(&[FunctionId::GetPrototypeOf]);
     let key = PropertyKey::from("a");
 
-    let result =
-        ordinary_set_with_own_descriptor(&agent, &obj, key, ECMAScriptValue::Undefined, &ECMAScriptValue::Null, None)
-            .unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "[[GetPrototypeOf]] called on TestObject");
+    let result = ordinary_set_with_own_descriptor(&obj, key, ECMAScriptValue::Undefined, &ECMAScriptValue::Null, None)
+        .unwrap_err();
+    assert_eq!(unwind_type_error(result), "[[GetPrototypeOf]] called on TestObject");
 }
 #[test]
 fn ordinary_set_with_own_descriptor_02() {
     // If ownDesc is None, call [[Set]] on the parent. (We check by having the parent throw when we call its [[Set]].)
     setup_test_agent();
-    let parent = TestObject::object(&agent, &[FunctionId::Set(None)]);
-    let obj = ordinary_object_create(&agent, Some(parent), &[]);
+    let parent = TestObject::object(&[FunctionId::Set(None)]);
+    let obj = ordinary_object_create(Some(parent), &[]);
     let key = PropertyKey::from("a");
 
-    let result =
-        ordinary_set_with_own_descriptor(&agent, &obj, key, ECMAScriptValue::Undefined, &ECMAScriptValue::Null, None)
-            .unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "[[Set]] called on TestObject");
+    let result = ordinary_set_with_own_descriptor(&obj, key, ECMAScriptValue::Undefined, &ECMAScriptValue::Null, None)
+        .unwrap_err();
+    assert_eq!(unwind_type_error(result), "[[Set]] called on TestObject");
 }
 #[test]
 fn ordinary_set_with_own_descriptor_03() {
     // ownDesc has writable:false; function should return false.
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let own_desc = PropertyDescriptor {
         property: PropertyKind::Data(DataProperty { writable: false, value: ECMAScriptValue::Undefined }),
         enumerable: true,
@@ -1531,60 +1508,51 @@ fn ordinary_set_with_own_descriptor_03() {
     let value = ECMAScriptValue::Undefined;
     let receiver = ECMAScriptValue::from(obj.clone());
 
-    let result = ordinary_set_with_own_descriptor(&agent, &obj, key, value, &receiver, Some(own_desc)).unwrap();
+    let result = ordinary_set_with_own_descriptor(&obj, key, value, &receiver, Some(own_desc)).unwrap();
     assert!(!result);
 }
 #[test]
 fn ordinary_set_with_own_descriptor_04() {
     // Type(receiver) is not object -> return false
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
     let receiver = ECMAScriptValue::from(999);
 
-    let result = ordinary_set_with_own_descriptor(&agent, &obj, key, value, &receiver, None).unwrap();
+    let result = ordinary_set_with_own_descriptor(&obj, key, value, &receiver, None).unwrap();
     assert!(!result);
 }
 #[test]
 fn ordinary_set_with_own_descriptor_05() {
     // receiver.[[GetOwnProperty]] throws
     setup_test_agent();
-    let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
+    let obj = TestObject::object(&[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
     let receiver = ECMAScriptValue::from(obj.clone());
 
-    let result = ordinary_set_with_own_descriptor(&agent, &obj, key, value, &receiver, None).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "[[GetOwnProperty]] called on TestObject");
+    let result = ordinary_set_with_own_descriptor(&obj, key, value, &receiver, None).unwrap_err();
+    assert_eq!(unwind_type_error(result), "[[GetOwnProperty]] called on TestObject");
 }
 #[test]
 fn ordinary_set_with_own_descriptor_06() {
     // existing is an accessor
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
     let receiver = ECMAScriptValue::from(obj.clone());
-    create_data_property(&agent, &obj, PropertyKey::from("result"), ECMAScriptValue::from("sentinel value")).unwrap();
-    let getter = create_builtin_function(
-        &agent,
-        test_getter,
-        false,
-        0_f64,
-        key.clone(),
-        &[],
-        None,
-        None,
-        Some(JSString::from("get")),
-    );
+    create_data_property(&obj, PropertyKey::from("result"), ECMAScriptValue::from("sentinel value")).unwrap();
+    let getter =
+        create_builtin_function(test_getter, false, 0_f64, key.clone(), &[], None, None, Some(JSString::from("get")));
     let accessor_prop = PotentialPropertyDescriptor {
         get: Some(ECMAScriptValue::from(getter)),
         enumerable: Some(true),
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&agent, &obj, key.clone(), accessor_prop).unwrap();
+    define_property_or_throw(&obj, key.clone(), accessor_prop).unwrap();
     let own_desc = PropertyDescriptor {
         property: PropertyKind::Data(DataProperty { writable: true, value: ECMAScriptValue::Undefined }),
         enumerable: true,
@@ -1592,14 +1560,14 @@ fn ordinary_set_with_own_descriptor_06() {
         spot: 0,
     };
 
-    let result = ordinary_set_with_own_descriptor(&agent, &obj, key, value, &receiver, Some(own_desc)).unwrap();
+    let result = ordinary_set_with_own_descriptor(&obj, key, value, &receiver, Some(own_desc)).unwrap();
     assert!(!result);
 }
 #[test]
 fn ordinary_set_with_own_descriptor_07() {
     // existing is read-only
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
     let receiver = ECMAScriptValue::from(obj.clone());
@@ -1610,7 +1578,7 @@ fn ordinary_set_with_own_descriptor_07() {
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&agent, &obj, key.clone(), readonly).unwrap();
+    define_property_or_throw(&obj, key.clone(), readonly).unwrap();
     let own_desc = PropertyDescriptor {
         property: PropertyKind::Data(DataProperty { writable: true, value: ECMAScriptValue::Undefined }),
         enumerable: true,
@@ -1618,14 +1586,14 @@ fn ordinary_set_with_own_descriptor_07() {
         spot: 0,
     };
 
-    let result = ordinary_set_with_own_descriptor(&agent, &obj, key, value, &receiver, Some(own_desc)).unwrap();
+    let result = ordinary_set_with_own_descriptor(&obj, key, value, &receiver, Some(own_desc)).unwrap();
     assert!(!result);
 }
 #[test]
 fn ordinary_set_with_own_descriptor_08() {
     // existing exists
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
     let receiver = ECMAScriptValue::from(obj.clone());
@@ -1636,7 +1604,7 @@ fn ordinary_set_with_own_descriptor_08() {
         configurable: Some(true),
         ..Default::default()
     };
-    define_property_or_throw(&agent, &obj, key.clone(), previously).unwrap();
+    define_property_or_throw(&obj, key.clone(), previously).unwrap();
     let own_desc = PropertyDescriptor {
         property: PropertyKind::Data(DataProperty { writable: true, value: ECMAScriptValue::from(0) }),
         enumerable: true,
@@ -1644,18 +1612,17 @@ fn ordinary_set_with_own_descriptor_08() {
         spot: 0,
     };
 
-    let result =
-        ordinary_set_with_own_descriptor(&agent, &obj, key.clone(), value.clone(), &receiver, Some(own_desc)).unwrap();
+    let result = ordinary_set_with_own_descriptor(&obj, key.clone(), value.clone(), &receiver, Some(own_desc)).unwrap();
     assert!(result);
 
-    let item = get(&agent, &obj, &key).unwrap();
+    let item = get(&obj, &key).unwrap();
     assert_eq!(item, value);
 }
 #[test]
 fn ordinary_set_with_own_descriptor_09() {
     // existing does not exist
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from("test sentinel");
     let receiver = ECMAScriptValue::from(obj.clone());
@@ -1666,48 +1633,37 @@ fn ordinary_set_with_own_descriptor_09() {
         spot: 0,
     };
 
-    let result =
-        ordinary_set_with_own_descriptor(&agent, &obj, key.clone(), value.clone(), &receiver, Some(own_desc)).unwrap();
+    let result = ordinary_set_with_own_descriptor(&obj, key.clone(), value.clone(), &receiver, Some(own_desc)).unwrap();
     assert!(result);
 
-    let item = get(&agent, &obj, &key).unwrap();
+    let item = get(&obj, &key).unwrap();
     assert_eq!(item, value);
 }
 fn test_setter(
-    agent: &Agent,
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
     // This is a setter; it is essentially:
     // function(val) { this.value = val; }
-    let obj = to_object(agent, this_value)?;
+    let obj = to_object(this_value)?;
     let key = PropertyKey::from("result");
     let mut args = arguments.iter();
     let val = args.next().cloned().unwrap_or(ECMAScriptValue::Undefined);
-    set(agent, &obj, key, val, true)?;
+    set(&obj, key, val, true)?;
     Ok(ECMAScriptValue::Undefined)
 }
 #[test]
 fn ordinary_set_with_own_descriptor_10() {
     // own_desc is an accessor descriptor, with the above setter function
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from("test sentinel");
     let receiver = ECMAScriptValue::from(obj.clone());
-    create_data_property(&agent, &obj, PropertyKey::from("result"), ECMAScriptValue::from("initial value")).unwrap();
-    let setter = create_builtin_function(
-        &agent,
-        test_setter,
-        false,
-        1_f64,
-        key.clone(),
-        &[],
-        None,
-        None,
-        Some(JSString::from("set")),
-    );
+    create_data_property(&obj, PropertyKey::from("result"), ECMAScriptValue::from("initial value")).unwrap();
+    let setter =
+        create_builtin_function(test_setter, false, 1_f64, key.clone(), &[], None, None, Some(JSString::from("set")));
     let accessor_prop = PropertyDescriptor {
         property: PropertyKind::Accessor(AccessorProperty {
             get: ECMAScriptValue::Undefined,
@@ -1718,22 +1674,21 @@ fn ordinary_set_with_own_descriptor_10() {
         spot: 0,
     };
 
-    let result =
-        ordinary_set_with_own_descriptor(&agent, &obj, key, value.clone(), &receiver, Some(accessor_prop)).unwrap();
+    let result = ordinary_set_with_own_descriptor(&obj, key, value.clone(), &receiver, Some(accessor_prop)).unwrap();
     assert!(result);
 
-    let item = get(&agent, &obj, &PropertyKey::from("result")).unwrap();
+    let item = get(&obj, &PropertyKey::from("result")).unwrap();
     assert_eq!(item, value);
 }
 #[test]
 fn ordinary_set_with_own_descriptor_11() {
     // own_desc is an accessor descriptor, with a setter function that throws
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from("test sentinel");
     let receiver = ECMAScriptValue::from(obj.clone());
-    let setter = agent.intrinsic(IntrinsicId::ThrowTypeError);
+    let setter = intrinsic(IntrinsicId::ThrowTypeError);
     let accessor_prop = PropertyDescriptor {
         property: PropertyKind::Accessor(AccessorProperty {
             get: ECMAScriptValue::Undefined,
@@ -1744,15 +1699,14 @@ fn ordinary_set_with_own_descriptor_11() {
         spot: 0,
     };
 
-    let result =
-        ordinary_set_with_own_descriptor(&agent, &obj, key, value, &receiver, Some(accessor_prop)).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Generic TypeError");
+    let result = ordinary_set_with_own_descriptor(&obj, key, value, &receiver, Some(accessor_prop)).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Generic TypeError");
 }
 #[test]
 fn ordinary_set_with_own_descriptor_12() {
     // own_desc is an accessor descriptor, with an undefined setter function
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from("test sentinel");
     let receiver = ECMAScriptValue::from(obj.clone());
@@ -1766,7 +1720,7 @@ fn ordinary_set_with_own_descriptor_12() {
         spot: 0,
     };
 
-    let result = ordinary_set_with_own_descriptor(&agent, &obj, key, value, &receiver, Some(accessor_prop)).unwrap();
+    let result = ordinary_set_with_own_descriptor(&obj, key, value, &receiver, Some(accessor_prop)).unwrap();
     assert!(!result);
 }
 
@@ -1774,31 +1728,30 @@ fn ordinary_set_with_own_descriptor_12() {
 fn ordinary_delete_01() {
     // [[GetOwnProperty]] throws
     setup_test_agent();
-    let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
+    let obj = TestObject::object(&[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_delete(&agent, &obj, &key).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "[[GetOwnProperty]] called on TestObject");
+    let result = ordinary_delete(&obj, &key).unwrap_err();
+    assert_eq!(unwind_type_error(result), "[[GetOwnProperty]] called on TestObject");
 }
 #[test]
 fn ordinary_delete_02() {
     // property isn't actually there
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
 
-    let result = ordinary_delete(&agent, &obj, &key).unwrap();
+    let result = ordinary_delete(&obj, &key).unwrap();
     assert!(result);
 }
 #[test]
 fn ordinary_delete_03() {
     // property isn't configurable
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from(0);
     define_property_or_throw(
-        &agent,
         &obj,
         key.clone(),
         PotentialPropertyDescriptor {
@@ -1811,30 +1764,30 @@ fn ordinary_delete_03() {
     )
     .unwrap();
 
-    let result = ordinary_delete(&agent, &obj, &key).unwrap();
+    let result = ordinary_delete(&obj, &key).unwrap();
     assert!(!result);
-    let item = get(&agent, &obj, &key).unwrap();
+    let item = get(&obj, &key).unwrap();
     assert_eq!(item, value);
 }
 #[test]
 fn ordinary_delete_04() {
     // property is normal
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from(0);
-    create_data_property(&agent, &obj, key.clone(), value).unwrap();
+    create_data_property(&obj, key.clone(), value).unwrap();
 
-    let result = ordinary_delete(&agent, &obj, &key).unwrap();
+    let result = ordinary_delete(&obj, &key).unwrap();
     assert!(result);
-    let item = get(&agent, &obj, &key).unwrap();
+    let item = get(&obj, &key).unwrap();
     assert_eq!(item, ECMAScriptValue::Undefined);
 }
 
 #[test]
 fn ordinary_own_property_keys_01() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
     let result = ordinary_own_property_keys(&obj);
     assert_eq!(result, &[]);
@@ -1843,18 +1796,18 @@ use crate::values::Symbol;
 #[test]
 fn ordinary_own_property_keys_02() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
-    let sym1 = Symbol::new(&agent, Some(JSString::from("TestSymbol 1")));
-    let sym2 = Symbol::new(&agent, Some(JSString::from("TestSymbol 2")));
-    create_data_property(&agent, &obj, PropertyKey::from(sym1.clone()), ECMAScriptValue::Null).unwrap();
-    create_data_property(&agent, &obj, PropertyKey::from("hillbilly"), ECMAScriptValue::Null).unwrap();
-    create_data_property(&agent, &obj, PropertyKey::from("automobile"), ECMAScriptValue::Null).unwrap();
-    create_data_property(&agent, &obj, PropertyKey::from("888"), ECMAScriptValue::Null).unwrap();
-    create_data_property(&agent, &obj, PropertyKey::from(sym2.clone()), ECMAScriptValue::Null).unwrap();
-    create_data_property(&agent, &obj, PropertyKey::from("1002"), ECMAScriptValue::Null).unwrap();
-    create_data_property(&agent, &obj, PropertyKey::from("green"), ECMAScriptValue::Null).unwrap();
-    create_data_property(&agent, &obj, PropertyKey::from("-1"), ECMAScriptValue::Null).unwrap();
-    create_data_property(&agent, &obj, PropertyKey::from("0"), ECMAScriptValue::Null).unwrap();
+    let obj = ordinary_object_create(None, &[]);
+    let sym1 = Symbol::new(Some(JSString::from("TestSymbol 1")));
+    let sym2 = Symbol::new(Some(JSString::from("TestSymbol 2")));
+    create_data_property(&obj, PropertyKey::from(sym1.clone()), ECMAScriptValue::Null).unwrap();
+    create_data_property(&obj, PropertyKey::from("hillbilly"), ECMAScriptValue::Null).unwrap();
+    create_data_property(&obj, PropertyKey::from("automobile"), ECMAScriptValue::Null).unwrap();
+    create_data_property(&obj, PropertyKey::from("888"), ECMAScriptValue::Null).unwrap();
+    create_data_property(&obj, PropertyKey::from(sym2.clone()), ECMAScriptValue::Null).unwrap();
+    create_data_property(&obj, PropertyKey::from("1002"), ECMAScriptValue::Null).unwrap();
+    create_data_property(&obj, PropertyKey::from("green"), ECMAScriptValue::Null).unwrap();
+    create_data_property(&obj, PropertyKey::from("-1"), ECMAScriptValue::Null).unwrap();
+    create_data_property(&obj, PropertyKey::from("0"), ECMAScriptValue::Null).unwrap();
 
     let result = ordinary_own_property_keys(&obj);
     assert_eq!(
@@ -1886,90 +1839,90 @@ fn array_index_key_02() {
 #[should_panic(expected = "unreachable code")]
 fn array_index_key_03() {
     setup_test_agent();
-    array_index_key(&PropertyKey::from(Symbol::new(&agent, None)));
+    array_index_key(&PropertyKey::from(Symbol::new(None)));
 }
 
 #[test]
 fn object_interface_to_boolean_obj() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
     assert!(obj.o.to_boolean_obj().is_none());
 }
 #[test]
 fn object_interface_to_function_obj() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
     assert!(obj.o.to_function_obj().is_none());
 }
 #[test]
 fn object_interface_to_callable_obj() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
     assert!(obj.o.to_callable_obj().is_none());
 }
 #[test]
 fn object_interface_to_builtin_function_obj() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
     assert!(obj.o.to_builtin_function_obj().is_none());
 }
 #[test]
 fn object_interface_is_arguments_object() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
     assert!(!obj.o.is_arguments_object());
 }
 #[test]
 fn object_interface_is_callable_obj() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
     assert!(!obj.o.is_callable_obj());
 }
 #[test]
 fn object_interface_is_error_object() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
     assert!(!obj.o.is_error_object());
 }
 #[test]
 fn object_interface_is_boolean_object() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
     assert!(!obj.o.is_boolean_object());
 }
 #[test]
 fn object_interface_is_number_object() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
     assert!(!obj.o.is_number_object());
 }
 #[test]
 fn object_interface_is_string_object() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
     assert!(!obj.o.is_string_object());
 }
 #[test]
 fn object_interface_is_date_object() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
     assert!(!obj.o.is_date_object());
 }
 #[test]
 fn object_interface_is_regexp_object() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
     assert!(!obj.o.is_regexp_object());
 }
@@ -1980,7 +1933,7 @@ fn ordinary_object_create_01() {
     setup_test_agent();
 
     // Then requesting a new object with no prototype or extra slots
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
 
     // Gives us the emptiest of all objects
     let data = obj.o.common_object_data().borrow();
@@ -1993,10 +1946,10 @@ fn ordinary_object_create_01() {
 fn ordinary_object_create_02() {
     // When an agent and a prototype are provided
     setup_test_agent();
-    let proto = ordinary_object_create(&agent, None, &[]);
+    let proto = ordinary_object_create(None, &[]);
 
     // Then requesting a new object with that prototype but no extra slots
-    let obj = ordinary_object_create(&agent, Some(proto.clone()), &[]);
+    let obj = ordinary_object_create(Some(proto.clone()), &[]);
 
     // Gives us an empty object with its prototype slot filled.
     let data = obj.o.common_object_data().borrow();
@@ -2010,10 +1963,10 @@ fn ordinary_object_create_02() {
 fn ordinary_object_create_03a() {
     // When an agent and a prototype are provided
     setup_test_agent();
-    let proto = ordinary_object_create(&agent, None, &[]);
+    let proto = ordinary_object_create(None, &[]);
 
     // Then requesting a new object with that prototype and needlessly requesting prototype or extensible slots
-    let obj = ordinary_object_create(&agent, Some(proto.clone()), &[InternalSlotName::Prototype]);
+    let obj = ordinary_object_create(Some(proto.clone()), &[InternalSlotName::Prototype]);
 
     // Gives us an empty object with its prototype slot filled.
     let data = obj.o.common_object_data().borrow();
@@ -2026,10 +1979,10 @@ fn ordinary_object_create_03a() {
 fn ordinary_object_create_03b() {
     // When an agent and a prototype are provided
     setup_test_agent();
-    let proto = ordinary_object_create(&agent, None, &[]);
+    let proto = ordinary_object_create(None, &[]);
 
     // Then requesting a new object with that prototype and needlessly requesting prototype or extensible slots
-    let obj = ordinary_object_create(&agent, Some(proto.clone()), &[InternalSlotName::Extensible]);
+    let obj = ordinary_object_create(Some(proto.clone()), &[InternalSlotName::Extensible]);
 
     // Gives us an empty object with its prototype slot filled.
     let data = obj.o.common_object_data().borrow();
@@ -2042,14 +1995,10 @@ fn ordinary_object_create_03b() {
 fn ordinary_object_create_03c() {
     // When an agent and a prototype are provided
     setup_test_agent();
-    let proto = ordinary_object_create(&agent, None, &[]);
+    let proto = ordinary_object_create(None, &[]);
 
     // Then requesting a new object with that prototype and needlessly requesting prototype or extensible slots
-    let obj = ordinary_object_create(
-        &agent,
-        Some(proto.clone()),
-        &[InternalSlotName::Prototype, InternalSlotName::Extensible],
-    );
+    let obj = ordinary_object_create(Some(proto.clone()), &[InternalSlotName::Prototype, InternalSlotName::Extensible]);
 
     // Gives us an empty object with its prototype slot filled.
     let data = obj.o.common_object_data().borrow();
@@ -2072,23 +2021,23 @@ fn ordinary_object_create_03c() {
 #[test_case(GENERATOR_OBJECT_SLOTS => panics "Additional info needed for generator object; use direct constructor"; "generator obj")]
 fn make_basic_object(slots: &[InternalSlotName]) -> Object {
     setup_test_agent();
-    super::make_basic_object(&agent, slots, None)
+    super::make_basic_object(slots, None)
 }
 
 #[test]
 fn get_prototype_of_01() {
     setup_test_agent();
-    let obj = ordinary_object_create(&test_agent(), None, &[]);
-    let result = obj.o.get_prototype_of(&agent);
+    let obj = ordinary_object_create(None, &[]);
+    let result = obj.o.get_prototype_of();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), None);
 }
 #[test]
 fn get_prototype_of_02() {
     setup_test_agent();
-    let proto = ordinary_object_create(&agent, None, &[]);
-    let obj = ordinary_object_create(&agent, Some(proto.clone()), &[]);
-    let result = obj.o.get_prototype_of(&agent);
+    let proto = ordinary_object_create(None, &[]);
+    let obj = ordinary_object_create(Some(proto.clone()), &[]);
+    let result = obj.o.get_prototype_of();
     assert!(result.is_ok());
     assert_eq!(result.unwrap().as_ref(), Some(&proto));
 }
@@ -2097,8 +2046,8 @@ fn get_prototype_of_02() {
 fn set_prototype_of_01() {
     // Not changing an empty prototype
     setup_test_agent();
-    let obj_a = ordinary_object_create(&agent, None, &[]);
-    let result = obj_a.o.set_prototype_of(&agent, None);
+    let obj_a = ordinary_object_create(None, &[]);
+    let result = obj_a.o.set_prototype_of(None);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), true);
     assert_eq!(obj_a.o.common_object_data().borrow().prototype, None);
@@ -2107,9 +2056,9 @@ fn set_prototype_of_01() {
 fn set_prototype_of_02() {
     // Not changing a Some() prototype
     setup_test_agent();
-    let obj_a = ordinary_object_create(&agent, None, &[]);
-    let obj_b = ordinary_object_create(&agent, Some(obj_a.clone()), &[]);
-    let result = obj_b.o.set_prototype_of(&agent, Some(obj_a.clone()));
+    let obj_a = ordinary_object_create(None, &[]);
+    let obj_b = ordinary_object_create(Some(obj_a.clone()), &[]);
+    let result = obj_b.o.set_prototype_of(Some(obj_a.clone()));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), true);
     assert_eq!(obj_b.o.common_object_data().borrow().prototype.as_ref(), Some(&obj_a));
@@ -2118,10 +2067,10 @@ fn set_prototype_of_02() {
 fn set_prototype_of_03() {
     // Changing a Some() prototype to a different Some() prototype
     setup_test_agent();
-    let proto = ordinary_object_create(&agent, None, &[]);
-    let obj_b = ordinary_object_create(&agent, Some(proto), &[]);
-    let new_proto = ordinary_object_create(&agent, None, &[]);
-    let result = obj_b.o.set_prototype_of(&agent, Some(new_proto.clone()));
+    let proto = ordinary_object_create(None, &[]);
+    let obj_b = ordinary_object_create(Some(proto), &[]);
+    let new_proto = ordinary_object_create(None, &[]);
+    let result = obj_b.o.set_prototype_of(Some(new_proto.clone()));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), true);
     assert_eq!(obj_b.o.common_object_data().borrow().prototype.as_ref(), Some(&new_proto));
@@ -2130,9 +2079,9 @@ fn set_prototype_of_03() {
 fn set_prototype_of_04() {
     // Trying to make a prototype loop
     setup_test_agent();
-    let proto = ordinary_object_create(&agent, None, &[]);
-    let obj_b = ordinary_object_create(&agent, Some(proto.clone()), &[]);
-    let result = proto.o.set_prototype_of(&agent, Some(obj_b));
+    let proto = ordinary_object_create(None, &[]);
+    let obj_b = ordinary_object_create(Some(proto.clone()), &[]);
+    let result = proto.o.set_prototype_of(Some(obj_b));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), false);
     assert_eq!(proto.o.common_object_data().borrow().prototype.as_ref(), None);
@@ -2141,11 +2090,11 @@ fn set_prototype_of_04() {
 fn set_prototype_of_05() {
     // Changing the prototype of an object that's not extensible
     setup_test_agent();
-    let proto = ordinary_object_create(&agent, None, &[]);
-    let obj_b = ordinary_object_create(&agent, Some(proto.clone()), &[]);
+    let proto = ordinary_object_create(None, &[]);
+    let obj_b = ordinary_object_create(Some(proto.clone()), &[]);
     obj_b.o.common_object_data().borrow_mut().extensible = false;
-    let new_proto = ordinary_object_create(&agent, None, &[]);
-    let result = obj_b.o.set_prototype_of(&agent, Some(new_proto));
+    let new_proto = ordinary_object_create(None, &[]);
+    let result = obj_b.o.set_prototype_of(Some(new_proto));
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), false);
     assert_eq!(obj_b.o.common_object_data().borrow().prototype.as_ref(), Some(&proto));
@@ -2154,17 +2103,17 @@ fn set_prototype_of_05() {
 #[test]
 fn is_extensible_01() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
-    let result = obj.o.is_extensible(&agent);
+    let obj = ordinary_object_create(None, &[]);
+    let result = obj.o.is_extensible();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), true);
 }
 #[test]
 fn is_extensible_02() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     obj.o.common_object_data().borrow_mut().extensible = false;
-    let result = obj.o.is_extensible(&agent);
+    let result = obj.o.is_extensible();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), false);
 }
@@ -2172,8 +2121,8 @@ fn is_extensible_02() {
 #[test]
 fn prevent_extensions_01() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
-    let result = obj.o.prevent_extensions(&agent);
+    let obj = ordinary_object_create(None, &[]);
+    let result = obj.o.prevent_extensions();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), true);
     assert_eq!(obj.o.common_object_data().borrow().extensible, false);
@@ -2182,16 +2131,16 @@ fn prevent_extensions_01() {
 #[test]
 fn get_own_property_01() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::String(JSString::from("blue"));
-    let result = obj.o.get_own_property(&agent, &key);
+    let result = obj.o.get_own_property(&key);
     assert!(result.is_ok());
     assert!(result.unwrap().is_none());
 }
 #[test]
 fn get_own_property_02() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::String(JSString::from("blue"));
     let value = ECMAScriptValue::Number(89.0);
     let desc = PotentialPropertyDescriptor {
@@ -2202,9 +2151,9 @@ fn get_own_property_02() {
         get: None,
         set: None,
     };
-    obj.o.define_own_property(&agent, key.clone(), desc).unwrap();
+    obj.o.define_own_property(key.clone(), desc).unwrap();
 
-    let result = obj.o.get_own_property(&agent, &key);
+    let result = obj.o.get_own_property(&key);
     assert!(result.is_ok());
     let maybe_pd = result.unwrap();
     assert!(maybe_pd.is_some());
@@ -2222,12 +2171,12 @@ fn get_own_property_02() {
 fn set_and_get() {
     setup_test_agent();
 
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let key = PropertyKey::String(JSString::from("blue"));
     let value = ECMAScriptValue::Number(56.7);
 
-    set(&agent, &obj, key.clone(), value, false).unwrap();
-    let result = get(&agent, &obj, &key).unwrap();
+    set(&obj, key.clone(), value, false).unwrap();
+    let result = get(&obj, &key).unwrap();
 
     assert_eq!(result, ECMAScriptValue::Number(56.7));
 }
@@ -2238,8 +2187,8 @@ mod private_element_find {
 
     fn setup() -> (Object, Vec<PrivateName>) {
         setup_test_agent();
-        let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
+        let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+        let obj = ordinary_object_create(Some(object_proto), &[]);
 
         let name1 = PrivateName::new("name1");
         let name2 = PrivateName::new("alice");
@@ -2293,9 +2242,9 @@ mod private_field_add {
     use super::*;
     use test_case::test_case;
 
-    fn setup(agent: &Agent) -> (Object, Vec<PrivateName>) {
-        let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let obj = ordinary_object_create(agent, Some(object_proto), &[]);
+    fn setup() -> (Object, Vec<PrivateName>) {
+        let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+        let obj = ordinary_object_create(Some(object_proto), &[]);
 
         let name1 = PrivateName::new("name1");
         let name2 = PrivateName::new("alice");
@@ -2324,9 +2273,9 @@ mod private_field_add {
     #[test_case(PrivateName::new("orange") => (true, Some(ECMAScriptValue::Null)); "orange")]
     fn normal(name: PrivateName) -> (bool, Option<ECMAScriptValue>) {
         setup_test_agent();
-        let (obj, _) = setup(&agent);
+        let (obj, _) = setup();
 
-        let result = private_field_add(&agent, &obj, name.clone(), ECMAScriptValue::Null);
+        let result = private_field_add(&obj, name.clone(), ECMAScriptValue::Null);
 
         (
             result.is_ok(),
@@ -2344,10 +2293,10 @@ mod private_field_add {
     #[test_case(2; "last")]
     fn previously_added(idx: usize) {
         setup_test_agent();
-        let (obj, names) = setup(&agent);
+        let (obj, names) = setup();
 
-        let result = private_field_add(&agent, &obj, names[idx].clone(), ECMAScriptValue::Null).unwrap_err();
-        assert_eq!(unwind_type_error(&agent, result), "PrivateName already defined");
+        let result = private_field_add(&obj, names[idx].clone(), ECMAScriptValue::Null).unwrap_err();
+        assert_eq!(unwind_type_error(result), "PrivateName already defined");
     }
 }
 
@@ -2355,9 +2304,9 @@ mod private_method_or_accessor_add {
     use super::*;
     //use test_case::test_case;
 
-    fn setup(agent: &Agent) -> (Object, PrivateName) {
-        let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let obj = ordinary_object_create(agent, Some(object_proto), &[]);
+    fn setup() -> (Object, PrivateName) {
+        let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+        let obj = ordinary_object_create(Some(object_proto), &[]);
 
         let name = PrivateName::new("name1");
 
@@ -2374,14 +2323,14 @@ mod private_method_or_accessor_add {
     #[test]
     fn add() {
         setup_test_agent();
-        let (obj, _) = setup(&agent);
+        let (obj, _) = setup();
         let key = PrivateName::new("orange");
         let method = Rc::new(PrivateElement {
             key: key.clone(),
             kind: PrivateElementKind::Method { value: ECMAScriptValue::from(100) },
         });
 
-        private_method_or_accessor_add(&agent, &obj, method).unwrap();
+        private_method_or_accessor_add(&obj, method).unwrap();
         let x = private_element_find(&obj, &key).map(|pe| match &pe.kind {
             PrivateElementKind::Method { value } => value.clone(),
             _ => {
@@ -2394,12 +2343,12 @@ mod private_method_or_accessor_add {
     #[test]
     fn replace() {
         setup_test_agent();
-        let (obj, key) = setup(&agent);
+        let (obj, key) = setup();
         let method =
             Rc::new(PrivateElement { key, kind: PrivateElementKind::Method { value: ECMAScriptValue::from(100) } });
 
-        let err = private_method_or_accessor_add(&agent, &obj, method).unwrap_err();
-        assert_eq!(unwind_type_error(&agent, err), "PrivateName already defined");
+        let err = private_method_or_accessor_add(&obj, method).unwrap_err();
+        assert_eq!(unwind_type_error(err), "PrivateName already defined");
     }
 }
 
@@ -2407,23 +2356,22 @@ mod private_get {
     use super::*;
     use test_case::test_case;
 
-    fn setup(agent: &Agent) -> (Object, PrivateName, PrivateName, PrivateName, PrivateName) {
-        let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let obj = ordinary_object_create(agent, Some(object_proto), &[]);
+    fn setup() -> (Object, PrivateName, PrivateName, PrivateName, PrivateName) {
+        let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+        let obj = ordinary_object_create(Some(object_proto), &[]);
 
         let field_name = PrivateName::new("field");
         let method_name = PrivateName::new("method");
         let getter_name = PrivateName::new("getter");
         let nogetter_name = PrivateName::new("nogetter");
 
-        private_field_add(agent, &obj, field_name.clone(), ECMAScriptValue::from("FIELD")).unwrap();
+        private_field_add(&obj, field_name.clone(), ECMAScriptValue::from("FIELD")).unwrap();
         let method = PrivateElement {
             key: method_name.clone(),
             kind: PrivateElementKind::Method { value: ECMAScriptValue::from("METHOD") },
         };
-        private_method_or_accessor_add(agent, &obj, Rc::new(method)).unwrap();
+        private_method_or_accessor_add(&obj, Rc::new(method)).unwrap();
         let getter_method = create_builtin_function(
-            agent,
             test_getter,
             false,
             0_f64,
@@ -2437,9 +2385,8 @@ mod private_get {
             key: getter_name.clone(),
             kind: PrivateElementKind::Accessor { get: Some(getter_method), set: None },
         };
-        private_method_or_accessor_add(agent, &obj, Rc::new(getter)).unwrap();
+        private_method_or_accessor_add(&obj, Rc::new(getter)).unwrap();
         define_property_or_throw(
-            agent,
             &obj,
             PropertyKey::from("result"),
             PotentialPropertyDescriptor {
@@ -2453,7 +2400,7 @@ mod private_get {
         .unwrap();
         let nogetter =
             PrivateElement { key: nogetter_name.clone(), kind: PrivateElementKind::Accessor { get: None, set: None } };
-        private_method_or_accessor_add(agent, &obj, Rc::new(nogetter)).unwrap();
+        private_method_or_accessor_add(&obj, Rc::new(nogetter)).unwrap();
 
         (obj, field_name, method_name, getter_name, nogetter_name)
     }
@@ -2472,7 +2419,7 @@ mod private_get {
     #[test_case(FieldName::Unavailable => Err(String::from("PrivateName not defined")); "undefined")]
     fn f(field: FieldName) -> Result<ECMAScriptValue, String> {
         setup_test_agent();
-        let (obj, field_name, method_name, getter_name, nogetter_name) = setup(&agent);
+        let (obj, field_name, method_name, getter_name, nogetter_name) = setup();
 
         let query = match field {
             FieldName::Field => field_name,
@@ -2481,7 +2428,7 @@ mod private_get {
             FieldName::NoGetter => nogetter_name,
             FieldName::Unavailable => PrivateName::new("unavailable"),
         };
-        private_get(&agent, &obj, &query).map_err(|e| unwind_type_error(&agent, e))
+        private_get(&obj, &query).map_err(|e| unwind_type_error(e))
     }
 }
 
@@ -2489,23 +2436,22 @@ mod private_set {
     use super::*;
     use test_case::test_case;
 
-    fn setup(agent: &Agent) -> (Object, PrivateName, PrivateName, PrivateName, PrivateName) {
-        let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let obj = ordinary_object_create(agent, Some(object_proto), &[]);
+    fn setup() -> (Object, PrivateName, PrivateName, PrivateName, PrivateName) {
+        let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+        let obj = ordinary_object_create(Some(object_proto), &[]);
 
         let field_name = PrivateName::new("field");
         let method_name = PrivateName::new("method");
         let setter_name = PrivateName::new("setter");
         let nosetter_name = PrivateName::new("nosetter");
 
-        private_field_add(agent, &obj, field_name.clone(), ECMAScriptValue::from("FIELD")).unwrap();
+        private_field_add(&obj, field_name.clone(), ECMAScriptValue::from("FIELD")).unwrap();
         let method = PrivateElement {
             key: method_name.clone(),
             kind: PrivateElementKind::Method { value: ECMAScriptValue::from("METHOD") },
         };
-        private_method_or_accessor_add(agent, &obj, Rc::new(method)).unwrap();
+        private_method_or_accessor_add(&obj, Rc::new(method)).unwrap();
         let getter_method = create_builtin_function(
-            agent,
             test_getter,
             false,
             0_f64,
@@ -2516,7 +2462,6 @@ mod private_set {
             Some(JSString::from("get")),
         );
         let setter_method = create_builtin_function(
-            agent,
             test_setter,
             false,
             1_f64,
@@ -2531,9 +2476,8 @@ mod private_set {
             key: setter_name.clone(),
             kind: PrivateElementKind::Accessor { get: Some(getter_method), set: Some(setter_method) },
         };
-        private_method_or_accessor_add(agent, &obj, Rc::new(setter)).unwrap();
+        private_method_or_accessor_add(&obj, Rc::new(setter)).unwrap();
         define_property_or_throw(
-            agent,
             &obj,
             PropertyKey::from("result"),
             PotentialPropertyDescriptor {
@@ -2547,7 +2491,7 @@ mod private_set {
         .unwrap();
         let nosetter =
             PrivateElement { key: nosetter_name.clone(), kind: PrivateElementKind::Accessor { get: None, set: None } };
-        private_method_or_accessor_add(agent, &obj, Rc::new(nosetter)).unwrap();
+        private_method_or_accessor_add(&obj, Rc::new(nosetter)).unwrap();
 
         (obj, field_name, method_name, setter_name, nosetter_name)
     }
@@ -2566,7 +2510,7 @@ mod private_set {
     #[test_case(FieldName::Unavailable => Err(String::from("PrivateName not defined")); "undefined")]
     fn f(field: FieldName) -> Result<ECMAScriptValue, String> {
         setup_test_agent();
-        let (obj, field_name, method_name, setter_name, nosetter_name) = setup(&agent);
+        let (obj, field_name, method_name, setter_name, nosetter_name) = setup();
         let new_value = ECMAScriptValue::from("NEW VALUE");
         let query = match field {
             FieldName::Field => field_name,
@@ -2576,9 +2520,9 @@ mod private_set {
             FieldName::Unavailable => PrivateName::new("unavailable"),
         };
 
-        private_set(&agent, &obj, &query, new_value).map_err(|e| unwind_type_error(&agent, e))?;
+        private_set(&obj, &query, new_value).map_err(|e| unwind_type_error(e))?;
 
-        Ok(private_get(&agent, &obj, &query).unwrap())
+        Ok(private_get(&obj, &query).unwrap())
     }
 }
 
@@ -2594,38 +2538,38 @@ mod create_data_property_or_throw {
         #[test]
         fn string() {
             setup_test_agent();
-            let obj = ordinary_object_create(&agent, None, &[]);
+            let obj = ordinary_object_create(None, &[]);
 
-            create_data_property_or_throw(&agent, &obj, "key", "blue").unwrap();
+            create_data_property_or_throw(&obj, "key", "blue").unwrap();
 
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::from("blue"));
+            assert_eq!(get(&obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::from("blue"));
         }
         #[test]
         fn boolean() {
             setup_test_agent();
-            let obj = ordinary_object_create(&agent, None, &[]);
+            let obj = ordinary_object_create(None, &[]);
 
-            create_data_property_or_throw(&agent, &obj, "key", true).unwrap();
+            create_data_property_or_throw(&obj, "key", true).unwrap();
 
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::from(true));
+            assert_eq!(get(&obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::from(true));
         }
         #[test]
         fn value() {
             setup_test_agent();
-            let obj = ordinary_object_create(&agent, None, &[]);
+            let obj = ordinary_object_create(None, &[]);
 
-            create_data_property_or_throw(&agent, &obj, "key", ECMAScriptValue::Null).unwrap();
+            create_data_property_or_throw(&obj, "key", ECMAScriptValue::Null).unwrap();
 
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::Null);
+            assert_eq!(get(&obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::Null);
         }
         #[test]
         fn integer() {
             setup_test_agent();
-            let obj = ordinary_object_create(&agent, None, &[]);
+            let obj = ordinary_object_create(None, &[]);
 
-            create_data_property_or_throw(&agent, &obj, "key", 10).unwrap();
+            create_data_property_or_throw(&obj, "key", 10).unwrap();
 
-            assert_eq!(get(&agent, &obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::from(10));
+            assert_eq!(get(&obj, &PropertyKey::from("key")).unwrap(), ECMAScriptValue::from(10));
         }
     }
 
@@ -2634,42 +2578,42 @@ mod create_data_property_or_throw {
         #[test]
         fn string() {
             setup_test_agent();
-            let obj = ordinary_object_create(&agent, None, &[]);
-            obj.o.prevent_extensions(&agent).unwrap();
+            let obj = ordinary_object_create(None, &[]);
+            obj.o.prevent_extensions().unwrap();
 
-            let err = create_data_property_or_throw(&agent, &obj, "key", "blue").unwrap_err();
+            let err = create_data_property_or_throw(&obj, "key", "blue").unwrap_err();
 
-            assert_eq!(unwind_type_error(&agent, err), "Unable to create data property");
+            assert_eq!(unwind_type_error(err), "Unable to create data property");
         }
         #[test]
         fn boolean() {
             setup_test_agent();
-            let obj = ordinary_object_create(&agent, None, &[]);
-            obj.o.prevent_extensions(&agent).unwrap();
+            let obj = ordinary_object_create(None, &[]);
+            obj.o.prevent_extensions().unwrap();
 
-            let err = create_data_property_or_throw(&agent, &obj, "key", true).unwrap_err();
+            let err = create_data_property_or_throw(&obj, "key", true).unwrap_err();
 
-            assert_eq!(unwind_type_error(&agent, err), "Unable to create data property");
+            assert_eq!(unwind_type_error(err), "Unable to create data property");
         }
         #[test]
         fn value() {
             setup_test_agent();
-            let obj = ordinary_object_create(&agent, None, &[]);
-            obj.o.prevent_extensions(&agent).unwrap();
+            let obj = ordinary_object_create(None, &[]);
+            obj.o.prevent_extensions().unwrap();
 
-            let err = create_data_property_or_throw(&agent, &obj, "key", ECMAScriptValue::Null).unwrap_err();
+            let err = create_data_property_or_throw(&obj, "key", ECMAScriptValue::Null).unwrap_err();
 
-            assert_eq!(unwind_type_error(&agent, err), "Unable to create data property");
+            assert_eq!(unwind_type_error(err), "Unable to create data property");
         }
         #[test]
         fn integer() {
             setup_test_agent();
-            let obj = ordinary_object_create(&agent, None, &[]);
-            obj.o.prevent_extensions(&agent).unwrap();
+            let obj = ordinary_object_create(None, &[]);
+            obj.o.prevent_extensions().unwrap();
 
-            let err = create_data_property_or_throw(&agent, &obj, "key", 10).unwrap_err();
+            let err = create_data_property_or_throw(&obj, "key", 10).unwrap_err();
 
-            assert_eq!(unwind_type_error(&agent, err), "Unable to create data property");
+            assert_eq!(unwind_type_error(err), "Unable to create data property");
         }
     }
 
@@ -2678,38 +2622,38 @@ mod create_data_property_or_throw {
         #[test]
         fn string() {
             setup_test_agent();
-            let obj = TestObject::object(&agent, &[FunctionId::DefineOwnProperty(None)]);
+            let obj = TestObject::object(&[FunctionId::DefineOwnProperty(None)]);
 
-            let err = create_data_property_or_throw(&agent, &obj, "key", "blue").unwrap_err();
+            let err = create_data_property_or_throw(&obj, "key", "blue").unwrap_err();
 
-            assert_eq!(unwind_type_error(&agent, err), "[[DefineOwnProperty]] called on TestObject");
+            assert_eq!(unwind_type_error(err), "[[DefineOwnProperty]] called on TestObject");
         }
         #[test]
         fn boolean() {
             setup_test_agent();
-            let obj = TestObject::object(&agent, &[FunctionId::DefineOwnProperty(None)]);
+            let obj = TestObject::object(&[FunctionId::DefineOwnProperty(None)]);
 
-            let err = create_data_property_or_throw(&agent, &obj, "key", true).unwrap_err();
+            let err = create_data_property_or_throw(&obj, "key", true).unwrap_err();
 
-            assert_eq!(unwind_type_error(&agent, err), "[[DefineOwnProperty]] called on TestObject");
+            assert_eq!(unwind_type_error(err), "[[DefineOwnProperty]] called on TestObject");
         }
         #[test]
         fn value() {
             setup_test_agent();
-            let obj = TestObject::object(&agent, &[FunctionId::DefineOwnProperty(None)]);
+            let obj = TestObject::object(&[FunctionId::DefineOwnProperty(None)]);
 
-            let err = create_data_property_or_throw(&agent, &obj, "key", ECMAScriptValue::Null).unwrap_err();
+            let err = create_data_property_or_throw(&obj, "key", ECMAScriptValue::Null).unwrap_err();
 
-            assert_eq!(unwind_type_error(&agent, err), "[[DefineOwnProperty]] called on TestObject");
+            assert_eq!(unwind_type_error(err), "[[DefineOwnProperty]] called on TestObject");
         }
         #[test]
         fn integer() {
             setup_test_agent();
-            let obj = TestObject::object(&agent, &[FunctionId::DefineOwnProperty(None)]);
+            let obj = TestObject::object(&[FunctionId::DefineOwnProperty(None)]);
 
-            let err = create_data_property_or_throw(&agent, &obj, "key", 10).unwrap_err();
+            let err = create_data_property_or_throw(&obj, "key", 10).unwrap_err();
 
-            assert_eq!(unwind_type_error(&agent, err), "[[DefineOwnProperty]] called on TestObject");
+            assert_eq!(unwind_type_error(err), "[[DefineOwnProperty]] called on TestObject");
         }
     }
 }
@@ -2718,10 +2662,10 @@ mod from_property_descriptor {
     use super::*;
     use test_case::test_case;
 
-    fn maybeprop(agent: &Agent, obj: &Object, key: impl Into<PropertyKey>) -> Option<ECMAScriptValue> {
+    fn maybeprop(obj: &Object, key: impl Into<PropertyKey>) -> Option<ECMAScriptValue> {
         let key = key.into();
-        if has_property(agent, obj, &key).unwrap() {
-            Some(get(agent, obj, &key).unwrap())
+        if has_property(obj, &key).unwrap() {
+            Some(get(obj, &key).unwrap())
         } else {
             None
         }
@@ -2766,13 +2710,13 @@ mod from_property_descriptor {
     }); "standard accessor")]
     fn happy(pd: Option<PropertyDescriptor>) -> Option<TestResult> {
         setup_test_agent();
-        from_property_descriptor(&agent, pd).map(|o| TestResult {
-            value: maybeprop(&agent, &o, "value"),
-            writable: maybeprop(&agent, &o, "writable"),
-            get: maybeprop(&agent, &o, "get"),
-            set: maybeprop(&agent, &o, "set"),
-            enumerable: maybeprop(&agent, &o, "enumerable").unwrap(),
-            configurable: maybeprop(&agent, &o, "configurable").unwrap(),
+        from_property_descriptor(pd).map(|o| TestResult {
+            value: maybeprop(&o, "value"),
+            writable: maybeprop(&o, "writable"),
+            get: maybeprop(&o, "get"),
+            set: maybeprop(&o, "set"),
+            enumerable: maybeprop(&o, "enumerable").unwrap(),
+            configurable: maybeprop(&o, "configurable").unwrap(),
         })
     }
 }
@@ -2781,30 +2725,29 @@ mod to_property_descriptor {
     use super::*;
     use test_case::test_case;
 
-    fn happy_data(agent: &Agent) -> ECMAScriptValue {
-        let obj = ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
-        create_data_property_or_throw(agent, &obj, "value", "blue").unwrap();
-        create_data_property_or_throw(agent, &obj, "writable", true).unwrap();
-        create_data_property_or_throw(agent, &obj, "enumerable", true).unwrap();
-        create_data_property_or_throw(agent, &obj, "configurable", true).unwrap();
+    fn happy_data() -> ECMAScriptValue {
+        let obj = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+        create_data_property_or_throw(&obj, "value", "blue").unwrap();
+        create_data_property_or_throw(&obj, "writable", true).unwrap();
+        create_data_property_or_throw(&obj, "enumerable", true).unwrap();
+        create_data_property_or_throw(&obj, "configurable", true).unwrap();
         ECMAScriptValue::from(obj)
     }
-    fn fcn_data(agent: &Agent) -> ECMAScriptValue {
-        let obj = ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
-        create_data_property_or_throw(agent, &obj, "get", ECMAScriptValue::Undefined).unwrap();
-        create_data_property_or_throw(agent, &obj, "set", ECMAScriptValue::Undefined).unwrap();
-        create_data_property_or_throw(agent, &obj, "enumerable", true).unwrap();
-        create_data_property_or_throw(agent, &obj, "configurable", true).unwrap();
+    fn fcn_data() -> ECMAScriptValue {
+        let obj = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+        create_data_property_or_throw(&obj, "get", ECMAScriptValue::Undefined).unwrap();
+        create_data_property_or_throw(&obj, "set", ECMAScriptValue::Undefined).unwrap();
+        create_data_property_or_throw(&obj, "enumerable", true).unwrap();
+        create_data_property_or_throw(&obj, "configurable", true).unwrap();
         ECMAScriptValue::from(obj)
     }
 
     fn faux_errors(
-        agent: &Agent,
         _this_value: ECMAScriptValue,
         _new_target: Option<&Object>,
         _arguments: &[ECMAScriptValue],
     ) -> Completion<ECMAScriptValue> {
-        Err(create_type_error(agent, "Test Sentinel"))
+        Err(create_type_error("Test Sentinel"))
     }
 
     #[test_case(happy_data => PotentialPropertyDescriptor {
@@ -2823,24 +2766,23 @@ mod to_property_descriptor {
         enumerable: Some(true),
         configurable: Some(true),
     }; "normal accessor")]
-    fn happy(create_input: fn(&Agent) -> ECMAScriptValue) -> PotentialPropertyDescriptor {
+    fn happy(create_input: fn() -> ECMAScriptValue) -> PotentialPropertyDescriptor {
         setup_test_agent();
-        let input = create_input(&agent);
-        let result = to_property_descriptor(&agent, &input);
+        let input = create_input();
+        let result = to_property_descriptor(&input);
         result.unwrap()
     }
 
-    fn create_hasprop_error(agent: &Agent, name: &str) -> ECMAScriptValue {
-        ECMAScriptValue::from(TestObject::object(agent, &[FunctionId::GetOwnProperty(Some(PropertyKey::from(name)))]))
+    fn create_hasprop_error(name: &str) -> ECMAScriptValue {
+        ECMAScriptValue::from(TestObject::object(&[FunctionId::GetOwnProperty(Some(PropertyKey::from(name)))]))
     }
-    fn create_getter_error(agent: &Agent, name: &str) -> ECMAScriptValue {
+    fn create_getter_error(name: &str) -> ECMAScriptValue {
         let realm = agent.current_realm_record().unwrap();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let obj = ordinary_object_create(agent, Some(object_prototype), &[]);
-        let function_proto = agent.intrinsic(IntrinsicId::FunctionPrototype);
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let obj = ordinary_object_create(Some(object_prototype), &[]);
+        let function_proto = intrinsic(IntrinsicId::FunctionPrototype);
         let key = PropertyKey::from(name);
         let getter = create_builtin_function(
-            agent,
             faux_errors,
             false,
             0_f64,
@@ -2856,35 +2798,35 @@ mod to_property_descriptor {
             get: Some(ECMAScriptValue::from(getter)),
             ..Default::default()
         };
-        define_property_or_throw(agent, &obj, key, desc).unwrap();
+        define_property_or_throw(&obj, key, desc).unwrap();
         ECMAScriptValue::from(obj)
     }
-    fn create_nonfcn(agent: &Agent, name: &str) -> ECMAScriptValue {
-        let obj = ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
-        create_data_property_or_throw(agent, &obj, name, name).unwrap();
+    fn create_nonfcn(name: &str) -> ECMAScriptValue {
+        let obj = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+        create_data_property_or_throw(&obj, name, name).unwrap();
         ECMAScriptValue::from(obj)
     }
 
-    #[test_case(|_| ECMAScriptValue::Undefined => "Must be an object"; "non-object")]
-    #[test_case(|a| create_hasprop_error(a, "enumerable") => "[[GetOwnProperty]] called on TestObject"; "enumerable has_property throws")]
-    #[test_case(|a| create_hasprop_error(a, "configurable") => "[[GetOwnProperty]] called on TestObject"; "configurable has_property throws")]
-    #[test_case(|a| create_hasprop_error(a, "value") => "[[GetOwnProperty]] called on TestObject"; "value has_property throws")]
-    #[test_case(|a| create_hasprop_error(a, "writable") => "[[GetOwnProperty]] called on TestObject"; "writable has_property throws")]
-    #[test_case(|a| create_hasprop_error(a, "get") => "[[GetOwnProperty]] called on TestObject"; "get has_property throws")]
-    #[test_case(|a| create_hasprop_error(a, "set") => "[[GetOwnProperty]] called on TestObject"; "set has_property throws")]
-    #[test_case(|a| create_getter_error(a, "enumerable") => "Test Sentinel"; "enumerable getter throws")]
-    #[test_case(|a| create_getter_error(a, "configurable") => "Test Sentinel"; "configurable getter throws")]
-    #[test_case(|a| create_getter_error(a, "value") => "Test Sentinel"; "value getter throws")]
-    #[test_case(|a| create_getter_error(a, "writable") => "Test Sentinel"; "writable getter throws")]
-    #[test_case(|a| create_getter_error(a, "get") => "Test Sentinel"; "get getter throws")]
-    #[test_case(|a| create_getter_error(a, "set") => "Test Sentinel"; "set getter throws")]
-    #[test_case(|a| create_nonfcn(a, "get") => "Getter must be callable (or undefined)"; "uncallable getter")]
-    #[test_case(|a| create_nonfcn(a, "set") => "Setter must be callable (or undefined)"; "uncallable setter")]
-    fn error(create_input: fn(&Agent) -> ECMAScriptValue) -> String {
+    #[test_case(|| ECMAScriptValue::Undefined => "Must be an object"; "non-object")]
+    #[test_case(|| create_hasprop_error("enumerable") => "[[GetOwnProperty]] called on TestObject"; "enumerable has_property throws")]
+    #[test_case(|| create_hasprop_error("configurable") => "[[GetOwnProperty]] called on TestObject"; "configurable has_property throws")]
+    #[test_case(|| create_hasprop_error("value") => "[[GetOwnProperty]] called on TestObject"; "value has_property throws")]
+    #[test_case(|| create_hasprop_error("writable") => "[[GetOwnProperty]] called on TestObject"; "writable has_property throws")]
+    #[test_case(|| create_hasprop_error("get") => "[[GetOwnProperty]] called on TestObject"; "get has_property throws")]
+    #[test_case(|| create_hasprop_error("set") => "[[GetOwnProperty]] called on TestObject"; "set has_property throws")]
+    #[test_case(|| create_getter_error("enumerable") => "Test Sentinel"; "enumerable getter throws")]
+    #[test_case(|| create_getter_error("configurable") => "Test Sentinel"; "configurable getter throws")]
+    #[test_case(|| create_getter_error("value") => "Test Sentinel"; "value getter throws")]
+    #[test_case(|| create_getter_error("writable") => "Test Sentinel"; "writable getter throws")]
+    #[test_case(|| create_getter_error("get") => "Test Sentinel"; "get getter throws")]
+    #[test_case(|| create_getter_error("set") => "Test Sentinel"; "set getter throws")]
+    #[test_case(|| create_nonfcn("get") => "Getter must be callable (or undefined)"; "uncallable getter")]
+    #[test_case(|| create_nonfcn("set") => "Setter must be callable (or undefined)"; "uncallable setter")]
+    fn error(create_input: fn() -> ECMAScriptValue) -> String {
         setup_test_agent();
-        let input = create_input(&agent);
-        let result = to_property_descriptor(&agent, &input);
-        unwind_type_error(&agent, result.unwrap_err())
+        let input = create_input();
+        let result = to_property_descriptor(&input);
+        unwind_type_error(result.unwrap_err())
     }
 }
 
@@ -2943,7 +2885,7 @@ mod create_array_from_list {
     ]; "some items")]
     fn cafl(items: &[ECMAScriptValue]) -> Vec<PropertyInfo> {
         setup_test_agent();
-        create_array_from_list(&agent, items).o.common_object_data().borrow().propdump()
+        create_array_from_list(items).o.common_object_data().borrow().propdump()
     }
 }
 
@@ -2951,18 +2893,17 @@ mod enumerable_own_property_names {
     use super::*;
     use test_case::test_case;
 
-    fn dead(agent: &Agent) -> Object {
-        DeadObject::object(agent)
+    fn dead() -> Object {
+        DeadObject::object()
     }
-    fn normal(agent: &Agent) -> Object {
-        let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let obj = ordinary_object_create(agent, Some(object_proto), &[]);
-        create_data_property_or_throw(agent, &obj, "one", 1.0).unwrap();
-        create_data_property_or_throw(agent, &obj, "three", 3.0).unwrap();
-        let sym = Symbol::new(agent, Some("two".into()));
-        create_data_property_or_throw(agent, &obj, sym, 2.0).unwrap();
+    fn normal() -> Object {
+        let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+        let obj = ordinary_object_create(Some(object_proto), &[]);
+        create_data_property_or_throw(&obj, "one", 1.0).unwrap();
+        create_data_property_or_throw(&obj, "three", 3.0).unwrap();
+        let sym = Symbol::new(Some("two".into()));
+        create_data_property_or_throw(&obj, sym, 2.0).unwrap();
         define_property_or_throw(
-            agent,
             &obj,
             "hidden",
             PotentialPropertyDescriptor {
@@ -2976,39 +2917,35 @@ mod enumerable_own_property_names {
         .unwrap();
         obj
     }
-    fn gop_override(
-        agent: &Agent,
-        this: &AdaptableObject,
-        key: &PropertyKey,
-    ) -> Completion<Option<PropertyDescriptor>> {
+    fn gop_override(this: &AdaptableObject, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         if this.something.get() == 0 {
             this.something.set(1);
             Ok(ordinary_get_own_property(this, key))
         } else {
-            Err(create_type_error(agent, "[[GetOwnProperty]] called more than once"))
+            Err(create_type_error("[[GetOwnProperty]] called more than once"))
         }
     }
-    fn ownprop(agent: &Agent) -> Object {
-        let obj = AdaptableObject::object(
-            agent,
-            AdaptableMethods { get_own_property_override: Some(gop_override), ..Default::default() },
-        );
-        create_data_property_or_throw(agent, &obj, "one", 1.0).unwrap();
+    fn ownprop() -> Object {
+        let obj = AdaptableObject::object(AdaptableMethods {
+            get_own_property_override: Some(gop_override),
+            ..Default::default()
+        });
+        create_data_property_or_throw(&obj, "one", 1.0).unwrap();
         obj
     }
-    fn getthrows(agent: &Agent) -> Object {
-        let obj = TestObject::object(agent, &[FunctionId::Get(None)]);
-        create_data_property_or_throw(agent, &obj, "one", 1.0).unwrap();
+    fn getthrows() -> Object {
+        let obj = TestObject::object(&[FunctionId::Get(None)]);
+        create_data_property_or_throw(&obj, "one", 1.0).unwrap();
         obj
     }
     fn lying_ownprops(_: &Agent, _: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
         Ok(vec!["one".into(), "two".into(), "three".into()])
     }
-    fn lyingkeys(agent: &Agent) -> Object {
-        AdaptableObject::object(
-            agent,
-            AdaptableMethods { own_property_keys_override: Some(lying_ownprops), ..Default::default() },
-        )
+    fn lyingkeys() -> Object {
+        AdaptableObject::object(AdaptableMethods {
+            own_property_keys_override: Some(lying_ownprops),
+            ..Default::default()
+        })
     }
 
     #[test_case(dead, EnumerationStyle::Key => Err("TypeError: own_property_keys called on DeadObject".to_string()); "own_property_keys throws")]
@@ -3017,24 +2954,24 @@ mod enumerable_own_property_names {
     #[test_case(ownprop, EnumerationStyle::Value => Err("TypeError: [[GetOwnProperty]] called more than once".to_string()); "GetOwnProperty throws")]
     #[test_case(getthrows, EnumerationStyle::Value => Err("TypeError: [[Get]] called on TestObject".to_string()); "get throws")]
     #[test_case(lyingkeys, EnumerationStyle::Value => Ok(Vec::<ECMAScriptValue>::new()); "ownkeys lies")]
-    fn f(make_obj: fn(&Agent) -> Object, kind: EnumerationStyle) -> Result<Vec<ECMAScriptValue>, String> {
+    fn f(make_obj: fn() -> Object, kind: EnumerationStyle) -> Result<Vec<ECMAScriptValue>, String> {
         setup_test_agent();
-        let obj = make_obj(&agent);
-        enumerable_own_property_names(&agent, &obj, kind).map_err(|err| unwind_any_error(&agent, err))
+        let obj = make_obj();
+        enumerable_own_property_names(&obj, kind).map_err(|err| unwind_any_error(err))
     }
 
     #[test]
     fn keyvalue() {
         setup_test_agent();
-        let obj = normal(&agent);
-        let result = enumerable_own_property_names(&agent, &obj, EnumerationStyle::KeyPlusValue).unwrap();
+        let obj = normal();
+        let result = enumerable_own_property_names(&obj, EnumerationStyle::KeyPlusValue).unwrap();
         assert_eq!(result.len(), 2);
-        assert_eq!(getv(&agent, &result[0], &"0".into()).unwrap(), "one".into());
-        assert_eq!(getv(&agent, &result[0], &"1".into()).unwrap(), 1.0.into());
-        assert_eq!(getv(&agent, &result[0], &"length".into()).unwrap(), 2.0.into());
-        assert_eq!(getv(&agent, &result[1], &"0".into()).unwrap(), "three".into());
-        assert_eq!(getv(&agent, &result[1], &"1".into()).unwrap(), 3.0.into());
-        assert_eq!(getv(&agent, &result[1], &"length".into()).unwrap(), 2.0.into());
+        assert_eq!(getv(&result[0], &"0".into()).unwrap(), "one".into());
+        assert_eq!(getv(&result[0], &"1".into()).unwrap(), 1.0.into());
+        assert_eq!(getv(&result[0], &"length".into()).unwrap(), 2.0.into());
+        assert_eq!(getv(&result[1], &"0".into()).unwrap(), "three".into());
+        assert_eq!(getv(&result[1], &"1".into()).unwrap(), 3.0.into());
+        assert_eq!(getv(&result[1], &"length".into()).unwrap(), 2.0.into());
     }
 }
 
@@ -3042,12 +2979,11 @@ mod set_integrity_level {
     use super::*;
     use test_case::test_case;
 
-    fn normal(agent: &Agent) -> Object {
-        let proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let obj = ordinary_object_create(agent, Some(proto), &[]);
-        create_data_property_or_throw(agent, &obj, "property", 67).unwrap();
+    fn normal() -> Object {
+        let proto = intrinsic(IntrinsicId::ObjectPrototype);
+        let obj = ordinary_object_create(Some(proto), &[]);
+        create_data_property_or_throw(&obj, "property", 67).unwrap();
         define_property_or_throw(
-            agent,
             &obj,
             "accessor",
             PotentialPropertyDescriptor {
@@ -3061,64 +2997,57 @@ mod set_integrity_level {
         .unwrap();
         obj
     }
-    fn dead(agent: &Agent) -> Object {
-        DeadObject::object(agent)
+    fn dead() -> Object {
+        DeadObject::object()
     }
-    fn prevention_disabled(agent: &Agent) -> Object {
-        AdaptableObject::object(
-            agent,
-            AdaptableMethods { prevent_extensions_override: Some(|_, _| Ok(false)), ..Default::default() },
-        )
+    fn prevention_disabled() -> Object {
+        AdaptableObject::object(AdaptableMethods {
+            prevent_extensions_override: Some(|_, _| Ok(false)),
+            ..Default::default()
+        })
     }
-    fn opk_throws(agent: &Agent) -> Object {
-        TestObject::object(agent, &[FunctionId::OwnPropertyKeys])
+    fn opk_throws() -> Object {
+        TestObject::object(&[FunctionId::OwnPropertyKeys])
     }
-    fn dop_throws(agent: &Agent) -> Object {
-        let obj = AdaptableObject::object(
-            agent,
-            AdaptableMethods {
-                define_own_property_override: Some(|agent, this, key, desc| {
-                    if this.something.get() == 0 {
-                        this.something.set(1);
-                        ordinary_define_own_property(agent, this, key, desc)
-                    } else {
-                        Err(create_type_error(agent, "Test Sentinel"))
-                    }
-                }),
-                ..Default::default()
-            },
-        );
-        create_data_property_or_throw(agent, &obj, "property", 99.0).unwrap();
+    fn dop_throws() -> Object {
+        let obj = AdaptableObject::object(AdaptableMethods {
+            define_own_property_override: Some(|agent, this, key, desc| {
+                if this.something.get() == 0 {
+                    this.something.set(1);
+                    ordinary_define_own_property(this, key, desc)
+                } else {
+                    Err(create_type_error("Test Sentinel"))
+                }
+            }),
+            ..Default::default()
+        });
+        create_data_property_or_throw(&obj, "property", 99.0).unwrap();
         obj
     }
-    fn gop_override(
-        agent: &Agent,
-        this: &AdaptableObject,
-        key: &PropertyKey,
-    ) -> Completion<Option<PropertyDescriptor>> {
+    fn gop_override(this: &AdaptableObject, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         if this.something.get() == 0 {
             this.something.set(1);
             Ok(ordinary_get_own_property(this, key))
         } else {
-            Err(create_type_error(agent, "[[GetOwnProperty]] called more than once"))
+            Err(create_type_error("[[GetOwnProperty]] called more than once"))
         }
     }
-    fn gop_throws(agent: &Agent) -> Object {
-        let obj = AdaptableObject::object(
-            agent,
-            AdaptableMethods { get_own_property_override: Some(gop_override), ..Default::default() },
-        );
-        create_data_property_or_throw(agent, &obj, "one", 1.0).unwrap();
+    fn gop_throws() -> Object {
+        let obj = AdaptableObject::object(AdaptableMethods {
+            get_own_property_override: Some(gop_override),
+            ..Default::default()
+        });
+        create_data_property_or_throw(&obj, "one", 1.0).unwrap();
         obj
     }
     fn lying_ownprops(_: &Agent, _: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
         Ok(vec!["one".into(), "two".into(), "three".into()])
     }
-    fn lyingkeys(agent: &Agent) -> Object {
-        AdaptableObject::object(
-            agent,
-            AdaptableMethods { own_property_keys_override: Some(lying_ownprops), ..Default::default() },
-        )
+    fn lyingkeys() -> Object {
+        AdaptableObject::object(AdaptableMethods {
+            own_property_keys_override: Some(lying_ownprops),
+            ..Default::default()
+        })
     }
 
     #[test_case(normal, IntegrityLevel::Frozen => Ok((true, vec![
@@ -3168,12 +3097,12 @@ mod set_integrity_level {
     #[test_case(dop_throws, IntegrityLevel::Frozen => Err("TypeError: Test Sentinel".to_string()); "Frozen: DefineOwn throws")]
     #[test_case(gop_throws, IntegrityLevel::Frozen => Err("TypeError: [[GetOwnProperty]] called more than once".to_string()); "GetOwnProp throws")]
     #[test_case(lyingkeys, IntegrityLevel::Frozen => Ok((true, Vec::<PropertyInfo>::new())); "lying own property keys")]
-    fn sil(make_obj: fn(&Agent) -> Object, level: IntegrityLevel) -> Result<(bool, Vec<PropertyInfo>), String> {
+    fn sil(make_obj: fn() -> Object, level: IntegrityLevel) -> Result<(bool, Vec<PropertyInfo>), String> {
         setup_test_agent();
-        let obj = make_obj(&agent);
-        set_integrity_level(&agent, &obj, level)
+        let obj = make_obj();
+        set_integrity_level(&obj, level)
             .map(|success| (success, obj.o.common_object_data().borrow().propdump()))
-            .map_err(|err| unwind_any_error(&agent, err))
+            .map_err(|err| unwind_any_error(err))
     }
 }
 
@@ -3181,20 +3110,19 @@ mod ordinary_has_instance {
     use super::*;
     use test_case::test_case;
 
-    type ValueMaker = fn(&Agent) -> ECMAScriptValue;
+    type ValueMaker = fn() -> ECMAScriptValue;
 
     fn undef(_: &Agent) -> ECMAScriptValue {
         ECMAScriptValue::Undefined
     }
-    fn bool_class(agent: &Agent) -> ECMAScriptValue {
-        let boolean = agent.intrinsic(IntrinsicId::Boolean);
+    fn bool_class() -> ECMAScriptValue {
+        let boolean = intrinsic(IntrinsicId::Boolean);
         ECMAScriptValue::from(boolean)
     }
-    fn basic_constructor(agent: &Agent) -> Object {
+    fn basic_constructor() -> Object {
         let realm = agent.current_realm_record();
-        let function_prototype = agent.intrinsic(IntrinsicId::FunctionPrototype);
+        let function_prototype = intrinsic(IntrinsicId::FunctionPrototype);
         create_builtin_function(
-            agent,
             throw_type_error,
             true,
             0_f64,
@@ -3205,11 +3133,10 @@ mod ordinary_has_instance {
             None,
         )
     }
-    fn ungettable_prototype(agent: &Agent) -> ECMAScriptValue {
-        let throw = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError));
-        let constructor = basic_constructor(agent);
+    fn ungettable_prototype() -> ECMAScriptValue {
+        let throw = ECMAScriptValue::from(intrinsic(IntrinsicId::ThrowTypeError));
+        let constructor = basic_constructor();
         define_property_or_throw(
-            agent,
             &constructor,
             "prototype",
             PotentialPropertyDescriptor::new().set(throw.clone()).get(throw).enumerable(false).configurable(false),
@@ -3218,10 +3145,9 @@ mod ordinary_has_instance {
 
         ECMAScriptValue::from(constructor)
     }
-    fn nonobject_prototype(agent: &Agent) -> ECMAScriptValue {
-        let constructor = basic_constructor(agent);
+    fn nonobject_prototype() -> ECMAScriptValue {
+        let constructor = basic_constructor();
         define_property_or_throw(
-            agent,
             &constructor,
             "prototype",
             PotentialPropertyDescriptor::new()
@@ -3234,29 +3160,25 @@ mod ordinary_has_instance {
 
         ECMAScriptValue::from(constructor)
     }
-    fn dead_object(agent: &Agent) -> ECMAScriptValue {
-        ECMAScriptValue::from(DeadObject::object(agent))
+    fn dead_object() -> ECMAScriptValue {
+        ECMAScriptValue::from(DeadObject::object())
     }
-    fn empty_object(agent: &Agent) -> ECMAScriptValue {
-        let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        ECMAScriptValue::from(ordinary_object_create(agent, Some(obj_proto), &[]))
+    fn empty_object() -> ECMAScriptValue {
+        let obj_proto = intrinsic(IntrinsicId::ObjectPrototype);
+        ECMAScriptValue::from(ordinary_object_create(Some(obj_proto), &[]))
     }
-    fn bool_child(agent: &Agent) -> ECMAScriptValue {
-        let bool_constructor = agent.intrinsic(IntrinsicId::Boolean);
-        ordinary_create_from_constructor(agent, &bool_constructor, IntrinsicId::BooleanPrototype, BOOLEAN_OBJECT_SLOTS)
+    fn bool_child() -> ECMAScriptValue {
+        let bool_constructor = intrinsic(IntrinsicId::Boolean);
+        ordinary_create_from_constructor(&bool_constructor, IntrinsicId::BooleanPrototype, BOOLEAN_OBJECT_SLOTS)
             .unwrap()
             .into()
     }
-    fn bool_grandchild(agent: &Agent) -> ECMAScriptValue {
-        let bool_constructor = agent.intrinsic(IntrinsicId::Boolean);
-        let bool_child = ordinary_create_from_constructor(
-            agent,
-            &bool_constructor,
-            IntrinsicId::BooleanPrototype,
-            BOOLEAN_OBJECT_SLOTS,
-        )
-        .unwrap();
-        let grandkid = ordinary_object_create(agent, Some(bool_child), &[]);
+    fn bool_grandchild() -> ECMAScriptValue {
+        let bool_constructor = intrinsic(IntrinsicId::Boolean);
+        let bool_child =
+            ordinary_create_from_constructor(&bool_constructor, IntrinsicId::BooleanPrototype, BOOLEAN_OBJECT_SLOTS)
+                .unwrap();
+        let grandkid = ordinary_object_create(Some(bool_child), &[]);
         grandkid.into()
     }
 
@@ -3270,10 +3192,10 @@ mod ordinary_has_instance {
     #[test_case(bool_class, bool_grandchild => Ok(true); "true instance via prototype chain (grandchild)")]
     fn ordinary_has_instance(make_c: ValueMaker, make_o: ValueMaker) -> Result<bool, String> {
         setup_test_agent();
-        let c = make_c(&agent);
-        let o = make_o(&agent);
+        let c = make_c();
+        let o = make_o();
 
-        agent.ordinary_has_instance(&c, &o).map_err(|completion| unwind_any_error(&agent, completion))
+        agent.ordinary_has_instance(&c, &o).map_err(|completion| unwind_any_error(completion))
     }
 }
 

--- a/src/object/tests.rs
+++ b/src/object/tests.rs
@@ -2428,7 +2428,7 @@ mod private_get {
             FieldName::NoGetter => nogetter_name,
             FieldName::Unavailable => PrivateName::new("unavailable"),
         };
-        private_get(&obj, &query).map_err(|e| unwind_type_error(e))
+        private_get(&obj, &query).map_err(unwind_type_error)
     }
 }
 
@@ -2520,7 +2520,7 @@ mod private_set {
             FieldName::Unavailable => PrivateName::new("unavailable"),
         };
 
-        private_set(&obj, &query, new_value).map_err(|e| unwind_type_error(e))?;
+        private_set(&obj, &query, new_value).map_err(unwind_type_error)?;
 
         Ok(private_get(&obj, &query).unwrap())
     }
@@ -2957,7 +2957,7 @@ mod enumerable_own_property_names {
     fn f(make_obj: fn() -> Object, kind: EnumerationStyle) -> Result<Vec<ECMAScriptValue>, String> {
         setup_test_agent();
         let obj = make_obj();
-        enumerable_own_property_names(&obj, kind).map_err(|err| unwind_any_error(err))
+        enumerable_own_property_names(&obj, kind).map_err(unwind_any_error)
     }
 
     #[test]
@@ -3102,7 +3102,7 @@ mod set_integrity_level {
         let obj = make_obj();
         set_integrity_level(&obj, level)
             .map(|success| (success, obj.o.common_object_data().borrow().propdump()))
-            .map_err(|err| unwind_any_error(err))
+            .map_err(unwind_any_error)
     }
 }
 
@@ -3195,7 +3195,7 @@ mod ordinary_has_instance {
         let c = make_c();
         let o = make_o();
 
-        super::ordinary_has_instance(&c, &o).map_err(|completion| unwind_any_error(completion))
+        super::ordinary_has_instance(&c, &o).map_err(unwind_any_error)
     }
 }
 

--- a/src/object/tests.rs
+++ b/src/object/tests.rs
@@ -525,7 +525,7 @@ fn is_generic_descriptor_01() {
 
 #[test]
 fn ordinary_get_prototype_of_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
 
@@ -535,7 +535,7 @@ fn ordinary_get_prototype_of_01() {
 
 #[test]
 fn ordinary_set_prototype_of_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let new_proto = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
     let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
@@ -546,7 +546,7 @@ fn ordinary_set_prototype_of_01() {
 }
 #[test]
 fn ordinary_set_prototype_of_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
 
     let result = ordinary_set_prototype_of(&obj, None);
@@ -555,7 +555,7 @@ fn ordinary_set_prototype_of_02() {
 }
 #[test]
 fn ordinary_set_prototype_of_03() {
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
 
@@ -565,7 +565,7 @@ fn ordinary_set_prototype_of_03() {
 }
 #[test]
 fn ordinary_set_prototype_of_04() {
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, None, &[]);
 
@@ -575,7 +575,7 @@ fn ordinary_set_prototype_of_04() {
 }
 #[test]
 fn ordinary_set_prototype_of_05() {
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
     obj.o.prevent_extensions(&agent).unwrap();
@@ -586,7 +586,7 @@ fn ordinary_set_prototype_of_05() {
 }
 #[test]
 fn ordinary_set_prototype_of_06() {
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
 
@@ -597,7 +597,7 @@ fn ordinary_set_prototype_of_06() {
 
 #[test]
 fn ordinary_is_extensible_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
 
@@ -611,7 +611,7 @@ fn ordinary_is_extensible_01() {
 
 #[test]
 fn ordinary_prevent_extensions_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
 
@@ -622,7 +622,7 @@ fn ordinary_prevent_extensions_01() {
 
 #[test]
 fn ordinary_get_own_property_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let key = PropertyKey::from("a");
@@ -632,7 +632,7 @@ fn ordinary_get_own_property_01() {
 }
 #[test]
 fn ordinary_get_own_property_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let key = PropertyKey::from("a");
@@ -658,7 +658,7 @@ fn ordinary_get_own_property_02() {
 #[test]
 fn ordinary_define_own_property_01() {
     // Add a new property, object is extensible (the default)
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let key = PropertyKey::from("a");
@@ -685,7 +685,7 @@ fn ordinary_define_own_property_01() {
 #[test]
 fn ordinary_define_own_property_02() {
     // Add a new property, object is not extensible
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let key = PropertyKey::from("a");
@@ -705,7 +705,7 @@ fn ordinary_define_own_property_02() {
 #[test]
 fn ordinary_define_own_property_03() {
     // Change an existing property
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let key = PropertyKey::from("a");
@@ -734,7 +734,7 @@ fn ordinary_define_own_property_03() {
 #[test]
 fn ordinary_define_own_property_04() {
     // [[GetOwnProperty]] throws
-    let agent = test_agent();
+    setup_test_agent();
     let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
     let ppd = PotentialPropertyDescriptor {
@@ -753,7 +753,7 @@ fn ordinary_define_own_property_04() {
 #[test]
 fn ordinary_define_own_property_05() {
     // [[IsExtensible]] throws
-    let agent = test_agent();
+    setup_test_agent();
     let obj = TestObject::object(&agent, &[FunctionId::IsExtensible]);
     let key = PropertyKey::from("a");
     let ppd = PotentialPropertyDescriptor {
@@ -787,7 +787,7 @@ fn validate_and_apply_property_descriptor_02() {
 #[test]
 fn validate_and_apply_property_descriptor_03() {
     // current Undefined; empty descriptor
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let ppd = PotentialPropertyDescriptor { ..Default::default() };
@@ -804,7 +804,7 @@ fn validate_and_apply_property_descriptor_03() {
 #[test]
 fn validate_and_apply_property_descriptor_04() {
     // current Undefined; overfull descriptor
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let ppd = PotentialPropertyDescriptor {
@@ -828,7 +828,7 @@ fn validate_and_apply_property_descriptor_04() {
 #[test]
 fn validate_and_apply_property_descriptor_05() {
     // current Undefined; accessor descriptor
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let ppd = PotentialPropertyDescriptor {
@@ -857,7 +857,7 @@ fn validate_and_apply_property_descriptor_05() {
 #[test]
 fn validate_and_apply_property_descriptor_06() {
     // object Undefined; current reasonable; any valid input
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let existing = PotentialPropertyDescriptor {
@@ -1203,7 +1203,7 @@ fn figure_expectation(
 }
 #[test]
 fn validate_and_apply_property_descriptor_many() {
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     for (name, ppd) in VAPDIter::new(&agent) {
@@ -1251,7 +1251,7 @@ fn validate_and_apply_property_descriptor_many() {
 
 #[test]
 fn ordinary_has_property_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
     let initial = PotentialPropertyDescriptor {
@@ -1281,7 +1281,7 @@ fn ordinary_has_property_01() {
 #[test]
 fn ordinary_has_property_02() {
     // [[GetOwnProperty]] throws
-    let agent = test_agent();
+    setup_test_agent();
     let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
 
@@ -1291,7 +1291,7 @@ fn ordinary_has_property_02() {
 #[test]
 fn ordinary_has_property_03() {
     // [GetPrototypeOf]] throws
-    let agent = test_agent();
+    setup_test_agent();
     let obj = TestObject::object(&agent, &[FunctionId::GetPrototypeOf]);
     let key = PropertyKey::from("a");
 
@@ -1302,7 +1302,7 @@ fn ordinary_has_property_03() {
 #[test]
 fn ordinary_get_01() {
     // [[GetOwnProperty]] throws
-    let agent = test_agent();
+    setup_test_agent();
     let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
 
@@ -1312,7 +1312,7 @@ fn ordinary_get_01() {
 #[test]
 fn ordinary_get_02() {
     // [[GetPrototypeOf]] throws
-    let agent = test_agent();
+    setup_test_agent();
     let obj = TestObject::object(&agent, &[FunctionId::GetPrototypeOf]);
     let key = PropertyKey::from("a");
 
@@ -1322,7 +1322,7 @@ fn ordinary_get_02() {
 #[test]
 fn ordinary_get_03() {
     // Top of the prototype chain
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
 
@@ -1332,7 +1332,7 @@ fn ordinary_get_03() {
 #[test]
 fn ordinary_get_04() {
     // Normal data property
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let initial = PotentialPropertyDescriptor {
@@ -1362,7 +1362,7 @@ fn test_getter(
 #[test]
 fn ordinary_get_05() {
     // Normal accessor property
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let getter = create_builtin_function(
@@ -1403,7 +1403,7 @@ fn ordinary_get_05() {
 #[test]
 fn ordinary_get_06() {
     // Accessor property on parent (this ensures we're passing "receiver" properly)
-    let agent = test_agent();
+    setup_test_agent();
     let parent = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let getter = create_builtin_function(
@@ -1449,7 +1449,7 @@ fn ordinary_get_06() {
 #[test]
 fn ordinary_get_07() {
     // Accessor properties undefined
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let initial = PotentialPropertyDescriptor {
@@ -1467,7 +1467,7 @@ fn ordinary_get_07() {
 #[test]
 fn ordinary_set_01() {
     // [[GetOwnProperty]] throws
-    let agent = test_agent();
+    setup_test_agent();
     let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
@@ -1479,7 +1479,7 @@ fn ordinary_set_01() {
 #[test]
 fn ordinary_set_02() {
     // success
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from("test sentinel");
@@ -1494,7 +1494,7 @@ fn ordinary_set_02() {
 #[test]
 fn ordinary_set_with_own_descriptor_01() {
     // [[GetPrototypeOf]] throws
-    let agent = test_agent();
+    setup_test_agent();
     let obj = TestObject::object(&agent, &[FunctionId::GetPrototypeOf]);
     let key = PropertyKey::from("a");
 
@@ -1506,7 +1506,7 @@ fn ordinary_set_with_own_descriptor_01() {
 #[test]
 fn ordinary_set_with_own_descriptor_02() {
     // If ownDesc is None, call [[Set]] on the parent. (We check by having the parent throw when we call its [[Set]].)
-    let agent = test_agent();
+    setup_test_agent();
     let parent = TestObject::object(&agent, &[FunctionId::Set(None)]);
     let obj = ordinary_object_create(&agent, Some(parent), &[]);
     let key = PropertyKey::from("a");
@@ -1519,7 +1519,7 @@ fn ordinary_set_with_own_descriptor_02() {
 #[test]
 fn ordinary_set_with_own_descriptor_03() {
     // ownDesc has writable:false; function should return false.
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let own_desc = PropertyDescriptor {
         property: PropertyKind::Data(DataProperty { writable: false, value: ECMAScriptValue::Undefined }),
@@ -1537,7 +1537,7 @@ fn ordinary_set_with_own_descriptor_03() {
 #[test]
 fn ordinary_set_with_own_descriptor_04() {
     // Type(receiver) is not object -> return false
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
@@ -1549,7 +1549,7 @@ fn ordinary_set_with_own_descriptor_04() {
 #[test]
 fn ordinary_set_with_own_descriptor_05() {
     // receiver.[[GetOwnProperty]] throws
-    let agent = test_agent();
+    setup_test_agent();
     let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
@@ -1561,7 +1561,7 @@ fn ordinary_set_with_own_descriptor_05() {
 #[test]
 fn ordinary_set_with_own_descriptor_06() {
     // existing is an accessor
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
@@ -1598,7 +1598,7 @@ fn ordinary_set_with_own_descriptor_06() {
 #[test]
 fn ordinary_set_with_own_descriptor_07() {
     // existing is read-only
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
@@ -1624,7 +1624,7 @@ fn ordinary_set_with_own_descriptor_07() {
 #[test]
 fn ordinary_set_with_own_descriptor_08() {
     // existing exists
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::Undefined;
@@ -1654,7 +1654,7 @@ fn ordinary_set_with_own_descriptor_08() {
 #[test]
 fn ordinary_set_with_own_descriptor_09() {
     // existing does not exist
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from("test sentinel");
@@ -1691,7 +1691,7 @@ fn test_setter(
 #[test]
 fn ordinary_set_with_own_descriptor_10() {
     // own_desc is an accessor descriptor, with the above setter function
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from("test sentinel");
@@ -1728,7 +1728,7 @@ fn ordinary_set_with_own_descriptor_10() {
 #[test]
 fn ordinary_set_with_own_descriptor_11() {
     // own_desc is an accessor descriptor, with a setter function that throws
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from("test sentinel");
@@ -1751,7 +1751,7 @@ fn ordinary_set_with_own_descriptor_11() {
 #[test]
 fn ordinary_set_with_own_descriptor_12() {
     // own_desc is an accessor descriptor, with an undefined setter function
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from("test sentinel");
@@ -1773,7 +1773,7 @@ fn ordinary_set_with_own_descriptor_12() {
 #[test]
 fn ordinary_delete_01() {
     // [[GetOwnProperty]] throws
-    let agent = test_agent();
+    setup_test_agent();
     let obj = TestObject::object(&agent, &[FunctionId::GetOwnProperty(None)]);
     let key = PropertyKey::from("a");
 
@@ -1783,7 +1783,7 @@ fn ordinary_delete_01() {
 #[test]
 fn ordinary_delete_02() {
     // property isn't actually there
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
 
@@ -1793,7 +1793,7 @@ fn ordinary_delete_02() {
 #[test]
 fn ordinary_delete_03() {
     // property isn't configurable
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from(0);
@@ -1819,7 +1819,7 @@ fn ordinary_delete_03() {
 #[test]
 fn ordinary_delete_04() {
     // property is normal
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::from("a");
     let value = ECMAScriptValue::from(0);
@@ -1833,7 +1833,7 @@ fn ordinary_delete_04() {
 
 #[test]
 fn ordinary_own_property_keys_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
 
     let result = ordinary_own_property_keys(&obj);
@@ -1842,7 +1842,7 @@ fn ordinary_own_property_keys_01() {
 use crate::values::Symbol;
 #[test]
 fn ordinary_own_property_keys_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let sym1 = Symbol::new(&agent, Some(JSString::from("TestSymbol 1")));
     let sym2 = Symbol::new(&agent, Some(JSString::from("TestSymbol 2")));
@@ -1885,90 +1885,90 @@ fn array_index_key_02() {
 #[test]
 #[should_panic(expected = "unreachable code")]
 fn array_index_key_03() {
-    let agent = test_agent();
+    setup_test_agent();
     array_index_key(&PropertyKey::from(Symbol::new(&agent, None)));
 }
 
 #[test]
 fn object_interface_to_boolean_obj() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(obj.o.to_boolean_obj().is_none());
 }
 #[test]
 fn object_interface_to_function_obj() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(obj.o.to_function_obj().is_none());
 }
 #[test]
 fn object_interface_to_callable_obj() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(obj.o.to_callable_obj().is_none());
 }
 #[test]
 fn object_interface_to_builtin_function_obj() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(obj.o.to_builtin_function_obj().is_none());
 }
 #[test]
 fn object_interface_is_arguments_object() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_arguments_object());
 }
 #[test]
 fn object_interface_is_callable_obj() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_callable_obj());
 }
 #[test]
 fn object_interface_is_error_object() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_error_object());
 }
 #[test]
 fn object_interface_is_boolean_object() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_boolean_object());
 }
 #[test]
 fn object_interface_is_number_object() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_number_object());
 }
 #[test]
 fn object_interface_is_string_object() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_string_object());
 }
 #[test]
 fn object_interface_is_date_object() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_date_object());
 }
 #[test]
 fn object_interface_is_regexp_object() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
 
     assert!(!obj.o.is_regexp_object());
@@ -1977,7 +1977,7 @@ fn object_interface_is_regexp_object() {
 #[test]
 fn ordinary_object_create_01() {
     // When: An agent is given
-    let agent = test_agent();
+    setup_test_agent();
 
     // Then requesting a new object with no prototype or extra slots
     let obj = ordinary_object_create(&agent, None, &[]);
@@ -1992,7 +1992,7 @@ fn ordinary_object_create_01() {
 #[test]
 fn ordinary_object_create_02() {
     // When an agent and a prototype are provided
-    let agent = test_agent();
+    setup_test_agent();
     let proto = ordinary_object_create(&agent, None, &[]);
 
     // Then requesting a new object with that prototype but no extra slots
@@ -2009,7 +2009,7 @@ fn ordinary_object_create_02() {
 #[test]
 fn ordinary_object_create_03a() {
     // When an agent and a prototype are provided
-    let agent = test_agent();
+    setup_test_agent();
     let proto = ordinary_object_create(&agent, None, &[]);
 
     // Then requesting a new object with that prototype and needlessly requesting prototype or extensible slots
@@ -2025,7 +2025,7 @@ fn ordinary_object_create_03a() {
 #[test]
 fn ordinary_object_create_03b() {
     // When an agent and a prototype are provided
-    let agent = test_agent();
+    setup_test_agent();
     let proto = ordinary_object_create(&agent, None, &[]);
 
     // Then requesting a new object with that prototype and needlessly requesting prototype or extensible slots
@@ -2041,7 +2041,7 @@ fn ordinary_object_create_03b() {
 #[test]
 fn ordinary_object_create_03c() {
     // When an agent and a prototype are provided
-    let agent = test_agent();
+    setup_test_agent();
     let proto = ordinary_object_create(&agent, None, &[]);
 
     // Then requesting a new object with that prototype and needlessly requesting prototype or extensible slots
@@ -2071,13 +2071,13 @@ fn ordinary_object_create_03c() {
 #[test_case(FUNCTION_OBJECT_SLOTS => panics "More items are needed for initialization. Use FunctionObject::object directly instead"; "function obj")]
 #[test_case(GENERATOR_OBJECT_SLOTS => panics "Additional info needed for generator object; use direct constructor"; "generator obj")]
 fn make_basic_object(slots: &[InternalSlotName]) -> Object {
-    let agent = test_agent();
+    setup_test_agent();
     super::make_basic_object(&agent, slots, None)
 }
 
 #[test]
 fn get_prototype_of_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&test_agent(), None, &[]);
     let result = obj.o.get_prototype_of(&agent);
     assert!(result.is_ok());
@@ -2085,7 +2085,7 @@ fn get_prototype_of_01() {
 }
 #[test]
 fn get_prototype_of_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let proto = ordinary_object_create(&agent, None, &[]);
     let obj = ordinary_object_create(&agent, Some(proto.clone()), &[]);
     let result = obj.o.get_prototype_of(&agent);
@@ -2096,7 +2096,7 @@ fn get_prototype_of_02() {
 #[test]
 fn set_prototype_of_01() {
     // Not changing an empty prototype
-    let agent = test_agent();
+    setup_test_agent();
     let obj_a = ordinary_object_create(&agent, None, &[]);
     let result = obj_a.o.set_prototype_of(&agent, None);
     assert!(result.is_ok());
@@ -2106,7 +2106,7 @@ fn set_prototype_of_01() {
 #[test]
 fn set_prototype_of_02() {
     // Not changing a Some() prototype
-    let agent = test_agent();
+    setup_test_agent();
     let obj_a = ordinary_object_create(&agent, None, &[]);
     let obj_b = ordinary_object_create(&agent, Some(obj_a.clone()), &[]);
     let result = obj_b.o.set_prototype_of(&agent, Some(obj_a.clone()));
@@ -2117,7 +2117,7 @@ fn set_prototype_of_02() {
 #[test]
 fn set_prototype_of_03() {
     // Changing a Some() prototype to a different Some() prototype
-    let agent = test_agent();
+    setup_test_agent();
     let proto = ordinary_object_create(&agent, None, &[]);
     let obj_b = ordinary_object_create(&agent, Some(proto), &[]);
     let new_proto = ordinary_object_create(&agent, None, &[]);
@@ -2129,7 +2129,7 @@ fn set_prototype_of_03() {
 #[test]
 fn set_prototype_of_04() {
     // Trying to make a prototype loop
-    let agent = test_agent();
+    setup_test_agent();
     let proto = ordinary_object_create(&agent, None, &[]);
     let obj_b = ordinary_object_create(&agent, Some(proto.clone()), &[]);
     let result = proto.o.set_prototype_of(&agent, Some(obj_b));
@@ -2140,7 +2140,7 @@ fn set_prototype_of_04() {
 #[test]
 fn set_prototype_of_05() {
     // Changing the prototype of an object that's not extensible
-    let agent = test_agent();
+    setup_test_agent();
     let proto = ordinary_object_create(&agent, None, &[]);
     let obj_b = ordinary_object_create(&agent, Some(proto.clone()), &[]);
     obj_b.o.common_object_data().borrow_mut().extensible = false;
@@ -2153,7 +2153,7 @@ fn set_prototype_of_05() {
 
 #[test]
 fn is_extensible_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let result = obj.o.is_extensible(&agent);
     assert!(result.is_ok());
@@ -2161,7 +2161,7 @@ fn is_extensible_01() {
 }
 #[test]
 fn is_extensible_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     obj.o.common_object_data().borrow_mut().extensible = false;
     let result = obj.o.is_extensible(&agent);
@@ -2171,7 +2171,7 @@ fn is_extensible_02() {
 
 #[test]
 fn prevent_extensions_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let result = obj.o.prevent_extensions(&agent);
     assert!(result.is_ok());
@@ -2181,7 +2181,7 @@ fn prevent_extensions_01() {
 
 #[test]
 fn get_own_property_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::String(JSString::from("blue"));
     let result = obj.o.get_own_property(&agent, &key);
@@ -2190,7 +2190,7 @@ fn get_own_property_01() {
 }
 #[test]
 fn get_own_property_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::String(JSString::from("blue"));
     let value = ECMAScriptValue::Number(89.0);
@@ -2220,7 +2220,7 @@ fn get_own_property_02() {
 
 #[test]
 fn set_and_get() {
-    let agent = test_agent();
+    setup_test_agent();
 
     let obj = ordinary_object_create(&agent, None, &[]);
     let key = PropertyKey::String(JSString::from("blue"));
@@ -2237,7 +2237,7 @@ mod private_element_find {
     use test_case::test_case;
 
     fn setup() -> (Object, Vec<PrivateName>) {
-        let agent = test_agent();
+        setup_test_agent();
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let obj = ordinary_object_create(&agent, Some(object_proto), &[]);
 
@@ -2323,7 +2323,7 @@ mod private_field_add {
 
     #[test_case(PrivateName::new("orange") => (true, Some(ECMAScriptValue::Null)); "orange")]
     fn normal(name: PrivateName) -> (bool, Option<ECMAScriptValue>) {
-        let agent = test_agent();
+        setup_test_agent();
         let (obj, _) = setup(&agent);
 
         let result = private_field_add(&agent, &obj, name.clone(), ECMAScriptValue::Null);
@@ -2343,7 +2343,7 @@ mod private_field_add {
     #[test_case(1; "second")]
     #[test_case(2; "last")]
     fn previously_added(idx: usize) {
-        let agent = test_agent();
+        setup_test_agent();
         let (obj, names) = setup(&agent);
 
         let result = private_field_add(&agent, &obj, names[idx].clone(), ECMAScriptValue::Null).unwrap_err();
@@ -2373,7 +2373,7 @@ mod private_method_or_accessor_add {
 
     #[test]
     fn add() {
-        let agent = test_agent();
+        setup_test_agent();
         let (obj, _) = setup(&agent);
         let key = PrivateName::new("orange");
         let method = Rc::new(PrivateElement {
@@ -2393,7 +2393,7 @@ mod private_method_or_accessor_add {
 
     #[test]
     fn replace() {
-        let agent = test_agent();
+        setup_test_agent();
         let (obj, key) = setup(&agent);
         let method =
             Rc::new(PrivateElement { key, kind: PrivateElementKind::Method { value: ECMAScriptValue::from(100) } });
@@ -2471,7 +2471,7 @@ mod private_get {
     #[test_case(FieldName::NoGetter => Err(String::from("PrivateName has no getter")); "no getter")]
     #[test_case(FieldName::Unavailable => Err(String::from("PrivateName not defined")); "undefined")]
     fn f(field: FieldName) -> Result<ECMAScriptValue, String> {
-        let agent = test_agent();
+        setup_test_agent();
         let (obj, field_name, method_name, getter_name, nogetter_name) = setup(&agent);
 
         let query = match field {
@@ -2565,7 +2565,7 @@ mod private_set {
     #[test_case(FieldName::NoSetter => Err(String::from("PrivateName has no setter")); "no-setter")]
     #[test_case(FieldName::Unavailable => Err(String::from("PrivateName not defined")); "undefined")]
     fn f(field: FieldName) -> Result<ECMAScriptValue, String> {
-        let agent = test_agent();
+        setup_test_agent();
         let (obj, field_name, method_name, setter_name, nosetter_name) = setup(&agent);
         let new_value = ECMAScriptValue::from("NEW VALUE");
         let query = match field {
@@ -2593,7 +2593,7 @@ mod create_data_property_or_throw {
         use super::*;
         #[test]
         fn string() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = ordinary_object_create(&agent, None, &[]);
 
             create_data_property_or_throw(&agent, &obj, "key", "blue").unwrap();
@@ -2602,7 +2602,7 @@ mod create_data_property_or_throw {
         }
         #[test]
         fn boolean() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = ordinary_object_create(&agent, None, &[]);
 
             create_data_property_or_throw(&agent, &obj, "key", true).unwrap();
@@ -2611,7 +2611,7 @@ mod create_data_property_or_throw {
         }
         #[test]
         fn value() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = ordinary_object_create(&agent, None, &[]);
 
             create_data_property_or_throw(&agent, &obj, "key", ECMAScriptValue::Null).unwrap();
@@ -2620,7 +2620,7 @@ mod create_data_property_or_throw {
         }
         #[test]
         fn integer() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = ordinary_object_create(&agent, None, &[]);
 
             create_data_property_or_throw(&agent, &obj, "key", 10).unwrap();
@@ -2633,7 +2633,7 @@ mod create_data_property_or_throw {
         use super::*;
         #[test]
         fn string() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = ordinary_object_create(&agent, None, &[]);
             obj.o.prevent_extensions(&agent).unwrap();
 
@@ -2643,7 +2643,7 @@ mod create_data_property_or_throw {
         }
         #[test]
         fn boolean() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = ordinary_object_create(&agent, None, &[]);
             obj.o.prevent_extensions(&agent).unwrap();
 
@@ -2653,7 +2653,7 @@ mod create_data_property_or_throw {
         }
         #[test]
         fn value() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = ordinary_object_create(&agent, None, &[]);
             obj.o.prevent_extensions(&agent).unwrap();
 
@@ -2663,7 +2663,7 @@ mod create_data_property_or_throw {
         }
         #[test]
         fn integer() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = ordinary_object_create(&agent, None, &[]);
             obj.o.prevent_extensions(&agent).unwrap();
 
@@ -2677,7 +2677,7 @@ mod create_data_property_or_throw {
         use super::*;
         #[test]
         fn string() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = TestObject::object(&agent, &[FunctionId::DefineOwnProperty(None)]);
 
             let err = create_data_property_or_throw(&agent, &obj, "key", "blue").unwrap_err();
@@ -2686,7 +2686,7 @@ mod create_data_property_or_throw {
         }
         #[test]
         fn boolean() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = TestObject::object(&agent, &[FunctionId::DefineOwnProperty(None)]);
 
             let err = create_data_property_or_throw(&agent, &obj, "key", true).unwrap_err();
@@ -2695,7 +2695,7 @@ mod create_data_property_or_throw {
         }
         #[test]
         fn value() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = TestObject::object(&agent, &[FunctionId::DefineOwnProperty(None)]);
 
             let err = create_data_property_or_throw(&agent, &obj, "key", ECMAScriptValue::Null).unwrap_err();
@@ -2704,7 +2704,7 @@ mod create_data_property_or_throw {
         }
         #[test]
         fn integer() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = TestObject::object(&agent, &[FunctionId::DefineOwnProperty(None)]);
 
             let err = create_data_property_or_throw(&agent, &obj, "key", 10).unwrap_err();
@@ -2765,7 +2765,7 @@ mod from_property_descriptor {
         configurable:ECMAScriptValue::from(true)
     }); "standard accessor")]
     fn happy(pd: Option<PropertyDescriptor>) -> Option<TestResult> {
-        let agent = test_agent();
+        setup_test_agent();
         from_property_descriptor(&agent, pd).map(|o| TestResult {
             value: maybeprop(&agent, &o, "value"),
             writable: maybeprop(&agent, &o, "writable"),
@@ -2824,7 +2824,7 @@ mod to_property_descriptor {
         configurable: Some(true),
     }; "normal accessor")]
     fn happy(create_input: fn(&Agent) -> ECMAScriptValue) -> PotentialPropertyDescriptor {
-        let agent = test_agent();
+        setup_test_agent();
         let input = create_input(&agent);
         let result = to_property_descriptor(&agent, &input);
         result.unwrap()
@@ -2881,7 +2881,7 @@ mod to_property_descriptor {
     #[test_case(|a| create_nonfcn(a, "get") => "Getter must be callable (or undefined)"; "uncallable getter")]
     #[test_case(|a| create_nonfcn(a, "set") => "Setter must be callable (or undefined)"; "uncallable setter")]
     fn error(create_input: fn(&Agent) -> ECMAScriptValue) -> String {
-        let agent = test_agent();
+        setup_test_agent();
         let input = create_input(&agent);
         let result = to_property_descriptor(&agent, &input);
         unwind_type_error(&agent, result.unwrap_err())
@@ -2942,7 +2942,7 @@ mod create_array_from_list {
         },
     ]; "some items")]
     fn cafl(items: &[ECMAScriptValue]) -> Vec<PropertyInfo> {
-        let agent = test_agent();
+        setup_test_agent();
         create_array_from_list(&agent, items).o.common_object_data().borrow().propdump()
     }
 }
@@ -3018,14 +3018,14 @@ mod enumerable_own_property_names {
     #[test_case(getthrows, EnumerationStyle::Value => Err("TypeError: [[Get]] called on TestObject".to_string()); "get throws")]
     #[test_case(lyingkeys, EnumerationStyle::Value => Ok(Vec::<ECMAScriptValue>::new()); "ownkeys lies")]
     fn f(make_obj: fn(&Agent) -> Object, kind: EnumerationStyle) -> Result<Vec<ECMAScriptValue>, String> {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = make_obj(&agent);
         enumerable_own_property_names(&agent, &obj, kind).map_err(|err| unwind_any_error(&agent, err))
     }
 
     #[test]
     fn keyvalue() {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = normal(&agent);
         let result = enumerable_own_property_names(&agent, &obj, EnumerationStyle::KeyPlusValue).unwrap();
         assert_eq!(result.len(), 2);
@@ -3169,7 +3169,7 @@ mod set_integrity_level {
     #[test_case(gop_throws, IntegrityLevel::Frozen => Err("TypeError: [[GetOwnProperty]] called more than once".to_string()); "GetOwnProp throws")]
     #[test_case(lyingkeys, IntegrityLevel::Frozen => Ok((true, Vec::<PropertyInfo>::new())); "lying own property keys")]
     fn sil(make_obj: fn(&Agent) -> Object, level: IntegrityLevel) -> Result<(bool, Vec<PropertyInfo>), String> {
-        let agent = test_agent();
+        setup_test_agent();
         let obj = make_obj(&agent);
         set_integrity_level(&agent, &obj, level)
             .map(|success| (success, obj.o.common_object_data().borrow().propdump()))
@@ -3269,7 +3269,7 @@ mod ordinary_has_instance {
     #[test_case(bool_class, bool_child => Ok(true); "true instance via prototype chain (child)")]
     #[test_case(bool_class, bool_grandchild => Ok(true); "true instance via prototype chain (grandchild)")]
     fn ordinary_has_instance(make_c: ValueMaker, make_o: ValueMaker) -> Result<bool, String> {
-        let agent = test_agent();
+        setup_test_agent();
         let c = make_c(&agent);
         let o = make_o(&agent);
 

--- a/src/object/tests.rs
+++ b/src/object/tests.rs
@@ -2777,7 +2777,7 @@ mod to_property_descriptor {
         ECMAScriptValue::from(TestObject::object(&[FunctionId::GetOwnProperty(Some(PropertyKey::from(name)))]))
     }
     fn create_getter_error(name: &str) -> ECMAScriptValue {
-        let realm = agent.current_realm_record().unwrap();
+        let realm = current_realm_record().unwrap();
         let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
         let obj = ordinary_object_create(Some(object_prototype), &[]);
         let function_proto = intrinsic(IntrinsicId::FunctionPrototype);
@@ -2938,7 +2938,7 @@ mod enumerable_own_property_names {
         create_data_property_or_throw(&obj, "one", 1.0).unwrap();
         obj
     }
-    fn lying_ownprops(_: &Agent, _: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
+    fn lying_ownprops(_: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
         Ok(vec!["one".into(), "two".into(), "three".into()])
     }
     fn lyingkeys() -> Object {
@@ -3002,7 +3002,7 @@ mod set_integrity_level {
     }
     fn prevention_disabled() -> Object {
         AdaptableObject::object(AdaptableMethods {
-            prevent_extensions_override: Some(|_, _| Ok(false)),
+            prevent_extensions_override: Some(|_| Ok(false)),
             ..Default::default()
         })
     }
@@ -3011,7 +3011,7 @@ mod set_integrity_level {
     }
     fn dop_throws() -> Object {
         let obj = AdaptableObject::object(AdaptableMethods {
-            define_own_property_override: Some(|agent, this, key, desc| {
+            define_own_property_override: Some(|this, key, desc| {
                 if this.something.get() == 0 {
                     this.something.set(1);
                     ordinary_define_own_property(this, key, desc)
@@ -3040,7 +3040,7 @@ mod set_integrity_level {
         create_data_property_or_throw(&obj, "one", 1.0).unwrap();
         obj
     }
-    fn lying_ownprops(_: &Agent, _: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
+    fn lying_ownprops(_: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
         Ok(vec!["one".into(), "two".into(), "three".into()])
     }
     fn lyingkeys() -> Object {
@@ -3112,7 +3112,7 @@ mod ordinary_has_instance {
 
     type ValueMaker = fn() -> ECMAScriptValue;
 
-    fn undef(_: &Agent) -> ECMAScriptValue {
+    fn undef() -> ECMAScriptValue {
         ECMAScriptValue::Undefined
     }
     fn bool_class() -> ECMAScriptValue {
@@ -3120,7 +3120,7 @@ mod ordinary_has_instance {
         ECMAScriptValue::from(boolean)
     }
     fn basic_constructor() -> Object {
-        let realm = agent.current_realm_record();
+        let realm = current_realm_record();
         let function_prototype = intrinsic(IntrinsicId::FunctionPrototype);
         create_builtin_function(
             throw_type_error,
@@ -3195,7 +3195,7 @@ mod ordinary_has_instance {
         let c = make_c();
         let o = make_o();
 
-        agent.ordinary_has_instance(&c, &o).map_err(|completion| unwind_any_error(completion))
+        super::ordinary_has_instance(&c, &o).map_err(|completion| unwind_any_error(completion))
     }
 }
 

--- a/src/object_object/tests.rs
+++ b/src/object_object/tests.rs
@@ -9,7 +9,7 @@ mod prototype {
 
         #[test]
         fn happy() {
-            let agent = test_agent();
+            setup_test_agent();
             let value = ECMAScriptValue::from(10);
 
             let result = object_prototype_value_of(&agent, value, None, &[]).unwrap();
@@ -25,7 +25,7 @@ mod prototype {
         }
         #[test]
         fn err() {
-            let agent = test_agent();
+            setup_test_agent();
             let result = object_prototype_value_of(&agent, ECMAScriptValue::Undefined, None, &[]).unwrap_err();
             assert_eq!(unwind_type_error(&agent, result), "Undefined and null cannot be converted to objects");
         }
@@ -53,7 +53,7 @@ mod prototype {
         #[test_case(greasy => "[object Grease]"; "to-string-tag")]
         #[test_case(|agent| ECMAScriptValue::from(DeadObject::object(agent)) => "get called on DeadObject"; "throw getting tag")]
         fn f(make: fn(agent: &Agent) -> ECMAScriptValue) -> String {
-            let agent = test_agent();
+            setup_test_agent();
             let value = make(&agent);
             match object_prototype_to_string(&agent, value, None, &[]) {
                 Ok(ok) => match ok {
@@ -93,7 +93,7 @@ mod constructor {
         Some(nt)
     }, &[] => "[[Get]] called on TestObject"; "ordinary_create_from_constructor throws")]
     fn function(new_target: fn(&Agent) -> Option<Object>, args: &[ECMAScriptValue]) -> String {
-        let agent = test_agent();
+        setup_test_agent();
         let nt = new_target(&agent);
 
         match object_constructor_function(&agent, ECMAScriptValue::Undefined, nt.as_ref(), args) {
@@ -115,7 +115,7 @@ mod constructor {
 
         #[test]
         fn happy() {
-            let agent = test_agent();
+            setup_test_agent();
             let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let target = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
             let fruits = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
@@ -252,7 +252,7 @@ mod constructor {
         #[test_case(set_throws, obj_with_item => "[[Set]] called on TestObject"; "Set method throws")]
         #[test_case(ordinary_obj, get_throws => "[[Get]] throws from AdaptableObject"; "Get method throws")]
         fn error(create_to: fn(&Agent) -> ECMAScriptValue, create_from: fn(&Agent) -> ECMAScriptValue) -> String {
-            let agent = test_agent();
+            setup_test_agent();
             let to = create_to(&agent);
             let from = create_from(&agent);
 
@@ -340,7 +340,7 @@ mod constructor {
             create_target: fn(&Agent) -> Object,
             create_params: fn(&Agent) -> ECMAScriptValue,
         ) -> Result<Vec<PropertyInfo>, String> {
-            let agent = test_agent();
+            setup_test_agent();
             let target = create_target(&agent);
             let params = create_params(&agent);
 
@@ -379,7 +379,7 @@ mod constructor {
             make_proto: fn(&Agent) -> ECMAScriptValue,
             make_props: fn(&Agent) -> ECMAScriptValue,
         ) -> Result<Vec<PropertyInfo>, String> {
-            let agent = test_agent();
+            setup_test_agent();
             let proto = make_proto(&agent);
             let props = make_props(&agent);
             match object_create(&agent, ECMAScriptValue::Undefined, None, &[proto.clone(), props]) {
@@ -428,7 +428,7 @@ mod constructor {
             make_obj: fn(&Agent) -> ECMAScriptValue,
             make_props: fn(&Agent) -> ECMAScriptValue,
         ) -> Result<Vec<PropertyInfo>, String> {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make_obj(&agent);
             let props = make_props(&agent);
             match object_define_properties(&agent, ECMAScriptValue::Undefined, None, &[obj.clone(), props]) {
@@ -514,7 +514,7 @@ mod constructor {
             make_key: fn(&Agent) -> ECMAScriptValue,
             make_attrs: fn(&Agent) -> ECMAScriptValue,
         ) -> Result<Vec<PropertyInfo>, String> {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make_obj(&agent);
             let key = make_key(&agent);
             let attrs = make_attrs(&agent);
@@ -547,7 +547,7 @@ mod constructor {
         #[test_case(undef => Err("TypeError: Undefined and null cannot be converted to objects".to_string()); "undefined")]
         #[test_case(dead => Err("TypeError: own_property_keys called on DeadObject".to_string()); "own_property throws")]
         fn errs(make_arg: fn(&Agent) -> ECMAScriptValue) -> Result<ECMAScriptValue, String> {
-            let agent = test_agent();
+            setup_test_agent();
             let arg = make_arg(&agent);
             object_entries(&agent, ECMAScriptValue::Undefined, None, &[arg])
                 .map_err(|err| unwind_any_error(&agent, err))
@@ -555,7 +555,7 @@ mod constructor {
 
         #[test]
         fn normal() {
-            let agent = test_agent();
+            setup_test_agent();
             let proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let obj = ordinary_object_create(&agent, Some(proto), &[]);
             create_data_property_or_throw(&agent, &obj, "one", 1.0).unwrap();
@@ -583,7 +583,7 @@ mod constructor {
 
         #[test]
         fn no_args() {
-            let agent = test_agent();
+            setup_test_agent();
             assert_eq!(
                 object_freeze(&agent, ECMAScriptValue::Undefined, None, &[]).unwrap(),
                 ECMAScriptValue::Undefined
@@ -591,7 +591,7 @@ mod constructor {
         }
         #[test]
         fn number() {
-            let agent = test_agent();
+            setup_test_agent();
             assert_eq!(
                 object_freeze(&agent, ECMAScriptValue::Undefined, None, &[2003.25.into()]).unwrap(),
                 ECMAScriptValue::from(2003.25)
@@ -599,14 +599,14 @@ mod constructor {
         }
         #[test]
         fn dead() {
-            let agent = test_agent();
+            setup_test_agent();
             let arg: ECMAScriptValue = DeadObject::object(&agent).into();
             let result = object_freeze(&agent, ECMAScriptValue::Undefined, None, &[arg]).unwrap_err();
             assert_eq!(unwind_any_error(&agent, result), "TypeError: prevent_extensions called on DeadObject");
         }
         #[test]
         fn ok() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = ordinary_object_create(&agent, None, &[]);
             create_data_property_or_throw(&agent, &obj, "property", "holiday").unwrap();
             let result: Object =
@@ -623,7 +623,7 @@ mod constructor {
         }
         #[test]
         fn prevention_prevented() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = AdaptableObject::object(
                 &agent,
                 AdaptableMethods { prevent_extensions_override: Some(|_, _| Ok(false)), ..Default::default() },

--- a/src/object_object/tests.rs
+++ b/src/object_object/tests.rs
@@ -12,11 +12,11 @@ mod prototype {
             setup_test_agent();
             let value = ECMAScriptValue::from(10);
 
-            let result = object_prototype_value_of(&agent, value, None, &[]).unwrap();
+            let result = object_prototype_value_of(value, None, &[]).unwrap();
             match &result {
                 ECMAScriptValue::Object(obj) => {
                     assert!(obj.o.is_number_object());
-                    assert_eq!(to_number(&agent, result).unwrap(), 10.0);
+                    assert_eq!(to_number(result).unwrap(), 10.0);
                 }
                 _ => {
                     panic!("Object.prototype.valueOf did not return an object. (Got: {:?})", result);
@@ -26,8 +26,8 @@ mod prototype {
         #[test]
         fn err() {
             setup_test_agent();
-            let result = object_prototype_value_of(&agent, ECMAScriptValue::Undefined, None, &[]).unwrap_err();
-            assert_eq!(unwind_type_error(&agent, result), "Undefined and null cannot be converted to objects");
+            let result = object_prototype_value_of(ECMAScriptValue::Undefined, None, &[]).unwrap_err();
+            assert_eq!(unwind_type_error(result), "Undefined and null cannot be converted to objects");
         }
     }
 
@@ -35,32 +35,32 @@ mod prototype {
         use super::*;
         use test_case::test_case;
 
-        fn greasy(agent: &Agent) -> ECMAScriptValue {
+        fn greasy() -> ECMAScriptValue {
             // Return an object whose @@toStringTag property has the value "Grease"
-            let to_string_tag_symbol = agent.wks(WksId::ToStringTag);
-            let obj = ordinary_object_create(agent, None, &[]);
-            set(agent, &obj, PropertyKey::from(to_string_tag_symbol), ECMAScriptValue::from("Grease"), false).unwrap();
+            let to_string_tag_symbol = wks(WksId::ToStringTag);
+            let obj = ordinary_object_create(None, &[]);
+            set(&obj, PropertyKey::from(to_string_tag_symbol), ECMAScriptValue::from("Grease"), false).unwrap();
             ECMAScriptValue::from(obj)
         }
 
-        #[test_case(|_| ECMAScriptValue::Undefined => "[object Undefined]"; "undefined")]
-        #[test_case(|_| ECMAScriptValue::Null => "[object Null]"; "null")]
-        #[test_case(|_| ECMAScriptValue::from(99) => "[object Number]"; "number")]
-        #[test_case(|_| ECMAScriptValue::from(true) => "[object Boolean]"; "boolean")]
-        #[test_case(|agent| ECMAScriptValue::from(create_type_error_object(agent, "test_error")) => "[object Error]"; "error object")]
-        #[test_case(|agent| ECMAScriptValue::from(agent.intrinsic(IntrinsicId::Boolean)) => "[object Function]"; "callable object")]
-        #[test_case(|agent| ECMAScriptValue::from(ordinary_object_create(agent, None, &[])) => "[object Object]"; "ordinary object")]
+        #[test_case(|| ECMAScriptValue::Undefined => "[object Undefined]"; "undefined")]
+        #[test_case(|| ECMAScriptValue::Null => "[object Null]"; "null")]
+        #[test_case(|| ECMAScriptValue::from(99) => "[object Number]"; "number")]
+        #[test_case(|| ECMAScriptValue::from(true) => "[object Boolean]"; "boolean")]
+        #[test_case(|| ECMAScriptValue::from(create_type_error_object("test_error")) => "[object Error]"; "error object")]
+        #[test_case(|| ECMAScriptValue::from(intrinsic(IntrinsicId::Boolean)) => "[object Function]"; "callable object")]
+        #[test_case(|| ECMAScriptValue::from(ordinary_object_create(None, &[])) => "[object Object]"; "ordinary object")]
         #[test_case(greasy => "[object Grease]"; "to-string-tag")]
-        #[test_case(|agent| ECMAScriptValue::from(DeadObject::object(agent)) => "get called on DeadObject"; "throw getting tag")]
-        fn f(make: fn(agent: &Agent) -> ECMAScriptValue) -> String {
+        #[test_case(|| ECMAScriptValue::from(DeadObject::object()) => "get called on DeadObject"; "throw getting tag")]
+        fn f(make: fn() -> ECMAScriptValue) -> String {
             setup_test_agent();
-            let value = make(&agent);
-            match object_prototype_to_string(&agent, value, None, &[]) {
+            let value = make();
+            match object_prototype_to_string(value, None, &[]) {
                 Ok(ok) => match ok {
                     ECMAScriptValue::String(s) => String::from(s),
                     _ => panic!("Object.prototype.toString did not return a string. (Got: {:?})", ok),
                 },
-                Err(err) => unwind_type_error(&agent, err),
+                Err(err) => unwind_type_error(err),
             }
         }
     }
@@ -70,38 +70,38 @@ mod constructor {
     use super::*;
     use test_case::test_case;
 
-    #[test_case(|a| Some(ordinary_object_create(a, None, &[])), &[ECMAScriptValue::from(10)] => "10"; "new target but no active function")]
-    #[test_case(|a| {
-        let obj = ordinary_object_create(a, None, &[]);
-        let realm = a.current_realm_record().unwrap();
-        a.push_execution_context(ExecutionContext::new(Some(obj.clone()), realm, None));
+    #[test_case(|| Some(ordinary_object_create(None, &[])), &[ECMAScriptValue::from(10)] => "10"; "new target but no active function")]
+    #[test_case(|| {
+        let obj = ordinary_object_create(None, &[]);
+        let realm = current_realm_record().unwrap();
+        push_execution_context(ExecutionContext::new(Some(obj.clone()), realm, None));
         Some(obj)
     }, &[ECMAScriptValue::from(11)] => "11"; "related new target")]
-    #[test_case(|a| {
-        let obj = ordinary_object_create(a, None, &[]);
-        let realm = a.current_realm_record().unwrap();
-        a.push_execution_context(ExecutionContext::new(Some(obj), realm, None));
-        Some(ordinary_object_create(a, None, &[]))
+    #[test_case(|| {
+        let obj = ordinary_object_create(None, &[]);
+        let realm = current_realm_record().unwrap();
+        push_execution_context(ExecutionContext::new(Some(obj), realm, None));
+        Some(ordinary_object_create(None, &[]))
     }, &[ECMAScriptValue::from(12)] => "[object Object]"; "unrelated new target")]
-    #[test_case(|_| None, &[ECMAScriptValue::Null] => "[object Object]"; "null value")]
-    #[test_case(|_| None, &[ECMAScriptValue::Undefined] => "[object Object]"; "undefined value")]
-    #[test_case(|a| {
-        let obj = ordinary_object_create(a, None, &[]);
-        let realm = a.current_realm_record().unwrap();
-        a.push_execution_context(ExecutionContext::new(Some(obj), realm, None));
-        let nt = TestObject::object(a, &[FunctionId::Get(None)]);
+    #[test_case(|| None, &[ECMAScriptValue::Null] => "[object Object]"; "null value")]
+    #[test_case(|| None, &[ECMAScriptValue::Undefined] => "[object Object]"; "undefined value")]
+    #[test_case(|| {
+        let obj = ordinary_object_create(None, &[]);
+        let realm = current_realm_record().unwrap();
+        push_execution_context(ExecutionContext::new(Some(obj), realm, None));
+        let nt = TestObject::object(&[FunctionId::Get(None)]);
         Some(nt)
     }, &[] => "[[Get]] called on TestObject"; "ordinary_create_from_constructor throws")]
-    fn function(new_target: fn(&Agent) -> Option<Object>, args: &[ECMAScriptValue]) -> String {
+    fn function(new_target: fn() -> Option<Object>, args: &[ECMAScriptValue]) -> String {
         setup_test_agent();
-        let nt = new_target(&agent);
+        let nt = new_target();
 
-        match object_constructor_function(&agent, ECMAScriptValue::Undefined, nt.as_ref(), args) {
+        match object_constructor_function(ECMAScriptValue::Undefined, nt.as_ref(), args) {
             Ok(ok) => match ok {
-                ECMAScriptValue::Object(obj) => String::from(to_string(&agent, obj).unwrap()),
+                ECMAScriptValue::Object(obj) => String::from(to_string(obj).unwrap()),
                 _ => panic!("Object() did not return an object. (Got: {:?})", ok),
             },
-            Err(err) => unwind_type_error(&agent, err),
+            Err(err) => unwind_type_error(err),
         }
     }
 
@@ -109,26 +109,25 @@ mod constructor {
         use super::*;
         use test_case::test_case;
 
-        fn fake_keys(_agent: &Agent, _this: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
+        fn fake_keys(_this: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
             Ok(vec![PropertyKey::from("once"), PropertyKey::from("twice")])
         }
 
         #[test]
         fn happy() {
             setup_test_agent();
-            let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let target = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
-            let fruits = ordinary_object_create(&agent, Some(object_proto.clone()), &[]);
-            create_data_property_or_throw(&agent, &fruits, "round", "apple").unwrap();
-            create_data_property_or_throw(&agent, &fruits, "long", "banana").unwrap();
-            create_data_property_or_throw(&agent, &fruits, "bunch", "grapes").unwrap();
-            let limbs = ordinary_object_create(&agent, Some(object_proto), &[]);
-            create_data_property_or_throw(&agent, &limbs, "spider", 8).unwrap();
-            create_data_property_or_throw(&agent, &limbs, "bee", 6).unwrap();
-            create_data_property_or_throw(&agent, &limbs, "dog", 4).unwrap();
-            create_data_property_or_throw(&agent, &limbs, "worm", 0).unwrap();
+            let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
+            let target = ordinary_object_create(Some(object_proto.clone()), &[]);
+            let fruits = ordinary_object_create(Some(object_proto.clone()), &[]);
+            create_data_property_or_throw(&fruits, "round", "apple").unwrap();
+            create_data_property_or_throw(&fruits, "long", "banana").unwrap();
+            create_data_property_or_throw(&fruits, "bunch", "grapes").unwrap();
+            let limbs = ordinary_object_create(Some(object_proto), &[]);
+            create_data_property_or_throw(&limbs, "spider", 8).unwrap();
+            create_data_property_or_throw(&limbs, "bee", 6).unwrap();
+            create_data_property_or_throw(&limbs, "dog", 4).unwrap();
+            create_data_property_or_throw(&limbs, "worm", 0).unwrap();
             define_property_or_throw(
-                &agent,
                 &limbs,
                 PropertyKey::from("not_visible"),
                 PotentialPropertyDescriptor {
@@ -140,13 +139,12 @@ mod constructor {
                 },
             )
             .unwrap();
-            let keys_not_props = ECMAScriptValue::from(AdaptableObject::object(
-                &agent,
-                AdaptableMethods { own_property_keys_override: Some(fake_keys), ..Default::default() },
-            ));
+            let keys_not_props = ECMAScriptValue::from(AdaptableObject::object(AdaptableMethods {
+                own_property_keys_override: Some(fake_keys),
+                ..Default::default()
+            }));
 
             let result = object_assign(
-                &agent,
                 ECMAScriptValue::Undefined,
                 None,
                 &[
@@ -163,16 +161,16 @@ mod constructor {
             match result {
                 ECMAScriptValue::Object(to) => {
                     assert_eq!(to, target);
-                    assert_eq!(get(&agent, &to, &PropertyKey::from("round")).unwrap(), ECMAScriptValue::from("apple"));
-                    assert_eq!(get(&agent, &to, &PropertyKey::from("long")).unwrap(), ECMAScriptValue::from("banana"));
-                    assert_eq!(get(&agent, &to, &PropertyKey::from("bunch")).unwrap(), ECMAScriptValue::from("grapes"));
-                    assert_eq!(get(&agent, &to, &PropertyKey::from("spider")).unwrap(), ECMAScriptValue::from(8));
-                    assert_eq!(get(&agent, &to, &PropertyKey::from("bee")).unwrap(), ECMAScriptValue::from(6));
-                    assert_eq!(get(&agent, &to, &PropertyKey::from("dog")).unwrap(), ECMAScriptValue::from(4));
-                    assert_eq!(get(&agent, &to, &PropertyKey::from("worm")).unwrap(), ECMAScriptValue::from(0));
-                    assert!(!has_own_property(&agent, &to, &PropertyKey::from("not_visible")).unwrap());
-                    assert!(!has_own_property(&agent, &to, &PropertyKey::from("once")).unwrap());
-                    assert!(!has_own_property(&agent, &to, &PropertyKey::from("twice")).unwrap());
+                    assert_eq!(get(&to, &PropertyKey::from("round")).unwrap(), ECMAScriptValue::from("apple"));
+                    assert_eq!(get(&to, &PropertyKey::from("long")).unwrap(), ECMAScriptValue::from("banana"));
+                    assert_eq!(get(&to, &PropertyKey::from("bunch")).unwrap(), ECMAScriptValue::from("grapes"));
+                    assert_eq!(get(&to, &PropertyKey::from("spider")).unwrap(), ECMAScriptValue::from(8));
+                    assert_eq!(get(&to, &PropertyKey::from("bee")).unwrap(), ECMAScriptValue::from(6));
+                    assert_eq!(get(&to, &PropertyKey::from("dog")).unwrap(), ECMAScriptValue::from(4));
+                    assert_eq!(get(&to, &PropertyKey::from("worm")).unwrap(), ECMAScriptValue::from(0));
+                    assert!(!has_own_property(&to, &PropertyKey::from("not_visible")).unwrap());
+                    assert!(!has_own_property(&to, &PropertyKey::from("once")).unwrap());
+                    assert!(!has_own_property(&to, &PropertyKey::from("twice")).unwrap());
                 }
                 _ => {
                     panic!("Got a non-object back: {:?}", result);
@@ -180,44 +178,37 @@ mod constructor {
             }
         }
 
-        fn ordinary_obj(agent: &Agent) -> ECMAScriptValue {
-            let proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            ECMAScriptValue::from(ordinary_object_create(agent, Some(proto), &[]))
+        fn ordinary_obj() -> ECMAScriptValue {
+            let proto = intrinsic(IntrinsicId::ObjectPrototype);
+            ECMAScriptValue::from(ordinary_object_create(Some(proto), &[]))
         }
-        fn own_property_keys_throws(agent: &Agent) -> ECMAScriptValue {
-            ECMAScriptValue::from(TestObject::object(agent, &[FunctionId::OwnPropertyKeys]))
+        fn own_property_keys_throws() -> ECMAScriptValue {
+            ECMAScriptValue::from(TestObject::object(&[FunctionId::OwnPropertyKeys]))
         }
-        fn own_prop_keys(_: &Agent, _: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
+        fn own_prop_keys(_: &AdaptableObject) -> Completion<Vec<PropertyKey>> {
             Ok(vec![PropertyKey::from("prop")])
         }
-        fn get_own_prop_err(
-            agent: &Agent,
-            _: &AdaptableObject,
-            _: &PropertyKey,
-        ) -> Completion<Option<PropertyDescriptor>> {
-            Err(create_type_error(agent, "Test Sentinel"))
+        fn get_own_prop_err(_: &AdaptableObject, _: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
+            Err(create_type_error("Test Sentinel"))
         }
-        fn get_own_property_throws(agent: &Agent) -> ECMAScriptValue {
-            let obj = AdaptableObject::object(
-                agent,
-                AdaptableMethods {
-                    own_property_keys_override: Some(own_prop_keys),
-                    get_own_property_override: Some(get_own_prop_err),
-                    ..Default::default()
-                },
-            );
+        fn get_own_property_throws() -> ECMAScriptValue {
+            let obj = AdaptableObject::object(AdaptableMethods {
+                own_property_keys_override: Some(own_prop_keys),
+                get_own_property_override: Some(get_own_prop_err),
+                ..Default::default()
+            });
             ECMAScriptValue::from(obj)
         }
-        fn set_throws(agent: &Agent) -> ECMAScriptValue {
-            ECMAScriptValue::from(TestObject::object(agent, &[FunctionId::Set(None)]))
+        fn set_throws() -> ECMAScriptValue {
+            ECMAScriptValue::from(TestObject::object(&[FunctionId::Set(None)]))
         }
-        fn obj_with_item(agent: &Agent) -> ECMAScriptValue {
-            let proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let obj = ordinary_object_create(agent, Some(proto), &[]);
-            create_data_property_or_throw(agent, &obj, "something", 782).unwrap();
+        fn obj_with_item() -> ECMAScriptValue {
+            let proto = intrinsic(IntrinsicId::ObjectPrototype);
+            let obj = ordinary_object_create(Some(proto), &[]);
+            create_data_property_or_throw(&obj, "something", 782).unwrap();
             ECMAScriptValue::from(obj)
         }
-        fn get_own_prop_ok(_: &Agent, _: &AdaptableObject, _: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
+        fn get_own_prop_ok(_: &AdaptableObject, _: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
             Ok(Some(PropertyDescriptor {
                 property: PropertyKind::Data(DataProperty { value: ECMAScriptValue::from(22), writable: true }),
                 enumerable: true,
@@ -225,39 +216,31 @@ mod constructor {
                 ..Default::default()
             }))
         }
-        fn get_err(
-            agent: &Agent,
-            _: &AdaptableObject,
-            _: &PropertyKey,
-            _: &ECMAScriptValue,
-        ) -> Completion<ECMAScriptValue> {
-            Err(create_type_error(agent, "[[Get]] throws from AdaptableObject"))
+        fn get_err(_: &AdaptableObject, _: &PropertyKey, _: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+            Err(create_type_error("[[Get]] throws from AdaptableObject"))
         }
-        fn get_throws(agent: &Agent) -> ECMAScriptValue {
-            let obj = AdaptableObject::object(
-                agent,
-                AdaptableMethods {
-                    own_property_keys_override: Some(own_prop_keys),
-                    get_own_property_override: Some(get_own_prop_ok),
-                    get_override: Some(get_err),
-                    ..Default::default()
-                },
-            );
+        fn get_throws() -> ECMAScriptValue {
+            let obj = AdaptableObject::object(AdaptableMethods {
+                own_property_keys_override: Some(own_prop_keys),
+                get_own_property_override: Some(get_own_prop_ok),
+                get_override: Some(get_err),
+                ..Default::default()
+            });
             ECMAScriptValue::from(obj)
         }
 
-        #[test_case(|_| ECMAScriptValue::Undefined, |_| ECMAScriptValue::Undefined => "Undefined and null cannot be converted to objects"; "to undefined")]
+        #[test_case(|| ECMAScriptValue::Undefined, || ECMAScriptValue::Undefined => "Undefined and null cannot be converted to objects"; "to undefined")]
         #[test_case(ordinary_obj, own_property_keys_throws => "[[OwnPropertyKeys]] called on TestObject"; "OwnPropertyKeys throws")]
         #[test_case(ordinary_obj, get_own_property_throws => "Test Sentinel"; "GetOwnProperty throws")]
         #[test_case(set_throws, obj_with_item => "[[Set]] called on TestObject"; "Set method throws")]
         #[test_case(ordinary_obj, get_throws => "[[Get]] throws from AdaptableObject"; "Get method throws")]
-        fn error(create_to: fn(&Agent) -> ECMAScriptValue, create_from: fn(&Agent) -> ECMAScriptValue) -> String {
+        fn error(create_to: fn() -> ECMAScriptValue, create_from: fn() -> ECMAScriptValue) -> String {
             setup_test_agent();
-            let to = create_to(&agent);
-            let from = create_from(&agent);
+            let to = create_to();
+            let from = create_from();
 
-            let err = object_assign(&agent, ECMAScriptValue::Undefined, None, &[to, from]).unwrap_err();
-            unwind_type_error(&agent, err)
+            let err = object_assign(ECMAScriptValue::Undefined, None, &[to, from]).unwrap_err();
+            unwind_type_error(err)
         }
     }
 
@@ -265,34 +248,30 @@ mod constructor {
         use super::*;
         use test_case::test_case;
 
-        fn normal_obj(agent: &Agent) -> Object {
-            ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[])
+        fn normal_obj() -> Object {
+            ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[])
         }
-        fn normal_params(agent: &Agent) -> ECMAScriptValue {
-            let obj = ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
-            let emotion_descriptor =
-                ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
-            create_data_property_or_throw(agent, &emotion_descriptor, "value", "happy").unwrap();
-            create_data_property_or_throw(agent, &emotion_descriptor, "writable", true).unwrap();
-            create_data_property_or_throw(agent, &emotion_descriptor, "enumerable", true).unwrap();
-            create_data_property_or_throw(agent, &emotion_descriptor, "configurable", true).unwrap();
-            create_data_property_or_throw(agent, &obj, "emotion", emotion_descriptor).unwrap();
-            let age_descriptor =
-                ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
-            create_data_property_or_throw(agent, &age_descriptor, "value", 27).unwrap();
-            create_data_property_or_throw(agent, &age_descriptor, "writable", true).unwrap();
-            create_data_property_or_throw(agent, &age_descriptor, "enumerable", true).unwrap();
-            create_data_property_or_throw(agent, &age_descriptor, "configurable", true).unwrap();
-            create_data_property_or_throw(agent, &obj, "age", age_descriptor).unwrap();
-            let favorite_descriptor =
-                ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
-            create_data_property_or_throw(agent, &favorite_descriptor, "value", "banana").unwrap();
-            create_data_property_or_throw(agent, &favorite_descriptor, "writable", false).unwrap();
-            create_data_property_or_throw(agent, &favorite_descriptor, "enumerable", true).unwrap();
-            create_data_property_or_throw(agent, &favorite_descriptor, "configurable", true).unwrap();
-            create_data_property_or_throw(agent, &obj, "favorite_fruit", favorite_descriptor).unwrap();
+        fn normal_params() -> ECMAScriptValue {
+            let obj = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+            let emotion_descriptor = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+            create_data_property_or_throw(&emotion_descriptor, "value", "happy").unwrap();
+            create_data_property_or_throw(&emotion_descriptor, "writable", true).unwrap();
+            create_data_property_or_throw(&emotion_descriptor, "enumerable", true).unwrap();
+            create_data_property_or_throw(&emotion_descriptor, "configurable", true).unwrap();
+            create_data_property_or_throw(&obj, "emotion", emotion_descriptor).unwrap();
+            let age_descriptor = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+            create_data_property_or_throw(&age_descriptor, "value", 27).unwrap();
+            create_data_property_or_throw(&age_descriptor, "writable", true).unwrap();
+            create_data_property_or_throw(&age_descriptor, "enumerable", true).unwrap();
+            create_data_property_or_throw(&age_descriptor, "configurable", true).unwrap();
+            create_data_property_or_throw(&obj, "age", age_descriptor).unwrap();
+            let favorite_descriptor = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+            create_data_property_or_throw(&favorite_descriptor, "value", "banana").unwrap();
+            create_data_property_or_throw(&favorite_descriptor, "writable", false).unwrap();
+            create_data_property_or_throw(&favorite_descriptor, "enumerable", true).unwrap();
+            create_data_property_or_throw(&favorite_descriptor, "configurable", true).unwrap();
+            create_data_property_or_throw(&obj, "favorite_fruit", favorite_descriptor).unwrap();
             define_property_or_throw(
-                agent,
                 &obj,
                 PropertyKey::from("hidden"),
                 PotentialPropertyDescriptor {
@@ -312,39 +291,39 @@ mod constructor {
             PropertyInfo { name: PropertyKey::from("age"), enumerable: true, configurable: true, kind: PropertyInfoKind::Data { value: ECMAScriptValue::from(27.0), writable: true } },
             PropertyInfo { name: PropertyKey::from("favorite_fruit"), enumerable: true, configurable: true, kind: PropertyInfoKind::Data { value: ECMAScriptValue::from("banana"), writable: false } }
         ]); "happy")]
-        #[test_case(normal_obj, |_| ECMAScriptValue::Undefined => Err(String::from("Undefined and null cannot be converted to objects")); "undefined props")]
-        #[test_case(normal_obj, |a| ECMAScriptValue::from(TestObject::object(a, &[FunctionId::OwnPropertyKeys])) => Err(String::from("[[OwnPropertyKeys]] called on TestObject")); "own_property_keys throws")]
-        #[test_case(|a| TestObject::object(a, &[FunctionId::DefineOwnProperty(None)]), normal_params => Err(String::from("[[DefineOwnProperty]] called on TestObject")); "define_property_or_throw throws")]
+        #[test_case(normal_obj, || ECMAScriptValue::Undefined => Err(String::from("Undefined and null cannot be converted to objects")); "undefined props")]
+        #[test_case(normal_obj, || ECMAScriptValue::from(TestObject::object(&[FunctionId::OwnPropertyKeys])) => Err(String::from("[[OwnPropertyKeys]] called on TestObject")); "own_property_keys throws")]
+        #[test_case(|| TestObject::object(&[FunctionId::DefineOwnProperty(None)]), normal_params => Err(String::from("[[DefineOwnProperty]] called on TestObject")); "define_property_or_throw throws")]
         #[test_case(normal_obj,
-                    |a| ECMAScriptValue::from(AdaptableObject::object(a, AdaptableMethods { own_property_keys_override: Some(|_, _| Ok(vec![PropertyKey::from("something")])),
+                    || ECMAScriptValue::from(AdaptableObject::object(AdaptableMethods { own_property_keys_override: Some(|_| Ok(vec![PropertyKey::from("something")])),
                     ..Default::default() })) =>
                     Ok(vec![]); "prop, but not")]
         #[test_case(normal_obj,
-                    |a| ECMAScriptValue::from(AdaptableObject::object(a, AdaptableMethods {
-                        own_property_keys_override: Some(|_, _| Ok(vec![PropertyKey::from("something")])),
-                        get_own_property_override: Some(|a,_,_| Err(create_type_error(a, "[[GetOwnProperty]] throws from AdaptableObject"))),
+                    || ECMAScriptValue::from(AdaptableObject::object(AdaptableMethods {
+                        own_property_keys_override: Some(|_| Ok(vec![PropertyKey::from("something")])),
+                        get_own_property_override: Some(|_, _| Err(create_type_error("[[GetOwnProperty]] throws from AdaptableObject"))),
                         ..Default::default()
                     })) =>
                     Err(String::from("[[GetOwnProperty]] throws from AdaptableObject")); "get_own_property throws")]
-        #[test_case(normal_obj, |a| {
-                        let obj = TestObject::object(a, &[FunctionId::Get(None)]);
-                        create_data_property_or_throw(a, &obj, "key", "blue").unwrap();
+        #[test_case(normal_obj, || {
+                        let obj = TestObject::object(&[FunctionId::Get(None)]);
+                        create_data_property_or_throw(&obj, "key", "blue").unwrap();
                         ECMAScriptValue::from(obj)
                     } => Err(String::from("[[Get]] called on TestObject")); "get throws")]
-        #[test_case(normal_obj, |a| {
-                        let obj = ordinary_object_create(a, Some(a.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
-                        create_data_property_or_throw(a, &obj, "key", "blue").unwrap();
+        #[test_case(normal_obj, || {
+                        let obj = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+                        create_data_property_or_throw(&obj, "key", "blue").unwrap();
                         ECMAScriptValue::from(obj)
                     } => Err(String::from("Must be an object")); "to_property_descriptor throws")]
         fn f(
-            create_target: fn(&Agent) -> Object,
-            create_params: fn(&Agent) -> ECMAScriptValue,
+            create_target: fn() -> Object,
+            create_params: fn() -> ECMAScriptValue,
         ) -> Result<Vec<PropertyInfo>, String> {
             setup_test_agent();
-            let target = create_target(&agent);
-            let params = create_params(&agent);
+            let target = create_target();
+            let params = create_params();
 
-            match object_define_properties_helper(&agent, target.clone(), params) {
+            match object_define_properties_helper(target.clone(), params) {
                 Ok(val) => match val {
                     ECMAScriptValue::Object(o) => {
                         assert_eq!(o, target);
@@ -352,7 +331,7 @@ mod constructor {
                     }
                     _ => panic!("Non-object came back from object_define_properties_helper(): {:?}", val),
                 },
-                Err(err) => Err(unwind_type_error(&agent, err)),
+                Err(err) => Err(unwind_type_error(err)),
             }
         }
     }
@@ -361,32 +340,32 @@ mod constructor {
         use super::*;
         use test_case::test_case;
 
-        #[test_case(|a| ECMAScriptValue::from(a.intrinsic(IntrinsicId::ObjectPrototype)), |_| ECMAScriptValue::Undefined => Ok(vec![]); "object proto; no props")]
-        #[test_case(|_| ECMAScriptValue::Null, |_| ECMAScriptValue::Undefined => Ok(vec![]); "null proto; no props")]
-        #[test_case(|_| ECMAScriptValue::from(22), |_| ECMAScriptValue::Undefined => Err(String::from("Prototype argument for Object.create must be an Object or null.")); "bad proto")]
-        #[test_case(|a| ECMAScriptValue::from(a.intrinsic(IntrinsicId::ObjectPrototype)),
-                    |a| {
-                        let obj = ordinary_object_create(a, Some(a.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
-                        let emotion_descriptor = ordinary_object_create(a, Some(a.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
-                        create_data_property_or_throw(a, &emotion_descriptor, "value", "happy").unwrap();
-                        create_data_property_or_throw(a, &emotion_descriptor, "writable", true).unwrap();
-                        create_data_property_or_throw(a, &emotion_descriptor, "enumerable", true).unwrap();
-                        create_data_property_or_throw(a, &emotion_descriptor, "configurable", true).unwrap();
-                        create_data_property_or_throw(a, &obj, "emotion", emotion_descriptor).unwrap();
+        #[test_case(|| ECMAScriptValue::from(intrinsic(IntrinsicId::ObjectPrototype)), || ECMAScriptValue::Undefined => Ok(vec![]); "object proto; no props")]
+        #[test_case(|| ECMAScriptValue::Null, || ECMAScriptValue::Undefined => Ok(vec![]); "null proto; no props")]
+        #[test_case(|| ECMAScriptValue::from(22), || ECMAScriptValue::Undefined => Err(String::from("Prototype argument for Object.create must be an Object or null.")); "bad proto")]
+        #[test_case(|| ECMAScriptValue::from(intrinsic(IntrinsicId::ObjectPrototype)),
+                    || {
+                        let obj = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+                        let emotion_descriptor = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+                        create_data_property_or_throw(&emotion_descriptor, "value", "happy").unwrap();
+                        create_data_property_or_throw(&emotion_descriptor, "writable", true).unwrap();
+                        create_data_property_or_throw(&emotion_descriptor, "enumerable", true).unwrap();
+                        create_data_property_or_throw(&emotion_descriptor, "configurable", true).unwrap();
+                        create_data_property_or_throw(&obj, "emotion", emotion_descriptor).unwrap();
                         ECMAScriptValue::from(obj)
                     } => Ok(vec![PropertyInfo { name: PropertyKey::from("emotion"), enumerable: true, configurable: true, kind: PropertyInfoKind::Data{ value: ECMAScriptValue::from("happy"), writable: true } },]); "with props")]
         fn f(
-            make_proto: fn(&Agent) -> ECMAScriptValue,
-            make_props: fn(&Agent) -> ECMAScriptValue,
+            make_proto: fn() -> ECMAScriptValue,
+            make_props: fn() -> ECMAScriptValue,
         ) -> Result<Vec<PropertyInfo>, String> {
             setup_test_agent();
-            let proto = make_proto(&agent);
-            let props = make_props(&agent);
-            match object_create(&agent, ECMAScriptValue::Undefined, None, &[proto.clone(), props]) {
+            let proto = make_proto();
+            let props = make_props();
+            match object_create(ECMAScriptValue::Undefined, None, &[proto.clone(), props]) {
                 Ok(val) => match val {
                     ECMAScriptValue::Object(o) => {
                         assert_eq!(
-                            o.o.get_prototype_of(&agent),
+                            o.o.get_prototype_of(),
                             match &proto {
                                 ECMAScriptValue::Null => Ok(None),
                                 ECMAScriptValue::Object(o) => Ok(Some(o.clone())),
@@ -397,7 +376,7 @@ mod constructor {
                     }
                     _ => panic!("Object.create returned a non-object: {:?}", val),
                 },
-                Err(err) => Err(unwind_type_error(&agent, err)),
+                Err(err) => Err(unwind_type_error(err)),
             }
         }
     }
@@ -406,32 +385,32 @@ mod constructor {
         use super::*;
         use test_case::test_case;
 
-        #[test_case(|_| ECMAScriptValue::Undefined, |_| ECMAScriptValue::Undefined => Err("Object.defineProperties called on non-object".to_string()); "non-object")]
-        #[test_case(|a| ECMAScriptValue::from(ordinary_object_create(a, Some(a.intrinsic(IntrinsicId::ObjectPrototype)), &[])),
-                    |a| {
-                        let obj = ordinary_object_create(a, Some(a.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
-                        let emotion_descriptor = ordinary_object_create(a, Some(a.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
-                        create_data_property_or_throw(a, &emotion_descriptor, "value", "happy").unwrap();
-                        create_data_property_or_throw(a, &emotion_descriptor, "writable", true).unwrap();
-                        create_data_property_or_throw(a, &emotion_descriptor, "enumerable", true).unwrap();
-                        create_data_property_or_throw(a, &emotion_descriptor, "configurable", true).unwrap();
-                        create_data_property_or_throw(a, &obj, "emotion", emotion_descriptor).unwrap();
+        #[test_case(|| ECMAScriptValue::Undefined, || ECMAScriptValue::Undefined => Err("Object.defineProperties called on non-object".to_string()); "non-object")]
+        #[test_case(|| ECMAScriptValue::from(ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[])),
+                    || {
+                        let obj = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+                        let emotion_descriptor = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+                        create_data_property_or_throw(&emotion_descriptor, "value", "happy").unwrap();
+                        create_data_property_or_throw(&emotion_descriptor, "writable", true).unwrap();
+                        create_data_property_or_throw(&emotion_descriptor, "enumerable", true).unwrap();
+                        create_data_property_or_throw(&emotion_descriptor, "configurable", true).unwrap();
+                        create_data_property_or_throw(&obj, "emotion", emotion_descriptor).unwrap();
                         ECMAScriptValue::from(obj)
                     } => Ok(vec![PropertyInfo { name: PropertyKey::from("emotion"), enumerable: true, configurable: true, kind: PropertyInfoKind::Data{ value: ECMAScriptValue::from("happy"), writable: true } },]); "with props")]
-        #[test_case(|a| ECMAScriptValue::from(ordinary_object_create(a, Some(a.intrinsic(IntrinsicId::ObjectPrototype)), &[])),
-                    |a| {
-                        let obj = ordinary_object_create(a, Some(a.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
-                        create_data_property_or_throw(a, &obj, "key", "blue").unwrap();
+        #[test_case(|| ECMAScriptValue::from(ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[])),
+                    || {
+                        let obj = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+                        create_data_property_or_throw(&obj, "key", "blue").unwrap();
                         ECMAScriptValue::from(obj)
                     } => Err("Must be an object".to_string()); "bad props")]
         fn f(
-            make_obj: fn(&Agent) -> ECMAScriptValue,
-            make_props: fn(&Agent) -> ECMAScriptValue,
+            make_obj: fn() -> ECMAScriptValue,
+            make_props: fn() -> ECMAScriptValue,
         ) -> Result<Vec<PropertyInfo>, String> {
             setup_test_agent();
-            let obj = make_obj(&agent);
-            let props = make_props(&agent);
-            match object_define_properties(&agent, ECMAScriptValue::Undefined, None, &[obj.clone(), props]) {
+            let obj = make_obj();
+            let props = make_props();
+            match object_define_properties(ECMAScriptValue::Undefined, None, &[obj.clone(), props]) {
                 Ok(val) => match &val {
                     ECMAScriptValue::Object(o) => {
                         assert_eq!(val, obj);
@@ -439,7 +418,7 @@ mod constructor {
                     }
                     _ => panic!("Got a non-object back from Object.defineProperties: {:?}", val),
                 },
-                Err(err) => Err(unwind_type_error(&agent, err)),
+                Err(err) => Err(unwind_type_error(err)),
             }
         }
     }
@@ -448,32 +427,25 @@ mod constructor {
         use super::*;
         use test_case::test_case;
 
-        fn plain_obj(agent: &Agent) -> ECMAScriptValue {
-            ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]).into()
+        fn plain_obj() -> ECMAScriptValue {
+            ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]).into()
         }
-        fn faux_errors(
-            agent: &Agent,
-            _: ECMAScriptValue,
-            _: Option<&Object>,
-            _: &[ECMAScriptValue],
-        ) -> Completion<ECMAScriptValue> {
-            Err(create_type_error(agent, "Test Sentinel"))
+        fn faux_errors(_: ECMAScriptValue, _: Option<&Object>, _: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
+            Err(create_type_error("Test Sentinel"))
         }
-        fn make_bad_property_key(agent: &Agent) -> ECMAScriptValue {
-            let obj = ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+        fn make_bad_property_key() -> ECMAScriptValue {
+            let obj = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
             let tostring_func = create_builtin_function(
-                agent,
                 faux_errors,
                 false,
                 0.0,
                 "toString".into(),
                 BUILTIN_FUNCTION_SLOTS,
-                agent.current_realm_record(),
-                Some(agent.intrinsic(IntrinsicId::FunctionPrototype)),
+                current_realm_record(),
+                Some(intrinsic(IntrinsicId::FunctionPrototype)),
                 None,
             );
             define_property_or_throw(
-                agent,
                 &obj,
                 "toString",
                 PotentialPropertyDescriptor {
@@ -487,20 +459,20 @@ mod constructor {
             .unwrap();
             obj.into()
         }
-        fn undefined(_: &Agent) -> ECMAScriptValue {
+        fn undefined() -> ECMAScriptValue {
             ECMAScriptValue::Undefined
         }
-        fn frozen_obj(agent: &Agent) -> ECMAScriptValue {
-            let obj = ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
-            obj.o.prevent_extensions(agent).unwrap();
+        fn frozen_obj() -> ECMAScriptValue {
+            let obj = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+            obj.o.prevent_extensions().unwrap();
             obj.into()
         }
-        fn attrs(agent: &Agent) -> ECMAScriptValue {
-            let obj = ordinary_object_create(agent, Some(agent.intrinsic(IntrinsicId::ObjectPrototype)), &[]);
-            create_data_property_or_throw(agent, &obj, "value", 99).unwrap();
-            create_data_property_or_throw(agent, &obj, "writable", true).unwrap();
-            create_data_property_or_throw(agent, &obj, "enumerable", true).unwrap();
-            create_data_property_or_throw(agent, &obj, "configurable", true).unwrap();
+        fn attrs() -> ECMAScriptValue {
+            let obj = ordinary_object_create(Some(intrinsic(IntrinsicId::ObjectPrototype)), &[]);
+            create_data_property_or_throw(&obj, "value", 99).unwrap();
+            create_data_property_or_throw(&obj, "writable", true).unwrap();
+            create_data_property_or_throw(&obj, "enumerable", true).unwrap();
+            create_data_property_or_throw(&obj, "configurable", true).unwrap();
             obj.into()
         }
 
@@ -510,16 +482,16 @@ mod constructor {
         #[test_case(frozen_obj, undefined, attrs => Err("Property cannot be assigned to".to_string()); "frozen starting object")]
         #[test_case(plain_obj, undefined, attrs => Ok(vec![PropertyInfo { name: PropertyKey::from("undefined"), enumerable: true, configurable: true, kind: PropertyInfoKind::Data{ value: ECMAScriptValue::from(99), writable: true } },]); "success")]
         fn f(
-            make_obj: fn(&Agent) -> ECMAScriptValue,
-            make_key: fn(&Agent) -> ECMAScriptValue,
-            make_attrs: fn(&Agent) -> ECMAScriptValue,
+            make_obj: fn() -> ECMAScriptValue,
+            make_key: fn() -> ECMAScriptValue,
+            make_attrs: fn() -> ECMAScriptValue,
         ) -> Result<Vec<PropertyInfo>, String> {
             setup_test_agent();
-            let obj = make_obj(&agent);
-            let key = make_key(&agent);
-            let attrs = make_attrs(&agent);
+            let obj = make_obj();
+            let key = make_key();
+            let attrs = make_attrs();
 
-            let result = object_define_property(&agent, ECMAScriptValue::Undefined, None, &[obj.clone(), key, attrs]);
+            let result = object_define_property(ECMAScriptValue::Undefined, None, &[obj.clone(), key, attrs]);
             match result {
                 Ok(val) => match &val {
                     ECMAScriptValue::Object(o) => {
@@ -528,7 +500,7 @@ mod constructor {
                     }
                     _ => panic!("Got a non-object back from Object.defineProperty: {:?}", val),
                 },
-                Err(err) => Err(unwind_type_error(&agent, err)),
+                Err(err) => Err(unwind_type_error(err)),
             }
         }
     }
@@ -537,44 +509,43 @@ mod constructor {
         use super::*;
         use test_case::test_case;
 
-        fn undef(_: &Agent) -> ECMAScriptValue {
+        fn undef() -> ECMAScriptValue {
             ECMAScriptValue::Undefined
         }
-        fn dead(agent: &Agent) -> ECMAScriptValue {
-            DeadObject::object(agent).into()
+        fn dead() -> ECMAScriptValue {
+            DeadObject::object().into()
         }
 
         #[test_case(undef => Err("TypeError: Undefined and null cannot be converted to objects".to_string()); "undefined")]
         #[test_case(dead => Err("TypeError: own_property_keys called on DeadObject".to_string()); "own_property throws")]
-        fn errs(make_arg: fn(&Agent) -> ECMAScriptValue) -> Result<ECMAScriptValue, String> {
+        fn errs(make_arg: fn() -> ECMAScriptValue) -> Result<ECMAScriptValue, String> {
             setup_test_agent();
-            let arg = make_arg(&agent);
-            object_entries(&agent, ECMAScriptValue::Undefined, None, &[arg])
-                .map_err(|err| unwind_any_error(&agent, err))
+            let arg = make_arg();
+            object_entries(ECMAScriptValue::Undefined, None, &[arg]).map_err(|err| unwind_any_error(err))
         }
 
         #[test]
         fn normal() {
             setup_test_agent();
-            let proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-            let obj = ordinary_object_create(&agent, Some(proto), &[]);
-            create_data_property_or_throw(&agent, &obj, "one", 1.0).unwrap();
-            create_data_property_or_throw(&agent, &obj, "favorite", "spaghetti").unwrap();
+            let proto = intrinsic(IntrinsicId::ObjectPrototype);
+            let obj = ordinary_object_create(Some(proto), &[]);
+            create_data_property_or_throw(&obj, "one", 1.0).unwrap();
+            create_data_property_or_throw(&obj, "favorite", "spaghetti").unwrap();
 
-            let result = object_entries(&agent, ECMAScriptValue::Undefined, None, &[obj.into()]).unwrap();
+            let result = object_entries(ECMAScriptValue::Undefined, None, &[obj.into()]).unwrap();
             let entries: Object = result.try_into().unwrap();
-            assert!(entries.is_array(&agent).unwrap());
-            assert_eq!(get(&agent, &entries, &"length".into()).unwrap(), 2.0.into());
-            let first: Object = get(&agent, &entries, &"0".into()).unwrap().try_into().unwrap();
-            assert!(first.is_array(&agent).unwrap());
-            assert_eq!(get(&agent, &first, &"length".into()).unwrap(), 2.0.into());
-            assert_eq!(get(&agent, &first, &"0".into()).unwrap(), "one".into());
-            assert_eq!(get(&agent, &first, &"1".into()).unwrap(), 1.0.into());
-            let second: Object = get(&agent, &entries, &"1".into()).unwrap().try_into().unwrap();
-            assert!(second.is_array(&agent).unwrap());
-            assert_eq!(get(&agent, &second, &"length".into()).unwrap(), 2.0.into());
-            assert_eq!(get(&agent, &second, &"0".into()).unwrap(), "favorite".into());
-            assert_eq!(get(&agent, &second, &"1".into()).unwrap(), "spaghetti".into());
+            assert!(entries.is_array().unwrap());
+            assert_eq!(get(&entries, &"length".into()).unwrap(), 2.0.into());
+            let first: Object = get(&entries, &"0".into()).unwrap().try_into().unwrap();
+            assert!(first.is_array().unwrap());
+            assert_eq!(get(&first, &"length".into()).unwrap(), 2.0.into());
+            assert_eq!(get(&first, &"0".into()).unwrap(), "one".into());
+            assert_eq!(get(&first, &"1".into()).unwrap(), 1.0.into());
+            let second: Object = get(&entries, &"1".into()).unwrap().try_into().unwrap();
+            assert!(second.is_array().unwrap());
+            assert_eq!(get(&second, &"length".into()).unwrap(), 2.0.into());
+            assert_eq!(get(&second, &"0".into()).unwrap(), "favorite".into());
+            assert_eq!(get(&second, &"1".into()).unwrap(), "spaghetti".into());
         }
     }
 
@@ -584,33 +555,30 @@ mod constructor {
         #[test]
         fn no_args() {
             setup_test_agent();
-            assert_eq!(
-                object_freeze(&agent, ECMAScriptValue::Undefined, None, &[]).unwrap(),
-                ECMAScriptValue::Undefined
-            );
+            assert_eq!(object_freeze(ECMAScriptValue::Undefined, None, &[]).unwrap(), ECMAScriptValue::Undefined);
         }
         #[test]
         fn number() {
             setup_test_agent();
             assert_eq!(
-                object_freeze(&agent, ECMAScriptValue::Undefined, None, &[2003.25.into()]).unwrap(),
+                object_freeze(ECMAScriptValue::Undefined, None, &[2003.25.into()]).unwrap(),
                 ECMAScriptValue::from(2003.25)
             );
         }
         #[test]
         fn dead() {
             setup_test_agent();
-            let arg: ECMAScriptValue = DeadObject::object(&agent).into();
-            let result = object_freeze(&agent, ECMAScriptValue::Undefined, None, &[arg]).unwrap_err();
-            assert_eq!(unwind_any_error(&agent, result), "TypeError: prevent_extensions called on DeadObject");
+            let arg: ECMAScriptValue = DeadObject::object().into();
+            let result = object_freeze(ECMAScriptValue::Undefined, None, &[arg]).unwrap_err();
+            assert_eq!(unwind_any_error(result), "TypeError: prevent_extensions called on DeadObject");
         }
         #[test]
         fn ok() {
             setup_test_agent();
-            let obj = ordinary_object_create(&agent, None, &[]);
-            create_data_property_or_throw(&agent, &obj, "property", "holiday").unwrap();
+            let obj = ordinary_object_create(None, &[]);
+            create_data_property_or_throw(&obj, "property", "holiday").unwrap();
             let result: Object =
-                object_freeze(&agent, ECMAScriptValue::Undefined, None, &[obj.into()]).unwrap().try_into().unwrap();
+                object_freeze(ECMAScriptValue::Undefined, None, &[obj.into()]).unwrap().try_into().unwrap();
             assert_eq!(
                 result.o.common_object_data().borrow().propdump(),
                 vec![PropertyInfo {
@@ -624,12 +592,12 @@ mod constructor {
         #[test]
         fn prevention_prevented() {
             setup_test_agent();
-            let obj = AdaptableObject::object(
-                &agent,
-                AdaptableMethods { prevent_extensions_override: Some(|_, _| Ok(false)), ..Default::default() },
-            );
-            let result = object_freeze(&agent, ECMAScriptValue::Undefined, None, &[obj.into()]).unwrap_err();
-            assert_eq!(unwind_any_error(&agent, result), "TypeError: Object cannot be frozen");
+            let obj = AdaptableObject::object(AdaptableMethods {
+                prevent_extensions_override: Some(|_| Ok(false)),
+                ..Default::default()
+            });
+            let result = object_freeze(ECMAScriptValue::Undefined, None, &[obj.into()]).unwrap_err();
+            assert_eq!(unwind_any_error(result), "TypeError: Object cannot be frozen");
         }
     }
 }

--- a/src/object_object/tests.rs
+++ b/src/object_object/tests.rs
@@ -521,7 +521,7 @@ mod constructor {
         fn errs(make_arg: fn() -> ECMAScriptValue) -> Result<ECMAScriptValue, String> {
             setup_test_agent();
             let arg = make_arg();
-            object_entries(ECMAScriptValue::Undefined, None, &[arg]).map_err(|err| unwind_any_error(err))
+            object_entries(ECMAScriptValue::Undefined, None, &[arg]).map_err(unwind_any_error)
         }
 
         #[test]

--- a/src/parser/additive_operators/mod.rs
+++ b/src/parser/additive_operators/mod.rs
@@ -163,12 +163,12 @@ impl AdditiveExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            AdditiveExpression::MultiplicativeExpression(n) => n.early_errors(agent, errs, strict),
+            AdditiveExpression::MultiplicativeExpression(n) => n.early_errors(errs, strict),
             AdditiveExpression::Add(l, r) | AdditiveExpression::Subtract(l, r) => {
-                l.early_errors(agent, errs, strict);
-                r.early_errors(agent, errs, strict);
+                l.early_errors(errs, strict);
+                r.early_errors(errs, strict);
             }
         }
     }

--- a/src/parser/additive_operators/tests.rs
+++ b/src/parser/additive_operators/tests.rs
@@ -158,8 +158,8 @@ mod additive_expression {
         AdditiveExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/additive_operators/tests.rs
+++ b/src/parser/additive_operators/tests.rs
@@ -153,7 +153,7 @@ mod additive_expression {
     #[test_case("package-3", true => sset(&[PACKAGE_NOT_ALLOWED]); "AE minus ME; AE bad")]
     #[test_case("3-package", true => sset(&[PACKAGE_NOT_ALLOWED]); "AE minus ME; ME bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         AdditiveExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()

--- a/src/parser/arrow_function_definitions/mod.rs
+++ b/src/parser/arrow_function_definitions/mod.rs
@@ -94,7 +94,7 @@ impl ArrowFunction {
         self.parameters.contains_arguments() || self.body.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  ArrowFunction : ArrowParameters => ConciseBody
         //  * It is a Syntax Error if ArrowParameters Contains YieldExpression is true.
@@ -105,21 +105,18 @@ impl ArrowFunction {
         //    LexicallyDeclaredNames of ConciseBody.
         if self.parameters.contains(ParseNodeKind::YieldExpression) {
             errs.push(create_syntax_error_object(
-                agent,
                 "Illegal yield expression in arrow function parameters",
                 Some(self.parameters.location()),
             ));
         }
         if self.parameters.contains(ParseNodeKind::AwaitExpression) {
             errs.push(create_syntax_error_object(
-                agent,
                 "Illegal await expression in arrow function parameters",
                 Some(self.parameters.location()),
             ));
         }
         if self.body.concise_body_contains_use_strict() && !self.parameters.is_simple_parameter_list() {
             errs.push(create_syntax_error_object(
-                agent,
                 "Illegal 'use strict' directive in function with non-simple parameter list",
                 Some(self.parameters.location()),
             ));
@@ -127,16 +124,12 @@ impl ArrowFunction {
         let bn = self.parameters.bound_names();
         let ldn = self.body.lexically_declared_names();
         for name in bn.into_iter().filter(|n| ldn.contains(n)) {
-            errs.push(create_syntax_error_object(
-                agent,
-                format!("‘{}’ already defined", name),
-                Some(self.body.location()),
-            ));
+            errs.push(create_syntax_error_object(format!("‘{}’ already defined", name), Some(self.body.location())));
         }
 
         let strict_function = strict || self.body.concise_body_contains_use_strict();
-        self.parameters.early_errors(agent, errs, strict_function);
-        self.body.early_errors(agent, errs, strict_function);
+        self.parameters.early_errors(errs, strict_function);
+        self.body.early_errors(errs, strict_function);
     }
 }
 
@@ -276,10 +269,10 @@ impl ArrowParameters {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            ArrowParameters::Identifier(id) => id.early_errors(agent, errs, strict),
-            ArrowParameters::Formals(afp) => afp.early_errors(agent, errs, strict),
+            ArrowParameters::Identifier(id) => id.early_errors(errs, strict),
+            ArrowParameters::Formals(afp) => afp.early_errors(errs, strict),
         }
     }
 
@@ -405,8 +398,8 @@ impl ArrowFormalParameters {
         self.params.is_simple_parameter_list()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.params.early_errors(agent, errs, strict);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.params.early_errors(errs, strict);
     }
 
     pub fn expected_argument_count(&self) -> f64 {
@@ -566,10 +559,10 @@ impl ConciseBody {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            ConciseBody::Expression(exp) => exp.early_errors(agent, errs, strict),
-            ConciseBody::Function { body, .. } => body.early_errors(agent, errs, strict),
+            ConciseBody::Expression(exp) => exp.early_errors(errs, strict),
+            ConciseBody::Function { body, .. } => body.early_errors(errs, strict),
         }
     }
 
@@ -686,8 +679,8 @@ impl ExpressionBody {
         self.expression.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.expression.early_errors(agent, errs, strict);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.expression.early_errors(errs, strict);
     }
 }
 

--- a/src/parser/arrow_function_definitions/tests.rs
+++ b/src/parser/arrow_function_definitions/tests.rs
@@ -127,8 +127,8 @@ mod arrow_function {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).arrow_function().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).arrow_function().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("(a=arguments) => a" => true; "left")]
@@ -255,8 +255,8 @@ mod arrow_parameters {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).arrow_parameters().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).arrow_parameters().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "id")]
@@ -385,8 +385,8 @@ mod concise_body {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).concise_body().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).concise_body().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments" => true; "Exp (yes)")]
@@ -482,8 +482,8 @@ mod expression_body {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).expression_body().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).expression_body().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments" => true; "yes")]
@@ -573,8 +573,8 @@ mod arrow_formal_parameters {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).arrow_formal_parameters().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).arrow_formal_parameters().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("(a=arguments)" => true; "yes")]

--- a/src/parser/arrow_function_definitions/tests.rs
+++ b/src/parser/arrow_function_definitions/tests.rs
@@ -125,7 +125,7 @@ mod arrow_function {
     #[test_case("a => { let a; }", false => sset(&[A_DUPLICATED]); "param/lex clash")]
     #[test_case("package => { 'use strict'; implements; }", false => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "strict mode trigger")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).arrow_function().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -253,7 +253,7 @@ mod arrow_parameters {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingIdentifier")]
     #[test_case("(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "ArrowFormalParameters")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).arrow_parameters().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -383,7 +383,7 @@ mod concise_body {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "ExpressionBody")]
     #[test_case("{ package; }", true => sset(&[PACKAGE_NOT_ALLOWED]); "{ FunctionBody }")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).concise_body().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -480,7 +480,7 @@ mod expression_body {
 
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "AssignmentExpression")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).expression_body().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -571,7 +571,7 @@ mod arrow_formal_parameters {
 
     #[test_case("(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "( UniqueFormalParameters )")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).arrow_formal_parameters().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))

--- a/src/parser/assignment_operators/tests.rs
+++ b/src/parser/assignment_operators/tests.rs
@@ -381,8 +381,8 @@ mod assignment_expression {
         AssignmentExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]
@@ -687,8 +687,8 @@ mod assignment_pattern {
         AssignmentPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("[arguments]" => true; "array (yes)")]
@@ -815,8 +815,8 @@ mod object_assignment_pattern {
         ObjectAssignmentPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("{}" => false; "empty")]
@@ -999,8 +999,8 @@ mod array_assignment_pattern {
         ArrayAssignmentPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("[]" => false; "Empty")]
@@ -1090,8 +1090,8 @@ mod assignment_rest_property {
         AssignmentRestProperty::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("...arguments" => true; "Rest (yes)")]
@@ -1171,8 +1171,8 @@ mod assignment_property_list {
         AssignmentPropertyList::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments" => true; "Item (yes)")]
@@ -1255,8 +1255,8 @@ mod assignment_element_list {
         AssignmentElementList::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments" => true; "Item (yes)")]
@@ -1336,8 +1336,8 @@ mod assignment_elision_element {
         AssignmentElisionElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments" => true; "Item (yes)")]
@@ -1433,8 +1433,8 @@ mod assignment_property {
         AssignmentProperty::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments" => true; "id (yes)")]
@@ -1522,8 +1522,8 @@ mod assignment_element {
         AssignmentElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments" => true; "Item (yes)")]
@@ -1589,8 +1589,8 @@ mod assignment_rest_element {
         AssignmentRestElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("...arguments" => true; "yes")]
@@ -1671,8 +1671,8 @@ mod destructuring_assignment_target {
         DestructuringAssignmentTarget::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments" => true; "Exp (yes)")]

--- a/src/parser/assignment_operators/tests.rs
+++ b/src/parser/assignment_operators/tests.rs
@@ -376,7 +376,7 @@ mod assignment_expression {
     #[test_case("(a=>a)||=b", true => sset(&[INVALID_LHS]); "LHS must be simple (logical or)")]
     #[test_case("(a=>a)??=b", true => sset(&[INVALID_LHS]); "LHS must be simple (coalesce)")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         AssignmentExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -682,7 +682,7 @@ mod assignment_pattern {
     #[test_case("{package}", true => sset(&[PACKAGE_NOT_ALLOWED]); "ObjectAssignmentPattern")]
     #[test_case("[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "ArrayAssignmentPattern")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         AssignmentPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -810,7 +810,7 @@ mod object_assignment_pattern {
     #[test_case("{package,}", true => sset(&[PACKAGE_NOT_ALLOWED]); "{ AssignmentPropertyList , } (trailing comma)")]
     #[test_case("{package,...interface}", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "{ AssignmentPropertyList , AssignmentRestProperty }")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ObjectAssignmentPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -994,7 +994,7 @@ mod array_assignment_pattern {
     #[test_case("[package,...interface]", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "[ AssignmentElementList , AssignmentRestElement ]")]
     #[test_case("[package,,...interface]", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "[ AssignmentElementList , Elision AssignmentRestElement ]")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ArrayAssignmentPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -1085,7 +1085,7 @@ mod assignment_rest_property {
     #[test_case("...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "... DestructuringAssignmentTarget")]
     #[test_case("...{a}", true => sset(&["`...` must be followed by an assignable reference in assignment contexts"]); "assignable refs")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         AssignmentRestProperty::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -1166,7 +1166,7 @@ mod assignment_property_list {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "AssignmentProperty")]
     #[test_case("package,interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "AssignmentPropertyList , AssignmentProperty")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         AssignmentPropertyList::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -1250,7 +1250,7 @@ mod assignment_element_list {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "AssignmentElisionElement")]
     #[test_case("package,interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "AssignmentElementList , AssignmentElisionElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         AssignmentElementList::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -1331,7 +1331,7 @@ mod assignment_elision_element {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "AssignmentElement")]
     #[test_case(",package", true => sset(&[PACKAGE_NOT_ALLOWED]); "Elision AssignmentElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         AssignmentElisionElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -1428,7 +1428,7 @@ mod assignment_property {
     #[test_case("package=interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "IdentifierReference Initializer")]
     #[test_case("[package]:interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "PropertyName : AssignmentElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         AssignmentProperty::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -1517,7 +1517,7 @@ mod assignment_element {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "DestructuringAssignmentTarget")]
     #[test_case("package=interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "DestructuringAssignmentTarget Initializer")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         AssignmentElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -1584,7 +1584,7 @@ mod assignment_rest_element {
 
     #[test_case("...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "... DestructuringAssignmentTarget")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         AssignmentRestElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -1666,7 +1666,7 @@ mod destructuring_assignment_target {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "lhs")]
     #[test_case("(a=>a)", true => sset(&[INVALID_LHS]); "not simple")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         DestructuringAssignmentTarget::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()

--- a/src/parser/async_arrow_function_definitions/mod.rs
+++ b/src/parser/async_arrow_function_definitions/mod.rs
@@ -255,7 +255,7 @@ impl AsyncArrowHead {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }
@@ -378,7 +378,7 @@ impl AsyncConciseBody {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 
@@ -459,7 +459,7 @@ impl AsyncArrowBindingIdentifier {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 
@@ -540,7 +540,7 @@ impl CoverCallExpressionAndAsyncArrowHead {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/async_arrow_function_definitions/mod.rs
+++ b/src/parser/async_arrow_function_definitions/mod.rs
@@ -171,7 +171,7 @@ impl AsyncArrowFunction {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 }

--- a/src/parser/async_arrow_function_definitions/tests.rs
+++ b/src/parser/async_arrow_function_definitions/tests.rs
@@ -1,7 +1,6 @@
 use super::testhelp::*;
 use super::*;
 use crate::prettyprint::testhelp::*;
-use crate::tests::*;
 use test_case::test_case;
 
 // ASYNC ARROW FUNCTION
@@ -250,7 +249,7 @@ fn async_arrow_function_test_early_errors() {
     AsyncArrowFunction::parse(&mut newparser("async x => x"), Scanner::new(), true, true, true)
         .unwrap()
         .0
-        .early_errors(&test_agent(), &mut vec![], true);
+        .early_errors(&mut vec![], true);
 }
 
 mod async_arrow_function {
@@ -356,11 +355,7 @@ fn async_concise_body_test_all_private_identifiers_valid(src: &str) -> bool {
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn async_concise_body_test_early_errors() {
-    AsyncConciseBody::parse(&mut newparser("x"), Scanner::new(), true).unwrap().0.early_errors(
-        &test_agent(),
-        &mut vec![],
-        true,
-    );
+    AsyncConciseBody::parse(&mut newparser("x"), Scanner::new(), true).unwrap().0.early_errors(&mut vec![], true);
 }
 
 mod async_concise_body {
@@ -413,11 +408,10 @@ fn async_arrow_binding_identifier_test_contains_01() {
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn async_arrow_binding_identifier_test_early_errors() {
-    AsyncArrowBindingIdentifier::parse(&mut newparser("x"), Scanner::new(), true).unwrap().0.early_errors(
-        &test_agent(),
-        &mut vec![],
-        true,
-    );
+    AsyncArrowBindingIdentifier::parse(&mut newparser("x"), Scanner::new(), true)
+        .unwrap()
+        .0
+        .early_errors(&mut vec![], true);
 }
 
 // COVER CALL EXPRESSION AND ASYNC ARROW HEAD
@@ -503,7 +497,7 @@ fn cceaaah_test_early_errors() {
     CoverCallExpressionAndAsyncArrowHead::parse(&mut newparser("x()"), Scanner::new(), true, true)
         .unwrap()
         .0
-        .early_errors(&test_agent(), &mut vec![], true);
+        .early_errors(&mut vec![], true);
 }
 
 // ASYNC ARROW HEAD
@@ -556,11 +550,7 @@ fn async_arrow_head_test_all_private_identifiers_valid(src: &str) -> bool {
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn async_arrow_head_test_early_errors() {
-    AsyncArrowHead::parse(&mut newparser("async(a)"), Scanner::new()).unwrap().0.early_errors(
-        &test_agent(),
-        &mut vec![],
-        true,
-    );
+    AsyncArrowHead::parse(&mut newparser("async(a)"), Scanner::new()).unwrap().0.early_errors(&mut vec![], true);
 }
 
 mod async_arrow_head {

--- a/src/parser/async_function_definitions/mod.rs
+++ b/src/parser/async_function_definitions/mod.rs
@@ -135,7 +135,7 @@ impl AsyncFunctionDeclaration {
     /// See [Early Errors for Async Function Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-async-function-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         // AsyncFunctionDeclaration :
         //     async function BindingIdentifier ( FormalParameters ) { AsyncFunctionBody }
@@ -159,18 +159,13 @@ impl AsyncFunctionDeclaration {
             // FunctionBodyContainsUseStrict of AsyncFunctionBody is true and IsSimpleParameterList of FormalParameters
             // is false
             errs.push(create_syntax_error_object(
-                agent,
                 "Strict functions must also have simple parameter lists",
                 Some(self.params.location()),
             ));
         }
         if self.params.contains(ParseNodeKind::AwaitExpression) {
             // FormalParameters Contains AwaitExpression is true.
-            errs.push(create_syntax_error_object(
-                agent,
-                "await expressions not expected here",
-                Some(self.params.location()),
-            ));
+            errs.push(create_syntax_error_object("await expressions not expected here", Some(self.params.location())));
         }
         let duplicates_checked = if strict_function {
             // The Early Error rules for UniqueFormalParameters : FormalParameters are applied.
@@ -180,7 +175,6 @@ impl AsyncFunctionDeclaration {
             let bn = self.params.bound_names();
             for name in duplicates(&bn) {
                 errs.push(create_syntax_error_object(
-                    agent,
                     format!("‘{}’ already defined", name),
                     Some(self.params.location()),
                 ));
@@ -195,7 +189,6 @@ impl AsyncFunctionDeclaration {
         let ldn: AHashSet<JSString> = self.body.lexically_declared_names().into_iter().collect();
         if !bn.is_disjoint(&ldn) {
             errs.push(create_syntax_error_object(
-                agent,
                 "Lexical decls in body duplicate parameters",
                 Some(self.body.location()),
             ));
@@ -203,42 +196,32 @@ impl AsyncFunctionDeclaration {
         // It is a Syntax Error if FormalParameters Contains SuperProperty is true.
         if self.params.contains(ParseNodeKind::SuperProperty) {
             errs.push(create_syntax_error_object(
-                agent,
                 "Parameters may not include super properties",
                 Some(self.params.location()),
             ));
         }
         // It is a Syntax Error if AsyncFunctionBody Contains SuperProperty is true.
         if self.body.contains(ParseNodeKind::SuperProperty) {
-            errs.push(create_syntax_error_object(
-                agent,
-                "Body may not contain super properties",
-                Some(self.body.location()),
-            ));
+            errs.push(create_syntax_error_object("Body may not contain super properties", Some(self.body.location())));
         }
         // It is a Syntax Error if FormalParameters Contains SuperCall is true.
         if self.params.contains(ParseNodeKind::SuperCall) {
             errs.push(create_syntax_error_object(
-                agent,
                 "Parameters may not include super calls",
                 Some(self.params.location()),
             ));
         }
         // It is a Syntax Error if AsyncFunctionBody Contains SuperCall is true.
         if self.body.contains(ParseNodeKind::SuperCall) {
-            errs.push(create_syntax_error_object(
-                agent,
-                "Body may not contain super calls",
-                Some(self.body.location()),
-            ));
+            errs.push(create_syntax_error_object("Body may not contain super calls", Some(self.body.location())));
         }
 
         // All the children
         if let Some(binding_identifier) = &self.ident {
-            binding_identifier.early_errors(agent, errs, strict_function);
+            binding_identifier.early_errors(errs, strict_function);
         }
-        self.params.early_errors(agent, errs, strict_function, duplicates_checked);
-        self.body.early_errors(agent, errs, strict_function);
+        self.params.early_errors(errs, strict_function, duplicates_checked);
+        self.body.early_errors(errs, strict_function);
 
         // And done.
     }
@@ -361,7 +344,7 @@ impl AsyncFunctionExpression {
     /// See [Early Errors for Async Function Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-async-function-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  AsyncFunctionExpression :
         //      async function BindingIdentifier[opt] ( FormalParameters ) { AsyncFunctionBody }
@@ -384,18 +367,13 @@ impl AsyncFunctionExpression {
             // FunctionBodyContainsUseStrict of AsyncFunctionBody is true and IsSimpleParameterList of FormalParameters
             // is false
             errs.push(create_syntax_error_object(
-                agent,
                 "Strict functions must also have simple parameter lists",
                 Some(self.params.location()),
             ));
         }
         if self.params.contains(ParseNodeKind::AwaitExpression) {
             // FormalParameters Contains AwaitExpression is true.
-            errs.push(create_syntax_error_object(
-                agent,
-                "await expressions not expected here",
-                Some(self.params.location()),
-            ));
+            errs.push(create_syntax_error_object("await expressions not expected here", Some(self.params.location())));
         }
         let duplicates_checked = if strict_function {
             // The Early Error rules for UniqueFormalParameters : FormalParameters are applied.
@@ -405,7 +383,6 @@ impl AsyncFunctionExpression {
             let bn = self.params.bound_names();
             for name in duplicates(&bn) {
                 errs.push(create_syntax_error_object(
-                    agent,
                     format!("‘{}’ already defined", name),
                     Some(self.params.location()),
                 ));
@@ -420,7 +397,6 @@ impl AsyncFunctionExpression {
         let ldn: AHashSet<JSString> = self.body.lexically_declared_names().into_iter().collect();
         if !bn.is_disjoint(&ldn) {
             errs.push(create_syntax_error_object(
-                agent,
                 "Lexical decls in body duplicate parameters",
                 Some(self.body.location()),
             ));
@@ -428,42 +404,32 @@ impl AsyncFunctionExpression {
         // It is a Syntax Error if FormalParameters Contains SuperProperty is true.
         if self.params.contains(ParseNodeKind::SuperProperty) {
             errs.push(create_syntax_error_object(
-                agent,
                 "Parameters may not include super properties",
                 Some(self.params.location()),
             ));
         }
         // It is a Syntax Error if AsyncFunctionBody Contains SuperProperty is true.
         if self.body.contains(ParseNodeKind::SuperProperty) {
-            errs.push(create_syntax_error_object(
-                agent,
-                "Body may not contain super properties",
-                Some(self.body.location()),
-            ));
+            errs.push(create_syntax_error_object("Body may not contain super properties", Some(self.body.location())));
         }
         // It is a Syntax Error if FormalParameters Contains SuperCall is true.
         if self.params.contains(ParseNodeKind::SuperCall) {
             errs.push(create_syntax_error_object(
-                agent,
                 "Parameters may not include super calls",
                 Some(self.params.location()),
             ));
         }
         // It is a Syntax Error if AsyncFunctionBody Contains SuperCall is true.
         if self.body.contains(ParseNodeKind::SuperCall) {
-            errs.push(create_syntax_error_object(
-                agent,
-                "Body may not contain super calls",
-                Some(self.body.location()),
-            ));
+            errs.push(create_syntax_error_object("Body may not contain super calls", Some(self.body.location())));
         }
 
         // All the children
         if let Some(binding_identifier) = &self.ident {
-            binding_identifier.early_errors(agent, errs, strict_function);
+            binding_identifier.early_errors(errs, strict_function);
         }
-        self.params.early_errors(agent, errs, strict_function, duplicates_checked);
-        self.body.early_errors(agent, errs, strict_function);
+        self.params.early_errors(errs, strict_function, duplicates_checked);
+        self.body.early_errors(errs, strict_function);
     }
 
     pub fn is_named_function(&self) -> bool {
@@ -597,7 +563,7 @@ impl AsyncMethod {
     /// See [Early Errors for Async Function Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-async-function-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  AsyncMethod : async ClassElementName ( UniqueFormalParameters ) { AsyncFunctionBody }
         //  * It is a Syntax Error if FunctionBodyContainsUseStrict of AsyncFunctionBody is true and
@@ -609,17 +575,15 @@ impl AsyncMethod {
         let cus = self.body.function_body_contains_use_strict();
         if cus && !self.params.is_simple_parameter_list() {
             errs.push(create_syntax_error_object(
-                agent,
                 "Illegal 'use strict' directive in function with non-simple parameter list",
                 Some(self.params.location()),
             ));
         }
         if self.has_direct_super() {
-            errs.push(create_syntax_error_object(agent, "Calls to ‘super’ not allowed here", Some(self.location())));
+            errs.push(create_syntax_error_object("Calls to ‘super’ not allowed here", Some(self.location())));
         }
         if self.params.contains(ParseNodeKind::AwaitExpression) {
             errs.push(create_syntax_error_object(
-                agent,
                 "Illegal await-expression in formal parameters of async function",
                 Some(self.params.location()),
             ))
@@ -628,7 +592,6 @@ impl AsyncMethod {
         for name in self.body.lexically_declared_names() {
             if bn.contains(&name) {
                 errs.push(create_syntax_error_object(
-                    agent,
                     format!("‘{}’ already defined", name),
                     Some(self.body.location()),
                 ));
@@ -636,9 +599,9 @@ impl AsyncMethod {
         }
 
         let strict_func = strict || cus;
-        self.ident.early_errors(agent, errs, strict_func);
-        self.params.early_errors(agent, errs, strict_func);
-        self.body.early_errors(agent, errs, strict_func);
+        self.ident.early_errors(errs, strict_func);
+        self.params.early_errors(errs, strict_func);
+        self.body.early_errors(errs, strict_func);
     }
 
     pub fn prop_name(&self) -> Option<JSString> {
@@ -742,8 +705,8 @@ impl AsyncFunctionBody {
         self.0.lexically_declared_names()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.0.early_errors(agent, errs, strict);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.0.early_errors(errs, strict);
     }
 
     /// Return a list of identifiers defined by the `var` statement for this node.
@@ -831,8 +794,8 @@ impl AwaitExpression {
         self.exp.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.exp.early_errors(agent, errs, strict);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.exp.early_errors(errs, strict);
     }
 
     /// Returns `true` if any subexpression starting from here (but not crossing function boundaries) contains an

--- a/src/parser/async_function_definitions/tests.rs
+++ b/src/parser/async_function_definitions/tests.rs
@@ -269,8 +269,8 @@ mod async_function_declaration {
         AsyncFunctionDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("   async function abc() {}" => Location{ starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 23 } }; "typical")]
@@ -473,8 +473,8 @@ mod async_function_expression {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).async_function_expression().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).async_function_expression().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("async function a(){}" => true; "named")]
@@ -650,11 +650,8 @@ mod async_method {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        AsyncMethod::parse(&mut newparser(src), Scanner::new(), true, true)
-            .unwrap()
-            .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        AsyncMethod::parse(&mut newparser(src), Scanner::new(), true, true).unwrap().0.early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("async [arguments](){}" => true; "yes")]
@@ -734,8 +731,8 @@ mod async_function_body {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        AsyncFunctionBody::parse(&mut newparser(src), Scanner::new()).0.early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        AsyncFunctionBody::parse(&mut newparser(src), Scanner::new()).0.early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments;" => true; "yes")]
@@ -822,11 +819,8 @@ mod await_expression {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        AwaitExpression::parse(&mut newparser(src), Scanner::new(), true)
-            .unwrap()
-            .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        AwaitExpression::parse(&mut newparser(src), Scanner::new(), true).unwrap().0.early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("await arguments" => true; "yes")]

--- a/src/parser/async_function_definitions/tests.rs
+++ b/src/parser/async_function_definitions/tests.rs
@@ -264,7 +264,7 @@ mod async_function_declaration {
     #[test_case("async function package(interface){implements;}", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "without default")]
     #[test_case("async function(package){interface;}", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "with default")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         AsyncFunctionDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -471,7 +471,7 @@ mod async_function_expression {
     #[test_case("async function package(interface){implements;}", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "without default")]
     #[test_case("async function(package){interface;}", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "with default")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).async_function_expression().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -648,7 +648,7 @@ mod async_method {
     #[test_case("async w(a){let a; const bb=0;}", false => sset(&[A_ALREADY_DEFN]); "duplicate lex")]
     #[test_case("async f(a){'use strict'; package;}", false => sset(&[PACKAGE_NOT_ALLOWED]); "directive works")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         AsyncMethod::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -732,7 +732,7 @@ mod async_function_body {
 
     #[test_case("package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "FunctionBody")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         AsyncFunctionBody::parse(&mut newparser(src), Scanner::new()).0.early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -820,7 +820,7 @@ mod await_expression {
 
     #[test_case("await package", true => sset(&[PACKAGE_NOT_ALLOWED]); "await UnaryExpression")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         AwaitExpression::parse(&mut newparser(src), Scanner::new(), true)
             .unwrap()

--- a/src/parser/async_generator_function_definitions/mod.rs
+++ b/src/parser/async_generator_function_definitions/mod.rs
@@ -121,7 +121,7 @@ impl AsyncGeneratorMethod {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 
@@ -263,7 +263,7 @@ impl AsyncGeneratorDeclaration {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 
@@ -379,7 +379,7 @@ impl AsyncGeneratorExpression {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 
@@ -449,7 +449,7 @@ impl AsyncGeneratorBody {
     }
 
     #[allow(clippy::ptr_arg)]
-    pub fn early_errors(&self, _agent: &Agent, _errs: &mut Vec<Object>, _strict: bool) {
+    pub fn early_errors(&self, _errs: &mut Vec<Object>, _strict: bool) {
         todo!()
     }
 

--- a/src/parser/async_generator_function_definitions/tests.rs
+++ b/src/parser/async_generator_function_definitions/tests.rs
@@ -1,7 +1,6 @@
 use super::testhelp::*;
 use super::*;
 use crate::prettyprint::testhelp::*;
-use crate::tests::*;
 use test_case::test_case;
 
 // ASYNC GENERATOR METHOD
@@ -181,7 +180,7 @@ mod async_generator_method {
         AsyncGeneratorMethod::parse(&mut newparser("async *a(){}"), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&test_agent(), &mut vec![], true);
+            .early_errors(&mut vec![], true);
     }
 
     #[test]
@@ -523,7 +522,7 @@ mod async_generator_declaration {
         AsyncGeneratorDeclaration::parse(&mut newparser("async function *a(){}"), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&test_agent(), &mut vec![], true);
+            .early_errors(&mut vec![], true);
     }
 
     #[test_case("   async function *a(){}" => Location { starting_line: 1, starting_column: 4, span: Span{ starting_index: 3, length: 21 }})]
@@ -754,7 +753,7 @@ mod async_generator_expression {
         AsyncGeneratorExpression::parse(&mut newparser("async function *a(){}"), Scanner::new())
             .unwrap()
             .0
-            .early_errors(&test_agent(), &mut vec![], true);
+            .early_errors(&mut vec![], true);
     }
 
     #[test_case("async function *a(){}" => true; "named")]
@@ -819,11 +818,7 @@ mod async_generator_body {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn early_errors() {
-        AsyncGeneratorBody::parse(&mut newparser("yield 3;"), Scanner::new()).0.early_errors(
-            &test_agent(),
-            &mut vec![],
-            true,
-        );
+        AsyncGeneratorBody::parse(&mut newparser("yield 3;"), Scanner::new()).0.early_errors(&mut vec![], true);
     }
 
     #[test_case("let a; const b=0; var c; function d() {}" => svec(&["c", "d"]); "function body")]

--- a/src/parser/binary_bitwise_operators/mod.rs
+++ b/src/parser/binary_bitwise_operators/mod.rs
@@ -139,12 +139,12 @@ impl BitwiseANDExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            BitwiseANDExpression::EqualityExpression(n) => n.early_errors(agent, errs, strict),
+            BitwiseANDExpression::EqualityExpression(n) => n.early_errors(errs, strict),
             BitwiseANDExpression::BitwiseAND(l, r) => {
-                l.early_errors(agent, errs, strict);
-                r.early_errors(agent, errs, strict);
+                l.early_errors(errs, strict);
+                r.early_errors(errs, strict);
             }
         }
     }
@@ -314,12 +314,12 @@ impl BitwiseXORExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            BitwiseXORExpression::BitwiseANDExpression(n) => n.early_errors(agent, errs, strict),
+            BitwiseXORExpression::BitwiseANDExpression(n) => n.early_errors(errs, strict),
             BitwiseXORExpression::BitwiseXOR(l, r) => {
-                l.early_errors(agent, errs, strict);
-                r.early_errors(agent, errs, strict);
+                l.early_errors(errs, strict);
+                r.early_errors(errs, strict);
             }
         }
     }
@@ -506,12 +506,12 @@ impl BitwiseORExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            BitwiseORExpression::BitwiseXORExpression(n) => n.early_errors(agent, errs, strict),
+            BitwiseORExpression::BitwiseXORExpression(n) => n.early_errors(errs, strict),
             BitwiseORExpression::BitwiseOR(l, r) => {
-                l.early_errors(agent, errs, strict);
-                r.early_errors(agent, errs, strict);
+                l.early_errors(errs, strict);
+                r.early_errors(errs, strict);
             }
         }
     }

--- a/src/parser/binary_bitwise_operators/tests.rs
+++ b/src/parser/binary_bitwise_operators/tests.rs
@@ -120,8 +120,8 @@ mod bitwise_and_expression {
         BitwiseANDExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]
@@ -271,8 +271,8 @@ mod bitwise_xor_expression {
         BitwiseXORExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]
@@ -428,8 +428,8 @@ mod bitwise_or_expression {
         BitwiseORExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/binary_bitwise_operators/tests.rs
+++ b/src/parser/binary_bitwise_operators/tests.rs
@@ -115,7 +115,7 @@ mod bitwise_and_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "fall thru")]
     #[test_case("package&interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "bitwise and")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         BitwiseANDExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -266,7 +266,7 @@ mod bitwise_xor_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "fall thru")]
     #[test_case("package^interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "bitwise xor")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         BitwiseXORExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -423,7 +423,7 @@ mod bitwise_or_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "fall thru")]
     #[test_case("package|interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "bitwise or")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         BitwiseORExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()

--- a/src/parser/binary_logical_operators/mod.rs
+++ b/src/parser/binary_logical_operators/mod.rs
@@ -143,12 +143,12 @@ impl LogicalANDExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            LogicalANDExpression::BitwiseORExpression(n) => n.early_errors(agent, errs, strict),
+            LogicalANDExpression::BitwiseORExpression(n) => n.early_errors(errs, strict),
             LogicalANDExpression::LogicalAND(l, r) => {
-                l.early_errors(agent, errs, strict);
-                r.early_errors(agent, errs, strict);
+                l.early_errors(errs, strict);
+                r.early_errors(errs, strict);
             }
         }
     }
@@ -319,12 +319,12 @@ impl LogicalORExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            LogicalORExpression::LogicalANDExpression(n) => n.early_errors(agent, errs, strict),
+            LogicalORExpression::LogicalANDExpression(n) => n.early_errors(errs, strict),
             LogicalORExpression::LogicalOR(l, r) => {
-                l.early_errors(agent, errs, strict);
-                r.early_errors(agent, errs, strict);
+                l.early_errors(errs, strict);
+                r.early_errors(errs, strict);
             }
         }
     }
@@ -473,9 +473,9 @@ impl CoalesceExpression {
         self.head.contains_arguments() || self.tail.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.head.early_errors(agent, errs, strict);
-        self.tail.early_errors(agent, errs, strict);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.head.early_errors(errs, strict);
+        self.tail.early_errors(errs, strict);
     }
 }
 
@@ -574,10 +574,10 @@ impl CoalesceExpressionHead {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            CoalesceExpressionHead::CoalesceExpression(n) => n.early_errors(agent, errs, strict),
-            CoalesceExpressionHead::BitwiseORExpression(n) => n.early_errors(agent, errs, strict),
+            CoalesceExpressionHead::CoalesceExpression(n) => n.early_errors(errs, strict),
+            CoalesceExpressionHead::BitwiseORExpression(n) => n.early_errors(errs, strict),
         }
     }
 }
@@ -707,10 +707,10 @@ impl ShortCircuitExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            ShortCircuitExpression::LogicalORExpression(n) => n.early_errors(agent, errs, strict),
-            ShortCircuitExpression::CoalesceExpression(n) => n.early_errors(agent, errs, strict),
+            ShortCircuitExpression::LogicalORExpression(n) => n.early_errors(errs, strict),
+            ShortCircuitExpression::CoalesceExpression(n) => n.early_errors(errs, strict),
         }
     }
 

--- a/src/parser/binary_logical_operators/tests.rs
+++ b/src/parser/binary_logical_operators/tests.rs
@@ -122,8 +122,8 @@ mod logical_and_expression {
         LogicalANDExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]
@@ -283,8 +283,8 @@ mod logical_or_expression {
         LogicalORExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]
@@ -434,8 +434,8 @@ mod coalesce_expression {
         CoalesceExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments??bob" => true; "a coal b (left)")]
@@ -540,8 +540,8 @@ mod coalesce_expression_head {
         let mut errs = vec![];
         let ce = CoalesceExpression::parse(&mut newparser(src), Scanner::new(), false, true, true).unwrap().0;
         let ceh = &ce.head;
-        ceh.early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        ceh.early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments??bob" => true; "Exp (yes)")]
@@ -664,8 +664,8 @@ mod short_circuit_expression {
         ShortCircuitExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/binary_logical_operators/tests.rs
+++ b/src/parser/binary_logical_operators/tests.rs
@@ -117,7 +117,7 @@ mod logical_and_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "fall thru")]
     #[test_case("package&&interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "logical and")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         LogicalANDExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -278,7 +278,7 @@ mod logical_or_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "fall thru")]
     #[test_case("package||interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "logical or")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         LogicalORExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -429,7 +429,7 @@ mod coalesce_expression {
 
     #[test_case("package??interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "coalesce")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         CoalesceExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -536,7 +536,7 @@ mod coalesce_expression_head {
     #[test_case("package??interface", true => sset(&[PACKAGE_NOT_ALLOWED]); "MultiplicativeExpression")]
     #[test_case("package??interface??q", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "AE plus ME; AE bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         let ce = CoalesceExpression::parse(&mut newparser(src), Scanner::new(), false, true, true).unwrap().0;
         let ceh = &ce.head;
@@ -659,7 +659,7 @@ mod short_circuit_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "fall thru")]
     #[test_case("package??interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "coalesce")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ShortCircuitExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()

--- a/src/parser/bitwise_shift_operators/mod.rs
+++ b/src/parser/bitwise_shift_operators/mod.rs
@@ -172,14 +172,14 @@ impl ShiftExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            ShiftExpression::AdditiveExpression(n) => n.early_errors(agent, errs, strict),
+            ShiftExpression::AdditiveExpression(n) => n.early_errors(errs, strict),
             ShiftExpression::LeftShift(l, r)
             | ShiftExpression::SignedRightShift(l, r)
             | ShiftExpression::UnsignedRightShift(l, r) => {
-                l.early_errors(agent, errs, strict);
-                r.early_errors(agent, errs, strict);
+                l.early_errors(errs, strict);
+                r.early_errors(errs, strict);
             }
         }
     }

--- a/src/parser/bitwise_shift_operators/tests.rs
+++ b/src/parser/bitwise_shift_operators/tests.rs
@@ -198,8 +198,8 @@ mod shift_expression {
         ShiftExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/bitwise_shift_operators/tests.rs
+++ b/src/parser/bitwise_shift_operators/tests.rs
@@ -193,7 +193,7 @@ mod shift_expression {
     #[test_case("package>>>3", true => sset(&[PACKAGE_NOT_ALLOWED]); "left ushr right; left bad")]
     #[test_case("3>>>package", true => sset(&[PACKAGE_NOT_ALLOWED]); "left ushr right; right bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ShiftExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()

--- a/src/parser/block/mod.rs
+++ b/src/parser/block/mod.rs
@@ -93,16 +93,9 @@ impl BlockStatement {
         node.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(
-        &self,
-        agent: &Agent,
-        errs: &mut Vec<Object>,
-        strict: bool,
-        within_iteration: bool,
-        within_switch: bool,
-    ) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_iteration: bool, within_switch: bool) {
         let BlockStatement::Block(node) = self;
-        node.early_errors(agent, errs, strict, within_iteration, within_switch);
+        node.early_errors(errs, strict, within_iteration, within_switch);
     }
 
     /// Returns `true` if any subexpression starting from here (but not crossing function boundaries) contains an
@@ -290,14 +283,7 @@ impl Block {
         self.statements.as_ref().map_or(false, |sl| sl.contains_arguments())
     }
 
-    pub fn early_errors(
-        &self,
-        agent: &Agent,
-        errs: &mut Vec<Object>,
-        strict: bool,
-        within_iteration: bool,
-        within_switch: bool,
-    ) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_iteration: bool, within_switch: bool) {
         if let Some(sl) = &self.statements {
             // Static Semantics: Early Errors
             // Block : { StatementList }
@@ -309,18 +295,14 @@ impl Block {
             let lex_names_set: AHashSet<JSString> = ldn.into_iter().collect();
             let unique_lexname_count = lex_names_set.len();
             if lexname_count != unique_lexname_count {
-                errs.push(create_syntax_error_object(agent, "Duplicate lexically declared names", Some(sl.location())));
+                errs.push(create_syntax_error_object("Duplicate lexically declared names", Some(sl.location())));
             }
             let vdn = sl.var_declared_names();
             let var_names_set: AHashSet<JSString> = vdn.into_iter().collect();
             if !lex_names_set.is_disjoint(&var_names_set) {
-                errs.push(create_syntax_error_object(
-                    agent,
-                    "Name defined both lexically and var-style",
-                    Some(sl.location()),
-                ));
+                errs.push(create_syntax_error_object("Name defined both lexically and var-style", Some(sl.location())));
             }
-            sl.early_errors(agent, errs, strict, within_iteration, within_switch);
+            sl.early_errors(errs, strict, within_iteration, within_switch);
         }
     }
 
@@ -494,16 +476,9 @@ impl StatementList {
         self.list.iter().all(|item| item.all_private_identifiers_valid(names))
     }
 
-    pub fn early_errors(
-        &self,
-        agent: &Agent,
-        errs: &mut Vec<Object>,
-        strict: bool,
-        within_iteration: bool,
-        within_switch: bool,
-    ) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_iteration: bool, within_switch: bool) {
         for item in self.list.iter() {
-            item.early_errors(agent, errs, strict, within_iteration, within_switch);
+            item.early_errors(errs, strict, within_iteration, within_switch);
         }
     }
 
@@ -717,19 +692,10 @@ impl StatementListItem {
         }
     }
 
-    pub fn early_errors(
-        &self,
-        agent: &Agent,
-        errs: &mut Vec<Object>,
-        strict: bool,
-        within_iteration: bool,
-        within_switch: bool,
-    ) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_iteration: bool, within_switch: bool) {
         match self {
-            StatementListItem::Statement(node) => {
-                node.early_errors(agent, errs, strict, within_iteration, within_switch)
-            }
-            StatementListItem::Declaration(node) => node.early_errors(agent, errs, strict),
+            StatementListItem::Statement(node) => node.early_errors(errs, strict, within_iteration, within_switch),
+            StatementListItem::Declaration(node) => node.early_errors(errs, strict),
         }
     }
 

--- a/src/parser/block/tests.rs
+++ b/src/parser/block/tests.rs
@@ -89,7 +89,7 @@ mod block_statement {
 
     #[test_case("{package;}", true => sset(&[PACKAGE_NOT_ALLOWED]); "Block")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         BlockStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -260,7 +260,7 @@ mod block {
     #[test_case("{ let a = 10; const a = 20; }", true => sset(&[DUPLICATE_LEXICAL]); "Duplicate lexically declared names")]
     #[test_case("{ var x; print(x); let x = 27; }", true => sset(&[LEX_DUPED_BY_VAR]); "Name declared both lex & var")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Block::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -519,7 +519,7 @@ mod statement_list {
     #[test_case("package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "StatementListItem")]
     #[test_case("package;implements;", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "StatementList StatementListItem")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         StatementList::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -778,7 +778,7 @@ mod statement_list_item {
     #[test_case("let package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "Declaration")]
     #[test_case("package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "Statement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         StatementListItem::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()

--- a/src/parser/block/tests.rs
+++ b/src/parser/block/tests.rs
@@ -94,8 +94,8 @@ mod block_statement {
         BlockStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("{arguments;}" => true; "yes")]
@@ -265,8 +265,8 @@ mod block {
         Block::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("{arguments;}" => true; "yes")]
@@ -524,8 +524,8 @@ mod statement_list {
         StatementList::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
     #[test_case("arguments;" => true; "Item (yes)")]
     #[test_case("no;" => false; "Item (no)")]
@@ -783,8 +783,8 @@ mod statement_list_item {
         StatementListItem::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments;" => true; "Stmt (yes)")]

--- a/src/parser/break_statement/mod.rs
+++ b/src/parser/break_statement/mod.rs
@@ -84,7 +84,7 @@ impl BreakStatement {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, within_breakable: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_breakable: bool) {
         // Static Semantics: Early Errors
         //  BreakStatement : break ;
         //      * It is a Syntax Error if this BreakStatement is not nested, directly or indirectly (but not crossing
@@ -94,13 +94,12 @@ impl BreakStatement {
             BreakStatement::Bare { .. } => {
                 if !within_breakable {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "break statement must lie within iteration or switch statement",
                         Some(self.location()),
                     ));
                 }
             }
-            BreakStatement::Labelled { label, .. } => label.early_errors(agent, errs, strict),
+            BreakStatement::Labelled { label, .. } => label.early_errors(errs, strict),
         }
     }
 }

--- a/src/parser/break_statement/tests.rs
+++ b/src/parser/break_statement/tests.rs
@@ -115,12 +115,11 @@ mod break_statement {
         setup_test_agent();
         let mut errs = vec![];
         BreakStatement::parse(&mut newparser(src), Scanner::new(), true, true).unwrap().0.early_errors(
-            &agent,
             &mut errs,
             strict,
             within_breakable,
         );
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("   break;" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 6 } }; "no label")]

--- a/src/parser/break_statement/tests.rs
+++ b/src/parser/break_statement/tests.rs
@@ -112,7 +112,7 @@ mod break_statement {
     #[test_case("break;", true, false => sset(&[ILLEGAL_BREAK]); "break not in a good spot")]
     #[test_case("break package;", true, true => sset(&[PACKAGE_NOT_ALLOWED]); "break LabelIdentifier ;")]
     fn early_errors(src: &str, strict: bool, within_breakable: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         BreakStatement::parse(&mut newparser(src), Scanner::new(), true, true).unwrap().0.early_errors(
             &agent,

--- a/src/parser/class_definitions/tests.rs
+++ b/src/parser/class_definitions/tests.rs
@@ -138,8 +138,8 @@ mod class_declaration {
     fn early_errors(src: &str) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_declaration().early_errors(&agent, &mut errs);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).class_declaration().early_errors(&mut errs);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("class a { [arguments]; }" => true; "named (yes)")]
@@ -254,8 +254,8 @@ mod class_expression {
     fn early_errors(src: &str) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_expression().early_errors(&agent, &mut errs);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).class_expression().early_errors(&mut errs);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("class a { [arguments]; }" => true; "named (yes)")]
@@ -446,8 +446,8 @@ mod class_tail {
     fn early_errors(src: &str) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_tail().early_errors(&agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).class_tail().early_errors(&mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("{}" => false; "empty")]
@@ -525,8 +525,8 @@ mod class_heritage {
     fn early_errors(src: &str) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_heritage().early_errors(&agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).class_heritage().early_errors(&mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("extends arguments" => true; "yes")]
@@ -614,8 +614,8 @@ mod class_body {
     fn early_errors(src: &str) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_body().early_errors(&agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).class_body().early_errors(&mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("[arguments];" => true; "yes")]
@@ -795,8 +795,8 @@ mod class_element_list {
     fn early_errors(src: &str) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_element_list().early_errors(&agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).class_element_list().early_errors(&mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("[arguments];" => true; "item (yes)")]
@@ -1110,8 +1110,8 @@ mod class_element {
     fn early_errors(src: &str) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_element().early_errors(&agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).class_element().early_errors(&mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("[arguments](){}" => true; "Method (yes)")]
@@ -1330,8 +1330,8 @@ mod field_definition {
     fn early_errors(src: &str) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).field_definition().early_errors(&agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).field_definition().early_errors(&mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("[arguments]" => true; "name (yes)")]
@@ -1456,8 +1456,8 @@ mod class_element_name {
     fn early_errors(src: &str) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_element_name().early_errors(&agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).class_element_name().early_errors(&mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => Some(JSString::from("a")); "normal")]
@@ -1536,8 +1536,8 @@ mod class_static_block {
     fn early_errors(src: &str) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_static_block().early_errors(&agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).class_static_block().early_errors(&mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("static { arguments; }" => true; "yes")]
@@ -1594,8 +1594,8 @@ mod class_static_block_body {
     fn early_errors(src: &str) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_static_block_body().early_errors(&agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).class_static_block_body().early_errors(&mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments;" => true; "yes")]
@@ -1651,8 +1651,8 @@ mod class_static_block_statement_list {
     fn early_errors(src: &str) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).class_static_block_statement_list().early_errors(&agent, &mut errs, true);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).class_static_block_statement_list().early_errors(&mut errs, true);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("", &[] => false; "empty")]

--- a/src/parser/class_definitions/tests.rs
+++ b/src/parser/class_definitions/tests.rs
@@ -136,7 +136,7 @@ mod class_declaration {
     #[test_case("class { a=package; }" => sset(&[PACKAGE_NOT_ALLOWED]); "class tail only")]
     #[test_case("class package { a=implements; }" => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "id + tail")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).class_declaration().early_errors(&agent, &mut errs);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -252,7 +252,7 @@ mod class_expression {
     #[test_case("class { a=package; }" => sset(&[PACKAGE_NOT_ALLOWED]); "class tail only")]
     #[test_case("class package { a=implements; }" => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "id + tail")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).class_expression().early_errors(&agent, &mut errs);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -444,7 +444,7 @@ mod class_tail {
     #[test_case("{}" => sset(&[]); "no body")]
 
     fn early_errors(src: &str) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).class_tail().early_errors(&agent, &mut errs, true);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -523,7 +523,7 @@ mod class_heritage {
     #[test_case("extends package" => sset(&[PACKAGE_NOT_ALLOWED]); "err")]
     #[test_case("extends Boolean" => sset(&[]); "ok")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).class_heritage().early_errors(&agent, &mut errs, true);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -612,7 +612,7 @@ mod class_body {
     #[test_case("static set #a(val){this.val=val;} #a(){}" => sset(&[PREV_STATIC_SETTER]); "static setter / method")]
     #[test_case("static #a(){} get #a(){return this.val;}" => sset(&[PRIVATE_A_ALREADY_DEFN]); "static method / getter")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).class_body().early_errors(&agent, &mut errs, true);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -793,7 +793,7 @@ mod class_element_list {
     #[test_case("a=package; b=implements;" => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "list (errs)")]
     #[test_case("a=10; b=20;" => sset(&[]); "list (ok)")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).class_element_list().early_errors(&agent, &mut errs, true);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -1108,7 +1108,7 @@ mod class_element {
     #[test_case("static prototype;" => sset(&[STATIC_PROTO]); "static proto field")]
     #[test_case("static constructor;" => sset(&[CONSTRUCTOR_FIELD]); "static constructor field")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).class_element().early_errors(&agent, &mut errs, true);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -1328,7 +1328,7 @@ mod field_definition {
     #[test_case("a=arguments" => sset(&[UNEXPECTED_ARGS]); "args in izer")]
     #[test_case("a=super()" => sset(&[UNEXPECTED_SUPER]); "super in izer")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).field_definition().early_errors(&agent, &mut errs, true);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -1454,7 +1454,7 @@ mod class_element_name {
     #[test_case("#constructor" => sset(&[PRIVATE_CONSTRUCTOR]); "private constructor")]
     #[test_case("#private" => sset(&[]); "simple private")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).class_element_name().early_errors(&agent, &mut errs, true);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -1534,7 +1534,7 @@ mod class_static_block {
     #[test_case("static {}" => sset(&[]); "empty")]
     #[test_case("static {package;}" => sset(&[PACKAGE_NOT_ALLOWED]); "something")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).class_static_block().early_errors(&agent, &mut errs, true);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -1592,7 +1592,7 @@ mod class_static_block_body {
     #[test_case("super();" => sset(&[UNEXPECTED_SUPER]); "super call")]
     #[test_case("await a();" => sset(&[UNEXPECTED_AWAIT]); "await expr")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).class_static_block_body().early_errors(&agent, &mut errs, true);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -1649,7 +1649,7 @@ mod class_static_block_statement_list {
     #[test_case("0;" => sset(&[]); "normal")]
     #[test_case("" => sset(&[]); "empty")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).class_static_block_statement_list().early_errors(&agent, &mut errs, true);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))

--- a/src/parser/comma_operator/mod.rs
+++ b/src/parser/comma_operator/mod.rs
@@ -163,12 +163,12 @@ impl Expression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            Expression::FallThru(node) => node.early_errors(agent, errs, strict),
+            Expression::FallThru(node) => node.early_errors(errs, strict),
             Expression::Comma(left, right) => {
-                left.early_errors(agent, errs, strict);
-                right.early_errors(agent, errs, strict);
+                left.early_errors(errs, strict);
+                right.early_errors(errs, strict);
             }
         }
     }

--- a/src/parser/comma_operator/tests.rs
+++ b/src/parser/comma_operator/tests.rs
@@ -87,8 +87,8 @@ mod expression {
         Expression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/comma_operator/tests.rs
+++ b/src/parser/comma_operator/tests.rs
@@ -82,7 +82,7 @@ mod expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "AssignmentExpression")]
     #[test_case("package,implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "Expression , AssignmentExpression")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Expression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()

--- a/src/parser/conditional_operator/mod.rs
+++ b/src/parser/conditional_operator/mod.rs
@@ -152,13 +152,13 @@ impl ConditionalExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            ConditionalExpression::FallThru(node) => node.early_errors(agent, errs, strict),
+            ConditionalExpression::FallThru(node) => node.early_errors(errs, strict),
             ConditionalExpression::Conditional(a, b, c) => {
-                a.early_errors(agent, errs, strict);
-                b.early_errors(agent, errs, strict);
-                c.early_errors(agent, errs, strict);
+                a.early_errors(errs, strict);
+                b.early_errors(errs, strict);
+                c.early_errors(errs, strict);
             }
         }
     }

--- a/src/parser/conditional_operator/tests.rs
+++ b/src/parser/conditional_operator/tests.rs
@@ -135,8 +135,8 @@ mod conditional_expression {
         ConditionalExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/conditional_operator/tests.rs
+++ b/src/parser/conditional_operator/tests.rs
@@ -130,7 +130,7 @@ mod conditional_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "fall thru")]
     #[test_case("package?interface:implements", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "conditional")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ConditionalExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()

--- a/src/parser/continue_statement/mod.rs
+++ b/src/parser/continue_statement/mod.rs
@@ -87,7 +87,7 @@ impl ContinueStatement {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, within_iteration: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_iteration: bool) {
         // Static Semantics: Early Errors
         // ContinueStatement :
         //      continue ;
@@ -96,13 +96,12 @@ impl ContinueStatement {
         //    function or static initialization block boundaries), within an IterationStatement.
         if !within_iteration {
             errs.push(create_syntax_error_object(
-                agent,
                 "Continue statements must lie within iteration statements.",
                 Some(self.location()),
             ));
         }
         if let ContinueStatement::Labelled { label, .. } = self {
-            label.early_errors(agent, errs, strict);
+            label.early_errors(errs, strict);
         }
     }
 }

--- a/src/parser/continue_statement/tests.rs
+++ b/src/parser/continue_statement/tests.rs
@@ -127,7 +127,7 @@ mod continue_statement {
     #[test_case("continue package;", true, true => sset(&[PACKAGE_NOT_ALLOWED]); "continue LabelIdentifier ; (within)")]
     #[test_case("continue package;", true, false => sset(&[PACKAGE_NOT_ALLOWED, CONTINUE_ITER]); "continue LabelIdentifier ; (beyond)")]
     fn early_errors(src: &str, strict: bool, within_iteration: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ContinueStatement::parse(&mut newparser(src), Scanner::new(), true, true).unwrap().0.early_errors(
             &agent,

--- a/src/parser/continue_statement/tests.rs
+++ b/src/parser/continue_statement/tests.rs
@@ -130,12 +130,11 @@ mod continue_statement {
         setup_test_agent();
         let mut errs = vec![];
         ContinueStatement::parse(&mut newparser(src), Scanner::new(), true, true).unwrap().0.early_errors(
-            &agent,
             &mut errs,
             strict,
             within_iteration,
         );
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("   continue;" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 9 } }; "no label")]

--- a/src/parser/declarations_and_variables/tests.rs
+++ b/src/parser/declarations_and_variables/tests.rs
@@ -126,8 +126,8 @@ mod lexical_declaration {
         LexicalDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("let a=arguments;" => true; "yes")]
@@ -257,12 +257,11 @@ mod binding_list {
         setup_test_agent();
         let mut errs = vec![];
         BindingList::parse(&mut newparser(src), Scanner::new(), true, true, true).unwrap().0.early_errors(
-            &agent,
             &mut errs,
             strict,
             is_constant_declaration,
         );
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Item (yes)")]
@@ -389,12 +388,11 @@ mod lexical_binding {
         setup_test_agent();
         let mut errs = vec![];
         LexicalBinding::parse(&mut newparser(src), Scanner::new(), true, true, true).unwrap().0.early_errors(
-            &agent,
             &mut errs,
             strict,
             is_constant_declaration,
         );
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "id")]
@@ -485,8 +483,8 @@ mod variable_statement {
         VariableStatement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("var a=arguments;" => true; "yes")]
@@ -611,8 +609,8 @@ mod variable_declaration_list {
         VariableDeclarationList::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Item (yes)")]
@@ -756,8 +754,8 @@ mod variable_declaration {
         VariableDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "Id")]
@@ -859,8 +857,8 @@ mod binding_pattern {
         BindingPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("{a=arguments}" => true; "Object (yes)")]
@@ -1084,8 +1082,8 @@ mod object_binding_pattern {
         ObjectBindingPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("{}" => false; "empty")]
@@ -1478,8 +1476,8 @@ mod array_binding_pattern {
         ArrayBindingPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("[]" => false; "emtpy")]
@@ -1580,8 +1578,8 @@ mod binding_rest_property {
         BindingRestProperty::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 }
 
@@ -1689,8 +1687,8 @@ mod binding_property_list {
         BindingPropertyList::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Item (yes)")]
@@ -1812,8 +1810,8 @@ mod binding_element_list {
         BindingElementList::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Item (yes)")]
@@ -1912,8 +1910,8 @@ mod binding_elision_element {
         BindingElisionElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Item (yes)")]
@@ -2033,8 +2031,8 @@ mod binding_property {
         BindingProperty::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Single (yes)")]
@@ -2180,8 +2178,8 @@ mod binding_element {
         BindingElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Single (yes)")]
@@ -2305,8 +2303,8 @@ mod single_name_binding {
         SingleNameBinding::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "Id")]
@@ -2423,8 +2421,8 @@ mod binding_rest_element {
         BindingRestElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("...a" => false; "id")]

--- a/src/parser/declarations_and_variables/tests.rs
+++ b/src/parser/declarations_and_variables/tests.rs
@@ -121,7 +121,7 @@ mod lexical_declaration {
     #[test_case("let a=1,a=2,b=3,b=4,c=5,c=6;", true => sset(&[DUPLICATE_LEX_ABC]); "many duplicates")]
     #[test_case("let package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "sub-productions")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         LexicalDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -254,7 +254,7 @@ mod binding_list {
     #[test_case("package", true, true => sset(&[PACKAGE_NOT_ALLOWED, MISSING_INITIALIZER]); "LexicalBinding")]
     #[test_case("package,implements", true, false => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingList , LexicalBinding")]
     fn early_errors(src: &str, strict: bool, is_constant_declaration: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         BindingList::parse(&mut newparser(src), Scanner::new(), true, true, true).unwrap().0.early_errors(
             &agent,
@@ -386,7 +386,7 @@ mod lexical_binding {
     #[test_case("package=implements", true, true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingIdentifier Initializer")]
     #[test_case("[package]=implements", true, false => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingPattern Initializer")]
     fn early_errors(src: &str, strict: bool, is_constant_declaration: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         LexicalBinding::parse(&mut newparser(src), Scanner::new(), true, true, true).unwrap().0.early_errors(
             &agent,
@@ -480,7 +480,7 @@ mod variable_statement {
 
     #[test_case("var package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "var VariableDeclarationList ;")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         VariableStatement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -606,7 +606,7 @@ mod variable_declaration_list {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "VariableDeclaration")]
     #[test_case("package,implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "VariableDeclarationList , VariableDeclaration")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         VariableDeclarationList::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -751,7 +751,7 @@ mod variable_declaration {
     #[test_case("package=implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingIdentifier Initializer")]
     #[test_case("[package]=implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingPattern Initializer")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         VariableDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -854,7 +854,7 @@ mod binding_pattern {
     #[test_case("{package}", true => sset(&[PACKAGE_NOT_ALLOWED]); "ObjectBindingPattern")]
     #[test_case("[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "ArrayBindingPattern")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         BindingPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -1079,7 +1079,7 @@ mod object_binding_pattern {
     #[test_case("{package,}", true => sset(&[PACKAGE_NOT_ALLOWED]); "{ BindingPropertyList , } (trailing comma)")]
     #[test_case("{package,...implements}", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "{ BindingPropertyList , BindingRestProperty }")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ObjectBindingPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -1473,7 +1473,7 @@ mod array_binding_pattern {
     #[test_case("[package,...implements]", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "[ BindingElementList , BindingRestElement ]")]
     #[test_case("[package,,...implements]", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "[ BindingElementList , Elision BindingRestElement ]")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ArrayBindingPattern::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -1575,7 +1575,7 @@ mod binding_rest_property {
 
     #[test_case("...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "... BindingIdentifier")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         BindingRestProperty::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -1684,7 +1684,7 @@ mod binding_property_list {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingProperty")]
     #[test_case("package,implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingPropertyList , BindingProperty")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         BindingPropertyList::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -1807,7 +1807,7 @@ mod binding_element_list {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingElisionElement")]
     #[test_case("package,implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingElementList , BindingElisionElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         BindingElementList::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -1907,7 +1907,7 @@ mod binding_elision_element {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingElement")]
     #[test_case(",package", true => sset(&[PACKAGE_NOT_ALLOWED]); "Elision BindingElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         BindingElisionElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -2028,7 +2028,7 @@ mod binding_property {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "SingleNameBinding")]
     #[test_case("[package]:implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "PropertyName : BindingElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         BindingProperty::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -2175,7 +2175,7 @@ mod binding_element {
     #[test_case("[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingPattern")]
     #[test_case("[package]=implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingPattern Initializer")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         BindingElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -2300,7 +2300,7 @@ mod single_name_binding {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingIdentifier")]
     #[test_case("package=implements", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "BindingIdentifier Initializer")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         SingleNameBinding::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -2418,7 +2418,7 @@ mod binding_rest_element {
     #[test_case("...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "... BindingIdentifier")]
     #[test_case("...[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "... BindingPattern")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         BindingRestElement::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()

--- a/src/parser/equality_operators/mod.rs
+++ b/src/parser/equality_operators/mod.rs
@@ -183,15 +183,15 @@ impl EqualityExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            EqualityExpression::RelationalExpression(n) => n.early_errors(agent, errs, strict),
+            EqualityExpression::RelationalExpression(n) => n.early_errors(errs, strict),
             EqualityExpression::Equal(l, r)
             | EqualityExpression::NotEqual(l, r)
             | EqualityExpression::StrictEqual(l, r)
             | EqualityExpression::NotStrictEqual(l, r) => {
-                l.early_errors(agent, errs, strict);
-                r.early_errors(agent, errs, strict);
+                l.early_errors(errs, strict);
+                r.early_errors(errs, strict);
             }
         }
     }

--- a/src/parser/equality_operators/tests.rs
+++ b/src/parser/equality_operators/tests.rs
@@ -260,7 +260,7 @@ mod equality_expression {
     #[test_case("package!==3", true => sset(&[PACKAGE_NOT_ALLOWED]); "left nse right; left bad")]
     #[test_case("3!==package", true => sset(&[PACKAGE_NOT_ALLOWED]); "left nse right; right bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         EqualityExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()

--- a/src/parser/equality_operators/tests.rs
+++ b/src/parser/equality_operators/tests.rs
@@ -265,8 +265,8 @@ mod equality_expression {
         EqualityExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/exponentiation_operator/mod.rs
+++ b/src/parser/exponentiation_operator/mod.rs
@@ -138,12 +138,12 @@ impl ExponentiationExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            ExponentiationExpression::UnaryExpression(n) => n.early_errors(agent, errs, strict),
+            ExponentiationExpression::UnaryExpression(n) => n.early_errors(errs, strict),
             ExponentiationExpression::Exponentiation(l, r) => {
-                l.early_errors(agent, errs, strict);
-                r.early_errors(agent, errs, strict);
+                l.early_errors(errs, strict);
+                r.early_errors(errs, strict);
             }
         }
     }

--- a/src/parser/exponentiation_operator/tests.rs
+++ b/src/parser/exponentiation_operator/tests.rs
@@ -127,7 +127,7 @@ mod exponentiation_expression {
     #[test_case("package**3", true => sset(&[PACKAGE_NOT_ALLOWED]); "left ** right; left bad")]
     #[test_case("3**package", true => sset(&[PACKAGE_NOT_ALLOWED]); "left ** right; right bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ExponentiationExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()

--- a/src/parser/exponentiation_operator/tests.rs
+++ b/src/parser/exponentiation_operator/tests.rs
@@ -132,8 +132,8 @@ mod exponentiation_expression {
         ExponentiationExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/expression_statement/mod.rs
+++ b/src/parser/expression_statement/mod.rs
@@ -105,8 +105,8 @@ impl ExpressionStatement {
         self.exp.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.exp.early_errors(agent, errs, strict);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.exp.early_errors(errs, strict);
     }
 }
 

--- a/src/parser/expression_statement/tests.rs
+++ b/src/parser/expression_statement/tests.rs
@@ -125,8 +125,8 @@ mod expression_statement {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).expression_statement().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).expression_statement().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments;" => true; "yes")]

--- a/src/parser/expression_statement/tests.rs
+++ b/src/parser/expression_statement/tests.rs
@@ -123,7 +123,7 @@ mod expression_statement {
 
     #[test_case("package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "normal")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).expression_statement().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))

--- a/src/parser/function_definitions/tests.rs
+++ b/src/parser/function_definitions/tests.rs
@@ -228,8 +228,8 @@ mod function_declaration {
         FunctionDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("   function a(){}" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 14 } }; "typical")]
@@ -377,11 +377,8 @@ mod function_expression {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        FunctionExpression::parse(&mut newparser(src), Scanner::new())
-            .unwrap()
-            .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        FunctionExpression::parse(&mut newparser(src), Scanner::new()).unwrap().0.early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("function a(){}" => true; "named")]
@@ -475,8 +472,8 @@ mod function_body {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).function_body().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).function_body().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments;" => true; "yes")]
@@ -607,8 +604,8 @@ mod function_statement_list {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).function_statement_list().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).function_statement_list().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("" => false; "empty")]

--- a/src/parser/function_definitions/tests.rs
+++ b/src/parser/function_definitions/tests.rs
@@ -223,7 +223,7 @@ mod function_declaration {
     #[test_case("function a(){super();}", false => sset(&[BAD_SUPER]); "SuperCall in body")]
     #[test_case("function a(){super.b;}", false => sset(&[BAD_SUPER]); "SuperProperty in body")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         FunctionDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -375,7 +375,7 @@ mod function_expression {
     #[test_case("function a(){super();}", false => sset(&[BAD_SUPER]); "SuperCall in body")]
     #[test_case("function a(){super.b;}", false => sset(&[BAD_SUPER]); "SuperProperty in body")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         FunctionExpression::parse(&mut newparser(src), Scanner::new())
             .unwrap()
@@ -473,7 +473,7 @@ mod function_body {
     #[test_case("break a;", false => sset(&[UNDEF_BREAK]); "undefined break")]
     #[test_case("while (1) continue a;", false => sset(&[UNDEF_CONTINUE]); "undefined continue")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).function_body().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -605,7 +605,7 @@ mod function_statement_list {
     #[test_case("package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "StatementList")]
     #[test_case("", true => sset(&[]); "[empty]")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).function_statement_list().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))

--- a/src/parser/generator_function_definitions/tests.rs
+++ b/src/parser/generator_function_definitions/tests.rs
@@ -134,8 +134,8 @@ mod generator_method {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).generator_method().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).generator_method().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test]
@@ -395,8 +395,8 @@ mod generator_declaration {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).generator_declaration().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).generator_declaration().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("   function *a(){}" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 15 } }; "typical")]
@@ -570,8 +570,8 @@ mod generator_expression {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).generator_expression().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).generator_expression().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("function *a(){}" => true; "named")]
@@ -637,8 +637,8 @@ mod generator_body {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).generator_body().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).generator_body().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("'one'; 3;" => false; "directive no strict")]
@@ -813,8 +813,8 @@ mod yield_expression {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).yield_expression().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).yield_expression().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("yield" => false; "bare")]

--- a/src/parser/generator_function_definitions/tests.rs
+++ b/src/parser/generator_function_definitions/tests.rs
@@ -132,7 +132,7 @@ mod generator_method {
     #[test_case("*a(b=yield 10){}", false => sset(&[YIELD_IN_GENPARAM]); "yield in generator params")]
     #[test_case("*a(b){super(b);}", false => sset(&[UNEXPECTED_SUPER]); "direct super")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).generator_method().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -393,7 +393,7 @@ mod generator_declaration {
     #[test_case("function *a(){super.b;}", false => sset(&[UNEXPECTED_SUPER2]); "SuperProperty in body")]
     #[test_case("function *a(b=yield 10){}", false => sset(&[YIELD_IN_GENPARAM]); "yield in generator params")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).generator_declaration().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -568,7 +568,7 @@ mod generator_expression {
     #[test_case("function *a(){super.b;}", false => sset(&[UNEXPECTED_SUPER2]); "SuperProperty in body")]
     #[test_case("function *a(b=yield 10){}", false => sset(&[YIELD_IN_GENPARAM]); "yield in generator params")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).generator_expression().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -635,7 +635,7 @@ mod generator_body {
 
     #[test_case("package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "statements")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).generator_body().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -811,7 +811,7 @@ mod yield_expression {
     #[test_case("yield", true => sset(&[]); "no expresion")]
     #[test_case("yield *package", true => sset(&[PACKAGE_NOT_ALLOWED]); "yield from")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).yield_expression().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))

--- a/src/parser/identifiers/mod.rs
+++ b/src/parser/identifiers/mod.rs
@@ -106,7 +106,7 @@ impl Identifier {
         false
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, in_module: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, in_module: bool) {
         // Static Semantics: Early Errors
         //      Identifier : IdentifierName but not ReservedWord
         //  * It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of IdentifierName
@@ -129,14 +129,12 @@ impl Identifier {
                 || id.string_value == "yield")
         {
             errs.push(create_syntax_error_object(
-                agent,
                 format!("‘{}’ not allowed as an identifier in strict mode", id.string_value).as_str(),
                 Some(self.location),
             ));
         }
         if in_module && id.string_value == "await" {
             errs.push(create_syntax_error_object(
-                agent,
                 "‘await’ not allowed as an identifier in modules",
                 Some(self.location),
             ));
@@ -179,7 +177,6 @@ impl Identifier {
             || id.string_value == "with"
         {
             errs.push(create_syntax_error_object(
-                agent,
                 format!("‘{}’ is a reserved word and may not be used as an identifier", id.string_value).as_str(),
                 Some(self.location),
             ));
@@ -317,7 +314,7 @@ impl IdentifierReference {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             IdentifierReference::Identifier { identifier: id, data } => {
@@ -327,26 +324,23 @@ impl IdentifierReference {
                 let sv = id.string_value();
                 if data.yield_flag && sv == "yield" {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "identifier 'yield' not allowed when yield expressions are valid",
                         Some(data.location),
                     ));
                 }
                 if data.await_flag && sv == "await" {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "identifier 'await' not allowed when await expressions are valid",
                         Some(data.location),
                     ));
                 }
-                id.early_errors(agent, errs, strict, data.in_module);
+                id.early_errors(errs, strict, data.in_module);
             }
             IdentifierReference::Yield { data } => {
                 // IdentifierReference : yield
                 //  * It is a Syntax Error if the code matched by this production is contained in strict mode code.
                 if strict {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "identifier not allowed in strict mode: yield",
                         Some(data.location),
                     ));
@@ -357,7 +351,6 @@ impl IdentifierReference {
                 //  * It is a Syntax Error if the goal symbol of the syntactic grammar is Module.
                 if data.in_module {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "identifier not allowed in modules: await",
                         Some(data.location),
                     ));
@@ -552,7 +545,7 @@ impl BindingIdentifier {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             BindingIdentifier::Identifier { identifier: id, data } => {
@@ -564,26 +557,23 @@ impl BindingIdentifier {
                 let sv = id.string_value();
                 if strict && [JSString::from("arguments"), JSString::from("eval")].contains(&sv) {
                     errs.push(create_syntax_error_object(
-                        agent,
                         format!("identifier not allowed in strict mode: {}", sv).as_str(),
                         Some(data.location),
                     ));
                 }
                 if data.yield_flag && sv == "yield" {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "identifier 'yield' not allowed when yield expressions are valid",
                         Some(data.location),
                     ));
                 }
                 if data.await_flag && sv == "await" {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "identifier 'await' not allowed when await expressions are valid",
                         Some(data.location),
                     ));
                 }
-                id.early_errors(agent, errs, strict, data.in_module);
+                id.early_errors(errs, strict, data.in_module);
             }
             BindingIdentifier::Yield { data } => {
                 // BindingIdentifier : yield
@@ -591,14 +581,12 @@ impl BindingIdentifier {
                 //  * It is a Syntax Error if this production has a [Yield] parameter.
                 if strict {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "identifier not allowed in strict mode: yield",
                         Some(data.location),
                     ));
                 }
                 if data.yield_flag {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "identifier 'yield' not allowed when yield expressions are valid",
                         Some(data.location),
                     ));
@@ -610,14 +598,12 @@ impl BindingIdentifier {
                 //  * It is a Syntax Error if this production has an [Await] parameter.
                 if data.in_module {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "identifier not allowed in modules: await",
                         Some(data.location),
                     ));
                 }
                 if data.await_flag {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "identifier 'await' not allowed when await expressions are valid",
                         Some(data.location),
                     ));
@@ -769,7 +755,7 @@ impl LabelIdentifier {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             LabelIdentifier::Identifier { identifier: id, data } => {
@@ -779,26 +765,23 @@ impl LabelIdentifier {
                 let sv = id.string_value();
                 if data.yield_flag && sv == "yield" {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "identifier 'yield' not allowed when yield expressions are valid",
                         Some(data.location),
                     ));
                 }
                 if data.await_flag && sv == "await" {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "identifier 'await' not allowed when await expressions are valid",
                         Some(data.location),
                     ));
                 }
-                id.early_errors(agent, errs, strict, data.in_module);
+                id.early_errors(errs, strict, data.in_module);
             }
             LabelIdentifier::Yield { data } => {
                 // LabelIdentifier : yield
                 //  * It is a Syntax Error if the code matched by this production is contained in strict mode code.
                 if strict {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "identifier not allowed in strict mode: yield",
                         Some(data.location),
                     ));
@@ -809,7 +792,6 @@ impl LabelIdentifier {
                 //  * It is a Syntax Error if the goal symbol of the syntactic grammar is Module.
                 if data.in_module {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "identifier not allowed in modules: await",
                         Some(data.location),
                     ));

--- a/src/parser/identifiers/tests.rs
+++ b/src/parser/identifiers/tests.rs
@@ -218,12 +218,12 @@ mod identifier {
             let (identifier, _) =
                 Identifier::parse(&mut newparser(uify_first_ch(id).as_str()), Scanner::new()).unwrap();
             let mut errs = vec![];
-            identifier.early_errors(&agent, &mut errs, strict, false);
+            identifier.early_errors(&mut errs, strict, false);
             if errs.is_empty() {
                 Ok(())
             } else {
                 assert_eq!(errs.len(), 1);
-                Err(unwind_syntax_error_object(&agent, errs.swap_remove(0)))
+                Err(unwind_syntax_error_object(errs.swap_remove(0)))
             }
         }
 
@@ -268,9 +268,9 @@ mod identifier {
             let (identifier, _) =
                 Identifier::parse(&mut newparser(uify_first_ch(id).as_str()), Scanner::new()).unwrap();
             let mut errs = vec![];
-            identifier.early_errors(&agent, &mut errs, false, false);
+            identifier.early_errors(&mut errs, false, false);
             assert_eq!(errs.len(), 1);
-            unwind_syntax_error_object(&agent, errs.swap_remove(0))
+            unwind_syntax_error_object(errs.swap_remove(0))
         }
 
         #[test_case("aw\\u0061it", true => Err(String::from("‘await’ not allowed as an identifier in modules")); "await in module")]
@@ -279,12 +279,12 @@ mod identifier {
             setup_test_agent();
             let (ident, _) = Identifier::parse(&mut newparser(src), Scanner::new()).unwrap();
             let mut errs = vec![];
-            ident.early_errors(&agent, &mut errs, false, in_module);
+            ident.early_errors(&mut errs, false, in_module);
             if errs.is_empty() {
                 Ok(())
             } else {
                 assert_eq!(errs.len(), 1);
-                Err(unwind_syntax_error_object(&agent, errs.swap_remove(0)))
+                Err(unwind_syntax_error_object(errs.swap_remove(0)))
             }
         }
     }
@@ -543,8 +543,8 @@ mod identifier_reference {
         )
         .unwrap();
         let mut errs = vec![];
-        item.early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        item.early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "IdentifierName/no")]
@@ -842,8 +842,8 @@ mod binding_identifier {
             )
             .unwrap();
             let mut errs = vec![];
-            item.early_errors(&agent, &mut errs, strict);
-            AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            item.early_errors(&mut errs, strict);
+            AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
         }
     }
 
@@ -1110,8 +1110,8 @@ mod label_identifier {
             )
             .unwrap();
             let mut errs = vec![];
-            item.early_errors(&agent, &mut errs, strict);
-            AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            item.early_errors(&mut errs, strict);
+            AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
         }
     }
 

--- a/src/parser/identifiers/tests.rs
+++ b/src/parser/identifiers/tests.rs
@@ -214,7 +214,7 @@ mod identifier {
         #[test_case("static", false => Ok(()); "static non-strict")]
         #[test_case("yield", false => Ok(()); "yield non-strict")]
         fn strict(id: &str, strict: bool) -> Result<(), String> {
-            let agent = test_agent();
+            setup_test_agent();
             let (identifier, _) =
                 Identifier::parse(&mut newparser(uify_first_ch(id).as_str()), Scanner::new()).unwrap();
             let mut errs = vec![];
@@ -264,7 +264,7 @@ mod identifier {
         #[test_case("while" => String::from("‘while’ is a reserved word and may not be used as an identifier"); "keyword while")]
         #[test_case("with" => String::from("‘with’ is a reserved word and may not be used as an identifier"); "keyword with")]
         fn keyword(id: &str) -> String {
-            let agent = test_agent();
+            setup_test_agent();
             let (identifier, _) =
                 Identifier::parse(&mut newparser(uify_first_ch(id).as_str()), Scanner::new()).unwrap();
             let mut errs = vec![];
@@ -276,7 +276,7 @@ mod identifier {
         #[test_case("aw\\u0061it", true => Err(String::from("‘await’ not allowed as an identifier in modules")); "await in module")]
         #[test_case("aw\\u0061it", false => Ok(()); "await in script")]
         fn module(src: &str, in_module: bool) -> Result<(), String> {
-            let agent = test_agent();
+            setup_test_agent();
             let (ident, _) = Identifier::parse(&mut newparser(src), Scanner::new()).unwrap();
             let mut errs = vec![];
             ident.early_errors(&agent, &mut errs, false, in_module);
@@ -533,7 +533,7 @@ mod identifier_reference {
         yield_expr_allowed: bool,
         await_expr_allowed: bool,
     ) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let goal = if in_module { ParseGoal::Module } else { ParseGoal::Script };
         let (item, _) = IdentifierReference::parse(
             &mut Parser::new(src, false, goal),
@@ -832,7 +832,7 @@ mod binding_identifier {
             yield_expr_allowed: bool,
             await_expr_allowed: bool,
         ) -> AHashSet<String> {
-            let agent = test_agent();
+            setup_test_agent();
             let goal = if in_module { ParseGoal::Module } else { ParseGoal::Script };
             let (item, _) = BindingIdentifier::parse(
                 &mut Parser::new(src, false, goal),
@@ -1100,7 +1100,7 @@ mod label_identifier {
             yield_expr_allowed: bool,
             await_expr_allowed: bool,
         ) -> AHashSet<String> {
-            let agent = test_agent();
+            setup_test_agent();
             let goal = if in_module { ParseGoal::Module } else { ParseGoal::Script };
             let (item, _) = LabelIdentifier::parse(
                 &mut Parser::new(src, false, goal),

--- a/src/parser/if_statement/mod.rs
+++ b/src/parser/if_statement/mod.rs
@@ -200,22 +200,15 @@ impl IfStatement {
         }
     }
 
-    pub fn early_errors(
-        &self,
-        agent: &Agent,
-        errs: &mut Vec<Object>,
-        strict: bool,
-        within_iteration: bool,
-        within_switch: bool,
-    ) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_iteration: bool, within_switch: bool) {
         let (e, s1, s2) = match self {
             IfStatement::WithElse(e, s1, s2, ..) => (e, s1, Some(s2)),
             IfStatement::WithoutElse(e, s1, ..) => (e, s1, None),
         };
-        e.early_errors(agent, errs, strict);
-        s1.early_errors(agent, errs, strict, within_iteration, within_switch);
+        e.early_errors(errs, strict);
+        s1.early_errors(errs, strict, within_iteration, within_switch);
         if let Some(s) = s2 {
-            s.early_errors(agent, errs, strict, within_iteration, within_switch);
+            s.early_errors(errs, strict, within_iteration, within_switch);
         }
     }
 

--- a/src/parser/if_statement/tests.rs
+++ b/src/parser/if_statement/tests.rs
@@ -247,8 +247,8 @@ mod if_statement {
         IfStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("if(arguments);else;" => true; "trinary (left)")]

--- a/src/parser/if_statement/tests.rs
+++ b/src/parser/if_statement/tests.rs
@@ -242,7 +242,7 @@ mod if_statement {
     #[test_case("if (a) alpha; else b: function f(){}", false => sset(&[LABELLED_FUNCTION_NOT_ALLOWED]); "labelled function (in else clause)")]
     #[test_case("if (a) b: function f(){} else c;", false => sset(&[LABELLED_FUNCTION_NOT_ALLOWED]); "labelled fucntion (in then clause)")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         IfStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()

--- a/src/parser/iteration_statements/tests.rs
+++ b/src/parser/iteration_statements/tests.rs
@@ -293,7 +293,7 @@ mod iteration_statement {
     #[test_case("for(;;)package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "ForStatement")]
     #[test_case("for(let package in b);", true => sset(&[PACKAGE_NOT_ALLOWED]); "ForInOfStatement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         IterationStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -491,7 +491,7 @@ mod do_while_statement {
 
     #[test_case("do package; while(implements);", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "do Statement while ( Expression ) ;")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         DoWhileStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -626,7 +626,7 @@ mod while_statement {
 
     #[test_case("while(package)implements;", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "while ( Expression ) Statement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         WhileStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -1541,7 +1541,7 @@ mod for_statement {
     #[test_case("for (let package; ; ) private;", true => sset(&[PACKAGE_NOT_ALLOWED, PRIVATE_NOT_ALLOWED]); "for ( LexicalDeclaration ;  ;  ) Statement")]
     #[test_case("for (let a;;) { var a; }", false => sset(&[A_LEXVARCLASH]); "lex/var clash")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ForStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -2449,7 +2449,7 @@ mod for_in_of_statement {
     #[test_case("for await (var package of implements) interface;", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "for await ( var ForBinding of AssignmentExpresion ) Statement")]
     #[test_case("for await (let package of implements) interface;", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "for await ( ForDeclaration of AssignmentExpresion ) Statement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ForInOfStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -2620,7 +2620,7 @@ mod for_declaration {
 
     #[test_case("let package", true => sset(&[PACKAGE_NOT_ALLOWED]); "normal")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).for_declaration().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -2726,7 +2726,7 @@ mod for_binding {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "identifier")]
     #[test_case("[a, package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "pattern")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).for_binding().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))

--- a/src/parser/iteration_statements/tests.rs
+++ b/src/parser/iteration_statements/tests.rs
@@ -298,8 +298,8 @@ mod iteration_statement {
         IterationStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("do arguments; while(0);" => true; "dowhile (yes)")]
@@ -496,8 +496,8 @@ mod do_while_statement {
         DoWhileStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("do arguments;while(0);" => true; "binary (left)")]
@@ -631,8 +631,8 @@ mod while_statement {
         WhileStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("while(arguments);" => true; "left")]
@@ -1546,8 +1546,8 @@ mod for_statement {
         ForStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("for(;;)arguments;" => true; "000-for (yes)")]
@@ -2454,8 +2454,8 @@ mod for_in_of_statement {
         ForInOfStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("for(arguments in a);" => true; "lhs-in (left)")]
@@ -2622,8 +2622,8 @@ mod for_declaration {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).for_declaration().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).for_declaration().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("let {a=arguments}" => true; "yes")]
@@ -2728,8 +2728,8 @@ mod for_binding {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).for_binding().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).for_binding().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "id")]

--- a/src/parser/labelled_statements/mod.rs
+++ b/src/parser/labelled_statements/mod.rs
@@ -126,16 +126,9 @@ impl LabelledStatement {
         self.item.contains_arguments()
     }
 
-    pub fn early_errors(
-        &self,
-        agent: &Agent,
-        errs: &mut Vec<Object>,
-        strict: bool,
-        within_iteration: bool,
-        within_switch: bool,
-    ) {
-        self.identifier.early_errors(agent, errs, strict);
-        self.item.early_errors(agent, errs, strict, within_iteration, within_switch);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_iteration: bool, within_switch: bool) {
+        self.identifier.early_errors(errs, strict);
+        self.item.early_errors(errs, strict, within_iteration, within_switch);
     }
 
     pub fn is_labelled_function(&self) -> bool {
@@ -332,27 +325,19 @@ impl LabelledItem {
         }
     }
 
-    pub fn early_errors(
-        &self,
-        agent: &Agent,
-        errs: &mut Vec<Object>,
-        strict: bool,
-        within_iteration: bool,
-        within_switch: bool,
-    ) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_iteration: bool, within_switch: bool) {
         // Static Semantics: Early Errors
         //  LabelledItem : FunctionDeclaration
         //      * It is a Syntax Error if any source text is matched by this production.
         if matches!(self, LabelledItem::Function(_)) {
             errs.push(create_syntax_error_object(
-                agent,
                 "Labelled functions not allowed in modern ECMAScript code",
                 Some(self.location()),
             ));
         }
         match self {
-            LabelledItem::Statement(stmt) => stmt.early_errors(agent, errs, strict, within_iteration, within_switch),
-            LabelledItem::Function(fcn) => fcn.early_errors(agent, errs, strict),
+            LabelledItem::Statement(stmt) => stmt.early_errors(errs, strict, within_iteration, within_switch),
+            LabelledItem::Function(fcn) => fcn.early_errors(errs, strict),
         }
     }
 

--- a/src/parser/labelled_statements/tests.rs
+++ b/src/parser/labelled_statements/tests.rs
@@ -143,8 +143,8 @@ mod labelled_statement {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).labelled_statement().early_errors(&agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).labelled_statement().early_errors(&mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("bob: function alice(){}" => true; "direct labelled function")]
@@ -364,8 +364,8 @@ mod labelled_item {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).labelled_item().early_errors(&agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).labelled_item().early_errors(&mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("function alice(){}" => true; "direct labelled function")]

--- a/src/parser/labelled_statements/tests.rs
+++ b/src/parser/labelled_statements/tests.rs
@@ -141,7 +141,7 @@ mod labelled_statement {
 
     #[test_case("package:implements;", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "LabelIdentifier : LabelledItem")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).labelled_statement().early_errors(&agent, &mut errs, strict, false, false);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -362,7 +362,7 @@ mod labelled_item {
     #[test_case("function package(){}", true => sset(&[PACKAGE_NOT_ALLOWED, LBL_FUNC_NOT_ALLOWED]); "FunctionDeclaration (strict)")]
     #[test_case("function a(){}", false => sset(&[LBL_FUNC_NOT_ALLOWED]); "FunctionDeclaration (non-strict)")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).labelled_item().early_errors(&agent, &mut errs, strict, false, false);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))

--- a/src/parser/left_hand_side_expressions/mod.rs
+++ b/src/parser/left_hand_side_expressions/mod.rs
@@ -373,25 +373,25 @@ impl MemberExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            MemberExpression::PrimaryExpression(n) => n.early_errors(agent, errs, strict),
+            MemberExpression::PrimaryExpression(n) => n.early_errors(errs, strict),
             MemberExpression::Expression(l, r, ..) => {
-                l.early_errors(agent, errs, strict);
-                r.early_errors(agent, errs, strict);
+                l.early_errors(errs, strict);
+                r.early_errors(errs, strict);
             }
-            MemberExpression::IdentifierName(n, ..) => n.early_errors(agent, errs, strict),
+            MemberExpression::IdentifierName(n, ..) => n.early_errors(errs, strict),
             MemberExpression::TemplateLiteral(l, r) => {
-                l.early_errors(agent, errs, strict);
-                r.early_errors(agent, errs, strict, 0xffff_ffff);
+                l.early_errors(errs, strict);
+                r.early_errors(errs, strict, 0xffff_ffff);
             }
-            MemberExpression::SuperProperty(n) => n.early_errors(agent, errs, strict),
-            MemberExpression::MetaProperty(meta) => meta.early_errors(agent, errs),
+            MemberExpression::SuperProperty(n) => n.early_errors(errs, strict),
+            MemberExpression::MetaProperty(meta) => meta.early_errors(errs),
             MemberExpression::NewArguments(l, r, ..) => {
-                l.early_errors(agent, errs, strict);
-                r.early_errors(agent, errs, strict);
+                l.early_errors(errs, strict);
+                r.early_errors(errs, strict);
             }
-            MemberExpression::PrivateId(n, ..) => n.early_errors(agent, errs, strict),
+            MemberExpression::PrivateId(n, ..) => n.early_errors(errs, strict),
         }
     }
 
@@ -580,10 +580,10 @@ impl SuperProperty {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
-            SuperProperty::Expression { exp, .. } => exp.early_errors(agent, errs, strict),
+            SuperProperty::Expression { exp, .. } => exp.early_errors(errs, strict),
             SuperProperty::IdentifierName { .. } => {}
         }
     }
@@ -685,7 +685,7 @@ impl MetaProperty {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>) {
         match self {
             MetaProperty::NewTarget { .. } => {}
             MetaProperty::ImportMeta { goal, .. } => {
@@ -694,7 +694,6 @@ impl MetaProperty {
                 //  * It is a Syntax Error if the syntactic goal symbol is not Module.
                 if *goal != ParseGoal::Module {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "import.meta allowed only in Module code",
                         Some(self.location()),
                     ));
@@ -853,11 +852,11 @@ impl Arguments {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             Arguments::Empty { .. } => {}
-            Arguments::ArgumentList(n, _) | Arguments::ArgumentListComma(n, _) => n.early_errors(agent, errs, strict),
+            Arguments::ArgumentList(n, _) | Arguments::ArgumentListComma(n, _) => n.early_errors(errs, strict),
         }
     }
 }
@@ -1093,13 +1092,13 @@ impl ArgumentList {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
-            ArgumentList::FallThru(boxed) | ArgumentList::Dots(boxed) => boxed.early_errors(agent, errs, strict),
+            ArgumentList::FallThru(boxed) | ArgumentList::Dots(boxed) => boxed.early_errors(errs, strict),
             ArgumentList::ArgumentList(list, exp) | ArgumentList::ArgumentListDots(list, exp) => {
-                list.early_errors(agent, errs, strict);
-                exp.early_errors(agent, errs, strict);
+                list.early_errors(errs, strict);
+                exp.early_errors(errs, strict);
             }
         }
     }
@@ -1234,10 +1233,10 @@ impl NewExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            NewExpression::MemberExpression(boxed) => boxed.early_errors(agent, errs, strict),
-            NewExpression::NewExpression(boxed, ..) => boxed.early_errors(agent, errs, strict),
+            NewExpression::MemberExpression(boxed) => boxed.early_errors(errs, strict),
+            NewExpression::NewExpression(boxed, ..) => boxed.early_errors(errs, strict),
         }
     }
 
@@ -1357,9 +1356,9 @@ impl CallMemberExpression {
         self.member_expression.contains_arguments() || self.arguments.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.member_expression.early_errors(agent, errs, strict);
-        self.arguments.early_errors(agent, errs, strict);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.member_expression.early_errors(errs, strict);
+        self.arguments.early_errors(errs, strict);
     }
 }
 
@@ -1438,8 +1437,8 @@ impl SuperCall {
         self.arguments.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.arguments.early_errors(agent, errs, strict);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.arguments.early_errors(errs, strict);
     }
 }
 
@@ -1524,8 +1523,8 @@ impl ImportCall {
         self.assignment_expression.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.assignment_expression.early_errors(agent, errs, strict);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.assignment_expression.early_errors(errs, strict);
     }
 }
 
@@ -1820,25 +1819,25 @@ impl CallExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            CallExpression::CallMemberExpression(node) => node.early_errors(agent, errs, strict),
-            CallExpression::SuperCall(node) => node.early_errors(agent, errs, strict),
-            CallExpression::ImportCall(node) => node.early_errors(agent, errs, strict),
+            CallExpression::CallMemberExpression(node) => node.early_errors(errs, strict),
+            CallExpression::SuperCall(node) => node.early_errors(errs, strict),
+            CallExpression::ImportCall(node) => node.early_errors(errs, strict),
             CallExpression::CallExpressionArguments(node, args) => {
-                node.early_errors(agent, errs, strict);
-                args.early_errors(agent, errs, strict);
+                node.early_errors(errs, strict);
+                args.early_errors(errs, strict);
             }
             CallExpression::CallExpressionExpression(node, exp, _) => {
-                node.early_errors(agent, errs, strict);
-                exp.early_errors(agent, errs, strict);
+                node.early_errors(errs, strict);
+                exp.early_errors(errs, strict);
             }
-            CallExpression::CallExpressionIdentifierName(node, _, _) => node.early_errors(agent, errs, strict),
+            CallExpression::CallExpressionIdentifierName(node, _, _) => node.early_errors(errs, strict),
             CallExpression::CallExpressionTemplateLiteral(node, tl) => {
-                node.early_errors(agent, errs, strict);
-                tl.early_errors(agent, errs, strict, 0xffff_ffff);
+                node.early_errors(errs, strict);
+                tl.early_errors(errs, strict, 0xffff_ffff);
             }
-            CallExpression::CallExpressionPrivateId(node, _, _) => node.early_errors(agent, errs, strict),
+            CallExpression::CallExpressionPrivateId(node, _, _) => node.early_errors(errs, strict),
         }
     }
 
@@ -2009,11 +2008,11 @@ impl LeftHandSideExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            LeftHandSideExpression::New(boxed) => boxed.early_errors(agent, errs, strict),
-            LeftHandSideExpression::Call(boxed) => boxed.early_errors(agent, errs, strict),
-            LeftHandSideExpression::Optional(boxed) => boxed.early_errors(agent, errs, strict),
+            LeftHandSideExpression::New(boxed) => boxed.early_errors(errs, strict),
+            LeftHandSideExpression::Call(boxed) => boxed.early_errors(errs, strict),
+            LeftHandSideExpression::Optional(boxed) => boxed.early_errors(errs, strict),
         }
     }
 
@@ -2209,19 +2208,19 @@ impl OptionalExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
             OptionalExpression::Member(left, right) => {
-                left.early_errors(agent, errs, strict);
-                right.early_errors(agent, errs, strict);
+                left.early_errors(errs, strict);
+                right.early_errors(errs, strict);
             }
             OptionalExpression::Call(left, right) => {
-                left.early_errors(agent, errs, strict);
-                right.early_errors(agent, errs, strict);
+                left.early_errors(errs, strict);
+                right.early_errors(errs, strict);
             }
             OptionalExpression::Opt(left, right) => {
-                left.early_errors(agent, errs, strict);
-                right.early_errors(agent, errs, strict);
+                left.early_errors(errs, strict);
+                right.early_errors(errs, strict);
             }
         }
     }
@@ -2568,7 +2567,7 @@ impl OptionalChain {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  OptionalChain :
         //      ?. TemplateLiteral
@@ -2586,27 +2585,27 @@ impl OptionalChain {
         //      | which is a valid statement and where automatic semicolon insertion does not apply.
         match self {
             OptionalChain::Template(tl, _) => {
-                errs.push(create_syntax_error_object(agent, "Template literal not allowed here", Some(tl.location())));
-                tl.early_errors(agent, errs, strict, 0xffff_ffff);
+                errs.push(create_syntax_error_object("Template literal not allowed here", Some(tl.location())));
+                tl.early_errors(errs, strict, 0xffff_ffff);
             }
             OptionalChain::PlusTemplate(node, tl) => {
-                node.early_errors(agent, errs, strict);
-                errs.push(create_syntax_error_object(agent, "Template literal not allowed here", Some(tl.location())));
-                tl.early_errors(agent, errs, strict, 0xffff_ffff);
+                node.early_errors(errs, strict);
+                errs.push(create_syntax_error_object("Template literal not allowed here", Some(tl.location())));
+                tl.early_errors(errs, strict, 0xffff_ffff);
             }
-            OptionalChain::Args(node, _) => node.early_errors(agent, errs, strict),
-            OptionalChain::Exp(node, _) => node.early_errors(agent, errs, strict),
+            OptionalChain::Args(node, _) => node.early_errors(errs, strict),
+            OptionalChain::Exp(node, _) => node.early_errors(errs, strict),
             OptionalChain::Ident(_, _) | OptionalChain::PrivateId(_, _) => {}
             OptionalChain::PlusArgs(node, args) => {
-                node.early_errors(agent, errs, strict);
-                args.early_errors(agent, errs, strict);
+                node.early_errors(errs, strict);
+                args.early_errors(errs, strict);
             }
             OptionalChain::PlusExp(node, exp, _) => {
-                node.early_errors(agent, errs, strict);
-                exp.early_errors(agent, errs, strict);
+                node.early_errors(errs, strict);
+                exp.early_errors(errs, strict);
             }
             OptionalChain::PlusIdent(node, _, _) | OptionalChain::PlusPrivateId(node, _, _) => {
-                node.early_errors(agent, errs, strict)
+                node.early_errors(errs, strict)
             }
         }
     }

--- a/src/parser/left_hand_side_expressions/tests.rs
+++ b/src/parser/left_hand_side_expressions/tests.rs
@@ -396,8 +396,8 @@ mod member_expression {
         MemberExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]
@@ -611,8 +611,8 @@ mod super_property {
         SuperProperty::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("super[arguments]" => true; "Expression (yes)")]
@@ -715,11 +715,8 @@ mod meta_property {
     fn early_errors(src: &str, goal: ParseGoal) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        MetaProperty::parse(&mut Parser::new(src, false, goal), Scanner::new())
-            .unwrap()
-            .0
-            .early_errors(&agent, &mut errs);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        MetaProperty::parse(&mut Parser::new(src, false, goal), Scanner::new()).unwrap().0.early_errors(&mut errs);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("  new.target" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 10 }}; "new.target")]
@@ -858,11 +855,8 @@ mod arguments {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Arguments::parse(&mut newparser(src), Scanner::new(), false, true)
-            .unwrap()
-            .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Arguments::parse(&mut newparser(src), Scanner::new(), false, true).unwrap().0.early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("()" => false; "empty")]
@@ -1077,8 +1071,8 @@ mod argument_list {
         ArgumentList::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments" => true; "AssignmentExpression (yes)")]
@@ -1217,8 +1211,8 @@ mod new_expression {
         NewExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]
@@ -1347,8 +1341,8 @@ mod call_member_expression {
         CallMemberExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("arguments()" => true; "Exp Args (left)")]
@@ -1419,11 +1413,8 @@ mod super_call {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        SuperCall::parse(&mut newparser(src), Scanner::new(), false, true)
-            .unwrap()
-            .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        SuperCall::parse(&mut newparser(src), Scanner::new(), false, true).unwrap().0.early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("super(arguments)" => true; "yes")]
@@ -1507,11 +1498,8 @@ mod import_call {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        ImportCall::parse(&mut newparser(src), Scanner::new(), false, true)
-            .unwrap()
-            .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        ImportCall::parse(&mut newparser(src), Scanner::new(), false, true).unwrap().0.early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("import(arguments)" => true; "yes")]
@@ -1896,8 +1884,8 @@ mod call_expression {
         CallExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a()" => true; "standard")]
@@ -2134,8 +2122,8 @@ mod optional_expression {
         OptionalExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a?.b" => true; "member exp")]
@@ -2581,8 +2569,8 @@ mod optional_chain {
         OptionalChain::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("?.()" => true; "args")]
@@ -2773,8 +2761,8 @@ mod left_hand_side_expression {
         LeftHandSideExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/left_hand_side_expressions/tests.rs
+++ b/src/parser/left_hand_side_expressions/tests.rs
@@ -391,7 +391,7 @@ mod member_expression {
     #[test_case("new a(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "new expr (args bad)")]
     #[test_case("package.#a", true => sset(&[PACKAGE_NOT_ALLOWED]); "private id")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         MemberExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -606,7 +606,7 @@ mod super_property {
     #[test_case("super.package", true => sset(&[]); "super.member")]
     #[test_case("super[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "super[exp]")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         SuperProperty::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -713,7 +713,7 @@ mod meta_property {
     #[test_case("import.meta", ParseGoal::Script => sset(&["import.meta allowed only in Module code"]); "import.meta (in script)")]
     #[test_case("import.meta", ParseGoal::Module => AHashSet::<String>::new(); "import.meta (in module)")]
     fn early_errors(src: &str, goal: ParseGoal) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         MetaProperty::parse(&mut Parser::new(src, false, goal), Scanner::new())
             .unwrap()
@@ -856,7 +856,7 @@ mod arguments {
     #[test_case("(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "argument list")]
     #[test_case("(package,)", true => sset(&[PACKAGE_NOT_ALLOWED]); "argument list; comma")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Arguments::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -1072,7 +1072,7 @@ mod argument_list {
     #[test_case("package,...a", true => sset(&[PACKAGE_NOT_ALLOWED]); "list, rest; head bad")]
     #[test_case("0,...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "list, rest; rest bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ArgumentList::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -1212,7 +1212,7 @@ mod new_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "exp")]
     #[test_case("new package", true => sset(&[PACKAGE_NOT_ALLOWED]); "new exp")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         NewExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -1342,7 +1342,7 @@ mod call_member_expression {
     #[test_case("package()", true => sset(&[PACKAGE_NOT_ALLOWED]); "exp bad")]
     #[test_case("a(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "args bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         CallMemberExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -1417,7 +1417,7 @@ mod super_call {
 
     #[test_case("super(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "normal")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         SuperCall::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -1505,7 +1505,7 @@ mod import_call {
 
     #[test_case("import(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "normal")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ImportCall::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -1891,7 +1891,7 @@ mod call_expression {
     #[test_case("package(0)`${0}`", true => sset(&[PACKAGE_NOT_ALLOWED]); "call templ; id bad")]
     #[test_case("a(0)`${package}`", true => sset(&[PACKAGE_NOT_ALLOWED]); "call templ; templ bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         CallExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -2129,7 +2129,7 @@ mod optional_expression {
     #[test_case("package?.a?.(0)", true => sset(&[PACKAGE_NOT_ALLOWED]); "opt opt; head bad")]
     #[test_case("a?.b?.(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "opt opt; tail bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         OptionalExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -2576,7 +2576,7 @@ mod optional_chain {
     #[test_case("?.(package)`${interface}`", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED, TEMPLATE_NOT_ALLOWED]); "chain template lit")]
     #[test_case("?.(package).#interface", true => sset(&[PACKAGE_NOT_ALLOWED]); "chain private")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         OptionalChain::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -2768,7 +2768,7 @@ mod left_hand_side_expression {
     #[test_case("package()", true => sset(&[PACKAGE_NOT_ALLOWED]); "call expression")]
     #[test_case("package?.()", true => sset(&[PACKAGE_NOT_ALLOWED]); "optional expression")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         LeftHandSideExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()

--- a/src/parser/method_definitions/mod.rs
+++ b/src/parser/method_definitions/mod.rs
@@ -338,7 +338,7 @@ impl MethodDefinition {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             MethodDefinition::NamedFunction(cen, ufp, fb, _) => {
@@ -349,23 +349,18 @@ impl MethodDefinition {
                 //        the LexicallyDeclaredNames of FunctionBody.
                 if fb.function_body_contains_use_strict() && !ufp.is_simple_parameter_list() {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "Illegal 'use strict' directive in function with non-simple parameter list",
                         Some(ufp.location()),
                     ));
                 }
                 let ldn = fb.lexically_declared_names();
                 for name in ufp.bound_names().into_iter().filter(|n| ldn.contains(n)) {
-                    errs.push(create_syntax_error_object(
-                        agent,
-                        format!("‘{}’ already defined", name),
-                        Some(ufp.location()),
-                    ));
+                    errs.push(create_syntax_error_object(format!("‘{}’ already defined", name), Some(ufp.location())));
                 }
                 let strict_function = strict || fb.function_body_contains_use_strict();
-                cen.early_errors(agent, errs, strict_function);
-                ufp.early_errors(agent, errs, strict_function);
-                fb.early_errors(agent, errs, strict_function);
+                cen.early_errors(errs, strict_function);
+                ufp.early_errors(errs, strict_function);
+                fb.early_errors(errs, strict_function);
             }
             MethodDefinition::Setter(cen, pspl, fb, _) => {
                 //  MethodDefinition : set ClassElementName ( PropertySetParameterList ) { FunctionBody }
@@ -377,40 +372,31 @@ impl MethodDefinition {
                 //        in the LexicallyDeclaredNames of FunctionBody.
                 let bn = pspl.bound_names();
                 for name in duplicates(&bn) {
-                    errs.push(create_syntax_error_object(
-                        agent,
-                        format!("‘{}’ already defined", name),
-                        Some(pspl.location()),
-                    ));
+                    errs.push(create_syntax_error_object(format!("‘{}’ already defined", name), Some(pspl.location())));
                 }
                 if fb.function_body_contains_use_strict() && !pspl.is_simple_parameter_list() {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "Illegal 'use strict' directive in function with non-simple parameter list",
                         Some(pspl.location()),
                     ));
                 }
                 let ldn = fb.lexically_declared_names();
                 for name in bn.into_iter().filter(|n| ldn.contains(n)) {
-                    errs.push(create_syntax_error_object(
-                        agent,
-                        format!("‘{}’ already defined", name),
-                        Some(pspl.location()),
-                    ));
+                    errs.push(create_syntax_error_object(format!("‘{}’ already defined", name), Some(pspl.location())));
                 }
                 let strict_function = strict || fb.function_body_contains_use_strict();
-                cen.early_errors(agent, errs, strict_function);
-                pspl.early_errors(agent, errs, strict_function);
-                fb.early_errors(agent, errs, strict_function);
+                cen.early_errors(errs, strict_function);
+                pspl.early_errors(errs, strict_function);
+                fb.early_errors(errs, strict_function);
             }
             MethodDefinition::Getter(cen, fb, _) => {
                 let strict_function = strict || fb.function_body_contains_use_strict();
-                cen.early_errors(agent, errs, strict_function);
-                fb.early_errors(agent, errs, strict_function);
+                cen.early_errors(errs, strict_function);
+                fb.early_errors(errs, strict_function);
             }
-            MethodDefinition::Generator(g) => g.early_errors(agent, errs, strict),
-            MethodDefinition::Async(a) => a.early_errors(agent, errs, strict),
-            MethodDefinition::AsyncGenerator(ag) => ag.early_errors(agent, errs, strict),
+            MethodDefinition::Generator(g) => g.early_errors(errs, strict),
+            MethodDefinition::Async(a) => a.early_errors(errs, strict),
+            MethodDefinition::AsyncGenerator(ag) => ag.early_errors(errs, strict),
         }
     }
 
@@ -507,8 +493,8 @@ impl PropertySetParameterList {
         self.node.is_simple_parameter_list()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.node.early_errors(agent, errs, strict);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.node.early_errors(errs, strict);
     }
 }
 

--- a/src/parser/method_definitions/tests.rs
+++ b/src/parser/method_definitions/tests.rs
@@ -567,8 +567,8 @@ mod method_definition {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).method_definition().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).method_definition().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a(){}" => Some(JSString::from("a")); "simple")]
@@ -677,11 +677,8 @@ mod property_set_parameter_list {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        PropertySetParameterList::parse(&mut newparser(src), Scanner::new())
-            .unwrap()
-            .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        PropertySetParameterList::parse(&mut newparser(src), Scanner::new()).unwrap().0.early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => vec!["a"]; "FormalParameter")]

--- a/src/parser/method_definitions/tests.rs
+++ b/src/parser/method_definitions/tests.rs
@@ -565,7 +565,7 @@ mod method_definition {
     #[test_case("set foo(a){let a;}", false => sset(&[A_ALREADY_DEFN]); "setter; duped lexical")]
     #[test_case("set foo([a, a]){}", false => sset(&[A_ALREADY_DEFN]); "setter; duped params")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).method_definition().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -675,7 +675,7 @@ mod property_set_parameter_list {
 
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "FormalParameter")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         PropertySetParameterList::parse(&mut newparser(src), Scanner::new())
             .unwrap()

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -654,7 +654,7 @@ pub enum ParsedText {
     // ... more to come
 }
 
-pub fn parse_text(agent: &Agent, src: &str, goal_symbol: ParseGoal) -> ParsedText {
+pub fn parse_text(src: &str, goal_symbol: ParseGoal) -> ParsedText {
     let mut parser = Parser::new(src, false, goal_symbol);
     match goal_symbol {
         ParseGoal::Script => {
@@ -662,7 +662,6 @@ pub fn parse_text(agent: &Agent, src: &str, goal_symbol: ParseGoal) -> ParsedTex
             match potential_script {
                 Err(pe) => {
                     let syntax_error = create_syntax_error_object(
-                        agent,
                         format!("{}:{}: {}", pe.location.starting_line, pe.location.starting_column, pe).as_str(),
                         Some(pe.location),
                     );
@@ -670,7 +669,7 @@ pub fn parse_text(agent: &Agent, src: &str, goal_symbol: ParseGoal) -> ParsedTex
                 }
                 Ok((node, _)) => {
                     let mut errs = vec![];
-                    node.early_errors(agent, &mut errs);
+                    node.early_errors(&mut errs);
                     if errs.is_empty() {
                         ParsedText::Script(node)
                     } else {

--- a/src/parser/multiplicative_operators/mod.rs
+++ b/src/parser/multiplicative_operators/mod.rs
@@ -204,12 +204,12 @@ impl MultiplicativeExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            MultiplicativeExpression::ExponentiationExpression(n) => n.early_errors(agent, errs, strict),
+            MultiplicativeExpression::ExponentiationExpression(n) => n.early_errors(errs, strict),
             MultiplicativeExpression::MultiplicativeExpressionExponentiationExpression(l, _, r) => {
-                l.early_errors(agent, errs, strict);
-                r.early_errors(agent, errs, strict);
+                l.early_errors(errs, strict);
+                r.early_errors(errs, strict);
             }
         }
     }

--- a/src/parser/multiplicative_operators/tests.rs
+++ b/src/parser/multiplicative_operators/tests.rs
@@ -209,7 +209,7 @@ mod multiplicative_expression {
     #[test_case("package%3", true => sset(&[PACKAGE_NOT_ALLOWED]); "left mod right; left bad")]
     #[test_case("3%package", true => sset(&[PACKAGE_NOT_ALLOWED]); "left mod right; right bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         MultiplicativeExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()

--- a/src/parser/multiplicative_operators/tests.rs
+++ b/src/parser/multiplicative_operators/tests.rs
@@ -214,8 +214,8 @@ mod multiplicative_expression {
         MultiplicativeExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/parameter_lists/mod.rs
+++ b/src/parser/parameter_lists/mod.rs
@@ -84,19 +84,15 @@ impl UniqueFormalParameters {
         self.formals.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  UniqueFormalParameters : FormalParameters
         //  * It is a Syntax Error if BoundNames of FormalParameters contains any duplicate elements.
         let bn = self.formals.bound_names();
         for name in duplicates(&bn) {
-            errs.push(create_syntax_error_object(
-                agent,
-                format!("‘{}’ already defined", name),
-                Some(self.formals.location()),
-            ));
+            errs.push(create_syntax_error_object(format!("‘{}’ already defined", name), Some(self.formals.location())));
         }
-        self.formals.early_errors(agent, errs, strict, true);
+        self.formals.early_errors(errs, strict, true);
     }
 
     pub fn bound_names(&self) -> Vec<JSString> {
@@ -356,7 +352,7 @@ impl FormalParameters {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, dups_already_checked: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, dups_already_checked: bool) {
         // Static Semantics: Early Errors
         //  FormalParameters : FormalParameterList
         //    If BoundNames of FormalParameterList contains any duplicate elements, it is a Syntax Error:
@@ -368,20 +364,16 @@ impl FormalParameters {
         if !dups_already_checked && (strict || !self.is_simple_parameter_list()) {
             let bn = self.bound_names();
             for name in duplicates(&bn) {
-                errs.push(create_syntax_error_object(
-                    agent,
-                    format!("‘{}’ already defined", name),
-                    Some(self.location()),
-                ));
+                errs.push(create_syntax_error_object(format!("‘{}’ already defined", name), Some(self.location())));
             }
         }
         match self {
             FormalParameters::Empty(_) => (),
-            FormalParameters::Rest(frp) => frp.early_errors(agent, errs, strict),
-            FormalParameters::List(fpl) | FormalParameters::ListComma(fpl, _) => fpl.early_errors(agent, errs, strict),
+            FormalParameters::Rest(frp) => frp.early_errors(errs, strict),
+            FormalParameters::List(fpl) | FormalParameters::ListComma(fpl, _) => fpl.early_errors(errs, strict),
             FormalParameters::ListRest(fpl, frp) => {
-                fpl.early_errors(agent, errs, strict);
-                frp.early_errors(agent, errs, strict);
+                fpl.early_errors(errs, strict);
+                frp.early_errors(errs, strict);
             }
         }
     }
@@ -566,12 +558,12 @@ impl FormalParameterList {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            FormalParameterList::Item(fp) => fp.early_errors(agent, errs, strict),
+            FormalParameterList::Item(fp) => fp.early_errors(errs, strict),
             FormalParameterList::List(fpl, fp) => {
-                fpl.early_errors(agent, errs, strict);
-                fp.early_errors(agent, errs, strict);
+                fpl.early_errors(errs, strict);
+                fp.early_errors(errs, strict);
             }
         }
     }
@@ -696,8 +688,8 @@ impl FunctionRestParameter {
         self.element.bound_names()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.element.early_errors(agent, errs, strict);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.element.early_errors(errs, strict);
     }
 
     /// Report whether this portion of a parameter list contains an expression
@@ -803,8 +795,8 @@ impl FormalParameter {
         self.element.bound_names()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.element.early_errors(agent, errs, strict)
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.element.early_errors(errs, strict)
     }
 
     /// Report whether this parameter contains an intializer

--- a/src/parser/parameter_lists/tests.rs
+++ b/src/parser/parameter_lists/tests.rs
@@ -60,8 +60,8 @@ mod unique_formal_parameters {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).unique_formal_parameters().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).unique_formal_parameters().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a,b" => vec!["a", "b"]; "FormalParameters")]
@@ -312,8 +312,8 @@ mod formal_parameters {
     fn early_errors(src: &str, strict: bool, dups_already_checked: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).formal_parameters().early_errors(&agent, &mut errs, strict, dups_already_checked);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).formal_parameters().early_errors(&mut errs, strict, dups_already_checked);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("" => false; "empty")]
@@ -479,8 +479,8 @@ mod formal_parameter_list {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).formal_parameter_list().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).formal_parameter_list().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a=arguments" => true; "Item (yes)")]
@@ -581,8 +581,8 @@ mod function_rest_parameter {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).function_rest_parameter().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).function_rest_parameter().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("...{a=arguments}" => true; "yes")]
@@ -677,8 +677,8 @@ mod formal_parameter {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).formal_parameter().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).formal_parameter().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a=arguments" => true; "yes")]

--- a/src/parser/parameter_lists/tests.rs
+++ b/src/parser/parameter_lists/tests.rs
@@ -58,7 +58,7 @@ mod unique_formal_parameters {
     #[test_case("a,b,a", true => sset(&[A_ALREADY_DEFINED]); "strict: duplicate ids")]
     #[test_case("a,b,a", false => sset(&[A_ALREADY_DEFINED]); "non-strict: duplicate ids")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).unique_formal_parameters().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -310,7 +310,7 @@ mod formal_parameters {
     #[test_case("a,a", true, true => sset(&[]); "strict; duplicates; already reported")]
     #[test_case("a,...a", false, false => sset(&[A_ALREADY_DEFINED]); "not-simple")]
     fn early_errors(src: &str, strict: bool, dups_already_checked: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).formal_parameters().early_errors(&agent, &mut errs, strict, dups_already_checked);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -477,7 +477,7 @@ mod formal_parameter_list {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "FormalParameter")]
     #[test_case("package,interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "FormalParameterList , FormalParameter")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).formal_parameter_list().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -579,7 +579,7 @@ mod function_rest_parameter {
 
     #[test_case("...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingRestElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).function_rest_parameter().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -675,7 +675,7 @@ mod formal_parameter {
 
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingElement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).formal_parameter().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))

--- a/src/parser/primary_expressions/mod.rs
+++ b/src/parser/primary_expressions/mod.rs
@@ -397,26 +397,26 @@ impl PrimaryExpression {
         matches!(self, PrimaryExpression::ArrayLiteral { .. } | PrimaryExpression::ObjectLiteral { .. })
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
             PrimaryExpression::This { .. } => {}
-            PrimaryExpression::IdentifierReference { node: id } => id.early_errors(agent, errs, strict),
+            PrimaryExpression::IdentifierReference { node: id } => id.early_errors(errs, strict),
             PrimaryExpression::Literal { node: lit } => lit.early_errors(),
-            PrimaryExpression::ArrayLiteral { node } => node.early_errors(agent, errs, strict),
-            PrimaryExpression::ObjectLiteral { node } => node.early_errors(agent, errs, strict),
-            PrimaryExpression::Parenthesized { node } => node.early_errors(agent, errs, strict),
-            PrimaryExpression::TemplateLiteral { node } => node.early_errors(agent, errs, strict, 0xffff_ffff),
-            PrimaryExpression::Function { node } => node.early_errors(agent, errs, strict),
-            PrimaryExpression::Class { node } => node.early_errors(agent, errs),
-            PrimaryExpression::Generator { node } => node.early_errors(agent, errs, strict),
-            PrimaryExpression::AsyncFunction { node } => node.early_errors(agent, errs, strict),
-            PrimaryExpression::AsyncGenerator { node } => node.early_errors(agent, errs, strict),
+            PrimaryExpression::ArrayLiteral { node } => node.early_errors(errs, strict),
+            PrimaryExpression::ObjectLiteral { node } => node.early_errors(errs, strict),
+            PrimaryExpression::Parenthesized { node } => node.early_errors(errs, strict),
+            PrimaryExpression::TemplateLiteral { node } => node.early_errors(errs, strict, 0xffff_ffff),
+            PrimaryExpression::Function { node } => node.early_errors(errs, strict),
+            PrimaryExpression::Class { node } => node.early_errors(errs),
+            PrimaryExpression::Generator { node } => node.early_errors(errs, strict),
+            PrimaryExpression::AsyncFunction { node } => node.early_errors(errs, strict),
+            PrimaryExpression::AsyncGenerator { node } => node.early_errors(errs, strict),
             PrimaryExpression::RegularExpression { regex, location } => {
                 // Static Semantics: Early Errors
                 //      PrimaryExpression : RegularExpressionLiteral
                 //  * It is a Syntax Error if IsValidRegularExpressionLiteral(RegularExpressionLiteral) is false.
                 if let Err(msg) = regex.validate_regular_expression_literal() {
-                    errs.push(create_syntax_error_object(agent, msg, Some(*location)));
+                    errs.push(create_syntax_error_object(msg, Some(*location)));
                 }
             }
         }
@@ -649,8 +649,8 @@ impl SpreadElement {
         self.ae.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.ae.early_errors(agent, errs, strict);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.ae.early_errors(errs, strict);
     }
 }
 
@@ -925,21 +925,21 @@ impl ElementList {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ElementList::AssignmentExpression { ae: b, .. } => {
-                b.early_errors(agent, errs, strict);
+                b.early_errors(errs, strict);
             }
             ElementList::SpreadElement { se: b, .. } => {
-                b.early_errors(agent, errs, strict);
+                b.early_errors(errs, strict);
             }
             ElementList::ElementListAssignmentExpression { el: a, ae: c, .. } => {
-                a.early_errors(agent, errs, strict);
-                c.early_errors(agent, errs, strict);
+                a.early_errors(errs, strict);
+                c.early_errors(errs, strict);
             }
             ElementList::ElementListSpreadElement { el: a, se: c, .. } => {
-                a.early_errors(agent, errs, strict);
-                c.early_errors(agent, errs, strict);
+                a.early_errors(errs, strict);
+                c.early_errors(errs, strict);
             }
         }
     }
@@ -1140,11 +1140,11 @@ impl ArrayLiteral {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ArrayLiteral::Empty { .. } => {}
             ArrayLiteral::ElementList { el: node, .. } | ArrayLiteral::ElementListElision { el: node, .. } => {
-                node.early_errors(agent, errs, strict)
+                node.early_errors(errs, strict)
             }
         }
     }
@@ -1254,8 +1254,8 @@ impl Initializer {
         self.ae.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.ae.early_errors(agent, errs, strict);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.ae.early_errors(errs, strict);
     }
 
     /// Determine if this parse node is an anonymous function
@@ -1335,10 +1335,10 @@ impl CoverInitializedName {
         izer.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         let CoverInitializedName::InitializedName(a, b) = self;
-        a.early_errors(agent, errs, strict);
-        b.early_errors(agent, errs, strict);
+        a.early_errors(errs, strict);
+        b.early_errors(errs, strict);
     }
 
     pub fn prop_name(&self) -> JSString {
@@ -1426,8 +1426,8 @@ impl ComputedPropertyName {
         self.ae.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.ae.early_errors(agent, errs, strict);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.ae.early_errors(errs, strict);
     }
 
     /// Reports whether this property key is formed by computation or not
@@ -1677,10 +1677,10 @@ impl PropertyName {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
             PropertyName::LiteralPropertyName(_) => (),
-            PropertyName::ComputedPropertyName(x) => x.early_errors(agent, errs, strict),
+            PropertyName::ComputedPropertyName(x) => x.early_errors(errs, strict),
         }
     }
 
@@ -1890,36 +1890,28 @@ impl PropertyDefinition {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
-            PropertyDefinition::IdentifierReference(idref) => idref.early_errors(agent, errs, strict),
+            PropertyDefinition::IdentifierReference(idref) => idref.early_errors(errs, strict),
             PropertyDefinition::PropertyNameAssignmentExpression(pn, ae) => {
-                pn.early_errors(agent, errs, strict);
-                ae.early_errors(agent, errs, strict);
+                pn.early_errors(errs, strict);
+                ae.early_errors(errs, strict);
             }
-            PropertyDefinition::AssignmentExpression(ae, _) => ae.early_errors(agent, errs, strict),
+            PropertyDefinition::AssignmentExpression(ae, _) => ae.early_errors(errs, strict),
             PropertyDefinition::MethodDefinition(md) => {
                 // PropertyDefinition : MethodDefinition
                 //  * It is a Syntax Error if HasDirectSuper of MethodDefinition is true.
                 //  * It is a Syntax Error if PrivateBoundIdentifiers of MethodDefinition is not empty.
                 if md.has_direct_super() {
                     // E.g.: x = { b() { super(); } };
-                    errs.push(create_syntax_error_object(
-                        agent,
-                        "'super' keyword unexpected here",
-                        Some(md.location()),
-                    ));
+                    errs.push(create_syntax_error_object("'super' keyword unexpected here", Some(md.location())));
                 }
                 if md.private_bound_identifier().is_some() {
                     // E.g.: x = { #b() {} };
-                    errs.push(create_syntax_error_object(
-                        agent,
-                        "Private identifier unexpected here",
-                        Some(md.location()),
-                    ));
+                    errs.push(create_syntax_error_object("Private identifier unexpected here", Some(md.location())));
                 }
-                md.early_errors(agent, errs, strict);
+                md.early_errors(errs, strict);
             }
             PropertyDefinition::CoverInitializedName(cin) => {
                 // In addition to describing an actual object initializer, the ObjectLiteral productions are also used
@@ -1938,11 +1930,10 @@ impl PropertyDefinition {
                 // Programming Note. Since covered expressions always wind up getting uncovered before early errors are
                 // checked, if we _actually_ get here, this really is an error.
                 errs.push(create_syntax_error_object(
-                    agent,
                     "Illegal destructuring syntax in non-destructuring context",
                     Some(cin.location()),
                 ));
-                cin.early_errors(agent, errs, strict);
+                cin.early_errors(errs, strict);
             }
         }
     }
@@ -2095,13 +2086,13 @@ impl PropertyDefinitionList {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
-            PropertyDefinitionList::OneDef(pd) => pd.early_errors(agent, errs, strict),
+            PropertyDefinitionList::OneDef(pd) => pd.early_errors(errs, strict),
             PropertyDefinitionList::ManyDefs(pdl, pd) => {
-                pdl.early_errors(agent, errs, strict);
-                pd.early_errors(agent, errs, strict);
+                pdl.early_errors(errs, strict);
+                pd.early_errors(errs, strict);
             }
         }
     }
@@ -2255,7 +2246,7 @@ impl ObjectLiteral {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
             ObjectLiteral::Empty { .. } => {}
@@ -2273,12 +2264,11 @@ impl ObjectLiteral {
                 //          ComputedPropertyName.
                 if pdl.special_proto_count() >= 2 {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "Duplicate __proto__ fields are not allowed in object literals",
                         Some(*location),
                     ));
                 }
-                pdl.early_errors(agent, errs, strict);
+                pdl.early_errors(errs, strict);
             }
         }
     }
@@ -2433,12 +2423,12 @@ impl Literal {
         //    Literal::BooleanLiteral(..) | Literal::NullLiteral => {},
         //    Literal::StringLiteral(s) => {
         //        if strict && s.has_legacy_octal_escapes() {
-        //            errs.push(create_syntax_error_object(agent, "Legacy octal escapes not allowed in strict mode"));
+        //            errs.push(create_syntax_error_object("Legacy octal escapes not allowed in strict mode"));
         //        }
         //    }
         //    Literal::NumericLiteral(n) => {
         //        if strict && n.has_legacy_octal_syntax() {
-        //            errs.push(create_syntax_error_object(agent, "Legacy octal syntax not allowed in strict mode"));
+        //            errs.push(create_syntax_error_object("Legacy octal syntax not allowed in strict mode"));
         //        }
         //    }
         //}
@@ -2587,7 +2577,7 @@ impl TemplateLiteral {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool, ts_limit: usize) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, ts_limit: usize) {
         // Static Semantics: Early Errors
         match self {
             TemplateLiteral::NoSubstitutionTemplate { data: td, tagged, location } => {
@@ -2596,7 +2586,6 @@ impl TemplateLiteral {
                 //    NoSubstitutionTemplate Contains NotEscapeSequence.
                 if !tagged && td.tv.is_none() {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "Invalid escape sequence in template literal",
                         Some(*location),
                     ));
@@ -2608,9 +2597,9 @@ impl TemplateLiteral {
                 //    TemplateStrings of TemplateLiteral with argument false is greater
                 //    than 2^32 - 1.
                 if self.template_strings(false).len() > ts_limit {
-                    errs.push(create_syntax_error_object(agent, "Template literal too complex", Some(st.location())))
+                    errs.push(create_syntax_error_object("Template literal too complex", Some(st.location())))
                 }
-                st.early_errors(agent, errs, strict);
+                st.early_errors(errs, strict);
             }
         }
     }
@@ -2750,19 +2739,15 @@ impl SubstitutionTemplate {
         self.expression.contains_arguments() || self.template_spans.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         // SubstitutionTemplate : TemplateHead Expression TemplateSpans
         //  * It is a Syntax Error if the [Tagged] parameter was not set and TemplateHead Contains NotEscapeSequence.
         if !self.tagged && self.template_head.tv.is_none() {
-            errs.push(create_syntax_error_object(
-                agent,
-                "Invalid escape sequence in template literal",
-                Some(self.location),
-            ));
+            errs.push(create_syntax_error_object("Invalid escape sequence in template literal", Some(self.location)));
         }
-        self.expression.early_errors(agent, errs, strict);
-        self.template_spans.early_errors(agent, errs, strict);
+        self.expression.early_errors(errs, strict);
+        self.template_spans.early_errors(errs, strict);
     }
 
     pub fn template_strings(&self, raw: bool) -> Vec<Option<JSString>> {
@@ -2927,21 +2912,20 @@ impl TemplateSpans {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  TemplateSpans :
         //      TemplateTail
         //      TemplateMiddleList TemplateTail
         //  * It is a Syntax Error if the [Tagged] parameter was not set and TemplateTail Contains NotEscapeSequence.
         if let TemplateSpans::List { tml: lst, .. } = self {
-            lst.early_errors(agent, errs, strict);
+            lst.early_errors(errs, strict);
         }
         match self {
             TemplateSpans::Tail { data: tail, tagged, location }
             | TemplateSpans::List { data: tail, tagged, location, .. } => {
                 if !tagged && tail.tv.is_none() {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "Invalid character escape in template literal",
                         Some(*location),
                     ));
@@ -3142,26 +3126,25 @@ impl TemplateMiddleList {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  TemplateMiddleList :
         //      TemplateMiddle Expression
         //      TemplateMiddleList TemplateMiddle Expression
         //  * It is a Syntax Error if the [Tagged] parameter was not set and TemplateMiddle Contains NotEscapeSequence.
         if let TemplateMiddleList::ListMid(lst, _, _, _) = self {
-            lst.early_errors(agent, errs, strict);
+            lst.early_errors(errs, strict);
         }
         match self {
             TemplateMiddleList::ListHead { data: tmid, exp, tagged, .. }
             | TemplateMiddleList::ListMid(_, tmid, exp, tagged) => {
                 if !tagged && tmid.tv.is_none() {
                     errs.push(create_syntax_error_object(
-                        agent,
                         "Invalid character escape in template literal",
                         Some(self.location()),
                     ));
                 }
-                exp.early_errors(agent, errs, strict);
+                exp.early_errors(errs, strict);
             }
         }
     }
@@ -3288,8 +3271,8 @@ impl ParenthesizedExpression {
         self.exp.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.exp.early_errors(agent, errs, strict)
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.exp.early_errors(errs, strict)
     }
 
     pub fn is_strictly_deletable(&self) -> bool {
@@ -3614,26 +3597,26 @@ impl CoverParenthesizedExpressionAndArrowParameterList {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
             CoverParenthesizedExpressionAndArrowParameterList::Expression { exp: node, .. }
             | CoverParenthesizedExpressionAndArrowParameterList::ExpComma { exp: node, .. } => {
-                node.early_errors(agent, errs, strict)
+                node.early_errors(errs, strict)
             }
             CoverParenthesizedExpressionAndArrowParameterList::Empty { .. } => {}
             CoverParenthesizedExpressionAndArrowParameterList::Ident { bi: node, .. } => {
-                node.early_errors(agent, errs, strict)
+                node.early_errors(errs, strict)
             }
             CoverParenthesizedExpressionAndArrowParameterList::Pattern { bp: node, .. } => {
-                node.early_errors(agent, errs, strict)
+                node.early_errors(errs, strict)
             }
             CoverParenthesizedExpressionAndArrowParameterList::ExpIdent { exp, bi: id, .. } => {
-                exp.early_errors(agent, errs, strict);
-                id.early_errors(agent, errs, strict);
+                exp.early_errors(errs, strict);
+                id.early_errors(errs, strict);
             }
             CoverParenthesizedExpressionAndArrowParameterList::ExpPattern { exp, bp: pat, .. } => {
-                exp.early_errors(agent, errs, strict);
-                pat.early_errors(agent, errs, strict);
+                exp.early_errors(errs, strict);
+                pat.early_errors(errs, strict);
             }
         }
     }

--- a/src/parser/primary_expressions/tests.rs
+++ b/src/parser/primary_expressions/tests.rs
@@ -520,8 +520,8 @@ mod primary_expression {
         PrimaryExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("this" => true; "this")]
@@ -996,8 +996,8 @@ mod spread_element {
         SpreadElement::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("...xyzzy" => false; "no")]
@@ -1356,11 +1356,8 @@ mod element_list {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        ElementList::parse(&mut newparser(src), Scanner::new(), false, true)
-            .unwrap()
-            .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        ElementList::parse(&mut newparser(src), Scanner::new(), false, true).unwrap().0.early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("xyzzy" => false; "AssignmentExpression (no)")]
@@ -1632,8 +1629,8 @@ mod array_literal {
         ArrayLiteral::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("[]" => false; "empty")]
@@ -1729,8 +1726,8 @@ mod initializer {
         Initializer::parse(&mut newparser(src), Scanner::new(), true, false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("=xyzzy" => false; "no")]
@@ -1814,8 +1811,8 @@ mod cover_initialized_name {
         CoverInitializedName::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test]
@@ -1900,8 +1897,8 @@ mod computed_property_name {
         ComputedPropertyName::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
     #[test_case("[xyzzy]" => false; "no")]
     #[test_case("[arguments]" => true; "yes")]
@@ -2142,8 +2139,8 @@ mod property_name {
         PropertyName::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => Some(JSString::from("a")); "normal")]
@@ -2401,8 +2398,8 @@ mod property_definition {
         PropertyDefinition::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => Some(JSString::from("a")); "identifier")]
@@ -2559,8 +2556,8 @@ mod property_definition_list {
         PropertyDefinitionList::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a:x" => 0; "one item, not proto")]
@@ -2745,8 +2742,8 @@ mod object_literal {
         ObjectLiteral::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("{}" => false; "{} (empty)")]
@@ -2836,8 +2833,8 @@ mod parenthesized_expression {
         ParenthesizedExpression::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("(a)" => false; "parenthesized idref")]
@@ -3008,8 +3005,8 @@ mod template_middle_list {
         TemplateMiddleList::parse(&mut newparser(src), Scanner::new(), false, true, tagged)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("}\\u{66}${0", true => vec![Some(JSString::from("\\u{66}"))]; "item-raw")]
@@ -3129,8 +3126,8 @@ mod template_spans {
         TemplateSpans::parse(&mut newparser(src), Scanner::new(), false, true, tagged)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("}\\u{66}`", true => vec![Some(JSString::from("\\u{66}"))]; "tail-raw")]
@@ -3249,8 +3246,8 @@ mod substitution_template {
     fn early_errors(src: &str, strict: bool, tagged: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).tagged_ok(tagged).substitution_template().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).tagged_ok(tagged).substitution_template().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("`a${0}\\u{66}`", true => vec![Some(JSString::from("a")), Some(JSString::from("\\u{66}"))]; "raw")]
@@ -3389,8 +3386,8 @@ mod template_literal {
             TemplateLiteral::parse(&mut newparser(src), Scanner::new(), false, true, tagged)
                 .unwrap()
                 .0
-                .early_errors(&agent, &mut errs, strict, 4294967295);
-            AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+                .early_errors(&mut errs, strict, 4294967295);
+            AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
         }
 
         #[test]
@@ -3405,13 +3402,11 @@ mod template_literal {
             src.push('`');
             let mut errs = vec![];
             TemplateLiteral::parse(&mut newparser(&src), Scanner::new(), false, true, false).unwrap().0.early_errors(
-                &agent,
                 &mut errs,
                 false,
                 limit - 1,
             );
-            let err_set =
-                AHashSet::<String>::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())));
+            let err_set = AHashSet::<String>::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())));
             assert_eq!(err_set, sset(&["Template literal too complex"]));
         }
     }
@@ -3997,8 +3992,8 @@ mod cover_parenthesized_expression_and_arrow_parameter_list {
         CoverParenthesizedExpressionAndArrowParameterList::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("   (a)" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 3 } }; "parenthesized")]

--- a/src/parser/primary_expressions/tests.rs
+++ b/src/parser/primary_expressions/tests.rs
@@ -515,7 +515,7 @@ mod primary_expression {
     #[test_case("`${package}`", true => sset(&[PACKAGE_NOT_ALLOWED]); "TemplateLiteral")]
     #[test_case("(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "ParenthesizedExpression")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         PrimaryExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -991,7 +991,7 @@ mod spread_element {
 
     #[test_case("...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "... AssignmentExpression")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         SpreadElement::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -1354,7 +1354,7 @@ mod element_list {
     #[test_case("package,,...b", true => sset(&[PACKAGE_NOT_ALLOWED]); "ElementList Elision SpreadElement: list err")]
     #[test_case("a,,...package", true => sset(&[PACKAGE_NOT_ALLOWED]); "ElementList Elision SpreadElement: element err")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ElementList::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -1627,7 +1627,7 @@ mod array_literal {
     #[test_case("[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "ElementList")]
     #[test_case("[package,,]", true => sset(&[PACKAGE_NOT_ALLOWED]); "ElementList Elision")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ArrayLiteral::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -1724,7 +1724,7 @@ mod initializer {
 
     #[test_case("=package", true => sset(&[PACKAGE_NOT_ALLOWED]); "normal")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Initializer::parse(&mut newparser(src), Scanner::new(), true, false, true)
             .unwrap()
@@ -1809,7 +1809,7 @@ mod cover_initialized_name {
     #[test_case("a=package", true => sset(&[PACKAGE_NOT_ALLOWED]); "exp errs")]
     #[test_case("package=3", true => sset(&[PACKAGE_NOT_ALLOWED]); "id errs")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         CoverInitializedName::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -1895,7 +1895,7 @@ mod computed_property_name {
 
     #[test_case("[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "[ AssignmentExpression ]")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ComputedPropertyName::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -2137,7 +2137,7 @@ mod property_name {
     #[test_case("package", true => sset(&[]); "LiteralPropertyName")]
     #[test_case("[package]", true => sset(&[PACKAGE_NOT_ALLOWED]); "ComputedPropertyName")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         PropertyName::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -2396,7 +2396,7 @@ mod property_definition {
     #[test_case("a(b=super()){}", true => sset(&[UNEXPECTED_SUPER]); "HasDirectSuper of MethodDefinition")]
     #[test_case("#a(){}", true => sset(&[UNEXPECTED_PRIVATE]); "unexpected private id in MethodDef")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         PropertyDefinition::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -2554,7 +2554,7 @@ mod property_definition_list {
     #[test_case("[package]:3,b", true => sset(&[PACKAGE_NOT_ALLOWED]); "list head")]
     #[test_case("a,[package]:3", true => sset(&[PACKAGE_NOT_ALLOWED]); "list tail")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         PropertyDefinitionList::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -2740,7 +2740,7 @@ mod object_literal {
     #[test_case("{__proto__:a,__proto__:b}", true => sset(&[DUP_PROTO]); "duplicate proto")]
     #[test_case("{__proto__:a,__proto__:b,}", true => sset(&[DUP_PROTO]); "duplicate proto; trailing comma")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ObjectLiteral::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
@@ -2831,7 +2831,7 @@ mod parenthesized_expression {
 
     #[test_case("(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "( Expression )")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ParenthesizedExpression::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -3003,7 +3003,7 @@ mod template_middle_list {
     #[test_case("}list${1}\\u{}${3", true, true => sset(&[]); "list mid exp; mid bad, but tagged")]
     #[test_case("}list${1}${package", true, false => sset(&[PACKAGE_NOT_ALLOWED]); "list mid exp; exp bad")]
     fn early_errors(src: &str, strict: bool, tagged: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         TemplateMiddleList::parse(&mut newparser(src), Scanner::new(), false, true, tagged)
             .unwrap()
@@ -3124,7 +3124,7 @@ mod template_spans {
     #[test_case("}${0}\\u{}`", true, false => sset(&[RE_ESCAPE_ONE]); "list tail; tail bad")]
     #[test_case("}${0}\\u{}`", true, true => sset(&[]); "list tail; tail bad, but tagged")]
     fn early_errors(src: &str, strict: bool, tagged: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         TemplateSpans::parse(&mut newparser(src), Scanner::new(), false, true, tagged)
             .unwrap()
@@ -3247,7 +3247,7 @@ mod substitution_template {
     #[test_case("`\\u{999999999999}${package}\\u{0x987654321987654321}`", true, true => sset(&[PACKAGE_NOT_ALLOWED]); "tagged")]
     #[test_case("`\\u{99}${package}\\u{98}`", true, false => sset(&[PACKAGE_NOT_ALLOWED]); "not tagged, but no unicode errs")]
     fn early_errors(src: &str, strict: bool, tagged: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).tagged_ok(tagged).substitution_template().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -3384,7 +3384,7 @@ mod template_literal {
         #[test_case("`\\u{`", true, true => sset(&[]); "no-substitution bad escape; tagged")]
         #[test_case("`${package}`", true, false => sset(&[PACKAGE_NOT_ALLOWED]); "substitution template")]
         fn simple(src: &str, strict: bool, tagged: bool) -> AHashSet<String> {
-            let agent = test_agent();
+            setup_test_agent();
             let mut errs = vec![];
             TemplateLiteral::parse(&mut newparser(src), Scanner::new(), false, true, tagged)
                 .unwrap()
@@ -3396,7 +3396,7 @@ mod template_literal {
         #[test]
         fn complex() {
             let limit = 1000;
-            let agent = test_agent();
+            setup_test_agent();
             let mut src = String::with_capacity(2 + 4 * limit);
             src.push('`');
             for _ in 0..limit {
@@ -3992,7 +3992,7 @@ mod cover_parenthesized_expression_and_arrow_parameter_list {
     #[test_case("(package, ...{a=b})", true => sset(&[PACKAGE_NOT_ALLOWED]); "exp rest pat; exp bad")]
     #[test_case("(a, ...{package=b})", true => sset(&[PACKAGE_NOT_ALLOWED]); "exp rest pat; pat bad")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         CoverParenthesizedExpressionAndArrowParameterList::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()

--- a/src/parser/relational_operators/mod.rs
+++ b/src/parser/relational_operators/mod.rs
@@ -272,19 +272,19 @@ impl RelationalExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            RelationalExpression::ShiftExpression(n) => n.early_errors(agent, errs, strict),
+            RelationalExpression::ShiftExpression(n) => n.early_errors(errs, strict),
             RelationalExpression::Less(l, r)
             | RelationalExpression::Greater(l, r)
             | RelationalExpression::LessEqual(l, r)
             | RelationalExpression::GreaterEqual(l, r)
             | RelationalExpression::InstanceOf(l, r)
             | RelationalExpression::In(l, r) => {
-                l.early_errors(agent, errs, strict);
-                r.early_errors(agent, errs, strict);
+                l.early_errors(errs, strict);
+                r.early_errors(errs, strict);
             }
-            RelationalExpression::PrivateIn(_, r, _) => r.early_errors(agent, errs, strict),
+            RelationalExpression::PrivateIn(_, r, _) => r.early_errors(errs, strict),
         }
     }
 

--- a/src/parser/relational_operators/tests.rs
+++ b/src/parser/relational_operators/tests.rs
@@ -453,8 +453,8 @@ mod relational_expression {
         RelationalExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/relational_operators/tests.rs
+++ b/src/parser/relational_operators/tests.rs
@@ -448,7 +448,7 @@ mod relational_expression {
     #[test_case("3 in package", true => sset(&[PACKAGE_NOT_ALLOWED]); "left in right; right bad")]
     #[test_case("#a in package", true => sset(&[PACKAGE_NOT_ALLOWED]); "privateid")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         RelationalExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()

--- a/src/parser/return_statement/mod.rs
+++ b/src/parser/return_statement/mod.rs
@@ -106,10 +106,10 @@ impl ReturnStatement {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ReturnStatement::Bare { .. } => {}
-            ReturnStatement::Expression { exp, .. } => exp.early_errors(agent, errs, strict),
+            ReturnStatement::Expression { exp, .. } => exp.early_errors(errs, strict),
         }
     }
 }

--- a/src/parser/return_statement/tests.rs
+++ b/src/parser/return_statement/tests.rs
@@ -104,7 +104,7 @@ mod return_statement {
     #[test_case("return;", true => sset(&[]); "return ;")]
     #[test_case("return package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "return Expression ;")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).return_statement().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))

--- a/src/parser/return_statement/tests.rs
+++ b/src/parser/return_statement/tests.rs
@@ -106,8 +106,8 @@ mod return_statement {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).return_statement().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).return_statement().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("return;" => false; "no exp")]

--- a/src/parser/scripts/tests.rs
+++ b/src/parser/scripts/tests.rs
@@ -138,7 +138,7 @@ mod script {
     #[test_case("let x; var x=10;" => sset(&[LEX_DUPED_BY_VAR]); "lex duped by var")]
     #[test_case("break a;" => sset(&[UNDEF_BREAK]); "undefined break target")]
     fn early_errors(src: &str) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Script::parse(&mut newparser(src), Scanner::new()).unwrap().0.early_errors(&agent, &mut errs);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -278,7 +278,7 @@ mod script_body {
     #[test_case("continue bob;", false => sset(&[CONTINUE_ITER, "undefined continue target detected"]); "undefined continue")]
     #[test_case("a.#mystery;", false => sset(&["invalid private identifier detected"]); "invalid private id")]
     fn early_errors(src: &str, direct: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         ScriptBody::parse(&mut directparser(src, direct), Scanner::new()).unwrap().0.early_errors(&agent, &mut errs);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))

--- a/src/parser/scripts/tests.rs
+++ b/src/parser/scripts/tests.rs
@@ -140,8 +140,8 @@ mod script {
     fn early_errors(src: &str) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Script::parse(&mut newparser(src), Scanner::new()).unwrap().0.early_errors(&agent, &mut errs);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Script::parse(&mut newparser(src), Scanner::new()).unwrap().0.early_errors(&mut errs);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("" => svec(&[]); "empty")]
@@ -280,8 +280,8 @@ mod script_body {
     fn early_errors(src: &str, direct: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        ScriptBody::parse(&mut directparser(src, direct), Scanner::new()).unwrap().0.early_errors(&agent, &mut errs);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        ScriptBody::parse(&mut directparser(src, direct), Scanner::new()).unwrap().0.early_errors(&mut errs);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("var a; function b(){}" => svec(&["a", "function b (  ) {  }"]); "statements")]

--- a/src/parser/statements_and_declarations/mod.rs
+++ b/src/parser/statements_and_declarations/mod.rs
@@ -354,28 +354,21 @@ impl Statement {
         }
     }
 
-    pub fn early_errors(
-        &self,
-        agent: &Agent,
-        errs: &mut Vec<Object>,
-        strict: bool,
-        within_iteration: bool,
-        within_switch: bool,
-    ) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_iteration: bool, within_switch: bool) {
         match self {
-            Statement::Block(node) => node.early_errors(agent, errs, strict, within_iteration, within_switch),
-            Statement::Break(node) => node.early_errors(agent, errs, strict, within_iteration || within_switch),
-            Statement::Breakable(node) => node.early_errors(agent, errs, strict, within_iteration, within_switch),
-            Statement::Continue(node) => node.early_errors(agent, errs, strict, within_iteration),
+            Statement::Block(node) => node.early_errors(errs, strict, within_iteration, within_switch),
+            Statement::Break(node) => node.early_errors(errs, strict, within_iteration || within_switch),
+            Statement::Breakable(node) => node.early_errors(errs, strict, within_iteration, within_switch),
+            Statement::Continue(node) => node.early_errors(errs, strict, within_iteration),
             Statement::Debugger(_) | Statement::Empty(_) => (),
-            Statement::Expression(node) => node.early_errors(agent, errs, strict),
-            Statement::If(node) => node.early_errors(agent, errs, strict, within_iteration, within_switch),
-            Statement::Labelled(node) => node.early_errors(agent, errs, strict, within_iteration, within_switch),
-            Statement::Return(node) => node.early_errors(agent, errs, strict),
-            Statement::Throw(node) => node.early_errors(agent, errs, strict),
-            Statement::Try(node) => node.early_errors(agent, errs, strict, within_iteration, within_switch),
-            Statement::Variable(node) => node.early_errors(agent, errs, strict),
-            Statement::With(node) => node.early_errors(agent, errs, strict, within_iteration, within_switch),
+            Statement::Expression(node) => node.early_errors(errs, strict),
+            Statement::If(node) => node.early_errors(errs, strict, within_iteration, within_switch),
+            Statement::Labelled(node) => node.early_errors(errs, strict, within_iteration, within_switch),
+            Statement::Return(node) => node.early_errors(errs, strict),
+            Statement::Throw(node) => node.early_errors(errs, strict),
+            Statement::Try(node) => node.early_errors(errs, strict, within_iteration, within_switch),
+            Statement::Variable(node) => node.early_errors(errs, strict),
+            Statement::With(node) => node.early_errors(errs, strict, within_iteration, within_switch),
         }
     }
 
@@ -639,11 +632,11 @@ impl Declaration {
     /// See [Early Errors][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#early-error
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            Declaration::Hoistable(node) => node.early_errors(agent, errs, strict),
-            Declaration::Class(node) => node.early_errors(agent, errs),
-            Declaration::Lexical(node) => node.early_errors(agent, errs, strict),
+            Declaration::Hoistable(node) => node.early_errors(errs, strict),
+            Declaration::Class(node) => node.early_errors(errs),
+            Declaration::Lexical(node) => node.early_errors(errs, strict),
         }
     }
 
@@ -814,12 +807,12 @@ impl HoistableDeclaration {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            HoistableDeclaration::Function(node) => node.early_errors(agent, errs, strict),
-            HoistableDeclaration::Generator(node) => node.early_errors(agent, errs, strict),
-            HoistableDeclaration::AsyncFunction(node) => node.early_errors(agent, errs, strict),
-            HoistableDeclaration::AsyncGenerator(node) => node.early_errors(agent, errs, strict),
+            HoistableDeclaration::Function(node) => node.early_errors(errs, strict),
+            HoistableDeclaration::Generator(node) => node.early_errors(errs, strict),
+            HoistableDeclaration::AsyncFunction(node) => node.early_errors(errs, strict),
+            HoistableDeclaration::AsyncGenerator(node) => node.early_errors(errs, strict),
         }
     }
 
@@ -976,17 +969,10 @@ impl BreakableStatement {
         }
     }
 
-    pub fn early_errors(
-        &self,
-        agent: &Agent,
-        errs: &mut Vec<Object>,
-        strict: bool,
-        within_iteration: bool,
-        within_switch: bool,
-    ) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_iteration: bool, within_switch: bool) {
         match self {
-            BreakableStatement::Iteration(node) => node.early_errors(agent, errs, strict, within_switch),
-            BreakableStatement::Switch(node) => node.early_errors(agent, errs, strict, within_iteration),
+            BreakableStatement::Iteration(node) => node.early_errors(errs, strict, within_switch),
+            BreakableStatement::Switch(node) => node.early_errors(errs, strict, within_iteration),
         }
     }
 

--- a/src/parser/statements_and_declarations/tests.rs
+++ b/src/parser/statements_and_declarations/tests.rs
@@ -525,8 +525,8 @@ mod statement {
         Statement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict, wi, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict, wi, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("bob: function alice(){}" => true; "direct labelled function")]
@@ -809,11 +809,8 @@ mod declaration {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Declaration::parse(&mut newparser(src), Scanner::new(), true, true)
-            .unwrap()
-            .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Declaration::parse(&mut newparser(src), Scanner::new(), true, true).unwrap().0.early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("function a(){}" => false; "Hoistable")]
@@ -1067,8 +1064,8 @@ mod hoistable_declaration {
         HoistableDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, false)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("function a(){}" => "function a (  ) {  }"; "function def")]
@@ -1221,8 +1218,8 @@ mod breakable_statement {
         BreakableStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("for(;;)arguments;" => true; "Iteration (yes)")]

--- a/src/parser/statements_and_declarations/tests.rs
+++ b/src/parser/statements_and_declarations/tests.rs
@@ -520,7 +520,7 @@ mod statement {
     #[test_case("try {} catch (package) {}", true, false => sset(&[PACKAGE_NOT_ALLOWED]); "TryStatement")]
     #[test_case("debugger;", true, false => sset(&[]); "DebuggerStatement")]
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Statement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()
@@ -807,7 +807,7 @@ mod declaration {
     #[test_case("class package{}", true => sset(&[PACKAGE_NOT_ALLOWED]); "ClassDeclaration")]
     #[test_case("let package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "LexicalDeclaration")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Declaration::parse(&mut newparser(src), Scanner::new(), true, true)
             .unwrap()
@@ -1062,7 +1062,7 @@ mod hoistable_declaration {
     #[test_case("async function package(){}", true => sset(&[PACKAGE_NOT_ALLOWED]); "AsyncFunctionDeclaration")]
     #[test_case("async function *package(){}", true => panics "not yet implemented" /* sset(&[PACKAGE_NOT_ALLOWED]) */; "AsyncGeneratorDeclaration")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         HoistableDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, false)
             .unwrap()
@@ -1216,7 +1216,7 @@ mod breakable_statement {
     #[test_case("while(package);", true => sset(&[PACKAGE_NOT_ALLOWED]); "IterationStatement")]
     #[test_case("switch(package){}", true => sset(&[PACKAGE_NOT_ALLOWED]); "SwitchStatement")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         BreakableStatement::parse(&mut newparser(src), Scanner::new(), true, true, true)
             .unwrap()

--- a/src/parser/switch_statement/tests.rs
+++ b/src/parser/switch_statement/tests.rs
@@ -122,8 +122,8 @@ mod switch_statement {
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).switch_statement().early_errors(&agent, &mut errs, strict, wi);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).switch_statement().early_errors(&mut errs, strict, wi);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("switch(arguments){}" => true; "left")]
@@ -388,8 +388,8 @@ mod case_block {
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).case_block().early_errors(&agent, &mut errs, strict, wi);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).case_block().early_errors(&mut errs, strict, wi);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("{ }" => Vec::<String>::new(); "empty")]
@@ -556,8 +556,8 @@ mod case_clauses {
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).case_clauses().early_errors(&agent, &mut errs, strict, wi);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).case_clauses().early_errors(&mut errs, strict, wi);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("case 0: let a;" => vec!["a"]; "single")]
@@ -694,8 +694,8 @@ mod case_clause {
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).case_clause().early_errors(&agent, &mut errs, strict, wi);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).case_clause().early_errors(&mut errs, strict, wi);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("case 0:" => Vec::<String>::new(); "no statements")]
@@ -822,8 +822,8 @@ mod default_clause {
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).default_clause().early_errors(&agent, &mut errs, strict, wi);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).default_clause().early_errors(&mut errs, strict, wi);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("default:" => Vec::<String>::new(); "no statements")]

--- a/src/parser/switch_statement/tests.rs
+++ b/src/parser/switch_statement/tests.rs
@@ -120,7 +120,7 @@ mod switch_statement {
     #[test_case("switch (a) { case 1: let b=20; case 2: let b=30; case 3: let a=3; }", false, false => sset(&[B_ALREADY]); "duplicate lexicals")]
     #[test_case("switch (a) { case 1: let b=20; case 2: var b=30; case 3: var left; let right; }", false, false => sset(&[B_DUPLEX]); "lex/var dups")]
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).switch_statement().early_errors(&agent, &mut errs, strict, wi);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -386,7 +386,7 @@ mod case_block {
     #[test_case("{ case package:; default: implements;}", true, false => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "before+default")]
     #[test_case("{ default:package; case implements:;}", true, false => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "default+after")]
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).case_block().early_errors(&agent, &mut errs, strict, wi);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -554,7 +554,7 @@ mod case_clauses {
     #[test_case("case implements: package; continue; case interface: break;", true, false => sset(&[PACKAGE_NOT_ALLOWED, CONTINUE_ITER, INTERFACE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "list")]
     #[test_case("case implements: package; continue; case interface: break;", false, true => sset(&[]); "not strict; in iter; list")]
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).case_clauses().early_errors(&agent, &mut errs, strict, wi);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -692,7 +692,7 @@ mod case_clause {
     #[test_case("case implements: package; continue;", true, false => sset(&[PACKAGE_NOT_ALLOWED, CONTINUE_ITER, IMPLEMENTS_NOT_ALLOWED]); "statement")]
     #[test_case("case implements: package; continue;", false, true => sset(&[]); "not strict; in iter")]
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).case_clause().early_errors(&agent, &mut errs, strict, wi);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -820,7 +820,7 @@ mod default_clause {
     #[test_case("default: package; continue;", true, false => sset(&[PACKAGE_NOT_ALLOWED, CONTINUE_ITER]); "statement")]
     #[test_case("default: package; continue;", false, true => sset(&[]); "not strict; in iter")]
     fn early_errors(src: &str, strict: bool, wi: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).default_clause().early_errors(&agent, &mut errs, strict, wi);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -797,26 +797,26 @@ mod parse_node_kind {
 }
 #[test]
 fn parse_text_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let res = parse_text(&agent, "0;", ParseGoal::Script);
     assert!(matches!(res, ParsedText::Script(_)));
 }
 #[test]
 fn parse_text_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let res = parse_text(&agent, "for", ParseGoal::Script);
     assert!(matches!(res, ParsedText::Errors(_)));
 }
 #[test]
 fn parse_text_03() {
-    let agent = test_agent();
+    setup_test_agent();
     let res = parse_text(&agent, "let x; let x;", ParseGoal::Script);
     assert!(matches!(res, ParsedText::Errors(_)));
 }
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn parse_text_04() {
-    let agent = test_agent();
+    setup_test_agent();
     parse_text(&agent, "let x; let x;", ParseGoal::Module);
 }
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::clone_on_copy)]
 use super::*;
-use crate::tests::test_agent;
+use crate::tests::setup_test_agent;
 use ahash::AHasher;
 use std::hash::{Hash, Hasher};
 use test_case::test_case;
@@ -798,26 +798,26 @@ mod parse_node_kind {
 #[test]
 fn parse_text_01() {
     setup_test_agent();
-    let res = parse_text(&agent, "0;", ParseGoal::Script);
+    let res = parse_text("0;", ParseGoal::Script);
     assert!(matches!(res, ParsedText::Script(_)));
 }
 #[test]
 fn parse_text_02() {
     setup_test_agent();
-    let res = parse_text(&agent, "for", ParseGoal::Script);
+    let res = parse_text("for", ParseGoal::Script);
     assert!(matches!(res, ParsedText::Errors(_)));
 }
 #[test]
 fn parse_text_03() {
     setup_test_agent();
-    let res = parse_text(&agent, "let x; let x;", ParseGoal::Script);
+    let res = parse_text("let x; let x;", ParseGoal::Script);
     assert!(matches!(res, ParsedText::Errors(_)));
 }
 #[test]
 #[should_panic(expected = "not yet implemented")]
 fn parse_text_04() {
     setup_test_agent();
-    parse_text(&agent, "let x; let x;", ParseGoal::Module);
+    parse_text("let x; let x;", ParseGoal::Module);
 }
 
 #[test_case(&["a"] => Vec::<String>::new(); "no dups")]

--- a/src/parser/throw_statement/mod.rs
+++ b/src/parser/throw_statement/mod.rs
@@ -81,8 +81,8 @@ impl ThrowStatement {
         self.exp.contains_arguments()
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
-        self.exp.early_errors(agent, errs, strict);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+        self.exp.early_errors(errs, strict);
     }
 }
 

--- a/src/parser/throw_statement/tests.rs
+++ b/src/parser/throw_statement/tests.rs
@@ -63,7 +63,7 @@ mod throw_statement {
 
     #[test_case("throw package;", true => sset(&[PACKAGE_NOT_ALLOWED]); "normal")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).throw_statement().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))

--- a/src/parser/throw_statement/tests.rs
+++ b/src/parser/throw_statement/tests.rs
@@ -65,8 +65,8 @@ mod throw_statement {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).throw_statement().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).throw_statement().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("throw arguments;" => true; "yes")]

--- a/src/parser/try_statement/mod.rs
+++ b/src/parser/try_statement/mod.rs
@@ -257,25 +257,18 @@ impl TryStatement {
         }
     }
 
-    pub fn early_errors(
-        &self,
-        agent: &Agent,
-        errs: &mut Vec<Object>,
-        strict: bool,
-        within_iteration: bool,
-        within_switch: bool,
-    ) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_iteration: bool, within_switch: bool) {
         let (block, catch, finally) = match self {
             TryStatement::Catch { block, catch, .. } => (block, Some(catch), None),
             TryStatement::Finally { block, finally, .. } => (block, None, Some(finally)),
             TryStatement::Full { block, catch, finally, .. } => (block, Some(catch), Some(finally)),
         };
-        block.early_errors(agent, errs, strict, within_iteration, within_switch);
+        block.early_errors(errs, strict, within_iteration, within_switch);
         if let Some(catch) = catch {
-            catch.early_errors(agent, errs, strict, within_iteration, within_switch);
+            catch.early_errors(errs, strict, within_iteration, within_switch);
         }
         if let Some(finally) = finally {
-            finally.early_errors(agent, errs, strict, within_iteration, within_switch);
+            finally.early_errors(errs, strict, within_iteration, within_switch);
         }
     }
 
@@ -427,14 +420,7 @@ impl Catch {
         self.parameter.as_ref().map_or(false, |cp| cp.contains_arguments()) || self.block.contains_arguments()
     }
 
-    pub fn early_errors(
-        &self,
-        agent: &Agent,
-        errs: &mut Vec<Object>,
-        strict: bool,
-        within_iteration: bool,
-        within_switch: bool,
-    ) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_iteration: bool, within_switch: bool) {
         // Static Semantics: Early Errors
         //  Catch : catch ( CatchParameter ) Block
         //  * It is a Syntax Error if BoundNames of CatchParameter contains any duplicate elements.
@@ -447,7 +433,6 @@ impl Catch {
             let vdn = self.block.var_declared_names();
             for name in duplicates(&bn) {
                 errs.push(create_syntax_error_object(
-                    agent,
                     format!("‘{}’ already defined", name),
                     Some(self.block.location()),
                 ));
@@ -455,15 +440,14 @@ impl Catch {
             for name in bn.iter() {
                 if ldn.contains(name) || vdn.contains(name) {
                     errs.push(create_syntax_error_object(
-                        agent,
                         format!("‘{}’ already defined", name),
                         Some(self.block.location()),
                     ));
                 }
             }
-            cp.early_errors(agent, errs, strict);
+            cp.early_errors(errs, strict);
         }
-        self.block.early_errors(agent, errs, strict, within_iteration, within_switch);
+        self.block.early_errors(errs, strict, within_iteration, within_switch);
     }
 
     /// Return a list of parse nodes for the var-style declarations contained within the children of this node.
@@ -572,15 +556,8 @@ impl Finally {
         self.block.contains_arguments()
     }
 
-    pub fn early_errors(
-        &self,
-        agent: &Agent,
-        errs: &mut Vec<Object>,
-        strict: bool,
-        within_iteration: bool,
-        within_switch: bool,
-    ) {
-        self.block.early_errors(agent, errs, strict, within_iteration, within_switch);
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_iteration: bool, within_switch: bool) {
+        self.block.early_errors(errs, strict, within_iteration, within_switch);
     }
 
     /// Return a list of parse nodes for the var-style declarations contained within the children of this node.
@@ -702,10 +679,10 @@ impl CatchParameter {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            CatchParameter::Ident(id) => id.early_errors(agent, errs, strict),
-            CatchParameter::Pattern(pat) => pat.early_errors(agent, errs, strict),
+            CatchParameter::Ident(id) => id.early_errors(errs, strict),
+            CatchParameter::Pattern(pat) => pat.early_errors(errs, strict),
         }
     }
 }

--- a/src/parser/try_statement/tests.rs
+++ b/src/parser/try_statement/tests.rs
@@ -230,7 +230,7 @@ mod try_statement {
     #[test_case("try{package;}finally{implements;}", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED]); "try Block Finally")]
     #[test_case("try{package;}catch(implements){}finally{interface;}", true => sset(&[PACKAGE_NOT_ALLOWED, IMPLEMENTS_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "try Block Catch Finally")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).try_statement().early_errors(&agent, &mut errs, strict, false, false);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -396,7 +396,7 @@ mod catch {
     #[test_case("catch({a,b}){let a, c;}", true => sset(&[A_ALREADY_DEFINED]); "duplicates in lexical")]
     #[test_case("catch({a,b}){var a, c;}", true => sset(&[A_ALREADY_DEFINED]); "duplicates in var")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).catch().early_errors(&agent, &mut errs, strict, false, false);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -496,7 +496,7 @@ mod finally {
 
     #[test_case("finally{package;}", true => sset(&[PACKAGE_NOT_ALLOWED]); "finally Block")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).finally().early_errors(&agent, &mut errs, strict, false, false);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
@@ -598,7 +598,7 @@ mod catch_parameter {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingIdentifier")]
     #[test_case("{package}", true => sset(&[PACKAGE_NOT_ALLOWED]); "BindingPattern")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).catch_parameter().early_errors(&agent, &mut errs, strict);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))

--- a/src/parser/try_statement/tests.rs
+++ b/src/parser/try_statement/tests.rs
@@ -232,8 +232,8 @@ mod try_statement {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).try_statement().early_errors(&agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).try_statement().early_errors(&mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("try { arguments; } catch {}" => true; "try-catch (left)")]
@@ -398,8 +398,8 @@ mod catch {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).catch().early_errors(&agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).catch().early_errors(&mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("catch({a=arguments}){}" => true; "param (left)")]
@@ -498,8 +498,8 @@ mod finally {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).finally().early_errors(&agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).finally().early_errors(&mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("finally{arguments;}" => true; "yes")]
@@ -600,8 +600,8 @@ mod catch_parameter {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).catch_parameter().early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).catch_parameter().early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "id")]

--- a/src/parser/unary_operators/mod.rs
+++ b/src/parser/unary_operators/mod.rs
@@ -261,9 +261,9 @@ impl UnaryExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
-            UnaryExpression::UpdateExpression(n) => n.early_errors(agent, errs, strict),
+            UnaryExpression::UpdateExpression(n) => n.early_errors(errs, strict),
             UnaryExpression::Delete { ue: n, .. } => {
                 // Static Semantics: Early Errors
                 //      UnaryExpression : delete UnaryExpression
@@ -287,17 +287,17 @@ impl UnaryExpression {
                     // node.js errors for these cases:
                     //  * "Private fields can not be deleted"
                     //  * "Delete of an unqualified identifier in strict mode."
-                    errs.push(create_syntax_error_object(agent, "Item is not deletable", Some(n.location())));
+                    errs.push(create_syntax_error_object("Item is not deletable", Some(n.location())));
                 }
-                n.early_errors(agent, errs, strict);
+                n.early_errors(errs, strict);
             }
             UnaryExpression::Void { ue, .. }
             | UnaryExpression::Typeof { ue, .. }
             | UnaryExpression::NoOp { ue, .. }
             | UnaryExpression::Negate { ue, .. }
             | UnaryExpression::Complement { ue, .. }
-            | UnaryExpression::Not { ue, .. } => ue.early_errors(agent, errs, strict),
-            UnaryExpression::Await(n) => n.early_errors(agent, errs, strict),
+            | UnaryExpression::Not { ue, .. } => ue.early_errors(errs, strict),
+            UnaryExpression::Await(n) => n.early_errors(errs, strict),
         }
     }
 

--- a/src/parser/unary_operators/tests.rs
+++ b/src/parser/unary_operators/tests.rs
@@ -404,8 +404,8 @@ mod unary_expression {
         UnaryExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/unary_operators/tests.rs
+++ b/src/parser/unary_operators/tests.rs
@@ -399,7 +399,7 @@ mod unary_expression {
     #[test_case("! package", true => sset(&[PACKAGE_NOT_ALLOWED]); "not")]
     #[test_case("await package", true => sset(&[PACKAGE_NOT_ALLOWED]); "await_")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         UnaryExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()

--- a/src/parser/update_expressions/mod.rs
+++ b/src/parser/update_expressions/mod.rs
@@ -228,19 +228,19 @@ impl UpdateExpression {
         }
     }
 
-    pub fn early_errors(&self, agent: &Agent, errs: &mut Vec<Object>, strict: bool) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         match self {
-            UpdateExpression::LeftHandSideExpression(n) => n.early_errors(agent, errs, strict),
+            UpdateExpression::LeftHandSideExpression(n) => n.early_errors(errs, strict),
             UpdateExpression::PostIncrement { lhs: n, .. } | UpdateExpression::PostDecrement { lhs: n, .. } => {
                 //  UpdateExpression :
                 //      LeftHandSideExpression ++
                 //      LeftHandSideExpression --
                 // * It is an early Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple.
                 if n.assignment_target_type(strict) != ATTKind::Simple {
-                    errs.push(create_syntax_error_object(agent, "Invalid target for update", Some(n.location())));
+                    errs.push(create_syntax_error_object("Invalid target for update", Some(n.location())));
                 }
-                n.early_errors(agent, errs, strict);
+                n.early_errors(errs, strict);
             }
             UpdateExpression::PreIncrement { ue: n, .. } | UpdateExpression::PreDecrement { ue: n, .. } => {
                 //  UpdateExpression :
@@ -248,9 +248,9 @@ impl UpdateExpression {
                 //      -- UnaryExpression
                 // * It is an early Syntax Error if AssignmentTargetType of UnaryExpression is not simple.
                 if n.assignment_target_type(strict) != ATTKind::Simple {
-                    errs.push(create_syntax_error_object(agent, "Invalid target for update", Some(n.location())));
+                    errs.push(create_syntax_error_object("Invalid target for update", Some(n.location())));
                 }
-                n.early_errors(agent, errs, strict);
+                n.early_errors(errs, strict);
             }
         }
     }

--- a/src/parser/update_expressions/tests.rs
+++ b/src/parser/update_expressions/tests.rs
@@ -252,8 +252,8 @@ mod update_expression {
         UpdateExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()
             .0
-            .early_errors(&agent, &mut errs, strict);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+            .early_errors(&mut errs, strict);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("a" => false; "identifier ref")]

--- a/src/parser/update_expressions/tests.rs
+++ b/src/parser/update_expressions/tests.rs
@@ -247,7 +247,7 @@ mod update_expression {
     #[test_case("--package", true => sset(&[PACKAGE_NOT_ALLOWED]); "pre-dec, simple")]
     #[test_case("--a(b)", true => sset(&["Invalid target for update"]); "pre-dec, complex")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         UpdateExpression::parse(&mut newparser(src), Scanner::new(), false, true)
             .unwrap()

--- a/src/parser/with_statement/mod.rs
+++ b/src/parser/with_statement/mod.rs
@@ -116,26 +116,18 @@ impl WithStatement {
         self.expression.contains_arguments() || self.statement.contains_arguments()
     }
 
-    pub fn early_errors(
-        &self,
-        agent: &Agent,
-        errs: &mut Vec<Object>,
-        strict: bool,
-        within_iteration: bool,
-        within_switch: bool,
-    ) {
+    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_iteration: bool, within_switch: bool) {
         // Static Semantics: Early Errors
         //  WithStatement : with ( Expression ) Statement
         //  * It is a Syntax Error if the source text matched by this production is contained in strict mode code.
         if strict {
             errs.push(create_syntax_error_object(
-                agent,
                 "'with' statements not allowed in strict mode",
                 Some(self.location()),
             ));
         }
-        self.expression.early_errors(agent, errs, strict);
-        self.statement.early_errors(agent, errs, strict, within_iteration, within_switch);
+        self.expression.early_errors(errs, strict);
+        self.statement.early_errors(errs, strict, within_iteration, within_switch);
     }
 
     /// Return a list of parse nodes for the var-style declarations contained within the children of this node.

--- a/src/parser/with_statement/tests.rs
+++ b/src/parser/with_statement/tests.rs
@@ -143,7 +143,7 @@ mod with_statement {
     #[test_case("with(a){}", true => sset(&[WITH_NOT_ALLOWED]); "strict")]
     #[test_case("with(function (){break;}()){continue;}", false => sset(&[BAD_BREAK, BAD_CONTINUE]); "non-strict")]
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        let agent = test_agent();
+        setup_test_agent();
         let mut errs = vec![];
         Maker::new(src).with_statement().early_errors(&agent, &mut errs, strict, false, false);
         AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))

--- a/src/parser/with_statement/tests.rs
+++ b/src/parser/with_statement/tests.rs
@@ -145,8 +145,8 @@ mod with_statement {
     fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
         setup_test_agent();
         let mut errs = vec![];
-        Maker::new(src).with_statement().early_errors(&agent, &mut errs, strict, false, false);
-        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(&agent, err.clone())))
+        Maker::new(src).with_statement().early_errors(&mut errs, strict, false, false);
+        AHashSet::from_iter(errs.iter().map(|err| unwind_syntax_error_object(err.clone())))
     }
 
     #[test_case("with(arguments);" => true; "Left")]

--- a/src/realm/mod.rs
+++ b/src/realm/mod.rs
@@ -130,14 +130,14 @@ pub struct Intrinsics {
 }
 
 impl Intrinsics {
-    fn new(agent: &Agent) -> Self {
+    fn new() -> Self {
         // Since an intrinsics struct needs to be populated in a particular order and then fixed up, RAII doesn't work
         // so grand. Therefore, a "dead object" is placed in each field instead. This quickly gives us an initialized
         // struct, and also generates run-time panics if any "un-initialized" members are actually used. (Option<Object>
         // could have done a similar thing, except that then the check would be made for _every_ access of the field
         // itself, rather than when the data the field references is manipulated. In other words, this is actually far
         // less overhead.)
-        let dead = DeadObject::object(agent);
+        let dead = DeadObject::object();
         Intrinsics {
             aggregate_error: dead.clone(),
             array: dead.clone(),
@@ -300,7 +300,7 @@ pub struct Realm {
 //  5. Set realmRec.[[TemplateMap]] to a new empty List.
 //  6. Return realmRec.
 pub fn create_realm() -> Rc<RefCell<Realm>> {
-    let r = Rc::new(RefCell::new(Realm { intrinsics: Intrinsics::new(agent), global_object: None, global_env: None }));
+    let r = Rc::new(RefCell::new(Realm { intrinsics: Intrinsics::new(), global_object: None, global_env: None }));
     create_intrinsics(r.clone());
     r
 }
@@ -327,22 +327,21 @@ pub fn create_intrinsics(realm_rec: Rc<RefCell<Realm>>) {
     // ToDo: All of step 3.
 
     // %Object.prototype%
-    let object_prototype = immutable_prototype_exotic_object_create(agent, None);
+    let object_prototype = immutable_prototype_exotic_object_create(None);
     realm_rec.borrow_mut().intrinsics.object_prototype = object_prototype.clone();
     // %Function.prototype%
-    let function_prototype = ordinary_object_create(agent, Some(object_prototype.clone()), &[]);
+    let function_prototype = ordinary_object_create(Some(object_prototype.clone()), &[]);
     realm_rec.borrow_mut().intrinsics.function_prototype = function_prototype.clone();
     // %ThrowTypeError%
-    realm_rec.borrow_mut().intrinsics.throw_type_error = create_throw_type_error_builtin(agent, realm_rec.clone());
+    realm_rec.borrow_mut().intrinsics.throw_type_error = create_throw_type_error_builtin(realm_rec.clone());
 
-    agent.provision_function_intrinsic(&realm_rec);
+    provision_function_intrinsic(&realm_rec);
 
     ///////////////////////////////////////////////////////////////////
     // %Boolean% and %Boolean.prototype%
-    let boolean_prototype = ordinary_object_create(agent, Some(object_prototype), &[InternalSlotName::BooleanData]);
+    let boolean_prototype = ordinary_object_create(Some(object_prototype), &[InternalSlotName::BooleanData]);
     realm_rec.borrow_mut().intrinsics.boolean_prototype = boolean_prototype.clone();
     let bool_constructor = create_builtin_function(
-        agent,
         throw_type_error,
         false,
         1_f64,
@@ -353,7 +352,6 @@ pub fn create_intrinsics(realm_rec: Rc<RefCell<Realm>>) {
         None,
     );
     define_property_or_throw(
-        agent,
         &bool_constructor,
         "prototype",
         PotentialPropertyDescriptor::new()
@@ -365,7 +363,6 @@ pub fn create_intrinsics(realm_rec: Rc<RefCell<Realm>>) {
     .unwrap();
     realm_rec.borrow_mut().intrinsics.boolean = bool_constructor.clone();
     define_property_or_throw(
-        agent,
         &boolean_prototype,
         "constructor",
         PotentialPropertyDescriptor::new()
@@ -377,23 +374,23 @@ pub fn create_intrinsics(realm_rec: Rc<RefCell<Realm>>) {
     .unwrap();
     ///////////////////////////////////////////////////////////////////
     // %Number% and %Number.prototype%
-    provision_number_intrinsic(agent, &realm_rec);
+    provision_number_intrinsic(&realm_rec);
 
-    provision_error_intrinsic(agent, &realm_rec);
-    provision_eval_error_intrinsic(agent, &realm_rec);
-    provision_range_error_intrinsic(agent, &realm_rec);
-    provision_reference_error_intrinsic(agent, &realm_rec);
-    provision_syntax_error_intrinsic(agent, &realm_rec);
-    provision_type_error_intrinsic(agent, &realm_rec);
-    provision_uri_error_intrinsic(agent, &realm_rec);
-    provision_object_intrinsic(agent, &realm_rec);
-    provision_array_intrinsic(agent, &realm_rec);
-    provision_symbol_intrinsic(agent, &realm_rec);
-    agent.provision_string_intrinsic(&realm_rec);
-    agent.provision_iterator_prototype(&realm_rec);
-    agent.provision_generator_function_intrinsics(&realm_rec);
+    provision_error_intrinsic(&realm_rec);
+    provision_eval_error_intrinsic(&realm_rec);
+    provision_range_error_intrinsic(&realm_rec);
+    provision_reference_error_intrinsic(&realm_rec);
+    provision_syntax_error_intrinsic(&realm_rec);
+    provision_type_error_intrinsic(&realm_rec);
+    provision_uri_error_intrinsic(&realm_rec);
+    provision_object_intrinsic(&realm_rec);
+    provision_array_intrinsic(&realm_rec);
+    provision_symbol_intrinsic(&realm_rec);
+    provision_string_intrinsic(&realm_rec);
+    provision_iterator_prototype(&realm_rec);
+    provision_generator_function_intrinsics(&realm_rec);
 
-    add_restricted_function_properties(agent, &function_prototype, realm_rec);
+    add_restricted_function_properties(&function_prototype, realm_rec);
 }
 
 // From function objects...
@@ -408,10 +405,9 @@ pub fn create_intrinsics(realm_rec: Rc<RefCell<Realm>>) {
 //    [[Enumerable]]: false, [[Configurable]]: true }).
 // 4. Return ! DefinePropertyOrThrow(F, "arguments", PropertyDescriptor { [[Get]]: thrower, [[Set]]: thrower,
 //    [[Enumerable]]: false, [[Configurable]]: true }).
-pub fn add_restricted_function_properties(agent: &Agent, f: &Object, realm: Rc<RefCell<Realm>>) {
+pub fn add_restricted_function_properties(f: &Object, realm: Rc<RefCell<Realm>>) {
     let thrower = ECMAScriptValue::Object(realm.borrow().intrinsics.get(IntrinsicId::ThrowTypeError));
     define_property_or_throw(
-        agent,
         f,
         "caller",
         PotentialPropertyDescriptor::new()
@@ -422,7 +418,6 @@ pub fn add_restricted_function_properties(agent: &Agent, f: &Object, realm: Rc<R
     )
     .unwrap();
     define_property_or_throw(
-        agent,
         f,
         "arguments",
         PotentialPropertyDescriptor::new().get(thrower.clone()).set(thrower).enumerable(false).configurable(true),
@@ -445,18 +440,16 @@ pub fn add_restricted_function_properties(agent: &Agent, f: &Object, realm: Rc<R
 // The "name" property of a %ThrowTypeError% function has the attributes { [[Writable]]: false, [[Enumerable]]: false,
 // [[Configurable]]: false }.
 pub fn throw_type_error(
-    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    Err(create_type_error(agent, "Generic TypeError"))
+    Err(create_type_error("Generic TypeError"))
 }
 
-fn create_throw_type_error_builtin(agent: &Agent, realm: Rc<RefCell<Realm>>) -> Object {
+fn create_throw_type_error_builtin(realm: Rc<RefCell<Realm>>) -> Object {
     let function_proto = realm.borrow().intrinsics.get(IntrinsicId::FunctionPrototype);
     let fcn = create_builtin_function(
-        agent,
         throw_type_error,
         false,
         0_f64,
@@ -466,16 +459,14 @@ fn create_throw_type_error_builtin(agent: &Agent, realm: Rc<RefCell<Realm>>) -> 
         Some(function_proto),
         None,
     );
-    fcn.o.prevent_extensions(agent).unwrap();
+    fcn.o.prevent_extensions().unwrap();
     define_property_or_throw(
-        agent,
         &fcn,
         "length",
         PotentialPropertyDescriptor::new().writable(false).enumerable(false).configurable(false),
     )
     .unwrap();
     define_property_or_throw(
-        agent,
         &fcn,
         "name",
         PotentialPropertyDescriptor::new().writable(false).enumerable(false).configurable(false),

--- a/src/realm/mod.rs
+++ b/src/realm/mod.rs
@@ -299,9 +299,9 @@ pub struct Realm {
 //  4. Set realmRec.[[GlobalEnv]] to undefined.
 //  5. Set realmRec.[[TemplateMap]] to a new empty List.
 //  6. Return realmRec.
-pub fn create_realm(agent: &Agent) -> Rc<RefCell<Realm>> {
+pub fn create_realm() -> Rc<RefCell<Realm>> {
     let r = Rc::new(RefCell::new(Realm { intrinsics: Intrinsics::new(agent), global_object: None, global_env: None }));
-    create_intrinsics(agent, r.clone());
+    create_intrinsics(r.clone());
     r
 }
 
@@ -323,7 +323,7 @@ pub fn create_realm(agent: &Agent) -> Rc<RefCell<Realm>> {
 //     not yet been created.
 //  4. Perform AddRestrictedFunctionProperties(intrinsics.[[%Function.prototype%]], realmRec).
 //  5. Return intrinsics.
-pub fn create_intrinsics(agent: &Agent, realm_rec: Rc<RefCell<Realm>>) {
+pub fn create_intrinsics(realm_rec: Rc<RefCell<Realm>>) {
     // ToDo: All of step 3.
 
     // %Object.prototype%

--- a/src/realm/tests.rs
+++ b/src/realm/tests.rs
@@ -75,13 +75,13 @@ fn intrinsic_id_clone() {
 #[test]
 fn intrinsics_debug() {
     setup_test_agent();
-    assert_ne!(format!("{:?}", Intrinsics::new(&agent)), "")
+    assert_ne!(format!("{:?}", Intrinsics::new()), "")
 }
 
 #[test]
 fn intrinsics_get() {
     setup_test_agent();
-    let realm_ptr = agent.current_realm_record().unwrap();
+    let realm_ptr = current_realm_record().unwrap();
     let realm = realm_ptr.borrow();
     let intrinsics = &realm.intrinsics;
     assert_eq!(intrinsics.get(IntrinsicId::Array), intrinsics.array);
@@ -126,7 +126,7 @@ fn intrinsics_get() {
 #[test]
 fn realm_debug() {
     setup_test_agent();
-    let realm_ptr = agent.current_realm_record().unwrap();
+    let realm_ptr = current_realm_record().unwrap();
     let realm = realm_ptr.borrow();
     assert_ne!(format!("{:?}", realm), "");
 }
@@ -134,7 +134,7 @@ fn realm_debug() {
 #[test]
 fn throw_type_error_test() {
     setup_test_agent();
-    let err = throw_type_error(&agent, ECMAScriptValue::Undefined, None, &[]).unwrap_err();
-    let msg = unwind_type_error(&agent, err);
+    let err = throw_type_error(ECMAScriptValue::Undefined, None, &[]).unwrap_err();
+    let msg = unwind_type_error(err);
     assert_eq!(msg, "Generic TypeError");
 }

--- a/src/realm/tests.rs
+++ b/src/realm/tests.rs
@@ -74,13 +74,13 @@ fn intrinsic_id_clone() {
 
 #[test]
 fn intrinsics_debug() {
-    let agent = test_agent();
+    setup_test_agent();
     assert_ne!(format!("{:?}", Intrinsics::new(&agent)), "")
 }
 
 #[test]
 fn intrinsics_get() {
-    let agent = test_agent();
+    setup_test_agent();
     let realm_ptr = agent.current_realm_record().unwrap();
     let realm = realm_ptr.borrow();
     let intrinsics = &realm.intrinsics;
@@ -125,7 +125,7 @@ fn intrinsics_get() {
 
 #[test]
 fn realm_debug() {
-    let agent = test_agent();
+    setup_test_agent();
     let realm_ptr = agent.current_realm_record().unwrap();
     let realm = realm_ptr.borrow();
     assert_ne!(format!("{:?}", realm), "");
@@ -133,7 +133,7 @@ fn realm_debug() {
 
 #[test]
 fn throw_type_error_test() {
-    let agent = test_agent();
+    setup_test_agent();
     let err = throw_type_error(&agent, ECMAScriptValue::Undefined, None, &[]).unwrap_err();
     let msg = unwind_type_error(&agent, err);
     assert_eq!(msg, "Generic TypeError");

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -243,7 +243,7 @@ impl Reference {
 // NOTE     The object that may be created in step 4.a is not accessible outside of the above abstract operation and the
 //          ordinary object [[Get]] internal method. An implementation might choose to avoid the actual creation of the
 //          object.
-pub fn get_value(agent: &Agent, v_completion: FullCompletion) -> Completion<ECMAScriptValue> {
+pub fn get_value(v_completion: FullCompletion) -> Completion<ECMAScriptValue> {
     let v = v_completion?;
     match v {
         NormalCompletion::Value(val) => Ok(val),
@@ -295,7 +295,6 @@ pub fn get_value(agent: &Agent, v_completion: FullCompletion) -> Completion<ECMA
 //          ordinary object [[Set]] internal method. An implementation might choose to avoid the actual creation of that
 //          object.
 pub fn put_value(
-    agent: &Agent,
     v_completion: FullCompletion,
     w_completion: Completion<ECMAScriptValue>,
 ) -> Completion<()> {
@@ -350,7 +349,6 @@ pub fn put_value(
 //  6. Assert: base is an Environment Record.
 //  7. Return base.InitializeBinding(V.[[ReferencedName]], W).
 pub fn initialize_referenced_binding(
-    agent: &Agent,
     v_completion: FullCompletion,
     w_completion: Completion<ECMAScriptValue>,
 ) -> Completion<()> {

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -249,21 +249,21 @@ pub fn get_value(v_completion: FullCompletion) -> Completion<ECMAScriptValue> {
         NormalCompletion::Value(val) => Ok(val),
         NormalCompletion::Reference(reference) => match &reference.base {
             Base::Value(val) => {
-                let base_obj = to_object(agent, val.clone())?;
+                let base_obj = to_object(val.clone())?;
                 match &reference.referenced_name {
-                    ReferencedName::PrivateName(private) => private_get(agent, &base_obj, private),
+                    ReferencedName::PrivateName(private) => private_get(&base_obj, private),
                     _ => {
                         let this_value = reference.get_this_value();
-                        base_obj.o.get(agent, &reference.referenced_name.try_into().unwrap(), &this_value)
+                        base_obj.o.get(&reference.referenced_name.try_into().unwrap(), &this_value)
                     }
                 }
             }
-            Base::Unresolvable => Err(create_reference_error(agent, "Unresolvable Reference")),
+            Base::Unresolvable => Err(create_reference_error("Unresolvable Reference")),
             Base::Environment(env) => {
-                env.get_binding_value(agent, &reference.referenced_name.try_into().unwrap(), reference.strict)
+                env.get_binding_value(&reference.referenced_name.try_into().unwrap(), reference.strict)
             }
         },
-        NormalCompletion::Empty => Err(create_reference_error(agent, "Unresolvable Reference")),
+        NormalCompletion::Empty => Err(create_reference_error("Unresolvable Reference")),
         NormalCompletion::Environment(_) => unreachable!(),
     }
 }
@@ -294,44 +294,39 @@ pub fn get_value(v_completion: FullCompletion) -> Completion<ECMAScriptValue> {
 // NOTE     The object that may be created in step 5.a is not accessible outside of the above abstract operation and the
 //          ordinary object [[Set]] internal method. An implementation might choose to avoid the actual creation of that
 //          object.
-pub fn put_value(
-    v_completion: FullCompletion,
-    w_completion: Completion<ECMAScriptValue>,
-) -> Completion<()> {
+pub fn put_value(v_completion: FullCompletion, w_completion: Completion<ECMAScriptValue>) -> Completion<()> {
     let v = v_completion?;
     let w = w_completion?;
     match v {
         NormalCompletion::Environment(_) => unreachable!(),
-        NormalCompletion::Value(_) | NormalCompletion::Empty => Err(create_reference_error(agent, "Invalid Reference")),
+        NormalCompletion::Value(_) | NormalCompletion::Empty => Err(create_reference_error("Invalid Reference")),
         NormalCompletion::Reference(r) => match &r.base {
             Base::Unresolvable => {
                 if r.strict {
-                    Err(create_reference_error(agent, "Unknown reference"))
+                    Err(create_reference_error("Unknown reference"))
                 } else {
-                    let global_object = get_global_object(agent).unwrap();
-                    set(agent, &global_object, r.referenced_name.try_into().unwrap(), w, false)?;
+                    let global_object = get_global_object().unwrap();
+                    set(&global_object, r.referenced_name.try_into().unwrap(), w, false)?;
                     Ok(())
                 }
             }
             Base::Value(val) => {
-                let base_obj = to_object(agent, val.clone())?;
+                let base_obj = to_object(val.clone())?;
                 match &r.referenced_name {
-                    ReferencedName::PrivateName(pn) => private_set(agent, &base_obj, pn, w),
+                    ReferencedName::PrivateName(pn) => private_set(&base_obj, pn, w),
                     _ => {
                         let this_value = r.get_this_value();
                         let propkey_ref: &PropertyKey = &r.referenced_name.try_into().unwrap();
-                        let succeeded = base_obj.o.set(agent, propkey_ref.clone(), w, &this_value)?;
+                        let succeeded = base_obj.o.set(propkey_ref.clone(), w, &this_value)?;
                         if !succeeded && r.strict {
-                            Err(create_type_error(agent, "Invalid Assignment Target"))
+                            Err(create_type_error("Invalid Assignment Target"))
                         } else {
                             Ok(())
                         }
                     }
                 }
             }
-            Base::Environment(env) => {
-                env.set_mutable_binding(agent, r.referenced_name.try_into().unwrap(), w, r.strict)
-            }
+            Base::Environment(env) => env.set_mutable_binding(r.referenced_name.try_into().unwrap(), w, r.strict),
         },
     }
 }
@@ -356,9 +351,7 @@ pub fn initialize_referenced_binding(
     let w = w_completion?;
     match v {
         NormalCompletion::Reference(reference) => match &reference.base {
-            Base::Environment(base) => {
-                base.initialize_binding(agent, &reference.referenced_name.try_into().unwrap(), w)
-            }
+            Base::Environment(base) => base.initialize_binding(&reference.referenced_name.try_into().unwrap(), w),
             _ => unreachable!(),
         },
         _ => unreachable!(),

--- a/src/reference/tests.rs
+++ b/src/reference/tests.rs
@@ -653,7 +653,7 @@ mod put_value {
         let reference =
             Reference::new(Base::Value(ECMAScriptValue::from(normal_object.clone())), key.clone(), strict, None);
 
-        let r = put_value(Ok(NormalCompletion::from(reference)), Ok(value)).map_err(|ac| unwind_type_error(ac));
+        let r = put_value(Ok(NormalCompletion::from(reference)), Ok(value)).map_err(unwind_type_error);
 
         let from_obj = get(&normal_object, &key).unwrap();
         assert_eq!(from_obj, ECMAScriptValue::Undefined);

--- a/src/reference/tests.rs
+++ b/src/reference/tests.rs
@@ -137,7 +137,7 @@ mod referenced_name {
         }
         #[test]
         fn symbol() {
-            let agent = test_agent();
+            setup_test_agent();
             let sym = Symbol::new(&agent, None);
             let rn = ReferencedName::from(sym.clone());
             assert_eq!(rn, ReferencedName::Symbol(sym));
@@ -158,7 +158,7 @@ mod referenced_name {
             }
             #[test]
             fn symbol() {
-                let agent = test_agent();
+                setup_test_agent();
                 let sym = Symbol::new(&agent, Some(JSString::from("crazy")));
                 let pk = PropertyKey::from(sym.clone());
                 let rn = ReferencedName::from(pk);
@@ -180,7 +180,7 @@ mod referenced_name {
             }
             #[test]
             fn symbol() {
-                let agent = test_agent();
+                setup_test_agent();
                 let sym = Symbol::new(&agent, None);
                 let rn = ReferencedName::from(sym);
                 let err = JSString::try_from(rn).unwrap_err();
@@ -205,7 +205,7 @@ mod referenced_name {
             }
             #[test]
             fn symbol() {
-                let agent = test_agent();
+                setup_test_agent();
                 let sym = Symbol::new(&agent, None);
                 let rn = ReferencedName::from(sym.clone());
                 let pk: PropertyKey = rn.try_into().unwrap();
@@ -232,7 +232,7 @@ mod referenced_name {
 
         #[test]
         fn symbol() {
-            let agent = test_agent();
+            setup_test_agent();
             let sym = Symbol::new(&agent, Some("symbol-test".into()));
             let rn = ReferencedName::from(sym);
             let result = format!("{rn}");
@@ -381,7 +381,7 @@ mod reference {
         }
         #[test]
         fn value_has_this() {
-            let agent = test_agent();
+            setup_test_agent();
             let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
             let normal_object = ordinary_object_create(&agent, Some(object_proto), &[]);
             let this_value = ECMAScriptValue::from(normal_object);
@@ -413,7 +413,7 @@ mod get_value {
 
     #[test]
     fn abrupt() {
-        let agent = test_agent();
+        setup_test_agent();
         let err = create_type_error(&agent, "Test Path");
         let result = get_value(&agent, Err(err)).unwrap_err();
         assert_eq!(unwind_type_error(&agent, result), "Test Path");
@@ -421,7 +421,7 @@ mod get_value {
 
     #[test]
     fn simple_value() {
-        let agent = test_agent();
+        setup_test_agent();
         let val = ECMAScriptValue::from("a value");
         let result = get_value(&agent, Ok(NormalCompletion::from(val))).unwrap();
         assert_eq!(result, ECMAScriptValue::from("a value"));
@@ -429,21 +429,21 @@ mod get_value {
 
     #[test]
     fn unresolvable() {
-        let agent = test_agent();
+        setup_test_agent();
         let badref = Reference::new(Base::Unresolvable, "no_ref", true, None);
         let result = get_value(&agent, Ok(NormalCompletion::from(badref))).unwrap_err();
         assert_eq!(unwind_reference_error(&agent, result), "Unresolvable Reference");
     }
     #[test]
     fn empty() {
-        let agent = test_agent();
+        setup_test_agent();
         let val = Ok(NormalCompletion::Empty);
         let result = get_value(&agent, val).unwrap_err();
         assert_eq!(unwind_reference_error(&agent, result), "Unresolvable Reference");
     }
     #[test]
     fn value_base() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let normal_object = ordinary_object_create(&agent, Some(object_proto), &[]);
         let value = ECMAScriptValue::from("value_base test value");
@@ -462,14 +462,14 @@ mod get_value {
     }
     #[test]
     fn to_object_err() {
-        let agent = test_agent();
+        setup_test_agent();
         let reference = Reference::new(Base::Value(ECMAScriptValue::Undefined), "test_value", true, None);
         let result = get_value(&agent, Ok(NormalCompletion::from(reference))).unwrap_err();
         assert_eq!(unwind_type_error(&agent, result), "Undefined and null cannot be converted to objects");
     }
     #[test]
     fn private() {
-        let agent = test_agent();
+        setup_test_agent();
         let pn = PrivateName::new("test name");
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let normal_object = ordinary_object_create(&agent, Some(object_proto), &[]);
@@ -481,7 +481,7 @@ mod get_value {
     }
     #[test]
     fn environment() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let global = ordinary_object_create(&agent, Some(object_proto), &[]);
         let this_obj = global.clone();
@@ -502,7 +502,7 @@ mod put_value {
 
     #[test]
     fn err_v() {
-        let agent = test_agent();
+        setup_test_agent();
         let v = create_type_error(&agent, "Error in V");
         let w = create_type_error(&agent, "Error in W");
         let result = put_value(&agent, Err(v), Err(w)).unwrap_err();
@@ -511,7 +511,7 @@ mod put_value {
     }
     #[test]
     fn err_w() {
-        let agent = test_agent();
+        setup_test_agent();
         let v = ECMAScriptValue::Undefined;
         let w = create_type_error(&agent, "Error in W");
         let result = put_value(&agent, Ok(NormalCompletion::from(v)), Err(w)).unwrap_err();
@@ -520,7 +520,7 @@ mod put_value {
     }
     #[test]
     fn bad_lhs() {
-        let agent = test_agent();
+        setup_test_agent();
         let result =
             put_value(&agent, Ok(NormalCompletion::from(ECMAScriptValue::Undefined)), Ok(ECMAScriptValue::Undefined))
                 .unwrap_err();
@@ -529,7 +529,7 @@ mod put_value {
     }
     #[test]
     fn unresolvable_strict() {
-        let agent = test_agent();
+        setup_test_agent();
         let reference = Reference::new(Base::Unresolvable, "blue", true, None);
         let result =
             put_value(&agent, Ok(NormalCompletion::from(reference)), Ok(ECMAScriptValue::Undefined)).unwrap_err();
@@ -537,7 +537,7 @@ mod put_value {
     }
     #[test]
     fn unresolvable_nonstrict() {
-        let agent = test_agent();
+        setup_test_agent();
         let value = ECMAScriptValue::from("Test Value for Unresolvable, non-strict writes");
         let reference = Reference::new(Base::Unresolvable, "blue", false, None);
         put_value(&agent, Ok(NormalCompletion::from(reference)), Ok(value.clone())).unwrap();
@@ -547,7 +547,7 @@ mod put_value {
     }
     #[test]
     fn unresolvable_throws() {
-        let agent = test_agent();
+        setup_test_agent();
         let value = ECMAScriptValue::from("Test Value");
         let reference = Reference::new(Base::Unresolvable, "thrower", false, None);
         let thrower = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError));
@@ -571,7 +571,7 @@ mod put_value {
     }
     #[test]
     fn private() {
-        let agent = test_agent();
+        setup_test_agent();
         let value = ECMAScriptValue::from("In my younger and more vulnerable years");
         let pn = PrivateName::new("test name");
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
@@ -588,14 +588,14 @@ mod put_value {
 
     #[test]
     fn bad_value() {
-        let agent = test_agent();
+        setup_test_agent();
         let reference = Reference::new(Base::Value(ECMAScriptValue::Undefined), "test", true, None);
         let result = put_value(&agent, Ok(NormalCompletion::from(reference)), Ok(ECMAScriptValue::Null)).unwrap_err();
         assert_eq!(unwind_type_error(&agent, result), "Undefined and null cannot be converted to objects");
     }
     #[test]
     fn ordinary() {
-        let agent = test_agent();
+        setup_test_agent();
         let value = ECMAScriptValue::from("my father gave me some advice");
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let normal_object = ordinary_object_create(&agent, Some(object_proto), &[]);
@@ -610,7 +610,7 @@ mod put_value {
     }
     #[test]
     fn object_throws() {
-        let agent = test_agent();
+        setup_test_agent();
         let value = ECMAScriptValue::from("that I’ve been turning over in my mind ever since.");
         let thrower = ECMAScriptValue::from(agent.intrinsic(IntrinsicId::ThrowTypeError));
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
@@ -637,7 +637,7 @@ mod put_value {
     #[test_case(false => Ok(()); "non-strict")]
     #[test_case(true => Err(String::from("Invalid Assignment Target")); "strict")]
     fn immutable(strict: bool) -> Result<(), String> {
-        let agent = test_agent();
+        setup_test_agent();
         let value = ECMAScriptValue::from("“Whenever you feel like criticizing anyone,”");
         let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let normal_object = ordinary_object_create(&agent, Some(object_proto), &[]);
@@ -668,7 +668,7 @@ mod put_value {
     }
     #[test]
     fn environment() {
-        let agent = test_agent();
+        setup_test_agent();
         let value = ECMAScriptValue::from(
             "he told me, “just remember that all the people in this world haven’t had the advantages that you’ve had.”",
         );
@@ -690,7 +690,7 @@ mod initialize_referenced_binding {
 
     #[test]
     fn err_v() {
-        let agent = test_agent();
+        setup_test_agent();
         let v = create_type_error(&agent, "Error in V");
         let w = create_type_error(&agent, "Error in W");
         let result = initialize_referenced_binding(&agent, Err(v), Err(w)).unwrap_err();
@@ -699,7 +699,7 @@ mod initialize_referenced_binding {
     }
     #[test]
     fn err_w() {
-        let agent = test_agent();
+        setup_test_agent();
         let v = ECMAScriptValue::Undefined;
         let w = create_type_error(&agent, "Error in W");
         let result = initialize_referenced_binding(&agent, Ok(NormalCompletion::from(v)), Err(w)).unwrap_err();
@@ -708,7 +708,7 @@ mod initialize_referenced_binding {
     }
     #[test]
     fn happy() {
-        let agent = test_agent();
+        setup_test_agent();
         let key = JSString::from("variable");
         let env = Rc::new(DeclarativeEnvironmentRecord::new(None, "test"));
         env.create_mutable_binding(&agent, key.clone(), true).unwrap();
@@ -723,7 +723,7 @@ mod initialize_referenced_binding {
     #[test]
     #[should_panic(expected = "unreachable code")]
     fn value_ref() {
-        let agent = test_agent();
+        setup_test_agent();
         let reference = Reference::new(Base::Value(ECMAScriptValue::Undefined), "phrase", true, None);
         initialize_referenced_binding(&agent, Ok(NormalCompletion::from(reference)), Ok(ECMAScriptValue::Undefined))
             .unwrap();
@@ -731,7 +731,7 @@ mod initialize_referenced_binding {
     #[test]
     #[should_panic(expected = "unreachable code")]
     fn unresolveable_ref() {
-        let agent = test_agent();
+        setup_test_agent();
         let reference = Reference::new(Base::Unresolvable, "phrase", true, None);
         initialize_referenced_binding(&agent, Ok(NormalCompletion::from(reference)), Ok(ECMAScriptValue::Undefined))
             .unwrap();
@@ -739,7 +739,7 @@ mod initialize_referenced_binding {
     #[test]
     #[should_panic(expected = "unreachable code")]
     fn value() {
-        let agent = test_agent();
+        setup_test_agent();
         initialize_referenced_binding(
             &agent,
             Ok(NormalCompletion::from(ECMAScriptValue::Undefined)),

--- a/src/string_object/tests.rs
+++ b/src/string_object/tests.rs
@@ -10,9 +10,9 @@ mod string_object {
     #[test]
     fn debug() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject {
-            common: RefCell::new(CommonObjectData::new(&agent, Some(prototype), true, STRING_OBJECT_SLOTS)),
+            common: RefCell::new(CommonObjectData::new(Some(prototype), true, STRING_OBJECT_SLOTS)),
             string_data: RefCell::new(JSString::from("baloney")),
         };
         assert_ne!(format!("{:?}", so), "");
@@ -21,10 +21,10 @@ mod string_object {
     #[test]
     fn object() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
-        let length = super::get(&agent, &so, &"length".into()).unwrap();
+        let length = super::get(&so, &"length".into()).unwrap();
         assert_eq!(length, ECMAScriptValue::from(6));
 
         let sobj = so.o.to_string_obj().unwrap();
@@ -34,8 +34,8 @@ mod string_object {
     #[test]
     fn is_boolean_object() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(!so.o.is_boolean_object());
     }
@@ -43,8 +43,8 @@ mod string_object {
     #[test]
     fn is_date_object() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(!so.o.is_date_object());
     }
@@ -52,8 +52,8 @@ mod string_object {
     #[test]
     fn is_array_object() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(!so.o.is_array_object());
     }
@@ -61,8 +61,8 @@ mod string_object {
     #[test]
     fn is_proxy_object() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(!so.o.is_proxy_object());
     }
@@ -70,8 +70,8 @@ mod string_object {
     #[test]
     fn is_symbol_object() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(!so.o.is_symbol_object());
     }
@@ -79,8 +79,8 @@ mod string_object {
     #[test]
     fn is_number_object() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(!so.o.is_number_object());
     }
@@ -88,8 +88,8 @@ mod string_object {
     #[test]
     fn is_arguments_object() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(!so.o.is_arguments_object());
     }
@@ -97,8 +97,8 @@ mod string_object {
     #[test]
     fn is_plain_object() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(!so.o.is_plain_object());
     }
@@ -106,8 +106,8 @@ mod string_object {
     #[test]
     fn is_regexp_object() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(!so.o.is_regexp_object());
     }
@@ -115,8 +115,8 @@ mod string_object {
     #[test]
     fn is_error_object() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(!so.o.is_error_object());
     }
@@ -124,8 +124,8 @@ mod string_object {
     #[test]
     fn is_callable_obj() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(!so.o.is_callable_obj());
     }
@@ -133,8 +133,8 @@ mod string_object {
     #[test]
     fn is_string_object() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(so.o.is_string_object());
     }
@@ -142,8 +142,8 @@ mod string_object {
     #[test]
     fn is_ordinary() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(so.o.is_ordinary());
     }
@@ -151,8 +151,8 @@ mod string_object {
     #[test]
     fn to_arguments_object() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(so.o.to_arguments_object().is_none());
     }
@@ -160,8 +160,8 @@ mod string_object {
     #[test]
     fn to_boolean_obj() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(so.o.to_boolean_obj().is_none());
     }
@@ -169,8 +169,8 @@ mod string_object {
     #[test]
     fn to_array_object() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(so.o.to_array_object().is_none());
     }
@@ -178,8 +178,8 @@ mod string_object {
     #[test]
     fn to_callable_obj() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(so.o.to_callable_obj().is_none());
     }
@@ -187,8 +187,8 @@ mod string_object {
     #[test]
     fn to_function_obj() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(so.o.to_function_obj().is_none());
     }
@@ -196,8 +196,8 @@ mod string_object {
     #[test]
     fn to_error_obj() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(so.o.to_error_obj().is_none());
     }
@@ -205,8 +205,8 @@ mod string_object {
     #[test]
     fn to_builtin_function_obj() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(so.o.to_builtin_function_obj().is_none());
     }
@@ -214,8 +214,8 @@ mod string_object {
     #[test]
     fn to_symbol_obj() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(so.o.to_symbol_obj().is_none());
     }
@@ -223,8 +223,8 @@ mod string_object {
     #[test]
     fn to_number_obj() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(so.o.to_number_obj().is_none());
     }
@@ -232,8 +232,8 @@ mod string_object {
     #[test]
     fn to_constructable() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let so = StringObject::object(&agent, "orange".into(), Some(prototype));
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let so = StringObject::object("orange".into(), Some(prototype));
 
         assert!(so.o.to_constructable().is_none());
     }
@@ -241,35 +241,35 @@ mod string_object {
     #[test]
     fn get_prototype_of() {
         setup_test_agent();
-        let str_obj = agent.create_string_object("orange".into());
-        let proto = str_obj.o.get_prototype_of(&agent).unwrap().unwrap();
-        assert_eq!(proto, agent.intrinsic(IntrinsicId::StringPrototype));
+        let str_obj = super::create_string_object("orange".into());
+        let proto = str_obj.o.get_prototype_of().unwrap().unwrap();
+        assert_eq!(proto, intrinsic(IntrinsicId::StringPrototype));
     }
 
     #[test]
     fn set_prototype_of() {
         setup_test_agent();
-        let str_obj = agent.create_string_object("orange".into());
-        let res = str_obj.o.set_prototype_of(&agent, None).unwrap();
+        let str_obj = super::create_string_object("orange".into());
+        let res = str_obj.o.set_prototype_of(None).unwrap();
         assert!(res);
-        assert!(str_obj.o.get_prototype_of(&agent).unwrap().is_none());
+        assert!(str_obj.o.get_prototype_of().unwrap().is_none());
     }
 
     #[test]
     fn is_extensible() {
         setup_test_agent();
-        let str_obj = agent.create_string_object("orange".into());
-        let res = str_obj.o.is_extensible(&agent).unwrap();
+        let str_obj = super::create_string_object("orange".into());
+        let res = str_obj.o.is_extensible().unwrap();
         assert!(res);
     }
 
     #[test]
     fn prevent_extensions() {
         setup_test_agent();
-        let str_obj = agent.create_string_object("orange".into());
-        let res = str_obj.o.prevent_extensions(&agent).unwrap();
+        let str_obj = super::create_string_object("orange".into());
+        let res = str_obj.o.prevent_extensions().unwrap();
         assert!(res);
-        assert!(!str_obj.o.is_extensible(&agent).unwrap());
+        assert!(!str_obj.o.is_extensible().unwrap());
     }
 
     #[test_case(
@@ -327,9 +327,9 @@ mod string_object {
         key: impl Into<PropertyKey>,
     ) -> (bool, AHashMap<PropertyKey, IdealizedPropertyDescriptor>) {
         setup_test_agent();
-        let str_obj = agent.create_string_object(value.into());
+        let str_obj = super::create_string_object(value.into());
         let receiver = ECMAScriptValue::Object(str_obj.clone());
-        let success = str_obj.o.set(&agent, key.into(), new_val.into(), &receiver).unwrap();
+        let success = str_obj.o.set(key.into(), new_val.into(), &receiver).unwrap();
         let properties = str_obj
             .o
             .common_object_data()
@@ -344,63 +344,63 @@ mod string_object {
     #[test]
     fn delete() {
         setup_test_agent();
-        let str_obj = agent.create_string_object("orange".into());
-        let res = str_obj.o.delete(&agent, &PropertyKey::from("rust")).unwrap();
+        let str_obj = super::create_string_object("orange".into());
+        let res = str_obj.o.delete(&PropertyKey::from("rust")).unwrap();
         assert_eq!(res, true);
     }
 
     #[test]
     fn id() {
         setup_test_agent();
-        let str_obj = agent.create_string_object("orange".into());
-        let str_obj2 = agent.create_string_object("orange".into());
+        let str_obj = super::create_string_object("orange".into());
+        let str_obj2 = super::create_string_object("orange".into());
         assert_ne!(str_obj.o.id(), str_obj2.o.id());
     }
 
     #[test]
     fn has_property() {
         setup_test_agent();
-        let str_obj = agent.create_string_object("orange".into());
-        let res = str_obj.o.has_property(&agent, &PropertyKey::from("rust")).unwrap();
+        let str_obj = super::create_string_object("orange".into());
+        let res = str_obj.o.has_property(&PropertyKey::from("rust")).unwrap();
         assert_eq!(res, false);
-        let res2 = str_obj.o.has_property(&agent, &PropertyKey::from("length")).unwrap();
+        let res2 = str_obj.o.has_property(&PropertyKey::from("length")).unwrap();
         assert_eq!(res2, true);
     }
 
     #[test]
     fn common_object_data() {
         setup_test_agent();
-        let str_obj = agent.create_string_object("orange".into());
+        let str_obj = super::create_string_object("orange".into());
         let cod = str_obj.o.common_object_data().borrow();
 
         assert_eq!(cod.properties.len(), 1);
         assert!(cod.properties.contains_key(&"length".into()));
-        let string_proto = agent.intrinsic(IntrinsicId::StringPrototype);
+        let string_proto = intrinsic(IntrinsicId::StringPrototype);
         assert_eq!(cod.prototype.as_ref().unwrap(), &string_proto);
         assert!(cod.extensible);
         assert_eq!(cod.slots, STRING_OBJECT_SLOTS);
         assert!(cod.private_elements.is_empty());
     }
 
-    #[test_case("orange", |agent| agent.wks(WksId::ToPrimitive).into() => None; "not a string")]
-    #[test_case("orange", |_| "blue".into() => None; "not an index")]
-    #[test_case("orange", |_| "0.5".into() => None; "not an integer")]
-    #[test_case("orange", |_| "-0".into() => None; "neg zero")]
-    #[test_case("orange", |_| "-10".into() => None; "negative number")]
-    #[test_case("orange", |_| "6".into() => None; "len or greater")]
-    #[test_case("orange", |_| "0".into() => Some(IdealizedPropertyDescriptor{configurable: false, enumerable:  true, writable: Some(false), value: Some("o".into()), get: None, set: None }); "valid; index 0")]
-    #[test_case("orange", |_| "1".into() => Some(IdealizedPropertyDescriptor{configurable: false, enumerable:  true, writable: Some(false), value: Some("r".into()), get: None, set: None }); "valid; index 1")]
-    #[test_case("orange", |_| "2".into() => Some(IdealizedPropertyDescriptor{configurable: false, enumerable:  true, writable: Some(false), value: Some("a".into()), get: None, set: None }); "valid; index 2")]
-    #[test_case("orange", |_| "3".into() => Some(IdealizedPropertyDescriptor{configurable: false, enumerable:  true, writable: Some(false), value: Some("n".into()), get: None, set: None }); "valid; index 3")]
-    #[test_case("orange", |_| "4".into() => Some(IdealizedPropertyDescriptor{configurable: false, enumerable:  true, writable: Some(false), value: Some("g".into()), get: None, set: None }); "valid; index 4")]
-    #[test_case("orange", |_| "5".into() => Some(IdealizedPropertyDescriptor{configurable: false, enumerable:  true, writable: Some(false), value: Some("e".into()), get: None, set: None }); "valid; index 5")]
+    #[test_case("orange", || wks(WksId::ToPrimitive).into() => None; "not a string")]
+    #[test_case("orange", || "blue".into() => None; "not an index")]
+    #[test_case("orange", || "0.5".into() => None; "not an integer")]
+    #[test_case("orange", || "-0".into() => None; "neg zero")]
+    #[test_case("orange", || "-10".into() => None; "negative number")]
+    #[test_case("orange", || "6".into() => None; "len or greater")]
+    #[test_case("orange", || "0".into() => Some(IdealizedPropertyDescriptor{configurable: false, enumerable:  true, writable: Some(false), value: Some("o".into()), get: None, set: None }); "valid; index 0")]
+    #[test_case("orange", || "1".into() => Some(IdealizedPropertyDescriptor{configurable: false, enumerable:  true, writable: Some(false), value: Some("r".into()), get: None, set: None }); "valid; index 1")]
+    #[test_case("orange", || "2".into() => Some(IdealizedPropertyDescriptor{configurable: false, enumerable:  true, writable: Some(false), value: Some("a".into()), get: None, set: None }); "valid; index 2")]
+    #[test_case("orange", || "3".into() => Some(IdealizedPropertyDescriptor{configurable: false, enumerable:  true, writable: Some(false), value: Some("n".into()), get: None, set: None }); "valid; index 3")]
+    #[test_case("orange", || "4".into() => Some(IdealizedPropertyDescriptor{configurable: false, enumerable:  true, writable: Some(false), value: Some("g".into()), get: None, set: None }); "valid; index 4")]
+    #[test_case("orange", || "5".into() => Some(IdealizedPropertyDescriptor{configurable: false, enumerable:  true, writable: Some(false), value: Some("e".into()), get: None, set: None }); "valid; index 5")]
     fn string_get_own_property(
         value: &str,
-        make_key: impl FnOnce(&Agent) -> PropertyKey,
+        make_key: impl FnOnce() -> PropertyKey,
     ) -> Option<IdealizedPropertyDescriptor> {
         setup_test_agent();
-        let probe = make_key(&agent);
-        let str_obj = agent.create_string_object(value.into());
+        let probe = make_key();
+        let str_obj = super::create_string_object(value.into());
         str_obj.o.to_string_obj().unwrap().string_get_own_property(&probe).map(IdealizedPropertyDescriptor::from)
     }
 
@@ -409,8 +409,8 @@ mod string_object {
     #[test_case("orange", "color" => None; "key not present")]
     fn get_own_property(value: &str, key: &str) -> Option<IdealizedPropertyDescriptor> {
         setup_test_agent();
-        let str_obj = agent.create_string_object(value.into());
-        str_obj.o.get_own_property(&agent, &key.into()).unwrap().map(IdealizedPropertyDescriptor::from)
+        let str_obj = super::create_string_object(value.into());
+        str_obj.o.get_own_property(&key.into()).unwrap().map(IdealizedPropertyDescriptor::from)
     }
 
     #[test_case(
@@ -505,9 +505,9 @@ mod string_object {
         key: &str,
     ) -> (bool, AHashMap<PropertyKey, IdealizedPropertyDescriptor>) {
         setup_test_agent();
-        let str_obj = agent.create_string_object(value.into());
+        let str_obj = super::create_string_object(value.into());
 
-        let success = str_obj.o.define_own_property(&agent, key.into(), new_value).unwrap();
+        let success = str_obj.o.define_own_property(key.into(), new_value).unwrap();
         let properties = str_obj
             .o
             .common_object_data()
@@ -523,24 +523,23 @@ mod string_object {
     #[test_case("orange", "friendliness" => ECMAScriptValue::Undefined; "doesn't exist")]
     fn get(value: &str, key: &str) -> ECMAScriptValue {
         setup_test_agent();
-        let str_obj = agent.create_string_object(value.into());
+        let str_obj = super::create_string_object(value.into());
 
         let receiver = ECMAScriptValue::from(str_obj.clone());
-        str_obj.o.get(&agent, &key.into(), &receiver).unwrap()
+        str_obj.o.get(&key.into(), &receiver).unwrap()
     }
 
     #[test]
     fn own_property_keys() {
         setup_test_agent();
-        let str_obj = agent.create_string_object("orange".into());
+        let str_obj = super::create_string_object("orange".into());
 
-        let to_prim = agent.wks(WksId::ToPrimitive);
-        let species = agent.wks(WksId::Species);
+        let to_prim = wks(WksId::ToPrimitive);
+        let species = wks(WksId::Species);
 
         str_obj
             .o
             .define_own_property(
-                &agent,
                 "60".into(),
                 PotentialPropertyDescriptor::new().value("q").writable(true).enumerable(true).configurable(true),
             )
@@ -548,7 +547,6 @@ mod string_object {
         str_obj
             .o
             .define_own_property(
-                &agent,
                 "6".into(),
                 PotentialPropertyDescriptor::new().value("s").writable(true).enumerable(true).configurable(true),
             )
@@ -556,7 +554,6 @@ mod string_object {
         str_obj
             .o
             .define_own_property(
-                &agent,
                 "zebra".into(),
                 PotentialPropertyDescriptor::new().value(0).writable(true).enumerable(true).configurable(true),
             )
@@ -564,7 +561,6 @@ mod string_object {
         str_obj
             .o
             .define_own_property(
-                &agent,
                 "alpha".into(),
                 PotentialPropertyDescriptor::new().value(1).writable(true).enumerable(true).configurable(true),
             )
@@ -572,7 +568,6 @@ mod string_object {
         str_obj
             .o
             .define_own_property(
-                &agent,
                 to_prim.clone().into(),
                 PotentialPropertyDescriptor::new().value(2).writable(true).enumerable(true).configurable(true),
             )
@@ -580,13 +575,12 @@ mod string_object {
         str_obj
             .o
             .define_own_property(
-                &agent,
                 species.clone().into(),
                 PotentialPropertyDescriptor::new().value(3).writable(true).enumerable(true).configurable(true),
             )
             .unwrap();
 
-        let keys = str_obj.o.own_property_keys(&agent).unwrap();
+        let keys = str_obj.o.own_property_keys().unwrap();
 
         assert_eq!(
             keys,
@@ -616,8 +610,8 @@ mod agent {
     #[test]
     fn string_create() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let s = agent.string_create("value".into(), Some(object_prototype.clone()));
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let s = super::string_create("value".into(), Some(object_prototype.clone()));
 
         let cod = s.o.common_object_data().borrow();
         assert_eq!(cod.prototype.as_ref().unwrap(), &object_prototype);
@@ -629,8 +623,8 @@ mod agent {
     #[test]
     fn create_string_object() {
         setup_test_agent();
-        let string_prototype = agent.intrinsic(IntrinsicId::StringPrototype);
-        let s = agent.create_string_object("value".into());
+        let string_prototype = intrinsic(IntrinsicId::StringPrototype);
+        let s = super::create_string_object("value".into());
 
         let cod = s.o.common_object_data().borrow();
         assert_eq!(cod.prototype.as_ref().unwrap(), &string_prototype);
@@ -666,7 +660,7 @@ mod agent {
             setup_test_agent();
 
             // The String prototype object: is %String.prototype%.
-            let string_proto = agent.intrinsic(IntrinsicId::StringPrototype);
+            let string_proto = intrinsic(IntrinsicId::StringPrototype);
 
             // The String prototype object: has a [[StringData]] internal slot whose value is the empty
             // String.
@@ -676,9 +670,7 @@ mod agent {
             // The String prototype object: has a "length" property whose initial value is +0𝔽 and whose
             // attributes are { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.
             assert_eq!(
-                IdealizedPropertyDescriptor::from(
-                    string_proto.o.get_own_property(&agent, &"length".into()).unwrap().unwrap()
-                ),
+                IdealizedPropertyDescriptor::from(string_proto.o.get_own_property(&"length".into()).unwrap().unwrap()),
                 IdealizedPropertyDescriptor {
                     configurable: false,
                     enumerable: false,
@@ -691,15 +683,15 @@ mod agent {
 
             // The String prototype object: has a [[Prototype]] internal slot whose value is
             // %Object.prototype%.
-            let object_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
+            let object_proto = intrinsic(IntrinsicId::ObjectPrototype);
             let sproto_proto = string_proto.o.common_object_data().borrow().prototype.as_ref().unwrap().clone();
             assert_eq!(sproto_proto, object_proto);
 
             // The initial value of String.prototype.constructor is %String%.
-            let string_constructor = agent.intrinsic(IntrinsicId::String);
+            let string_constructor = intrinsic(IntrinsicId::String);
             assert_eq!(
                 IdealizedPropertyDescriptor::from(
-                    string_proto.o.get_own_property(&agent, &"constructor".into()).unwrap().unwrap()
+                    string_proto.o.get_own_property(&"constructor".into()).unwrap().unwrap()
                 ),
                 IdealizedPropertyDescriptor {
                     configurable: true,
@@ -749,15 +741,15 @@ mod agent {
             setup_test_agent();
             let key = match key.into() {
                 ToKey::String(s) => PropertyKey::from(s),
-                ToKey::Symbol(id) => PropertyKey::from(agent.wks(id)),
+                ToKey::Symbol(id) => PropertyKey::from(wks(id)),
             };
-            let proto = agent.intrinsic(IntrinsicId::StringPrototype);
-            let val = super::get(&agent, &proto, &key).unwrap();
+            let proto = intrinsic(IntrinsicId::StringPrototype);
+            let val = super::get(&proto, &key).unwrap();
             assert!(is_callable(&val));
-            let name = getv(&agent, &val, &"name".into()).unwrap();
-            let name = to_string(&agent, name).unwrap();
-            let length = getv(&agent, &val, &"length".into()).unwrap();
-            let length = to_string(&agent, length).unwrap();
+            let name = getv(&val, &"name".into()).unwrap();
+            let name = to_string(name).unwrap();
+            let length = getv(&val, &"length".into()).unwrap();
+            let length = to_string(length).unwrap();
             format!("{};{}", String::from(name), length)
         }
 
@@ -765,25 +757,25 @@ mod agent {
         fn string_intrinsic() {
             setup_test_agent();
             // The String constructor: is %String%.
-            let string_object = agent.intrinsic(IntrinsicId::String);
+            let string_object = intrinsic(IntrinsicId::String);
 
             // The String constructor: is the initial value of the "String" property of the global object.
-            let global = agent.current_realm_record().unwrap().borrow().global_object.as_ref().unwrap().clone();
-            let sfg_val = get(&agent, &global, &"String".into()).unwrap();
-            let string_from_global = to_object(&agent, sfg_val).unwrap();
+            let global = current_realm_record().unwrap().borrow().global_object.as_ref().unwrap().clone();
+            let sfg_val = get(&global, &"String".into()).unwrap();
+            let string_from_global = to_object(sfg_val).unwrap();
             assert_eq!(string_object, string_from_global);
 
             // The String constructor: has a [[Prototype]] internal slot whose value is %Function.prototype%.
-            let function_proto = agent.intrinsic(IntrinsicId::FunctionPrototype);
+            let function_proto = intrinsic(IntrinsicId::FunctionPrototype);
             let from_constructor = string_object.o.common_object_data().borrow().prototype.as_ref().unwrap().clone();
             assert_eq!(from_constructor, function_proto);
 
             // The initial value of String.prototype is the String prototype object. This property has the
             // attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.
-            let string_prototype = agent.intrinsic(IntrinsicId::StringPrototype);
+            let string_prototype = intrinsic(IntrinsicId::StringPrototype);
             assert_eq!(
                 IdealizedPropertyDescriptor::from(
-                    string_object.o.get_own_property(&agent, &"prototype".into()).unwrap().unwrap(),
+                    string_object.o.get_own_property(&"prototype".into()).unwrap().unwrap(),
                 ),
                 IdealizedPropertyDescriptor {
                     configurable: false,
@@ -803,42 +795,42 @@ mod agent {
             setup_test_agent();
             let key = match key.into() {
                 ToKey::String(s) => PropertyKey::from(s),
-                ToKey::Symbol(id) => PropertyKey::from(agent.wks(id)),
+                ToKey::Symbol(id) => PropertyKey::from(wks(id)),
             };
-            let cstr = agent.intrinsic(IntrinsicId::String);
-            let val = super::get(&agent, &cstr, &key).unwrap();
+            let cstr = intrinsic(IntrinsicId::String);
+            let val = super::get(&cstr, &key).unwrap();
             assert!(is_callable(&val));
-            let name = getv(&agent, &val, &"name".into()).unwrap();
-            let name = to_string(&agent, name).unwrap();
-            let length = getv(&agent, &val, &"length".into()).unwrap();
-            let length = to_string(&agent, length).unwrap();
+            let name = getv(&val, &"name".into()).unwrap();
+            let name = to_string(name).unwrap();
+            let length = getv(&val, &"length".into()).unwrap();
+            let length = to_string(length).unwrap();
             format!("{};{}", String::from(name), length)
         }
     }
 
-    #[test_case(|_| ECMAScriptValue::from("blue") => sok("blue"); "string value")]
-    #[test_case(|a| ECMAScriptValue::from(a.create_string_object(JSString::from("red"))) => sok("red"); "string object value")]
-    #[test_case(|_| ECMAScriptValue::Undefined => serr("TypeError: unit testing requires that 'this' be a String"); "bad value")]
-    #[test_case(|a| ECMAScriptValue::from(ordinary_object_create(a, None, &[])) => serr("TypeError: unit testing requires that 'this' be a String"); "bad object value")]
-    fn this_string_value(make_val: impl FnOnce(&Agent) -> ECMAScriptValue) -> Result<String, String> {
+    #[test_case(|| ECMAScriptValue::from("blue") => sok("blue"); "string value")]
+    #[test_case(|| ECMAScriptValue::from(super::super::create_string_object(JSString::from("red"))) => sok("red"); "string object value")]
+    #[test_case(|| ECMAScriptValue::Undefined => serr("TypeError: unit testing requires that 'this' be a String"); "bad value")]
+    #[test_case(|| ECMAScriptValue::from(ordinary_object_create(None, &[])) => serr("TypeError: unit testing requires that 'this' be a String"); "bad object value")]
+    fn this_string_value(make_val: impl FnOnce() -> ECMAScriptValue) -> Result<String, String> {
         setup_test_agent();
-        let val = make_val(&agent);
-        agent.this_string_value(val, "unit testing").map(String::from).map_err(|e| unwind_any_error(&agent, e))
+        let val = make_val();
+        super::this_string_value(val, "unit testing").map(String::from).map_err(|e| unwind_any_error(e))
     }
 }
 
-#[test_case(|_| (None, vec![]) => Ok((false, "".to_string())); "AsFunc / no args")]
-#[test_case(|_| (None, vec![ECMAScriptValue::from(true)]) => Ok((false, "true".to_string())); "AsFunc / stringable")]
-#[test_case(|a| (None, vec![ECMAScriptValue::from(a.wks(WksId::ToPrimitive))]) => Ok((false, "Symbol(Symbol.toPrimitive)".to_string())); "AsFunc / Symbol")]
-#[test_case(|a| (None, vec![ECMAScriptValue::from(DeadObject::object(a))]) => serr("TypeError: get called on DeadObject"); "to_string failure")]
-#[test_case(|a| (Some(DeadObject::object(a)), vec![ECMAScriptValue::Null]) => serr("TypeError: get called on DeadObject"); "get_proto_from_cstr failure")]
-#[test_case(|a| (Some(a.intrinsic(IntrinsicId::String)), vec![ECMAScriptValue::Undefined]) => Ok((true, "undefined".to_string())); "AsCstr / stringable")]
+#[test_case(|| (None, vec![]) => Ok((false, "".to_string())); "AsFunc / no args")]
+#[test_case(|| (None, vec![ECMAScriptValue::from(true)]) => Ok((false, "true".to_string())); "AsFunc / stringable")]
+#[test_case(|| (None, vec![ECMAScriptValue::from(wks(WksId::ToPrimitive))]) => Ok((false, "Symbol(Symbol.toPrimitive)".to_string())); "AsFunc / Symbol")]
+#[test_case(|| (None, vec![ECMAScriptValue::from(DeadObject::object())]) => serr("TypeError: get called on DeadObject"); "to_string failure")]
+#[test_case(|| (Some(DeadObject::object()), vec![ECMAScriptValue::Null]) => serr("TypeError: get called on DeadObject"); "get_proto_from_cstr failure")]
+#[test_case(|| (Some(intrinsic(IntrinsicId::String)), vec![ECMAScriptValue::Undefined]) => Ok((true, "undefined".to_string())); "AsCstr / stringable")]
 fn string_constructor_function(
-    make_params: impl FnOnce(&Agent) -> (Option<Object>, Vec<ECMAScriptValue>),
+    make_params: impl FnOnce() -> (Option<Object>, Vec<ECMAScriptValue>),
 ) -> Result<(bool, String), String> {
     setup_test_agent();
-    let (new_target, arguments) = make_params(&agent);
-    super::string_constructor_function(&agent, ECMAScriptValue::Undefined, new_target.as_ref(), &arguments)
+    let (new_target, arguments) = make_params();
+    super::string_constructor_function(ECMAScriptValue::Undefined, new_target.as_ref(), &arguments)
         .map(|val| match val {
             ECMAScriptValue::String(s) => (false, String::from(s)),
             ECMAScriptValue::Object(o) => {
@@ -846,66 +838,66 @@ fn string_constructor_function(
             }
             _ => panic!("Bad value from string_constructor_function: {:?}", val),
         })
-        .map_err(|err| unwind_any_error(&agent, err))
+        .map_err(|err| unwind_any_error(err))
 }
 
-#[test_case(|_| vec![ECMAScriptValue::from(112), ECMAScriptValue::from(97), ECMAScriptValue::from(115), ECMAScriptValue::from(115)] => sok("pass"); "normal")]
-#[test_case(|a| vec![ECMAScriptValue::from(a.wks(WksId::ToPrimitive))] => serr("TypeError: Symbol values cannot be converted to Number values"); "bad args")]
-#[test_case(|_| vec![] => sok(""); "emtpy args")]
-fn string_from_char_code(make_params: impl FnOnce(&Agent) -> Vec<ECMAScriptValue>) -> Result<String, String> {
+#[test_case(|| vec![ECMAScriptValue::from(112), ECMAScriptValue::from(97), ECMAScriptValue::from(115), ECMAScriptValue::from(115)] => sok("pass"); "normal")]
+#[test_case(|| vec![ECMAScriptValue::from(wks(WksId::ToPrimitive))] => serr("TypeError: Symbol values cannot be converted to Number values"); "bad args")]
+#[test_case(|| vec![] => sok(""); "emtpy args")]
+fn string_from_char_code(make_params: impl FnOnce() -> Vec<ECMAScriptValue>) -> Result<String, String> {
     setup_test_agent();
-    let args = make_params(&agent);
-    super::string_from_char_code(&agent, ECMAScriptValue::Undefined, None, &args)
+    let args = make_params();
+    super::string_from_char_code(ECMAScriptValue::Undefined, None, &args)
         .map(|val| match val {
             ECMAScriptValue::String(s) => String::from(s),
             _ => panic!("Expected String value from String.fromCharCode: {:?}", val),
         })
-        .map_err(|e| unwind_any_error(&agent, e))
+        .map_err(|e| unwind_any_error(e))
 }
 
-#[test_case(|_| (ECMAScriptValue::Undefined, vec![]) => serr("TypeError: Undefined and null are not allowed in this context"); "'this' bad")]
-#[test_case(|a| (ECMAScriptValue::from(a.create_string_object("hello".into())), vec![ECMAScriptValue::from("ell")]) => Ok(1.0); "search from zero")]
-#[test_case(|a| (ECMAScriptValue::from(a.create_string_object("hello".into())), vec![ECMAScriptValue::from("ell"), ECMAScriptValue::from(2)]) => Ok(-1.0); "search from two")]
-#[test_case(|a| (ECMAScriptValue::from(DeadObject::object(a)), vec![]) => serr("TypeError: get called on DeadObject"); "unstringable this")]
-#[test_case(|a| (ECMAScriptValue::from(""), vec![ECMAScriptValue::from(DeadObject::object(a))]) => serr("TypeError: get called on DeadObject"); "unstringable search")]
-#[test_case(|a| (ECMAScriptValue::from(""), vec![ECMAScriptValue::from(""), ECMAScriptValue::from(DeadObject::object(a))]) => serr("TypeError: get called on DeadObject"); "unnumberable position")]
+#[test_case(|| (ECMAScriptValue::Undefined, vec![]) => serr("TypeError: Undefined and null are not allowed in this context"); "'this' bad")]
+#[test_case(|| (ECMAScriptValue::from(super::create_string_object("hello".into())), vec![ECMAScriptValue::from("ell")]) => Ok(1.0); "search from zero")]
+#[test_case(|| (ECMAScriptValue::from(super::create_string_object("hello".into())), vec![ECMAScriptValue::from("ell"), ECMAScriptValue::from(2)]) => Ok(-1.0); "search from two")]
+#[test_case(|| (ECMAScriptValue::from(DeadObject::object()), vec![]) => serr("TypeError: get called on DeadObject"); "unstringable this")]
+#[test_case(|| (ECMAScriptValue::from(""), vec![ECMAScriptValue::from(DeadObject::object())]) => serr("TypeError: get called on DeadObject"); "unstringable search")]
+#[test_case(|| (ECMAScriptValue::from(""), vec![ECMAScriptValue::from(""), ECMAScriptValue::from(DeadObject::object())]) => serr("TypeError: get called on DeadObject"); "unnumberable position")]
 fn string_prototype_index_of(
-    make_params: impl FnOnce(&Agent) -> (ECMAScriptValue, Vec<ECMAScriptValue>),
+    make_params: impl FnOnce() -> (ECMAScriptValue, Vec<ECMAScriptValue>),
 ) -> Result<f64, String> {
     setup_test_agent();
-    let (this_value, arguments) = make_params(&agent);
-    super::string_prototype_index_of(&agent, this_value, None, &arguments)
+    let (this_value, arguments) = make_params();
+    super::string_prototype_index_of(this_value, None, &arguments)
         .map(|val| match val {
             ECMAScriptValue::Number(n) => n,
             _ => panic!("Expected number value from String.prototype.indexOf: {:?}", val),
         })
-        .map_err(|e| unwind_any_error(&agent, e))
+        .map_err(|e| unwind_any_error(e))
 }
 
-#[test_case(|a| ECMAScriptValue::from(a.create_string_object("a string".into())) => sok("a string"); "from string object")]
-#[test_case(|a| ECMAScriptValue::from(DeadObject::object(a)) => serr("TypeError: String.prototype.toString requires that 'this' be a String"); "bad this value")]
-fn string_prototype_to_string(make_params: impl FnOnce(&Agent) -> ECMAScriptValue) -> Result<String, String> {
+#[test_case(|| ECMAScriptValue::from(super::create_string_object("a string".into())) => sok("a string"); "from string object")]
+#[test_case(|| ECMAScriptValue::from(DeadObject::object()) => serr("TypeError: String.prototype.toString requires that 'this' be a String"); "bad this value")]
+fn string_prototype_to_string(make_params: impl FnOnce() -> ECMAScriptValue) -> Result<String, String> {
     setup_test_agent();
-    let this_value = make_params(&agent);
-    super::string_prototype_to_string(&agent, this_value, None, &[])
+    let this_value = make_params();
+    super::string_prototype_to_string(this_value, None, &[])
         .map(|val| match val {
             ECMAScriptValue::String(s) => String::from(s),
             _ => panic!("Expected string value from String.prototype.toString: {:?}", val),
         })
-        .map_err(|e| unwind_any_error(&agent, e))
+        .map_err(|e| unwind_any_error(e))
 }
 
-#[test_case(|a| ECMAScriptValue::from(a.create_string_object("a string".into())) => sok("a string"); "from string object")]
-#[test_case(|a| ECMAScriptValue::from(DeadObject::object(a)) => serr("TypeError: String.prototype.valueOf requires that 'this' be a String"); "bad this value")]
-fn string_prototype_value_of(make_params: impl FnOnce(&Agent) -> ECMAScriptValue) -> Result<String, String> {
+#[test_case(|| ECMAScriptValue::from(super::create_string_object("a string".into())) => sok("a string"); "from string object")]
+#[test_case(|| ECMAScriptValue::from(DeadObject::object()) => serr("TypeError: String.prototype.valueOf requires that 'this' be a String"); "bad this value")]
+fn string_prototype_value_of(make_params: impl FnOnce() -> ECMAScriptValue) -> Result<String, String> {
     setup_test_agent();
-    let this_value = make_params(&agent);
-    super::string_prototype_value_of(&agent, this_value, None, &[])
+    let this_value = make_params();
+    super::string_prototype_value_of(this_value, None, &[])
         .map(|val| match val {
             ECMAScriptValue::String(s) => String::from(s),
             _ => panic!("Expected string value from String.prototype.valueOf: {:?}", val),
         })
-        .map_err(|e| unwind_any_error(&agent, e))
+        .map_err(|e| unwind_any_error(e))
 }
 
 tbd_function!(string_from_code_point);

--- a/src/string_object/tests.rs
+++ b/src/string_object/tests.rs
@@ -9,7 +9,7 @@ mod string_object {
 
     #[test]
     fn debug() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject {
             common: RefCell::new(CommonObjectData::new(&agent, Some(prototype), true, STRING_OBJECT_SLOTS)),
@@ -20,7 +20,7 @@ mod string_object {
 
     #[test]
     fn object() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -33,7 +33,7 @@ mod string_object {
 
     #[test]
     fn is_boolean_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -42,7 +42,7 @@ mod string_object {
 
     #[test]
     fn is_date_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -51,7 +51,7 @@ mod string_object {
 
     #[test]
     fn is_array_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -60,7 +60,7 @@ mod string_object {
 
     #[test]
     fn is_proxy_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -69,7 +69,7 @@ mod string_object {
 
     #[test]
     fn is_symbol_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -78,7 +78,7 @@ mod string_object {
 
     #[test]
     fn is_number_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -87,7 +87,7 @@ mod string_object {
 
     #[test]
     fn is_arguments_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -96,7 +96,7 @@ mod string_object {
 
     #[test]
     fn is_plain_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -105,7 +105,7 @@ mod string_object {
 
     #[test]
     fn is_regexp_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -114,7 +114,7 @@ mod string_object {
 
     #[test]
     fn is_error_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -123,7 +123,7 @@ mod string_object {
 
     #[test]
     fn is_callable_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -132,7 +132,7 @@ mod string_object {
 
     #[test]
     fn is_string_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -141,7 +141,7 @@ mod string_object {
 
     #[test]
     fn is_ordinary() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -150,7 +150,7 @@ mod string_object {
 
     #[test]
     fn to_arguments_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -159,7 +159,7 @@ mod string_object {
 
     #[test]
     fn to_boolean_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -168,7 +168,7 @@ mod string_object {
 
     #[test]
     fn to_array_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -177,7 +177,7 @@ mod string_object {
 
     #[test]
     fn to_callable_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -186,7 +186,7 @@ mod string_object {
 
     #[test]
     fn to_function_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -195,7 +195,7 @@ mod string_object {
 
     #[test]
     fn to_error_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -204,7 +204,7 @@ mod string_object {
 
     #[test]
     fn to_builtin_function_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -213,7 +213,7 @@ mod string_object {
 
     #[test]
     fn to_symbol_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -222,7 +222,7 @@ mod string_object {
 
     #[test]
     fn to_number_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -231,7 +231,7 @@ mod string_object {
 
     #[test]
     fn to_constructable() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = StringObject::object(&agent, "orange".into(), Some(prototype));
 
@@ -240,7 +240,7 @@ mod string_object {
 
     #[test]
     fn get_prototype_of() {
-        let agent = test_agent();
+        setup_test_agent();
         let str_obj = agent.create_string_object("orange".into());
         let proto = str_obj.o.get_prototype_of(&agent).unwrap().unwrap();
         assert_eq!(proto, agent.intrinsic(IntrinsicId::StringPrototype));
@@ -248,7 +248,7 @@ mod string_object {
 
     #[test]
     fn set_prototype_of() {
-        let agent = test_agent();
+        setup_test_agent();
         let str_obj = agent.create_string_object("orange".into());
         let res = str_obj.o.set_prototype_of(&agent, None).unwrap();
         assert!(res);
@@ -257,7 +257,7 @@ mod string_object {
 
     #[test]
     fn is_extensible() {
-        let agent = test_agent();
+        setup_test_agent();
         let str_obj = agent.create_string_object("orange".into());
         let res = str_obj.o.is_extensible(&agent).unwrap();
         assert!(res);
@@ -265,7 +265,7 @@ mod string_object {
 
     #[test]
     fn prevent_extensions() {
-        let agent = test_agent();
+        setup_test_agent();
         let str_obj = agent.create_string_object("orange".into());
         let res = str_obj.o.prevent_extensions(&agent).unwrap();
         assert!(res);
@@ -326,7 +326,7 @@ mod string_object {
         new_val: impl Into<ECMAScriptValue>,
         key: impl Into<PropertyKey>,
     ) -> (bool, AHashMap<PropertyKey, IdealizedPropertyDescriptor>) {
-        let agent = test_agent();
+        setup_test_agent();
         let str_obj = agent.create_string_object(value.into());
         let receiver = ECMAScriptValue::Object(str_obj.clone());
         let success = str_obj.o.set(&agent, key.into(), new_val.into(), &receiver).unwrap();
@@ -343,7 +343,7 @@ mod string_object {
 
     #[test]
     fn delete() {
-        let agent = test_agent();
+        setup_test_agent();
         let str_obj = agent.create_string_object("orange".into());
         let res = str_obj.o.delete(&agent, &PropertyKey::from("rust")).unwrap();
         assert_eq!(res, true);
@@ -351,7 +351,7 @@ mod string_object {
 
     #[test]
     fn id() {
-        let agent = test_agent();
+        setup_test_agent();
         let str_obj = agent.create_string_object("orange".into());
         let str_obj2 = agent.create_string_object("orange".into());
         assert_ne!(str_obj.o.id(), str_obj2.o.id());
@@ -359,7 +359,7 @@ mod string_object {
 
     #[test]
     fn has_property() {
-        let agent = test_agent();
+        setup_test_agent();
         let str_obj = agent.create_string_object("orange".into());
         let res = str_obj.o.has_property(&agent, &PropertyKey::from("rust")).unwrap();
         assert_eq!(res, false);
@@ -369,7 +369,7 @@ mod string_object {
 
     #[test]
     fn common_object_data() {
-        let agent = test_agent();
+        setup_test_agent();
         let str_obj = agent.create_string_object("orange".into());
         let cod = str_obj.o.common_object_data().borrow();
 
@@ -398,7 +398,7 @@ mod string_object {
         value: &str,
         make_key: impl FnOnce(&Agent) -> PropertyKey,
     ) -> Option<IdealizedPropertyDescriptor> {
-        let agent = test_agent();
+        setup_test_agent();
         let probe = make_key(&agent);
         let str_obj = agent.create_string_object(value.into());
         str_obj.o.to_string_obj().unwrap().string_get_own_property(&probe).map(IdealizedPropertyDescriptor::from)
@@ -408,7 +408,7 @@ mod string_object {
     #[test_case("orange", "3" => Some(IdealizedPropertyDescriptor{configurable: false, enumerable: true, writable: Some(false), value: Some(ECMAScriptValue::from("n")), get: None, set: None}); "stringish get")]
     #[test_case("orange", "color" => None; "key not present")]
     fn get_own_property(value: &str, key: &str) -> Option<IdealizedPropertyDescriptor> {
-        let agent = test_agent();
+        setup_test_agent();
         let str_obj = agent.create_string_object(value.into());
         str_obj.o.get_own_property(&agent, &key.into()).unwrap().map(IdealizedPropertyDescriptor::from)
     }
@@ -504,7 +504,7 @@ mod string_object {
         new_value: PotentialPropertyDescriptor,
         key: &str,
     ) -> (bool, AHashMap<PropertyKey, IdealizedPropertyDescriptor>) {
-        let agent = test_agent();
+        setup_test_agent();
         let str_obj = agent.create_string_object(value.into());
 
         let success = str_obj.o.define_own_property(&agent, key.into(), new_value).unwrap();
@@ -522,7 +522,7 @@ mod string_object {
     #[test_case("orange", "length" => ECMAScriptValue::from(6); "exists")]
     #[test_case("orange", "friendliness" => ECMAScriptValue::Undefined; "doesn't exist")]
     fn get(value: &str, key: &str) -> ECMAScriptValue {
-        let agent = test_agent();
+        setup_test_agent();
         let str_obj = agent.create_string_object(value.into());
 
         let receiver = ECMAScriptValue::from(str_obj.clone());
@@ -531,7 +531,7 @@ mod string_object {
 
     #[test]
     fn own_property_keys() {
-        let agent = test_agent();
+        setup_test_agent();
         let str_obj = agent.create_string_object("orange".into());
 
         let to_prim = agent.wks(WksId::ToPrimitive);
@@ -615,7 +615,7 @@ mod agent {
 
     #[test]
     fn string_create() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let s = agent.string_create("value".into(), Some(object_prototype.clone()));
 
@@ -628,7 +628,7 @@ mod agent {
 
     #[test]
     fn create_string_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let string_prototype = agent.intrinsic(IntrinsicId::StringPrototype);
         let s = agent.create_string_object("value".into());
 
@@ -663,7 +663,7 @@ mod agent {
 
         #[test]
         fn string_prototype_intrinsic() {
-            let agent = test_agent();
+            setup_test_agent();
 
             // The String prototype object: is %String.prototype%.
             let string_proto = agent.intrinsic(IntrinsicId::StringPrototype);
@@ -746,7 +746,7 @@ mod agent {
         #[test_case("valueOf" => "valueOf;0"; "valueOf function")]
         #[test_case(WksId::Iterator => "[Symbol.iterator];0"; "@@iterator function")]
         fn prototype_func(key: impl Into<ToKey>) -> String {
-            let agent = test_agent();
+            setup_test_agent();
             let key = match key.into() {
                 ToKey::String(s) => PropertyKey::from(s),
                 ToKey::Symbol(id) => PropertyKey::from(agent.wks(id)),
@@ -763,7 +763,7 @@ mod agent {
 
         #[test]
         fn string_intrinsic() {
-            let agent = test_agent();
+            setup_test_agent();
             // The String constructor: is %String%.
             let string_object = agent.intrinsic(IntrinsicId::String);
 
@@ -800,7 +800,7 @@ mod agent {
         #[test_case("fromCodePoint" => "fromCodePoint;1"; "String.fromCodePoint")]
         #[test_case("raw" => "raw;1"; "String.raw")]
         fn constructor_func(key: impl Into<ToKey>) -> String {
-            let agent = test_agent();
+            setup_test_agent();
             let key = match key.into() {
                 ToKey::String(s) => PropertyKey::from(s),
                 ToKey::Symbol(id) => PropertyKey::from(agent.wks(id)),
@@ -821,7 +821,7 @@ mod agent {
     #[test_case(|_| ECMAScriptValue::Undefined => serr("TypeError: unit testing requires that 'this' be a String"); "bad value")]
     #[test_case(|a| ECMAScriptValue::from(ordinary_object_create(a, None, &[])) => serr("TypeError: unit testing requires that 'this' be a String"); "bad object value")]
     fn this_string_value(make_val: impl FnOnce(&Agent) -> ECMAScriptValue) -> Result<String, String> {
-        let agent = test_agent();
+        setup_test_agent();
         let val = make_val(&agent);
         agent.this_string_value(val, "unit testing").map(String::from).map_err(|e| unwind_any_error(&agent, e))
     }
@@ -836,7 +836,7 @@ mod agent {
 fn string_constructor_function(
     make_params: impl FnOnce(&Agent) -> (Option<Object>, Vec<ECMAScriptValue>),
 ) -> Result<(bool, String), String> {
-    let agent = test_agent();
+    setup_test_agent();
     let (new_target, arguments) = make_params(&agent);
     super::string_constructor_function(&agent, ECMAScriptValue::Undefined, new_target.as_ref(), &arguments)
         .map(|val| match val {
@@ -853,7 +853,7 @@ fn string_constructor_function(
 #[test_case(|a| vec![ECMAScriptValue::from(a.wks(WksId::ToPrimitive))] => serr("TypeError: Symbol values cannot be converted to Number values"); "bad args")]
 #[test_case(|_| vec![] => sok(""); "emtpy args")]
 fn string_from_char_code(make_params: impl FnOnce(&Agent) -> Vec<ECMAScriptValue>) -> Result<String, String> {
-    let agent = test_agent();
+    setup_test_agent();
     let args = make_params(&agent);
     super::string_from_char_code(&agent, ECMAScriptValue::Undefined, None, &args)
         .map(|val| match val {
@@ -872,7 +872,7 @@ fn string_from_char_code(make_params: impl FnOnce(&Agent) -> Vec<ECMAScriptValue
 fn string_prototype_index_of(
     make_params: impl FnOnce(&Agent) -> (ECMAScriptValue, Vec<ECMAScriptValue>),
 ) -> Result<f64, String> {
-    let agent = test_agent();
+    setup_test_agent();
     let (this_value, arguments) = make_params(&agent);
     super::string_prototype_index_of(&agent, this_value, None, &arguments)
         .map(|val| match val {
@@ -885,7 +885,7 @@ fn string_prototype_index_of(
 #[test_case(|a| ECMAScriptValue::from(a.create_string_object("a string".into())) => sok("a string"); "from string object")]
 #[test_case(|a| ECMAScriptValue::from(DeadObject::object(a)) => serr("TypeError: String.prototype.toString requires that 'this' be a String"); "bad this value")]
 fn string_prototype_to_string(make_params: impl FnOnce(&Agent) -> ECMAScriptValue) -> Result<String, String> {
-    let agent = test_agent();
+    setup_test_agent();
     let this_value = make_params(&agent);
     super::string_prototype_to_string(&agent, this_value, None, &[])
         .map(|val| match val {
@@ -898,7 +898,7 @@ fn string_prototype_to_string(make_params: impl FnOnce(&Agent) -> ECMAScriptValu
 #[test_case(|a| ECMAScriptValue::from(a.create_string_object("a string".into())) => sok("a string"); "from string object")]
 #[test_case(|a| ECMAScriptValue::from(DeadObject::object(a)) => serr("TypeError: String.prototype.valueOf requires that 'this' be a String"); "bad this value")]
 fn string_prototype_value_of(make_params: impl FnOnce(&Agent) -> ECMAScriptValue) -> Result<String, String> {
-    let agent = test_agent();
+    setup_test_agent();
     let this_value = make_params(&agent);
     super::string_prototype_value_of(&agent, this_value, None, &[])
         .map(|val| match val {

--- a/src/string_object/tests.rs
+++ b/src/string_object/tests.rs
@@ -815,7 +815,7 @@ mod agent {
     fn this_string_value(make_val: impl FnOnce() -> ECMAScriptValue) -> Result<String, String> {
         setup_test_agent();
         let val = make_val();
-        super::this_string_value(val, "unit testing").map(String::from).map_err(|e| unwind_any_error(e))
+        super::this_string_value(val, "unit testing").map(String::from).map_err(unwind_any_error)
     }
 }
 
@@ -838,12 +838,12 @@ fn string_constructor_function(
             }
             _ => panic!("Bad value from string_constructor_function: {:?}", val),
         })
-        .map_err(|err| unwind_any_error(err))
+        .map_err(unwind_any_error)
 }
 
 #[test_case(|| vec![ECMAScriptValue::from(112), ECMAScriptValue::from(97), ECMAScriptValue::from(115), ECMAScriptValue::from(115)] => sok("pass"); "normal")]
 #[test_case(|| vec![ECMAScriptValue::from(wks(WksId::ToPrimitive))] => serr("TypeError: Symbol values cannot be converted to Number values"); "bad args")]
-#[test_case(|| vec![] => sok(""); "emtpy args")]
+#[test_case(Vec::new => sok(""); "emtpy args")]
 fn string_from_char_code(make_params: impl FnOnce() -> Vec<ECMAScriptValue>) -> Result<String, String> {
     setup_test_agent();
     let args = make_params();
@@ -852,7 +852,7 @@ fn string_from_char_code(make_params: impl FnOnce() -> Vec<ECMAScriptValue>) -> 
             ECMAScriptValue::String(s) => String::from(s),
             _ => panic!("Expected String value from String.fromCharCode: {:?}", val),
         })
-        .map_err(|e| unwind_any_error(e))
+        .map_err(unwind_any_error)
 }
 
 #[test_case(|| (ECMAScriptValue::Undefined, vec![]) => serr("TypeError: Undefined and null are not allowed in this context"); "'this' bad")]
@@ -871,7 +871,7 @@ fn string_prototype_index_of(
             ECMAScriptValue::Number(n) => n,
             _ => panic!("Expected number value from String.prototype.indexOf: {:?}", val),
         })
-        .map_err(|e| unwind_any_error(e))
+        .map_err(unwind_any_error)
 }
 
 #[test_case(|| ECMAScriptValue::from(super::create_string_object("a string".into())) => sok("a string"); "from string object")]
@@ -884,7 +884,7 @@ fn string_prototype_to_string(make_params: impl FnOnce() -> ECMAScriptValue) -> 
             ECMAScriptValue::String(s) => String::from(s),
             _ => panic!("Expected string value from String.prototype.toString: {:?}", val),
         })
-        .map_err(|e| unwind_any_error(e))
+        .map_err(unwind_any_error)
 }
 
 #[test_case(|| ECMAScriptValue::from(super::create_string_object("a string".into())) => sok("a string"); "from string object")]
@@ -897,7 +897,7 @@ fn string_prototype_value_of(make_params: impl FnOnce() -> ECMAScriptValue) -> R
             ECMAScriptValue::String(s) => String::from(s),
             _ => panic!("Expected string value from String.prototype.valueOf: {:?}", val),
         })
-        .map_err(|e| unwind_any_error(e))
+        .map_err(unwind_any_error)
 }
 
 tbd_function!(string_from_code_point);

--- a/src/symbol_object/tests.rs
+++ b/src/symbol_object/tests.rs
@@ -365,8 +365,8 @@ fn symbol_match(expected: &str) -> impl FnOnce(Result<ECMAScriptValue, String>) 
     }
 }
 
-#[test_case(|| Some(ordinary_object_create(None, &[])), || vec![] => serr("TypeError: Symbol is not a constructor"); "called as constructor")]
-#[test_case(|| None, || vec![] => using symbol_match("Symbol()"); "empty description")]
+#[test_case(|| Some(ordinary_object_create(None, &[])), Vec::new => serr("TypeError: Symbol is not a constructor"); "called as constructor")]
+#[test_case(|| None, Vec::new => using symbol_match("Symbol()"); "empty description")]
 #[test_case(|| None, || vec![ECMAScriptValue::from("giants")] => using symbol_match("Symbol(giants)"); "with description")]
 #[test_case(|| None, || vec![ECMAScriptValue::from(wks(WksId::ToPrimitive))] => serr("TypeError: Symbols may not be converted to strings"); "with bad description")]
 fn symbol_constructor_function(
@@ -376,7 +376,7 @@ fn symbol_constructor_function(
     setup_test_agent();
     let nt = tgt_maker();
     let args = arg_maker();
-    super::symbol_constructor_function(ECMAScriptValue::Undefined, nt.as_ref(), &args).map_err(|e| unwind_any_error(e))
+    super::symbol_constructor_function(ECMAScriptValue::Undefined, nt.as_ref(), &args).map_err(unwind_any_error)
 }
 
 mod symbol_for {
@@ -634,7 +634,7 @@ mod symbol_to_string {
     fn normal(maker: fn() -> ECMAScriptValue) -> Result<String, String> {
         setup_test_agent();
         let this_value = maker();
-        symbol_to_string(this_value, None, &[]).map(|val| format!("{val}")).map_err(|ac| unwind_any_error(ac))
+        symbol_to_string(this_value, None, &[]).map(|val| format!("{val}")).map_err(unwind_any_error)
     }
 }
 

--- a/src/symbol_object/tests.rs
+++ b/src/symbol_object/tests.rs
@@ -7,7 +7,7 @@ mod symbol_object {
 
     #[test]
     fn debug() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = SymbolObject {
             common: RefCell::new(CommonObjectData::new(&agent, Some(prototype), true, SYMBOL_OBJECT_SLOTS)),
@@ -18,7 +18,7 @@ mod symbol_object {
 
     #[test]
     fn object() {
-        let agent = test_agent();
+        setup_test_agent();
         let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let prototype = ordinary_object_create(&agent, Some(object_prototype), &[]);
         define_property_or_throw(&agent, &prototype, "marker", PotentialPropertyDescriptor::new().value("sentinel"))
@@ -34,7 +34,7 @@ mod symbol_object {
 
     #[test]
     fn symbol_data() {
-        let agent = test_agent();
+        setup_test_agent();
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let so = SymbolObject {
             common: RefCell::new(CommonObjectData::new(&agent, Some(prototype), true, SYMBOL_OBJECT_SLOTS)),
@@ -48,7 +48,7 @@ mod symbol_object {
 
     #[test]
     fn is_callable_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -57,7 +57,7 @@ mod symbol_object {
 
     #[test]
     fn is_number_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -66,7 +66,7 @@ mod symbol_object {
 
     #[test]
     fn is_arguments_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -75,7 +75,7 @@ mod symbol_object {
 
     #[test]
     fn is_boolean_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -84,7 +84,7 @@ mod symbol_object {
 
     #[test]
     fn is_array_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -93,7 +93,7 @@ mod symbol_object {
 
     #[test]
     fn is_error_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -102,7 +102,7 @@ mod symbol_object {
 
     #[test]
     fn is_regexp_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -111,7 +111,7 @@ mod symbol_object {
 
     #[test]
     fn is_proxy_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -120,7 +120,7 @@ mod symbol_object {
 
     #[test]
     fn is_string_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -129,7 +129,7 @@ mod symbol_object {
 
     #[test]
     fn is_date_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -138,7 +138,7 @@ mod symbol_object {
 
     #[test]
     fn to_callable_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -147,7 +147,7 @@ mod symbol_object {
 
     #[test]
     fn to_error_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -156,7 +156,7 @@ mod symbol_object {
 
     #[test]
     fn to_constructable() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -165,7 +165,7 @@ mod symbol_object {
 
     #[test]
     fn to_array_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -174,7 +174,7 @@ mod symbol_object {
 
     #[test]
     fn to_boolean_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -183,7 +183,7 @@ mod symbol_object {
 
     #[test]
     fn to_number_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -192,7 +192,7 @@ mod symbol_object {
 
     #[test]
     fn to_function_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -201,7 +201,7 @@ mod symbol_object {
 
     #[test]
     fn to_builtin_function_obj() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -210,7 +210,7 @@ mod symbol_object {
 
     #[test]
     fn is_ordinary() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -219,7 +219,7 @@ mod symbol_object {
 
     #[test]
     fn is_plain_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -228,7 +228,7 @@ mod symbol_object {
 
     #[test]
     fn to_arguments_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let obj = create_symbol_object(&agent, sym);
 
@@ -237,7 +237,7 @@ mod symbol_object {
 
     #[test]
     fn get_prototype_of() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let sym_obj = create_symbol_object(&agent, sym);
         let proto = sym_obj.o.get_prototype_of(&agent).unwrap().unwrap();
@@ -246,7 +246,7 @@ mod symbol_object {
 
     #[test]
     fn set_prototype_of() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let sym_obj = create_symbol_object(&agent, sym);
         let res = sym_obj.o.set_prototype_of(&agent, None).unwrap();
@@ -256,7 +256,7 @@ mod symbol_object {
 
     #[test]
     fn is_extensible() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let sym_obj = create_symbol_object(&agent, sym);
         let res = sym_obj.o.is_extensible(&agent).unwrap();
@@ -265,7 +265,7 @@ mod symbol_object {
 
     #[test]
     fn prevent_extensions() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let sym_obj = create_symbol_object(&agent, sym);
         let res = sym_obj.o.prevent_extensions(&agent).unwrap();
@@ -275,7 +275,7 @@ mod symbol_object {
 
     #[test]
     fn define_and_get_own_property() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let sym_obj = create_symbol_object(&agent, sym);
         let res = sym_obj
@@ -299,7 +299,7 @@ mod symbol_object {
 
     #[test]
     fn has_property() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let sym_obj = create_symbol_object(&agent, sym);
         let res = sym_obj.o.has_property(&agent, &PropertyKey::from("rust")).unwrap();
@@ -311,7 +311,7 @@ mod symbol_object {
 
     #[test]
     fn get() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let sym_obj = create_symbol_object(&agent, sym);
         let res = sym_obj.o.get(&agent, &PropertyKey::from("rust"), &ECMAScriptValue::Undefined).unwrap();
@@ -323,7 +323,7 @@ mod symbol_object {
 
     #[test]
     fn set() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let sym_obj = create_symbol_object(&agent, sym);
         let receiver = ECMAScriptValue::Object(sym_obj.clone());
@@ -333,7 +333,7 @@ mod symbol_object {
 
     #[test]
     fn delete() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let sym_obj = create_symbol_object(&agent, sym);
         let res = sym_obj.o.delete(&agent, &PropertyKey::from("rust")).unwrap();
@@ -342,7 +342,7 @@ mod symbol_object {
 
     #[test]
     fn own_keys() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let sym_obj = create_symbol_object(&agent, sym);
         let res = sym_obj.o.own_property_keys(&agent).unwrap();
@@ -351,7 +351,7 @@ mod symbol_object {
 
     #[test]
     fn id() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::ToPrimitive);
         let sym_obj = create_symbol_object(&agent, sym.clone());
         let sym_obj2 = create_symbol_object(&agent, sym);
@@ -378,7 +378,7 @@ fn symbol_constructor_function(
     tgt_maker: fn(&Agent) -> Option<Object>,
     arg_maker: fn(&Agent) -> Vec<ECMAScriptValue>,
 ) -> Result<ECMAScriptValue, String> {
-    let agent = test_agent();
+    setup_test_agent();
     let nt = tgt_maker(&agent);
     let args = arg_maker(&agent);
     super::symbol_constructor_function(&agent, ECMAScriptValue::Undefined, nt.as_ref(), &args)
@@ -390,7 +390,7 @@ mod symbol_for {
 
     #[test]
     fn new() {
-        let agent = test_agent();
+        setup_test_agent();
         let gsr = agent.global_symbol_registry();
         let count_prior = gsr.borrow().len();
         let result = symbol_for(&agent, ECMAScriptValue::Undefined, None, &["key".into()]);
@@ -405,7 +405,7 @@ mod symbol_for {
 
     #[test]
     fn duplicate() {
-        let agent = test_agent();
+        setup_test_agent();
         let gsr = agent.global_symbol_registry();
         let count_prior = gsr.borrow().len();
         let first = symbol_for(&agent, ECMAScriptValue::Undefined, None, &["key".into()]);
@@ -422,7 +422,7 @@ mod symbol_for {
 
     #[test]
     fn bad_key() {
-        let agent = test_agent();
+        setup_test_agent();
         let to_primitive = agent.wks(WksId::ToPrimitive);
         let result = symbol_for(&agent, ECMAScriptValue::Undefined, None, &[to_primitive.into()]).unwrap_err();
         assert_eq!(unwind_any_error(&agent, result), "TypeError: Symbols may not be converted to strings");
@@ -434,7 +434,7 @@ mod symbol_key_for {
 
     #[test]
     fn not_symbol() {
-        let agent = test_agent();
+        setup_test_agent();
         let this_value = ECMAScriptValue::Undefined;
         let new_target = None;
         let arguments = &[];
@@ -446,7 +446,7 @@ mod symbol_key_for {
 
     #[test]
     fn not_in_registry() {
-        let agent = test_agent();
+        setup_test_agent();
         let this_value = ECMAScriptValue::Undefined;
         let new_target = None;
         let sym = agent.wks(WksId::ToPrimitive);
@@ -459,7 +459,7 @@ mod symbol_key_for {
 
     #[test]
     fn in_registry() {
-        let agent = test_agent();
+        setup_test_agent();
         let this_value = ECMAScriptValue::Undefined;
         let new_target = None;
         let registry_sym =
@@ -477,7 +477,7 @@ mod this_symbol_value {
 
     #[test]
     fn not_symbol() {
-        let agent = test_agent();
+        setup_test_agent();
         let this_value = ECMAScriptValue::Undefined;
 
         let result = this_symbol_value(&agent, this_value);
@@ -487,7 +487,7 @@ mod this_symbol_value {
 
     #[test]
     fn symbol() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = Symbol::new(&agent, Some("test_sentinel".into()));
         let this_value = ECMAScriptValue::from(sym.clone());
 
@@ -499,7 +499,7 @@ mod this_symbol_value {
 
     #[test]
     fn symbol_in_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = Symbol::new(&agent, Some("test_sentinel".into()));
         let o = create_symbol_object(&agent, sym.clone());
         let this_value = ECMAScriptValue::from(o);
@@ -536,7 +536,7 @@ mod symbol_registry {
     fn len() {
         let mut sr = SymbolRegistry::new();
         assert_eq!(sr.len(), 0);
-        let agent = test_agent();
+        setup_test_agent();
         let s1 = Symbol::new(&agent, Some("fisrt".into()));
         let s2 = Symbol::new(&agent, Some("second".into()));
         let s3: Symbol = Symbol::new(&agent, Some("third".into()));
@@ -550,7 +550,7 @@ mod symbol_registry {
     fn is_empty() {
         let mut sr = SymbolRegistry::new();
         assert!(sr.is_empty());
-        let agent = test_agent();
+        setup_test_agent();
         let s1 = Symbol::new(&agent, Some("fisrt".into()));
         sr.add("1".into(), s1);
         assert!(!sr.is_empty());
@@ -562,7 +562,7 @@ mod symbol_registry {
         #[test]
         fn safe() {
             let mut sr = SymbolRegistry::new();
-            let agent = test_agent();
+            setup_test_agent();
             let s1 = Symbol::new(&agent, Some("fisrt".into()));
             let s2 = Symbol::new(&agent, Some("second".into()));
             let s3: Symbol = Symbol::new(&agent, Some("third".into()));
@@ -576,7 +576,7 @@ mod symbol_registry {
         #[should_panic(expected = "second")]
         fn duplicates() {
             let mut sr = SymbolRegistry::new();
-            let agent = test_agent();
+            setup_test_agent();
             let s1 = Symbol::new(&agent, Some("fisrt".into()));
             let s2 = Symbol::new(&agent, Some("second".into()));
             sr.add("1".into(), s1);
@@ -587,7 +587,7 @@ mod symbol_registry {
     #[test]
     fn key_by_symbol() {
         let mut sr = SymbolRegistry::new();
-        let agent = test_agent();
+        setup_test_agent();
         let s1 = Symbol::new(&agent, Some("fisrt".into()));
         let s2 = Symbol::new(&agent, Some("second".into()));
         let s3 = Symbol::new(&agent, Some("third".into()));
@@ -605,7 +605,7 @@ mod symbol_registry {
     #[test]
     fn symbol_by_key() {
         let mut sr = SymbolRegistry::new();
-        let agent = test_agent();
+        setup_test_agent();
         let s1 = Symbol::new(&agent, Some("fisrt".into()));
         let s2 = Symbol::new(&agent, Some("second".into()));
         let s3 = Symbol::new(&agent, Some("third".into()));
@@ -625,7 +625,7 @@ mod create_symbol_object {
 
     #[test]
     fn normal() {
-        let agent = test_agent();
+        setup_test_agent();
         let s1 = Symbol::new(&agent, Some("train".into()));
         let sobj = create_symbol_object(&agent, s1.clone());
         assert_eq!(s1, this_symbol_value(&agent, sobj.into()).unwrap());
@@ -639,7 +639,7 @@ mod symbol_to_string {
     #[test_case(|_| ECMAScriptValue::Undefined => serr("TypeError: Not a symbol"); "Not a symbol")]
     #[test_case(|a| ECMAScriptValue::from(Symbol::new(a, Some("test sentinel".into()))) => sok("Symbol(test sentinel)"); "true symbol")]
     fn normal(maker: fn(&Agent) -> ECMAScriptValue) -> Result<String, String> {
-        let agent = test_agent();
+        setup_test_agent();
         let this_value = maker(&agent);
         symbol_to_string(&agent, this_value, None, &[])
             .map(|val| format!("{val}"))
@@ -652,7 +652,7 @@ mod symbol_value_of {
 
     #[test]
     fn symbol() {
-        let agent = test_agent();
+        setup_test_agent();
         let s = Symbol::new(&agent, Some("test sentinel".into()));
         let this_value = ECMAScriptValue::from(s.clone());
         let result = symbol_value_of(&agent, this_value, None, &[]).unwrap();
@@ -661,7 +661,7 @@ mod symbol_value_of {
 
     #[test]
     fn error() {
-        let agent = test_agent();
+        setup_test_agent();
         let this_value = ECMAScriptValue::Undefined;
         let result = symbol_value_of(&agent, this_value, None, &[]).unwrap_err();
         assert_eq!(unwind_any_error(&agent, result), "TypeError: Not a symbol");
@@ -675,7 +675,7 @@ mod symbol_description {
     #[test_case(None => ECMAScriptValue::Undefined; "no description")]
     #[test_case(Some("alice") => ECMAScriptValue::from("alice"); "with description")]
     fn normal(src: Option<&str>) -> ECMAScriptValue {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = Symbol::new(&agent, src.map(JSString::from));
         let this_value = ECMAScriptValue::from(sym);
         symbol_description(&agent, this_value, None, &[]).unwrap()
@@ -683,7 +683,7 @@ mod symbol_description {
 
     #[test]
     fn bad_this() {
-        let agent = test_agent();
+        setup_test_agent();
         let this_value = ECMAScriptValue::Undefined;
         let result = symbol_description(&agent, this_value, None, &[]).unwrap_err();
         assert_eq!(unwind_any_error(&agent, result), "TypeError: Not a symbol");

--- a/src/symbol_object/tests.rs
+++ b/src/symbol_object/tests.rs
@@ -8,9 +8,9 @@ mod symbol_object {
     #[test]
     fn debug() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
         let so = SymbolObject {
-            common: RefCell::new(CommonObjectData::new(&agent, Some(prototype), true, SYMBOL_OBJECT_SLOTS)),
+            common: RefCell::new(CommonObjectData::new(Some(prototype), true, SYMBOL_OBJECT_SLOTS)),
             symbol_data: RefCell::new(None),
         };
         assert_ne!(format!("{:?}", so), "");
@@ -19,38 +19,37 @@ mod symbol_object {
     #[test]
     fn object() {
         setup_test_agent();
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let prototype = ordinary_object_create(&agent, Some(object_prototype), &[]);
-        define_property_or_throw(&agent, &prototype, "marker", PotentialPropertyDescriptor::new().value("sentinel"))
-            .unwrap();
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let prototype = ordinary_object_create(Some(object_prototype), &[]);
+        define_property_or_throw(&prototype, "marker", PotentialPropertyDescriptor::new().value("sentinel")).unwrap();
 
-        let obj = SymbolObject::object(&agent, Some(prototype));
+        let obj = SymbolObject::object(Some(prototype));
 
         assert!(obj.o.is_symbol_object());
-        let recovered_proto = obj.o.get_prototype_of(&agent).unwrap().unwrap();
-        let prop = super::get(&agent, &recovered_proto, &PropertyKey::from("marker")).unwrap();
+        let recovered_proto = obj.o.get_prototype_of().unwrap().unwrap();
+        let prop = super::get(&recovered_proto, &PropertyKey::from("marker")).unwrap();
         assert_eq!(prop, ECMAScriptValue::from("sentinel"));
     }
 
     #[test]
     fn symbol_data() {
         setup_test_agent();
-        let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
+        let prototype = intrinsic(IntrinsicId::ObjectPrototype);
         let so = SymbolObject {
-            common: RefCell::new(CommonObjectData::new(&agent, Some(prototype), true, SYMBOL_OBJECT_SLOTS)),
-            symbol_data: RefCell::new(Some(agent.wks(WksId::ToPrimitive))),
+            common: RefCell::new(CommonObjectData::new(Some(prototype), true, SYMBOL_OBJECT_SLOTS)),
+            symbol_data: RefCell::new(Some(wks(WksId::ToPrimitive))),
         };
 
         let sd = so.symbol_data();
         let recovered = sd.borrow().clone();
-        assert_eq!(recovered, Some(agent.wks(WksId::ToPrimitive)));
+        assert_eq!(recovered, Some(wks(WksId::ToPrimitive)));
     }
 
     #[test]
     fn is_callable_obj() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(!obj.o.is_callable_obj());
     }
@@ -58,8 +57,8 @@ mod symbol_object {
     #[test]
     fn is_number_object() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(!obj.o.is_number_object());
     }
@@ -67,8 +66,8 @@ mod symbol_object {
     #[test]
     fn is_arguments_object() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(!obj.o.is_arguments_object());
     }
@@ -76,8 +75,8 @@ mod symbol_object {
     #[test]
     fn is_boolean_object() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(!obj.o.is_boolean_object());
     }
@@ -85,8 +84,8 @@ mod symbol_object {
     #[test]
     fn is_array_object() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(!obj.o.is_array_object());
     }
@@ -94,8 +93,8 @@ mod symbol_object {
     #[test]
     fn is_error_object() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(!obj.o.is_error_object());
     }
@@ -103,8 +102,8 @@ mod symbol_object {
     #[test]
     fn is_regexp_object() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(!obj.o.is_regexp_object());
     }
@@ -112,8 +111,8 @@ mod symbol_object {
     #[test]
     fn is_proxy_object() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(!obj.o.is_proxy_object());
     }
@@ -121,8 +120,8 @@ mod symbol_object {
     #[test]
     fn is_string_object() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(!obj.o.is_string_object());
     }
@@ -130,8 +129,8 @@ mod symbol_object {
     #[test]
     fn is_date_object() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(!obj.o.is_date_object());
     }
@@ -139,8 +138,8 @@ mod symbol_object {
     #[test]
     fn to_callable_obj() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(obj.o.to_callable_obj().is_none());
     }
@@ -148,8 +147,8 @@ mod symbol_object {
     #[test]
     fn to_error_obj() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(obj.o.to_error_obj().is_none());
     }
@@ -157,8 +156,8 @@ mod symbol_object {
     #[test]
     fn to_constructable() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(obj.o.to_constructable().is_none());
     }
@@ -166,8 +165,8 @@ mod symbol_object {
     #[test]
     fn to_array_object() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(obj.o.to_array_object().is_none());
     }
@@ -175,8 +174,8 @@ mod symbol_object {
     #[test]
     fn to_boolean_obj() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(obj.o.to_boolean_obj().is_none());
     }
@@ -184,8 +183,8 @@ mod symbol_object {
     #[test]
     fn to_number_obj() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(obj.o.to_number_obj().is_none());
     }
@@ -193,8 +192,8 @@ mod symbol_object {
     #[test]
     fn to_function_obj() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(obj.o.to_function_obj().is_none());
     }
@@ -202,8 +201,8 @@ mod symbol_object {
     #[test]
     fn to_builtin_function_obj() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(obj.o.to_builtin_function_obj().is_none());
     }
@@ -211,8 +210,8 @@ mod symbol_object {
     #[test]
     fn is_ordinary() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(obj.o.is_ordinary());
     }
@@ -220,8 +219,8 @@ mod symbol_object {
     #[test]
     fn is_plain_object() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(!obj.o.is_plain_object());
     }
@@ -229,8 +228,8 @@ mod symbol_object {
     #[test]
     fn to_arguments_object() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let obj = create_symbol_object(sym);
 
         assert!(obj.o.to_arguments_object().is_none());
     }
@@ -238,56 +237,52 @@ mod symbol_object {
     #[test]
     fn get_prototype_of() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&agent, sym);
-        let proto = sym_obj.o.get_prototype_of(&agent).unwrap().unwrap();
-        assert_eq!(proto, agent.intrinsic(IntrinsicId::SymbolPrototype));
+        let sym = wks(WksId::ToPrimitive);
+        let sym_obj = create_symbol_object(sym);
+        let proto = sym_obj.o.get_prototype_of().unwrap().unwrap();
+        assert_eq!(proto, intrinsic(IntrinsicId::SymbolPrototype));
     }
 
     #[test]
     fn set_prototype_of() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&agent, sym);
-        let res = sym_obj.o.set_prototype_of(&agent, None).unwrap();
+        let sym = wks(WksId::ToPrimitive);
+        let sym_obj = create_symbol_object(sym);
+        let res = sym_obj.o.set_prototype_of(None).unwrap();
         assert!(res);
-        assert!(sym_obj.o.get_prototype_of(&agent).unwrap().is_none());
+        assert!(sym_obj.o.get_prototype_of().unwrap().is_none());
     }
 
     #[test]
     fn is_extensible() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&agent, sym);
-        let res = sym_obj.o.is_extensible(&agent).unwrap();
+        let sym = wks(WksId::ToPrimitive);
+        let sym_obj = create_symbol_object(sym);
+        let res = sym_obj.o.is_extensible().unwrap();
         assert!(res);
     }
 
     #[test]
     fn prevent_extensions() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&agent, sym);
-        let res = sym_obj.o.prevent_extensions(&agent).unwrap();
+        let sym = wks(WksId::ToPrimitive);
+        let sym_obj = create_symbol_object(sym);
+        let res = sym_obj.o.prevent_extensions().unwrap();
         assert!(res);
-        assert!(!sym_obj.o.is_extensible(&agent).unwrap());
+        assert!(!sym_obj.o.is_extensible().unwrap());
     }
 
     #[test]
     fn define_and_get_own_property() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let sym_obj = create_symbol_object(sym);
         let res = sym_obj
             .o
-            .define_own_property(
-                &agent,
-                PropertyKey::from("rust"),
-                PotentialPropertyDescriptor::new().value("is awesome"),
-            )
+            .define_own_property(PropertyKey::from("rust"), PotentialPropertyDescriptor::new().value("is awesome"))
             .unwrap();
         assert!(res);
-        let val = sym_obj.o.get_own_property(&agent, &PropertyKey::from("rust")).unwrap().unwrap();
+        let val = sym_obj.o.get_own_property(&PropertyKey::from("rust")).unwrap().unwrap();
         assert_eq!(val.enumerable, false);
         assert_eq!(val.configurable, false);
         assert!(matches!(val.property, PropertyKind::Data(..)));
@@ -300,61 +295,61 @@ mod symbol_object {
     #[test]
     fn has_property() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&agent, sym);
-        let res = sym_obj.o.has_property(&agent, &PropertyKey::from("rust")).unwrap();
+        let sym = wks(WksId::ToPrimitive);
+        let sym_obj = create_symbol_object(sym);
+        let res = sym_obj.o.has_property(&PropertyKey::from("rust")).unwrap();
         assert_eq!(res, false);
-        let tst = agent.wks(WksId::ToStringTag);
-        let res2 = sym_obj.o.has_property(&agent, &PropertyKey::from(tst)).unwrap();
+        let tst = wks(WksId::ToStringTag);
+        let res2 = sym_obj.o.has_property(&PropertyKey::from(tst)).unwrap();
         assert_eq!(res2, true);
     }
 
     #[test]
     fn get() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&agent, sym);
-        let res = sym_obj.o.get(&agent, &PropertyKey::from("rust"), &ECMAScriptValue::Undefined).unwrap();
+        let sym = wks(WksId::ToPrimitive);
+        let sym_obj = create_symbol_object(sym);
+        let res = sym_obj.o.get(&PropertyKey::from("rust"), &ECMAScriptValue::Undefined).unwrap();
         assert_eq!(res, ECMAScriptValue::Undefined);
-        let tst = agent.wks(WksId::ToStringTag);
-        let res2 = sym_obj.o.get(&agent, &PropertyKey::from(tst), &ECMAScriptValue::Undefined).unwrap();
+        let tst = wks(WksId::ToStringTag);
+        let res2 = sym_obj.o.get(&PropertyKey::from(tst), &ECMAScriptValue::Undefined).unwrap();
         assert_eq!(res2, ECMAScriptValue::from("Symbol"));
     }
 
     #[test]
     fn set() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let sym_obj = create_symbol_object(sym);
         let receiver = ECMAScriptValue::Object(sym_obj.clone());
-        let res = sym_obj.o.set(&agent, PropertyKey::from("rust"), ECMAScriptValue::Null, &receiver).unwrap();
+        let res = sym_obj.o.set(PropertyKey::from("rust"), ECMAScriptValue::Null, &receiver).unwrap();
         assert_eq!(res, true);
     }
 
     #[test]
     fn delete() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&agent, sym);
-        let res = sym_obj.o.delete(&agent, &PropertyKey::from("rust")).unwrap();
+        let sym = wks(WksId::ToPrimitive);
+        let sym_obj = create_symbol_object(sym);
+        let res = sym_obj.o.delete(&PropertyKey::from("rust")).unwrap();
         assert_eq!(res, true);
     }
 
     #[test]
     fn own_keys() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&agent, sym);
-        let res = sym_obj.o.own_property_keys(&agent).unwrap();
+        let sym = wks(WksId::ToPrimitive);
+        let sym_obj = create_symbol_object(sym);
+        let res = sym_obj.o.own_property_keys().unwrap();
         assert!(res.is_empty())
     }
 
     #[test]
     fn id() {
         setup_test_agent();
-        let sym = agent.wks(WksId::ToPrimitive);
-        let sym_obj = create_symbol_object(&agent, sym.clone());
-        let sym_obj2 = create_symbol_object(&agent, sym);
+        let sym = wks(WksId::ToPrimitive);
+        let sym_obj = create_symbol_object(sym.clone());
+        let sym_obj2 = create_symbol_object(sym);
         assert_ne!(sym_obj.o.id(), sym_obj2.o.id());
     }
 }
@@ -370,19 +365,18 @@ fn symbol_match(expected: &str) -> impl FnOnce(Result<ECMAScriptValue, String>) 
     }
 }
 
-#[test_case(|a| Some(ordinary_object_create(a, None, &[])), |_| vec![] => serr("TypeError: Symbol is not a constructor"); "called as constructor")]
-#[test_case(|_| None, |_| vec![] => using symbol_match("Symbol()"); "empty description")]
-#[test_case(|_| None, |_| vec![ECMAScriptValue::from("giants")] => using symbol_match("Symbol(giants)"); "with description")]
-#[test_case(|_| None, |a| vec![ECMAScriptValue::from(a.wks(WksId::ToPrimitive))] => serr("TypeError: Symbols may not be converted to strings"); "with bad description")]
+#[test_case(|| Some(ordinary_object_create(None, &[])), || vec![] => serr("TypeError: Symbol is not a constructor"); "called as constructor")]
+#[test_case(|| None, || vec![] => using symbol_match("Symbol()"); "empty description")]
+#[test_case(|| None, || vec![ECMAScriptValue::from("giants")] => using symbol_match("Symbol(giants)"); "with description")]
+#[test_case(|| None, || vec![ECMAScriptValue::from(wks(WksId::ToPrimitive))] => serr("TypeError: Symbols may not be converted to strings"); "with bad description")]
 fn symbol_constructor_function(
-    tgt_maker: fn(&Agent) -> Option<Object>,
-    arg_maker: fn(&Agent) -> Vec<ECMAScriptValue>,
+    tgt_maker: fn() -> Option<Object>,
+    arg_maker: fn() -> Vec<ECMAScriptValue>,
 ) -> Result<ECMAScriptValue, String> {
     setup_test_agent();
-    let nt = tgt_maker(&agent);
-    let args = arg_maker(&agent);
-    super::symbol_constructor_function(&agent, ECMAScriptValue::Undefined, nt.as_ref(), &args)
-        .map_err(|e| unwind_any_error(&agent, e))
+    let nt = tgt_maker();
+    let args = arg_maker();
+    super::symbol_constructor_function(ECMAScriptValue::Undefined, nt.as_ref(), &args).map_err(|e| unwind_any_error(e))
 }
 
 mod symbol_for {
@@ -391,9 +385,9 @@ mod symbol_for {
     #[test]
     fn new() {
         setup_test_agent();
-        let gsr = agent.global_symbol_registry();
+        let gsr = global_symbol_registry();
         let count_prior = gsr.borrow().len();
-        let result = symbol_for(&agent, ECMAScriptValue::Undefined, None, &["key".into()]);
+        let result = symbol_for(ECMAScriptValue::Undefined, None, &["key".into()]);
         if let Ok(ECMAScriptValue::Symbol(sym)) = result {
             assert_eq!(sym.descriptive_string(), "Symbol(key)");
             let count_after = gsr.borrow().len();
@@ -406,10 +400,10 @@ mod symbol_for {
     #[test]
     fn duplicate() {
         setup_test_agent();
-        let gsr = agent.global_symbol_registry();
+        let gsr = global_symbol_registry();
         let count_prior = gsr.borrow().len();
-        let first = symbol_for(&agent, ECMAScriptValue::Undefined, None, &["key".into()]);
-        let second = symbol_for(&agent, ECMAScriptValue::Undefined, None, &["key".into()]);
+        let first = symbol_for(ECMAScriptValue::Undefined, None, &["key".into()]);
+        let second = symbol_for(ECMAScriptValue::Undefined, None, &["key".into()]);
         if let (Ok(ECMAScriptValue::Symbol(first)), Ok(ECMAScriptValue::Symbol(second))) = (first, second) {
             assert_eq!(first, second);
             assert_eq!(first.descriptive_string(), "Symbol(key)");
@@ -423,9 +417,9 @@ mod symbol_for {
     #[test]
     fn bad_key() {
         setup_test_agent();
-        let to_primitive = agent.wks(WksId::ToPrimitive);
-        let result = symbol_for(&agent, ECMAScriptValue::Undefined, None, &[to_primitive.into()]).unwrap_err();
-        assert_eq!(unwind_any_error(&agent, result), "TypeError: Symbols may not be converted to strings");
+        let to_primitive = wks(WksId::ToPrimitive);
+        let result = symbol_for(ECMAScriptValue::Undefined, None, &[to_primitive.into()]).unwrap_err();
+        assert_eq!(unwind_any_error(result), "TypeError: Symbols may not be converted to strings");
     }
 }
 
@@ -439,9 +433,9 @@ mod symbol_key_for {
         let new_target = None;
         let arguments = &[];
 
-        let result = symbol_key_for(&agent, this_value, new_target, arguments);
+        let result = symbol_key_for(this_value, new_target, arguments);
 
-        assert_eq!(unwind_any_error(&agent, result.unwrap_err()), "TypeError: value is not a symbol");
+        assert_eq!(unwind_any_error(result.unwrap_err()), "TypeError: value is not a symbol");
     }
 
     #[test]
@@ -449,10 +443,10 @@ mod symbol_key_for {
         setup_test_agent();
         let this_value = ECMAScriptValue::Undefined;
         let new_target = None;
-        let sym = agent.wks(WksId::ToPrimitive);
+        let sym = wks(WksId::ToPrimitive);
         let arguments = &[ECMAScriptValue::from(sym)];
 
-        let result = symbol_key_for(&agent, this_value, new_target, arguments);
+        let result = symbol_key_for(this_value, new_target, arguments);
 
         assert_eq!(result.unwrap(), ECMAScriptValue::Undefined);
     }
@@ -462,11 +456,10 @@ mod symbol_key_for {
         setup_test_agent();
         let this_value = ECMAScriptValue::Undefined;
         let new_target = None;
-        let registry_sym =
-            symbol_for(&agent, ECMAScriptValue::Undefined, new_target, &["test_sentinel".into()]).unwrap();
+        let registry_sym = symbol_for(ECMAScriptValue::Undefined, new_target, &["test_sentinel".into()]).unwrap();
         let arguments = &[registry_sym];
 
-        let results = symbol_key_for(&agent, this_value, new_target, arguments);
+        let results = symbol_key_for(this_value, new_target, arguments);
 
         assert_eq!(results.unwrap().to_string(), "test_sentinel");
     }
@@ -480,18 +473,18 @@ mod this_symbol_value {
         setup_test_agent();
         let this_value = ECMAScriptValue::Undefined;
 
-        let result = this_symbol_value(&agent, this_value);
+        let result = this_symbol_value(this_value);
 
-        assert_eq!(unwind_any_error(&agent, result.unwrap_err()), "TypeError: Not a symbol");
+        assert_eq!(unwind_any_error(result.unwrap_err()), "TypeError: Not a symbol");
     }
 
     #[test]
     fn symbol() {
         setup_test_agent();
-        let sym = Symbol::new(&agent, Some("test_sentinel".into()));
+        let sym = Symbol::new(Some("test_sentinel".into()));
         let this_value = ECMAScriptValue::from(sym.clone());
 
-        let result = this_symbol_value(&agent, this_value).unwrap();
+        let result = this_symbol_value(this_value).unwrap();
 
         assert_eq!(result, sym);
         assert_eq!(result.description(), sym.description());
@@ -500,11 +493,11 @@ mod this_symbol_value {
     #[test]
     fn symbol_in_object() {
         setup_test_agent();
-        let sym = Symbol::new(&agent, Some("test_sentinel".into()));
-        let o = create_symbol_object(&agent, sym.clone());
+        let sym = Symbol::new(Some("test_sentinel".into()));
+        let o = create_symbol_object(sym.clone());
         let this_value = ECMAScriptValue::from(o);
 
-        let result = this_symbol_value(&agent, this_value).unwrap();
+        let result = this_symbol_value(this_value).unwrap();
 
         assert_eq!(result, sym);
         assert_eq!(String::from(result.description().unwrap()), "test_sentinel");
@@ -537,9 +530,9 @@ mod symbol_registry {
         let mut sr = SymbolRegistry::new();
         assert_eq!(sr.len(), 0);
         setup_test_agent();
-        let s1 = Symbol::new(&agent, Some("fisrt".into()));
-        let s2 = Symbol::new(&agent, Some("second".into()));
-        let s3: Symbol = Symbol::new(&agent, Some("third".into()));
+        let s1 = Symbol::new(Some("fisrt".into()));
+        let s2 = Symbol::new(Some("second".into()));
+        let s3: Symbol = Symbol::new(Some("third".into()));
         sr.add("1".into(), s1);
         sr.add("2".into(), s2);
         sr.add("3".into(), s3);
@@ -551,7 +544,7 @@ mod symbol_registry {
         let mut sr = SymbolRegistry::new();
         assert!(sr.is_empty());
         setup_test_agent();
-        let s1 = Symbol::new(&agent, Some("fisrt".into()));
+        let s1 = Symbol::new(Some("fisrt".into()));
         sr.add("1".into(), s1);
         assert!(!sr.is_empty());
     }
@@ -563,9 +556,9 @@ mod symbol_registry {
         fn safe() {
             let mut sr = SymbolRegistry::new();
             setup_test_agent();
-            let s1 = Symbol::new(&agent, Some("fisrt".into()));
-            let s2 = Symbol::new(&agent, Some("second".into()));
-            let s3: Symbol = Symbol::new(&agent, Some("third".into()));
+            let s1 = Symbol::new(Some("fisrt".into()));
+            let s2 = Symbol::new(Some("second".into()));
+            let s3: Symbol = Symbol::new(Some("third".into()));
             sr.add("1".into(), s1);
             sr.add("2".into(), s2);
             sr.add("3".into(), s3);
@@ -577,8 +570,8 @@ mod symbol_registry {
         fn duplicates() {
             let mut sr = SymbolRegistry::new();
             setup_test_agent();
-            let s1 = Symbol::new(&agent, Some("fisrt".into()));
-            let s2 = Symbol::new(&agent, Some("second".into()));
+            let s1 = Symbol::new(Some("fisrt".into()));
+            let s2 = Symbol::new(Some("second".into()));
             sr.add("1".into(), s1);
             sr.add("1".into(), s2);
         }
@@ -588,10 +581,10 @@ mod symbol_registry {
     fn key_by_symbol() {
         let mut sr = SymbolRegistry::new();
         setup_test_agent();
-        let s1 = Symbol::new(&agent, Some("fisrt".into()));
-        let s2 = Symbol::new(&agent, Some("second".into()));
-        let s3 = Symbol::new(&agent, Some("third".into()));
-        let s4 = Symbol::new(&agent, Some("fourth".into()));
+        let s1 = Symbol::new(Some("fisrt".into()));
+        let s2 = Symbol::new(Some("second".into()));
+        let s3 = Symbol::new(Some("third".into()));
+        let s4 = Symbol::new(Some("fourth".into()));
         sr.add("1".into(), s1.clone());
         sr.add("2".into(), s2.clone());
         sr.add("3".into(), s3.clone());
@@ -606,9 +599,9 @@ mod symbol_registry {
     fn symbol_by_key() {
         let mut sr = SymbolRegistry::new();
         setup_test_agent();
-        let s1 = Symbol::new(&agent, Some("fisrt".into()));
-        let s2 = Symbol::new(&agent, Some("second".into()));
-        let s3 = Symbol::new(&agent, Some("third".into()));
+        let s1 = Symbol::new(Some("fisrt".into()));
+        let s2 = Symbol::new(Some("second".into()));
+        let s3 = Symbol::new(Some("third".into()));
         sr.add("1".into(), s1.clone());
         sr.add("2".into(), s2.clone());
         sr.add("3".into(), s3.clone());
@@ -626,9 +619,9 @@ mod create_symbol_object {
     #[test]
     fn normal() {
         setup_test_agent();
-        let s1 = Symbol::new(&agent, Some("train".into()));
-        let sobj = create_symbol_object(&agent, s1.clone());
-        assert_eq!(s1, this_symbol_value(&agent, sobj.into()).unwrap());
+        let s1 = Symbol::new(Some("train".into()));
+        let sobj = create_symbol_object(s1.clone());
+        assert_eq!(s1, this_symbol_value(sobj.into()).unwrap());
     }
 }
 
@@ -636,14 +629,12 @@ mod symbol_to_string {
     use super::*;
     use test_case::test_case;
 
-    #[test_case(|_| ECMAScriptValue::Undefined => serr("TypeError: Not a symbol"); "Not a symbol")]
-    #[test_case(|a| ECMAScriptValue::from(Symbol::new(a, Some("test sentinel".into()))) => sok("Symbol(test sentinel)"); "true symbol")]
-    fn normal(maker: fn(&Agent) -> ECMAScriptValue) -> Result<String, String> {
+    #[test_case(|| ECMAScriptValue::Undefined => serr("TypeError: Not a symbol"); "Not a symbol")]
+    #[test_case(|| ECMAScriptValue::from(Symbol::new(Some("test sentinel".into()))) => sok("Symbol(test sentinel)"); "true symbol")]
+    fn normal(maker: fn() -> ECMAScriptValue) -> Result<String, String> {
         setup_test_agent();
-        let this_value = maker(&agent);
-        symbol_to_string(&agent, this_value, None, &[])
-            .map(|val| format!("{val}"))
-            .map_err(|ac| unwind_any_error(&agent, ac))
+        let this_value = maker();
+        symbol_to_string(this_value, None, &[]).map(|val| format!("{val}")).map_err(|ac| unwind_any_error(ac))
     }
 }
 
@@ -653,9 +644,9 @@ mod symbol_value_of {
     #[test]
     fn symbol() {
         setup_test_agent();
-        let s = Symbol::new(&agent, Some("test sentinel".into()));
+        let s = Symbol::new(Some("test sentinel".into()));
         let this_value = ECMAScriptValue::from(s.clone());
-        let result = symbol_value_of(&agent, this_value, None, &[]).unwrap();
+        let result = symbol_value_of(this_value, None, &[]).unwrap();
         assert_eq!(result, ECMAScriptValue::from(s));
     }
 
@@ -663,8 +654,8 @@ mod symbol_value_of {
     fn error() {
         setup_test_agent();
         let this_value = ECMAScriptValue::Undefined;
-        let result = symbol_value_of(&agent, this_value, None, &[]).unwrap_err();
-        assert_eq!(unwind_any_error(&agent, result), "TypeError: Not a symbol");
+        let result = symbol_value_of(this_value, None, &[]).unwrap_err();
+        assert_eq!(unwind_any_error(result), "TypeError: Not a symbol");
     }
 }
 
@@ -676,16 +667,16 @@ mod symbol_description {
     #[test_case(Some("alice") => ECMAScriptValue::from("alice"); "with description")]
     fn normal(src: Option<&str>) -> ECMAScriptValue {
         setup_test_agent();
-        let sym = Symbol::new(&agent, src.map(JSString::from));
+        let sym = Symbol::new(src.map(JSString::from));
         let this_value = ECMAScriptValue::from(sym);
-        symbol_description(&agent, this_value, None, &[]).unwrap()
+        symbol_description(this_value, None, &[]).unwrap()
     }
 
     #[test]
     fn bad_this() {
         setup_test_agent();
         let this_value = ECMAScriptValue::Undefined;
-        let result = symbol_description(&agent, this_value, None, &[]).unwrap_err();
-        assert_eq!(unwind_any_error(&agent, result), "TypeError: Not a symbol");
+        let result = symbol_description(this_value, None, &[]).unwrap_err();
+        assert_eq!(unwind_any_error(result), "TypeError: Not a symbol");
     }
 }

--- a/src/tests/integration.rs
+++ b/src/tests/integration.rs
@@ -13,11 +13,11 @@ mod update_expression {
         #[test_case("let a = 10n;let b = a++;({ a, b })" => (BigInt::from(11).into(), BigInt::from(10).into()); "bigint")]
         fn normal(src: &str) -> (ECMAScriptValue, ECMAScriptValue) {
             setup_test_agent();
-            let result = process_ecmascript(&agent, src).unwrap();
+            let result = process_ecmascript(src).unwrap();
 
-            let result_obj = to_object(&agent, result).unwrap();
-            let a = get(&agent, &result_obj, &"a".into()).unwrap();
-            let b = get(&agent, &result_obj, &"b".into()).unwrap();
+            let result_obj = to_object(result).unwrap();
+            let a = get(&result_obj, &"a".into()).unwrap();
+            let b = get(&result_obj, &"b".into()).unwrap();
             (a, b)
         }
 
@@ -27,7 +27,7 @@ mod update_expression {
         #[test_case("const a=0;a++;" => "Thrown: TypeError: Cannot change read-only value"; "PutValue errs")]
         fn errors(src: &str) -> String {
             setup_test_agent();
-            let result = process_ecmascript(&agent, src).unwrap_err();
+            let result = process_ecmascript(src).unwrap_err();
             result.to_string()
         }
     }
@@ -40,11 +40,11 @@ mod update_expression {
         #[test_case("let a = 10n;let b = a--;({ a, b })" => (BigInt::from(9).into(), BigInt::from(10).into()); "bigint")]
         fn normal(src: &str) -> (ECMAScriptValue, ECMAScriptValue) {
             setup_test_agent();
-            let result = process_ecmascript(&agent, src).unwrap();
+            let result = process_ecmascript(src).unwrap();
 
-            let result_obj = to_object(&agent, result).unwrap();
-            let a = get(&agent, &result_obj, &"a".into()).unwrap();
-            let b = get(&agent, &result_obj, &"b".into()).unwrap();
+            let result_obj = to_object(result).unwrap();
+            let a = get(&result_obj, &"a".into()).unwrap();
+            let b = get(&result_obj, &"b".into()).unwrap();
             (a, b)
         }
 
@@ -54,7 +54,7 @@ mod update_expression {
         #[test_case("const a=0;a--;" => "Thrown: TypeError: Cannot change read-only value"; "PutValue errs")]
         fn errors(src: &str) -> String {
             setup_test_agent();
-            let result = process_ecmascript(&agent, src).unwrap_err();
+            let result = process_ecmascript(src).unwrap_err();
             result.to_string()
         }
     }
@@ -67,11 +67,11 @@ mod update_expression {
         #[test_case("let a = 10n;let b = ++a;({ a, b })" => (BigInt::from(11).into(), BigInt::from(11).into()); "bigint")]
         fn normal(src: &str) -> (ECMAScriptValue, ECMAScriptValue) {
             setup_test_agent();
-            let result = process_ecmascript(&agent, src).unwrap();
+            let result = process_ecmascript(src).unwrap();
 
-            let result_obj = to_object(&agent, result).unwrap();
-            let a = get(&agent, &result_obj, &"a".into()).unwrap();
-            let b = get(&agent, &result_obj, &"b".into()).unwrap();
+            let result_obj = to_object(result).unwrap();
+            let a = get(&result_obj, &"a".into()).unwrap();
+            let b = get(&result_obj, &"b".into()).unwrap();
             (a, b)
         }
 
@@ -81,7 +81,7 @@ mod update_expression {
         #[test_case("const a=0;++a;" => "Thrown: TypeError: Cannot change read-only value"; "PutValue errs")]
         fn errors(src: &str) -> String {
             setup_test_agent();
-            let result = process_ecmascript(&agent, src).unwrap_err();
+            let result = process_ecmascript(src).unwrap_err();
             result.to_string()
         }
     }
@@ -94,11 +94,11 @@ mod update_expression {
         #[test_case("let a = 10n;let b = --a;({ a, b })" => (BigInt::from(9).into(), BigInt::from(9).into()); "bigint")]
         fn normal(src: &str) -> (ECMAScriptValue, ECMAScriptValue) {
             setup_test_agent();
-            let result = process_ecmascript(&agent, src).unwrap();
+            let result = process_ecmascript(src).unwrap();
 
-            let result_obj = to_object(&agent, result).unwrap();
-            let a = get(&agent, &result_obj, &"a".into()).unwrap();
-            let b = get(&agent, &result_obj, &"b".into()).unwrap();
+            let result_obj = to_object(result).unwrap();
+            let a = get(&result_obj, &"a".into()).unwrap();
+            let b = get(&result_obj, &"b".into()).unwrap();
             (a, b)
         }
 
@@ -108,7 +108,7 @@ mod update_expression {
         #[test_case("const a=0;--a;" => "Thrown: TypeError: Cannot change read-only value"; "PutValue errs")]
         fn errors(src: &str) -> String {
             setup_test_agent();
-            let result = process_ecmascript(&agent, src).unwrap_err();
+            let result = process_ecmascript(src).unwrap_err();
             result.to_string()
         }
     }
@@ -127,14 +127,14 @@ mod unary_expression {
     #[test_case("'use strict'; delete Boolean.prototype" => serr("Thrown: TypeError: property not deletable"); "strict, not deletable")]
     fn delete(src: &str) -> Result<ECMAScriptValue, String> {
         setup_test_agent();
-        process_ecmascript(&agent, src).map_err(|e| e.to_string())
+        process_ecmascript(src).map_err(|e| e.to_string())
     }
 
     #[test_case("void 3;" => Ok(ECMAScriptValue::Undefined); "simple")]
     #[test_case("void a;" => serr("Thrown: ReferenceError: Unresolvable Reference"); "err")]
     fn void(src: &str) -> Result<ECMAScriptValue, String> {
         setup_test_agent();
-        process_ecmascript(&agent, src).map_err(|e| e.to_string())
+        process_ecmascript(src).map_err(|e| e.to_string())
     }
 
     #[test_case("typeof a;" => Ok("undefined".into()); "undefined via unresolvable")]
@@ -150,7 +150,7 @@ mod unary_expression {
     #[test_case("typeof Boolean;" => Ok("function".into()); "function")]
     fn typeof_op(src: &str) -> Result<ECMAScriptValue, String> {
         setup_test_agent();
-        process_ecmascript(&agent, src).map_err(|e| e.to_string())
+        process_ecmascript(src).map_err(|e| e.to_string())
     }
 }
 
@@ -168,7 +168,7 @@ mod member_expression {
     #[test_case("let m={'1':99};m[1]" => vok(99); "exp member exp")]
     fn run(src: &str) -> Result<ECMAScriptValue, String> {
         setup_test_agent();
-        process_ecmascript(&agent, src).map_err(|e| e.to_string())
+        process_ecmascript(src).map_err(|e| e.to_string())
     }
 }
 
@@ -185,7 +185,7 @@ mod exponentiation_expression {
     #[test_case("(-Infinity) ** 8" => vok(f64::INFINITY) ; "-Inf ** 8")]
     fn run(src: &str) -> Result<ECMAScriptValue, String> {
         setup_test_agent();
-        process_ecmascript(&agent, src).map_err(|e| e.to_string())
+        process_ecmascript(src).map_err(|e| e.to_string())
     }
 }
 
@@ -202,7 +202,7 @@ mod if_statement {
     #[test_case("if (false) 1; else a;" => serr("Thrown: ReferenceError: Unresolvable Reference"); "err in stmt2")]
     fn run(src: &str) -> Result<ECMAScriptValue, String> {
         setup_test_agent();
-        process_ecmascript(&agent, src).map_err(|e| e.to_string())
+        process_ecmascript(src).map_err(|e| e.to_string())
     }
 }
 
@@ -218,7 +218,7 @@ mod do_while {
     #[test_case("do null; while (a);" => serr("Thrown: ReferenceError: Unresolvable Reference"); "err in expr")]
     fn run(src: &str) -> Result<ECMAScriptValue, String> {
         setup_test_agent();
-        process_ecmascript(&agent, src).map_err(|e| e.to_string())
+        process_ecmascript(src).map_err(|e| e.to_string())
     }
 }
 
@@ -254,7 +254,7 @@ mod labelled_statement {
     " => vok("1 "); "loopless targeted break")]
     fn run(src: &str) -> Result<ECMAScriptValue, String> {
         setup_test_agent();
-        process_ecmascript(&agent, src).map_err(|e| e.to_string())
+        process_ecmascript(src).map_err(|e| e.to_string())
     }
 }
 
@@ -264,7 +264,7 @@ mod labelled_statement {
 #[test_case(r"'9876543210'.length;" => vok(10); "coerced string length")]
 fn string_exotic_object(src: &str) -> Result<ECMAScriptValue, String> {
     setup_test_agent();
-    process_ecmascript(&agent, src).map_err(|e| e.to_string())
+    process_ecmascript(src).map_err(|e| e.to_string())
 }
 
 #[test_case("String()" => vok(""); "no args")]
@@ -274,7 +274,7 @@ fn string_exotic_object(src: &str) -> Result<ECMAScriptValue, String> {
 #[test_case("String(Symbol('oops'))" => vok("Symbol(oops)"); "symbol in function")]
 fn string_constructor(src: &str) -> Result<ECMAScriptValue, String> {
     setup_test_agent();
-    process_ecmascript(&agent, src).map_err(|e| e.to_string())
+    process_ecmascript(src).map_err(|e| e.to_string())
 }
 
 #[test_case("String.fromCharCode(112, 97, 115, 115)" => vok("pass"); "normal")]
@@ -284,7 +284,7 @@ fn string_constructor(src: &str) -> Result<ECMAScriptValue, String> {
 #[test_case("String.fromCharCode.length" => vok(1); "length")]
 fn string_from_char_code(src: &str) -> Result<ECMAScriptValue, String> {
     setup_test_agent();
-    process_ecmascript(&agent, src).map_err(|e| e.to_string())
+    process_ecmascript(src).map_err(|e| e.to_string())
 }
 
 #[test_case("'12345'.indexOf('2')" => vok(1); "found a match")]
@@ -298,7 +298,7 @@ fn string_from_char_code(src: &str) -> Result<ECMAScriptValue, String> {
 #[test_case("'what if things are undefined?'.indexOf()" => vok(19); "first arg missing")]
 fn string_prototype_index_of(src: &str) -> Result<ECMAScriptValue, String> {
     setup_test_agent();
-    process_ecmascript(&agent, src).map_err(|e| e.to_string())
+    process_ecmascript(src).map_err(|e| e.to_string())
 }
 
 #[test_case("String.prototype.toString.call(0)" => serr("Thrown: TypeError: String.prototype.toString requires that 'this' be a String"); "bad this")]
@@ -306,7 +306,7 @@ fn string_prototype_index_of(src: &str) -> Result<ECMAScriptValue, String> {
 #[test_case("'alpha'.toString()" => vok("alpha"); "string literal")]
 fn string_prototype_to_string(src: &str) -> Result<ECMAScriptValue, String> {
     setup_test_agent();
-    process_ecmascript(&agent, src).map_err(|e| e.to_string())
+    process_ecmascript(src).map_err(|e| e.to_string())
 }
 
 #[test_case("String.prototype.valueOf.call(0)" => serr("Thrown: TypeError: String.prototype.valueOf requires that 'this' be a String"); "bad this")]
@@ -314,12 +314,12 @@ fn string_prototype_to_string(src: &str) -> Result<ECMAScriptValue, String> {
 #[test_case("'alpha'.valueOf()" => vok("alpha"); "string literal")]
 fn string_prototype_value_of(src: &str) -> Result<ECMAScriptValue, String> {
     setup_test_agent();
-    process_ecmascript(&agent, src).map_err(|e| e.to_string())
+    process_ecmascript(src).map_err(|e| e.to_string())
 }
 
 #[test_case("(x => x * 2).call(undefined, 99);" => vok(198); "call a user defined func")]
 #[test_case("Number.prototype.toString.call(991)" => vok("991"); "call a builtin func")]
 fn function_prototype_call(src: &str) -> Result<ECMAScriptValue, String> {
     setup_test_agent();
-    process_ecmascript(&agent, src).map_err(|e| e.to_string())
+    process_ecmascript(src).map_err(|e| e.to_string())
 }

--- a/src/tests/integration.rs
+++ b/src/tests/integration.rs
@@ -12,7 +12,7 @@ mod update_expression {
         #[test_case("let a = 10;let b = a++;({ a, b })" => (11.into(), 10.into()); "number")]
         #[test_case("let a = 10n;let b = a++;({ a, b })" => (BigInt::from(11).into(), BigInt::from(10).into()); "bigint")]
         fn normal(src: &str) -> (ECMAScriptValue, ECMAScriptValue) {
-            let agent = test_agent();
+            setup_test_agent();
             let result = process_ecmascript(&agent, src).unwrap();
 
             let result_obj = to_object(&agent, result).unwrap();
@@ -26,7 +26,7 @@ mod update_expression {
         #[test_case("let a={ toString: undefined, valueOf: undefined };a++;" => "Thrown: TypeError: Cannot convert object to primitive value"; "ToNumeric errs")]
         #[test_case("const a=0;a++;" => "Thrown: TypeError: Cannot change read-only value"; "PutValue errs")]
         fn errors(src: &str) -> String {
-            let agent = test_agent();
+            setup_test_agent();
             let result = process_ecmascript(&agent, src).unwrap_err();
             result.to_string()
         }
@@ -39,7 +39,7 @@ mod update_expression {
         #[test_case("let a = 10;let b = a--;({ a, b })" => (9.into(), 10.into()); "number")]
         #[test_case("let a = 10n;let b = a--;({ a, b })" => (BigInt::from(9).into(), BigInt::from(10).into()); "bigint")]
         fn normal(src: &str) -> (ECMAScriptValue, ECMAScriptValue) {
-            let agent = test_agent();
+            setup_test_agent();
             let result = process_ecmascript(&agent, src).unwrap();
 
             let result_obj = to_object(&agent, result).unwrap();
@@ -53,7 +53,7 @@ mod update_expression {
         #[test_case("let a={ toString: undefined, valueOf: undefined };a--;" => "Thrown: TypeError: Cannot convert object to primitive value"; "ToNumeric errs")]
         #[test_case("const a=0;a--;" => "Thrown: TypeError: Cannot change read-only value"; "PutValue errs")]
         fn errors(src: &str) -> String {
-            let agent = test_agent();
+            setup_test_agent();
             let result = process_ecmascript(&agent, src).unwrap_err();
             result.to_string()
         }
@@ -66,7 +66,7 @@ mod update_expression {
         #[test_case("let a = 10;let b = ++a;({ a, b })" => (11.into(), 11.into()); "number")]
         #[test_case("let a = 10n;let b = ++a;({ a, b })" => (BigInt::from(11).into(), BigInt::from(11).into()); "bigint")]
         fn normal(src: &str) -> (ECMAScriptValue, ECMAScriptValue) {
-            let agent = test_agent();
+            setup_test_agent();
             let result = process_ecmascript(&agent, src).unwrap();
 
             let result_obj = to_object(&agent, result).unwrap();
@@ -80,7 +80,7 @@ mod update_expression {
         #[test_case("let a={ toString: undefined, valueOf: undefined };++a;" => "Thrown: TypeError: Cannot convert object to primitive value"; "ToNumeric errs")]
         #[test_case("const a=0;++a;" => "Thrown: TypeError: Cannot change read-only value"; "PutValue errs")]
         fn errors(src: &str) -> String {
-            let agent = test_agent();
+            setup_test_agent();
             let result = process_ecmascript(&agent, src).unwrap_err();
             result.to_string()
         }
@@ -93,7 +93,7 @@ mod update_expression {
         #[test_case("let a = 10;let b = --a;({ a, b })" => (9.into(), 9.into()); "number")]
         #[test_case("let a = 10n;let b = --a;({ a, b })" => (BigInt::from(9).into(), BigInt::from(9).into()); "bigint")]
         fn normal(src: &str) -> (ECMAScriptValue, ECMAScriptValue) {
-            let agent = test_agent();
+            setup_test_agent();
             let result = process_ecmascript(&agent, src).unwrap();
 
             let result_obj = to_object(&agent, result).unwrap();
@@ -107,7 +107,7 @@ mod update_expression {
         #[test_case("let a={ toString: undefined, valueOf: undefined };--a;" => "Thrown: TypeError: Cannot convert object to primitive value"; "ToNumeric errs")]
         #[test_case("const a=0;--a;" => "Thrown: TypeError: Cannot change read-only value"; "PutValue errs")]
         fn errors(src: &str) -> String {
-            let agent = test_agent();
+            setup_test_agent();
             let result = process_ecmascript(&agent, src).unwrap_err();
             result.to_string()
         }
@@ -126,14 +126,14 @@ mod unary_expression {
     #[test_case("delete a.b;" => serr("Thrown: ReferenceError: Unresolvable Reference"); "error from expression")]
     #[test_case("'use strict'; delete Boolean.prototype" => serr("Thrown: TypeError: property not deletable"); "strict, not deletable")]
     fn delete(src: &str) -> Result<ECMAScriptValue, String> {
-        let agent = test_agent();
+        setup_test_agent();
         process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 
     #[test_case("void 3;" => Ok(ECMAScriptValue::Undefined); "simple")]
     #[test_case("void a;" => serr("Thrown: ReferenceError: Unresolvable Reference"); "err")]
     fn void(src: &str) -> Result<ECMAScriptValue, String> {
-        let agent = test_agent();
+        setup_test_agent();
         process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 
@@ -149,7 +149,7 @@ mod unary_expression {
     #[test_case("typeof {};" => Ok("object".into()); "object")]
     #[test_case("typeof Boolean;" => Ok("function".into()); "function")]
     fn typeof_op(src: &str) -> Result<ECMAScriptValue, String> {
-        let agent = test_agent();
+        setup_test_agent();
         process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 }
@@ -167,7 +167,7 @@ mod member_expression {
     #[test_case("let m={},c={toString:undefined, valueOf:undefined};m[c]" => serr("Thrown: TypeError: Cannot convert object to primitive value"); "exp syntax; tokey throws")]
     #[test_case("let m={'1':99};m[1]" => vok(99); "exp member exp")]
     fn run(src: &str) -> Result<ECMAScriptValue, String> {
-        let agent = test_agent();
+        setup_test_agent();
         process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 }
@@ -184,7 +184,7 @@ mod exponentiation_expression {
     #[test_case("(-Infinity) ** 3" => vok(f64::NEG_INFINITY); "-Inf ** 3")]
     #[test_case("(-Infinity) ** 8" => vok(f64::INFINITY) ; "-Inf ** 8")]
     fn run(src: &str) -> Result<ECMAScriptValue, String> {
-        let agent = test_agent();
+        setup_test_agent();
         process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 }
@@ -201,7 +201,7 @@ mod if_statement {
     #[test_case("if (true) a; else -1;" => serr("Thrown: ReferenceError: Unresolvable Reference"); "err in stmt1")]
     #[test_case("if (false) 1; else a;" => serr("Thrown: ReferenceError: Unresolvable Reference"); "err in stmt2")]
     fn run(src: &str) -> Result<ECMAScriptValue, String> {
-        let agent = test_agent();
+        setup_test_agent();
         process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 }
@@ -217,7 +217,7 @@ mod do_while {
     #[test_case("do a; while (false);" => serr("Thrown: ReferenceError: Unresolvable Reference"); "err in stmt")]
     #[test_case("do null; while (a);" => serr("Thrown: ReferenceError: Unresolvable Reference"); "err in expr")]
     fn run(src: &str) -> Result<ECMAScriptValue, String> {
-        let agent = test_agent();
+        setup_test_agent();
         process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 }
@@ -253,7 +253,7 @@ mod labelled_statement {
         result;
     " => vok("1 "); "loopless targeted break")]
     fn run(src: &str) -> Result<ECMAScriptValue, String> {
-        let agent = test_agent();
+        setup_test_agent();
         process_ecmascript(&agent, src).map_err(|e| e.to_string())
     }
 }
@@ -263,7 +263,7 @@ mod labelled_statement {
 #[test_case(r"'9876543210'[2];" => vok("7"); "coerced string indexed properties")]
 #[test_case(r"'9876543210'.length;" => vok(10); "coerced string length")]
 fn string_exotic_object(src: &str) -> Result<ECMAScriptValue, String> {
-    let agent = test_agent();
+    setup_test_agent();
     process_ecmascript(&agent, src).map_err(|e| e.to_string())
 }
 
@@ -273,7 +273,7 @@ fn string_exotic_object(src: &str) -> Result<ECMAScriptValue, String> {
 #[test_case("new String(Symbol('oops'))" => serr("Thrown: TypeError: Symbols may not be converted to strings"); "error in constructor")]
 #[test_case("String(Symbol('oops'))" => vok("Symbol(oops)"); "symbol in function")]
 fn string_constructor(src: &str) -> Result<ECMAScriptValue, String> {
-    let agent = test_agent();
+    setup_test_agent();
     process_ecmascript(&agent, src).map_err(|e| e.to_string())
 }
 
@@ -283,7 +283,7 @@ fn string_constructor(src: &str) -> Result<ECMAScriptValue, String> {
 #[test_case("String.fromCharCode.name" => vok("fromCharCode"); "name")]
 #[test_case("String.fromCharCode.length" => vok(1); "length")]
 fn string_from_char_code(src: &str) -> Result<ECMAScriptValue, String> {
-    let agent = test_agent();
+    setup_test_agent();
     process_ecmascript(&agent, src).map_err(|e| e.to_string())
 }
 
@@ -297,7 +297,7 @@ fn string_from_char_code(src: &str) -> Result<ECMAScriptValue, String> {
 #[test_case("'a'.indexOf('a', Symbol('a'))" => serr("Thrown: TypeError: Symbol values cannot be converted to Number values"); "fail location 4")]
 #[test_case("'what if things are undefined?'.indexOf()" => vok(19); "first arg missing")]
 fn string_prototype_index_of(src: &str) -> Result<ECMAScriptValue, String> {
-    let agent = test_agent();
+    setup_test_agent();
     process_ecmascript(&agent, src).map_err(|e| e.to_string())
 }
 
@@ -305,7 +305,7 @@ fn string_prototype_index_of(src: &str) -> Result<ECMAScriptValue, String> {
 #[test_case("new String('alpha').toString()" => vok("alpha"); "string object")]
 #[test_case("'alpha'.toString()" => vok("alpha"); "string literal")]
 fn string_prototype_to_string(src: &str) -> Result<ECMAScriptValue, String> {
-    let agent = test_agent();
+    setup_test_agent();
     process_ecmascript(&agent, src).map_err(|e| e.to_string())
 }
 
@@ -313,13 +313,13 @@ fn string_prototype_to_string(src: &str) -> Result<ECMAScriptValue, String> {
 #[test_case("new String('alpha').valueOf()" => vok("alpha"); "string object")]
 #[test_case("'alpha'.valueOf()" => vok("alpha"); "string literal")]
 fn string_prototype_value_of(src: &str) -> Result<ECMAScriptValue, String> {
-    let agent = test_agent();
+    setup_test_agent();
     process_ecmascript(&agent, src).map_err(|e| e.to_string())
 }
 
 #[test_case("(x => x * 2).call(undefined, 99);" => vok(198); "call a user defined func")]
 #[test_case("Number.prototype.toString.call(991)" => vok("991"); "call a builtin func")]
 fn function_prototype_call(src: &str) -> Result<ECMAScriptValue, String> {
-    let agent = test_agent();
+    setup_test_agent();
     process_ecmascript(&agent, src).map_err(|e| e.to_string())
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -504,7 +504,6 @@ impl AdaptableObject {
 
 // error
 pub fn faux_errors(
-    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -512,12 +511,12 @@ pub fn faux_errors(
     Err(create_type_error("Test Sentinel"))
 }
 
-pub fn make_toprimitive_throw_obj(agent: &Agent) -> Object {
-    let realm = agent.current_realm_record().unwrap();
-    let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let function_proto = agent.intrinsic(IntrinsicId::FunctionPrototype);
+pub fn make_toprimitive_throw_obj() -> Object {
+    let realm = current_realm_record().unwrap();
+    let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+    let function_proto = intrinsic(IntrinsicId::FunctionPrototype);
     let target = ordinary_object_create(Some(object_prototype), &[]);
-    let to_prim_sym = agent.wks(WksId::ToPrimitive);
+    let to_prim_sym = wks(WksId::ToPrimitive);
     let key = PropertyKey::from(to_prim_sym);
     let fcn = create_builtin_function(
         faux_errors,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -550,8 +550,8 @@ pub fn create_named_realm(name: &str) -> Rc<RefCell<Realm>> {
 
     r
 }
-pub fn get_realm_name(realm: &Realm) -> String {
-    let op = intrinsics.get(IntrinsicId::ObjectPrototype);
+pub fn get_realm_name() -> String {
+    let op = intrinsic(IntrinsicId::ObjectPrototype);
     let name = get(&op, &"name".into()).unwrap();
     to_string(name).unwrap().into()
 }
@@ -609,7 +609,7 @@ macro_rules! tbd_function {
         #[should_panic(expected = "not yet implemented")]
         fn $name() {
             setup_test_agent();
-            super::$name(&ECMAScriptValue::Undefined, None, &[]).unwrap();
+            super::$name(ECMAScriptValue::Undefined, None, &[]).unwrap();
         }
     };
 }
@@ -654,7 +654,7 @@ macro_rules! default_set_prototype_of_test {
         fn set_prototype_of() {
             setup_test_agent();
             let obj = make();
-            let res = obj.o.set_prototype_of(&None).unwrap();
+            let res = obj.o.set_prototype_of(None).unwrap();
             assert!(res);
             assert!(obj.o.get_prototype_of().unwrap().is_none());
         }
@@ -692,7 +692,7 @@ macro_rules! default_delete_test {
         fn delete() {
             setup_test_agent();
             let obj = make();
-            let res = obj.o.delete(&&PropertyKey::from("rust")).unwrap();
+            let res = obj.o.delete(&PropertyKey::from("rust")).unwrap();
             assert_eq!(res, true);
         }
     };
@@ -716,7 +716,7 @@ macro_rules! default_has_property_test {
         fn has_property() {
             setup_test_agent();
             let obj = make();
-            let res = obj.o.has_property(&&PropertyKey::from("test_sentinel")).unwrap();
+            let res = obj.o.has_property(&PropertyKey::from("test_sentinel")).unwrap();
             assert_eq!(res, false);
             obj.o
                 .define_own_property(
@@ -728,7 +728,7 @@ macro_rules! default_has_property_test {
                         .configurable(true),
                 )
                 .unwrap();
-            let res2 = obj.o.has_property(&&PropertyKey::from("test_sentinel")).unwrap();
+            let res2 = obj.o.has_property(&PropertyKey::from("test_sentinel")).unwrap();
             assert_eq!(res2, true);
         }
     };
@@ -797,7 +797,7 @@ macro_rules! default_define_own_property_test {
             setup_test_agent();
             let obj = make();
 
-            let success = obj.o.define_own_property(& key.into(), new_value).unwrap();
+            let success = obj.o.define_own_property(key.into(), new_value).unwrap();
             let properties = obj
                 .o
                 .common_object_data()
@@ -813,10 +813,10 @@ macro_rules! default_define_own_property_test {
 #[macro_export]
 macro_rules! default_get_test {
     ( $key_on_proto:expr, $val_on_proto:expr ) => {
-        #[test_case(|_| "test_sentinel".into() => ECMAScriptValue::from("present"); "exists")]
-        #[test_case(|_| "friendliness".into() => ECMAScriptValue::Undefined; "doesn't exist")]
+        #[test_case(|| "test_sentinel".into() => ECMAScriptValue::from("present"); "exists")]
+        #[test_case(|| "friendliness".into() => ECMAScriptValue::Undefined; "doesn't exist")]
         #[test_case($key_on_proto => $val_on_proto; "from prototype")]
-        fn get(make_key: impl FnOnce(&Agent) -> PropertyKey) -> ECMAScriptValue {
+        fn get(make_key: impl FnOnce() -> PropertyKey) -> ECMAScriptValue {
             setup_test_agent();
             let obj = make();
             let key = make_key();
@@ -832,7 +832,7 @@ macro_rules! default_get_test {
                 .unwrap();
 
             let receiver = ECMAScriptValue::from(obj.clone());
-            obj.o.get(&&key, &receiver).unwrap()
+            obj.o.get(&key, &receiver).unwrap()
         }
     };
 }
@@ -865,7 +865,7 @@ macro_rules! default_set_test {
             setup_test_agent();
             let obj = make();
             let receiver = ECMAScriptValue::Object(obj.clone());
-            let success = obj.o.set(& key.into(), new_val.into(), &receiver).unwrap();
+            let success = obj.o.set(key.into(), new_val.into(), &receiver).unwrap();
             let properties = obj
                 .o
                 .common_object_data()

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -71,14 +71,14 @@ where
     }
 }
 
-pub fn unwind_error_object(agent: &Agent, kind: &str, err: Object) -> String {
+pub fn unwind_error_object(kind: &str, err: Object) -> String {
     assert!(err.o.to_error_obj().is_some());
-    let name = get(agent, &err, &PropertyKey::from("name")).expect("Error object was missing 'name' property");
+    let name = get(&err, &PropertyKey::from("name")).expect("Error object was missing 'name' property");
     assert!(matches!(name, ECMAScriptValue::String(_)));
     if let ECMAScriptValue::String(name_value) = name {
         assert_eq!(name_value, kind);
     }
-    let message = get(agent, &err, &PropertyKey::from("message")).expect("Error object was missing 'message' property");
+    let message = get(&err, &PropertyKey::from("message")).expect("Error object was missing 'message' property");
     assert!(matches!(message, ECMAScriptValue::String(_)));
     if let ECMAScriptValue::String(message_value) = message {
         String::from(message_value)
@@ -87,41 +87,41 @@ pub fn unwind_error_object(agent: &Agent, kind: &str, err: Object) -> String {
     }
 }
 
-pub fn unwind_error(agent: &Agent, kind: &str, completion: AbruptCompletion) -> String {
+pub fn unwind_error(kind: &str, completion: AbruptCompletion) -> String {
     assert!(matches!(completion, AbruptCompletion::Throw { value: ECMAScriptValue::Object(_) }));
     if let AbruptCompletion::Throw { value: ECMAScriptValue::Object(err) } = completion {
-        unwind_error_object(agent, kind, err)
+        unwind_error_object(kind, err)
     } else {
         unreachable!()
     }
 }
 
-pub fn unwind_type_error(agent: &Agent, completion: AbruptCompletion) -> String {
-    unwind_error(agent, "TypeError", completion)
+pub fn unwind_type_error(completion: AbruptCompletion) -> String {
+    unwind_error("TypeError", completion)
 }
 
-pub fn unwind_syntax_error(agent: &Agent, completion: AbruptCompletion) -> String {
-    unwind_error(agent, "SyntaxError", completion)
+pub fn unwind_syntax_error(completion: AbruptCompletion) -> String {
+    unwind_error("SyntaxError", completion)
 }
 
-pub fn unwind_syntax_error_object(agent: &Agent, err: Object) -> String {
-    unwind_error_object(agent, "SyntaxError", err)
+pub fn unwind_syntax_error_object(err: Object) -> String {
+    unwind_error_object("SyntaxError", err)
 }
 
-pub fn unwind_reference_error(agent: &Agent, completion: AbruptCompletion) -> String {
-    unwind_error(agent, "ReferenceError", completion)
+pub fn unwind_reference_error(completion: AbruptCompletion) -> String {
+    unwind_error("ReferenceError", completion)
 }
 
-pub fn unwind_reference_error_object(agent: &Agent, err: Object) -> String {
-    unwind_error_object(agent, "ReferenceError", err)
+pub fn unwind_reference_error_object(err: Object) -> String {
+    unwind_error_object("ReferenceError", err)
 }
 
-pub fn unwind_range_error(agent: &Agent, completion: AbruptCompletion) -> String {
-    unwind_error(agent, "RangeError", completion)
+pub fn unwind_range_error(completion: AbruptCompletion) -> String {
+    unwind_error("RangeError", completion)
 }
 
-pub fn unwind_range_error_object(agent: &Agent, err: Object) -> String {
-    unwind_error_object(agent, "RangeError", err)
+pub fn unwind_range_error_object(err: Object) -> String {
+    unwind_error_object("RangeError", err)
 }
 
 pub fn calculate_hash<F: BuildHasher, T: Hash>(factory: &F, t: &T) -> u64 {
@@ -130,10 +130,13 @@ pub fn calculate_hash<F: BuildHasher, T: Hash>(factory: &F, t: &T) -> u64 {
     s.finish()
 }
 
-pub fn test_agent() -> Agent {
-    let agent = Agent::new(Rc::new(RefCell::new(SymbolRegistry::new())));
-    agent.initialize_host_defined_realm(true);
-    agent
+pub fn setup_test_agent() {
+    let sym_registry = Rc::new(RefCell::new(SymbolRegistry::new()));
+    AGENT.with(|agent| {
+        agent.reset();
+        agent.set_global_symbol_registry(sym_registry);
+    });
+    initialize_host_defined_realm(true);
 }
 
 #[derive(Debug)]
@@ -169,65 +172,60 @@ impl ObjectInterface for TestObject {
         self.common.borrow().objid
     }
 
-    fn get_prototype_of(&self, agent: &Agent) -> Completion<Option<Object>> {
+    fn get_prototype_of(&self) -> Completion<Option<Object>> {
         if self.get_prototype_of_throws {
-            Err(create_type_error(agent, "[[GetPrototypeOf]] called on TestObject"))
+            Err(create_type_error("[[GetPrototypeOf]] called on TestObject"))
         } else {
             Ok(ordinary_get_prototype_of(self))
         }
     }
-    fn set_prototype_of(&self, agent: &Agent, obj: Option<Object>) -> Completion<bool> {
+    fn set_prototype_of(&self, obj: Option<Object>) -> Completion<bool> {
         if self.set_prototype_of_throws {
-            Err(create_type_error(agent, "[[SetPrototypeOf]] called on TestObject"))
+            Err(create_type_error("[[SetPrototypeOf]] called on TestObject"))
         } else {
             Ok(ordinary_set_prototype_of(self, obj))
         }
     }
-    fn is_extensible(&self, agent: &Agent) -> Completion<bool> {
+    fn is_extensible(&self) -> Completion<bool> {
         if self.is_extensible_throws {
-            Err(create_type_error(agent, "[[IsExtensible]] called on TestObject"))
+            Err(create_type_error("[[IsExtensible]] called on TestObject"))
         } else {
             Ok(ordinary_is_extensible(self))
         }
     }
-    fn prevent_extensions(&self, agent: &Agent) -> Completion<bool> {
+    fn prevent_extensions(&self) -> Completion<bool> {
         if self.prevent_extensions_throws {
-            Err(create_type_error(agent, "[[PreventExtensions]] called on TestObject"))
+            Err(create_type_error("[[PreventExtensions]] called on TestObject"))
         } else {
             Ok(ordinary_prevent_extensions(self))
         }
     }
-    fn get_own_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         if self.get_own_property_throws.0 && self.get_own_property_throws.1.as_ref().map_or(true, |k| *k == *key) {
-            Err(create_type_error(agent, "[[GetOwnProperty]] called on TestObject"))
+            Err(create_type_error("[[GetOwnProperty]] called on TestObject"))
         } else {
             Ok(ordinary_get_own_property(self, key))
         }
     }
-    fn define_own_property(
-        &self,
-        agent: &Agent,
-        key: PropertyKey,
-        desc: PotentialPropertyDescriptor,
-    ) -> Completion<bool> {
+    fn define_own_property(&self, key: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool> {
         if self.define_own_property_throws.0 && self.define_own_property_throws.1.as_ref().map_or(true, |k| *k == key) {
-            Err(create_type_error(agent, "[[DefineOwnProperty]] called on TestObject"))
+            Err(create_type_error("[[DefineOwnProperty]] called on TestObject"))
         } else {
-            ordinary_define_own_property(agent, self, key, desc)
+            ordinary_define_own_property(self, key, desc)
         }
     }
-    fn has_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
+    fn has_property(&self, key: &PropertyKey) -> Completion<bool> {
         if self.has_property_throws.0 && self.has_property_throws.1.as_ref().map_or(true, |k| *k == *key) {
-            Err(create_type_error(agent, "[[HasProperty]] called on TestObject"))
+            Err(create_type_error("[[HasProperty]] called on TestObject"))
         } else {
-            ordinary_has_property(agent, self, key)
+            ordinary_has_property(self, key)
         }
     }
-    fn get(&self, agent: &Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+    fn get(&self, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         if self.get_throws.0 && self.get_throws.1.as_ref().map_or(true, |k| *k == *key) {
-            Err(create_type_error(agent, "[[Get]] called on TestObject"))
+            Err(create_type_error("[[Get]] called on TestObject"))
         } else {
-            ordinary_get(agent, self, key, receiver)
+            ordinary_get(self, key, receiver)
         }
     }
     fn set(
@@ -238,21 +236,21 @@ impl ObjectInterface for TestObject {
         receiver: &ECMAScriptValue,
     ) -> Completion<bool> {
         if self.set_throws.0 && self.set_throws.1.as_ref().map_or(true, |k| *k == key) {
-            Err(create_type_error(agent, "[[Set]] called on TestObject"))
+            Err(create_type_error("[[Set]] called on TestObject"))
         } else {
-            ordinary_set(agent, self, key, value, receiver)
+            ordinary_set(self, key, value, receiver)
         }
     }
-    fn delete(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
+    fn delete(&self, key: &PropertyKey) -> Completion<bool> {
         if self.delete_throws.0 && self.delete_throws.1.as_ref().map_or(true, |k| *k == *key) {
-            Err(create_type_error(agent, "[[Delete]] called on TestObject"))
+            Err(create_type_error("[[Delete]] called on TestObject"))
         } else {
-            ordinary_delete(agent, self, key)
+            ordinary_delete(self, key)
         }
     }
-    fn own_property_keys(&self, agent: &Agent) -> Completion<Vec<PropertyKey>> {
+    fn own_property_keys(&self) -> Completion<Vec<PropertyKey>> {
         if self.own_property_keys_throws {
-            Err(create_type_error(agent, "[[OwnPropertyKeys]] called on TestObject"))
+            Err(create_type_error("[[OwnPropertyKeys]] called on TestObject"))
         } else {
             Ok(ordinary_own_property_keys(self))
         }
@@ -305,11 +303,11 @@ impl TestObject {
         }
         (false, None)
     }
-    pub fn object(agent: &Agent, throwers: &[FunctionId]) -> Object {
+    pub fn object(throwers: &[FunctionId]) -> Object {
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         Object {
             o: Rc::new(Self {
-                common: RefCell::new(CommonObjectData::new(agent, Some(prototype), true, ORDINARY_OBJECT_SLOTS)),
+                common: RefCell::new(CommonObjectData::new(Some(prototype), true, ORDINARY_OBJECT_SLOTS)),
                 get_prototype_of_throws: throwers.contains(&FunctionId::GetPrototypeOf),
                 set_prototype_of_throws: throwers.contains(&FunctionId::SetPrototypeOf),
                 is_extensible_throws: throwers.contains(&FunctionId::IsExtensible),
@@ -326,30 +324,24 @@ impl TestObject {
     }
 }
 
-type GetPrototypeOfFunction = fn(agent: &Agent, this: &AdaptableObject) -> Completion<Option<Object>>;
-type SetPrototypeOfFunction = fn(agent: &Agent, this: &AdaptableObject, obj: Option<Object>) -> Completion<bool>;
-type IsExtensibleFunction = fn(agent: &Agent, this: &AdaptableObject) -> Completion<bool>;
-type PreventExtensionsFunction = fn(agent: &Agent, this: &AdaptableObject) -> Completion<bool>;
-type GetOwnPropertyFunction =
-    fn(agent: &Agent, this: &AdaptableObject, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>>;
+type GetPrototypeOfFunction = fn(this: &AdaptableObject) -> Completion<Option<Object>>;
+type SetPrototypeOfFunction = fn(this: &AdaptableObject, obj: Option<Object>) -> Completion<bool>;
+type IsExtensibleFunction = fn(this: &AdaptableObject) -> Completion<bool>;
+type PreventExtensionsFunction = fn(this: &AdaptableObject) -> Completion<bool>;
+type GetOwnPropertyFunction = fn(this: &AdaptableObject, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>>;
 type DefineOwnPropertyFunction =
-    fn(agent: &Agent, this: &AdaptableObject, key: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool>;
-type HasPropertyFunction = fn(agent: &Agent, this: &AdaptableObject, key: &PropertyKey) -> Completion<bool>;
-type GetFunction = fn(
-    agent: &Agent,
-    this: &AdaptableObject,
-    key: &PropertyKey,
-    receiver: &ECMAScriptValue,
-) -> Completion<ECMAScriptValue>;
+    fn(this: &AdaptableObject, key: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool>;
+type HasPropertyFunction = fn(this: &AdaptableObject, key: &PropertyKey) -> Completion<bool>;
+type GetFunction =
+    fn(this: &AdaptableObject, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue>;
 type SetFunction = fn(
-    agent: &Agent,
     this: &AdaptableObject,
     key: PropertyKey,
     value: ECMAScriptValue,
     receiver: &ECMAScriptValue,
 ) -> Completion<bool>;
-type DeleteFunction = fn(agent: &Agent, this: &AdaptableObject, key: &PropertyKey) -> Completion<bool>;
-type OwnPropertyKeysFunction = fn(agent: &Agent, this: &AdaptableObject) -> Completion<Vec<PropertyKey>>;
+type DeleteFunction = fn(this: &AdaptableObject, key: &PropertyKey) -> Completion<bool>;
+type OwnPropertyKeysFunction = fn(this: &AdaptableObject) -> Completion<Vec<PropertyKey>>;
 
 pub struct AdaptableObject {
     common: RefCell<CommonObjectData>,
@@ -403,81 +395,70 @@ impl ObjectInterface for AdaptableObject {
         self.common.borrow().objid
     }
 
-    fn get_prototype_of(&self, agent: &Agent) -> Completion<Option<Object>> {
+    fn get_prototype_of(&self) -> Completion<Option<Object>> {
         match &self.get_prototype_of_override {
-            Some(func) => func(agent, self),
+            Some(func) => func(self),
             None => Ok(ordinary_get_prototype_of(self)),
         }
     }
 
-    fn set_prototype_of(&self, agent: &Agent, obj: Option<Object>) -> Completion<bool> {
+    fn set_prototype_of(&self, obj: Option<Object>) -> Completion<bool> {
         match &self.set_prototype_of_override {
-            Some(func) => func(agent, self, obj),
+            Some(func) => func(self, obj),
             None => Ok(ordinary_set_prototype_of(self, obj)),
         }
     }
-    fn is_extensible(&self, agent: &Agent) -> Completion<bool> {
+    fn is_extensible(&self) -> Completion<bool> {
         match &self.is_extensible_override {
-            Some(func) => func(agent, self),
+            Some(func) => func(self),
             None => Ok(ordinary_is_extensible(self)),
         }
     }
-    fn prevent_extensions(&self, agent: &Agent) -> Completion<bool> {
+    fn prevent_extensions(&self) -> Completion<bool> {
         match &self.prevent_extensions_override {
-            Some(func) => func(agent, self),
+            Some(func) => func(self),
             None => Ok(ordinary_prevent_extensions(self)),
         }
     }
-    fn get_own_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
+    fn get_own_property(&self, key: &PropertyKey) -> Completion<Option<PropertyDescriptor>> {
         match &self.get_own_property_override {
-            Some(func) => func(agent, self, key),
+            Some(func) => func(self, key),
             None => Ok(ordinary_get_own_property(self, key)),
         }
     }
-    fn define_own_property(
-        &self,
-        agent: &Agent,
-        key: PropertyKey,
-        desc: PotentialPropertyDescriptor,
-    ) -> Completion<bool> {
+    fn define_own_property(&self, key: PropertyKey, desc: PotentialPropertyDescriptor) -> Completion<bool> {
         match &self.define_own_property_override {
-            Some(func) => func(agent, self, key, desc),
-            None => ordinary_define_own_property(agent, self, key, desc),
+            Some(func) => func(self, key, desc),
+            None => ordinary_define_own_property(self, key, desc),
         }
     }
-    fn has_property(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
+    fn has_property(&self, key: &PropertyKey) -> Completion<bool> {
         match &self.has_property_override {
-            Some(func) => func(agent, self, key),
-            None => ordinary_has_property(agent, self, key),
+            Some(func) => func(self, key),
+            None => ordinary_has_property(self, key),
         }
     }
-    fn get(&self, agent: &Agent, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+    fn get(&self, key: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
         match &self.get_override {
-            Some(func) => func(agent, self, key, receiver),
-            None => ordinary_get(agent, self, key, receiver),
+            Some(func) => func(self, key, receiver),
+            None => ordinary_get(self, key, receiver),
         }
     }
-    fn set(
-        &self,
-        agent: &Agent,
-        key: PropertyKey,
-        value: ECMAScriptValue,
-        receiver: &ECMAScriptValue,
-    ) -> Completion<bool> {
+    fn set(&self, key: PropertyKey, value: ECMAScriptValue, receiver: &ECMAScriptValue) -> Completion<bool> {
         match &self.set_override {
-            Some(func) => func(agent, self, key, value, receiver),
-            None => ordinary_set(agent, self, key, value, receiver),
+            Some(func) => func(self, key, value, receiver),
+            None => ordinary_set(self, key, value, receiver),
         }
     }
-    fn delete(&self, agent: &Agent, key: &PropertyKey) -> Completion<bool> {
+    fn delete(&self, key: &PropertyKey) -> Completion<bool> {
         match &self.delete_override {
-            Some(func) => func(agent, self, key),
-            None => ordinary_delete(agent, self, key),
+            Some(func) => func(self, key),
+            None => ordinary_delete(self, key),
         }
     }
-    fn own_property_keys(&self, agent: &Agent) -> Completion<Vec<PropertyKey>> {
+    fn own_property_keys(&self) -> Completion<Vec<PropertyKey>> {
         match &self.own_property_keys_override {
-            Some(func) => func(agent, self),
+            Some(func) => func(self),
             None => Ok(ordinary_own_property_keys(self)),
         }
     }
@@ -499,11 +480,11 @@ pub struct AdaptableMethods {
 }
 
 impl AdaptableObject {
-    pub fn object(agent: &Agent, methods: AdaptableMethods) -> Object {
+    pub fn object(methods: AdaptableMethods) -> Object {
         let prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
         Object {
             o: Rc::new(Self {
-                common: RefCell::new(CommonObjectData::new(agent, Some(prototype), true, ORDINARY_OBJECT_SLOTS)),
+                common: RefCell::new(CommonObjectData::new(Some(prototype), true, ORDINARY_OBJECT_SLOTS)),
                 get_prototype_of_override: methods.get_prototype_of_override,
                 set_prototype_of_override: methods.set_prototype_of_override,
                 is_extensible_override: methods.is_extensible_override,
@@ -528,18 +509,17 @@ pub fn faux_errors(
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    Err(create_type_error(agent, "Test Sentinel"))
+    Err(create_type_error("Test Sentinel"))
 }
 
 pub fn make_toprimitive_throw_obj(agent: &Agent) -> Object {
     let realm = agent.current_realm_record().unwrap();
     let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let function_proto = agent.intrinsic(IntrinsicId::FunctionPrototype);
-    let target = ordinary_object_create(agent, Some(object_prototype), &[]);
+    let target = ordinary_object_create(Some(object_prototype), &[]);
     let to_prim_sym = agent.wks(WksId::ToPrimitive);
     let key = PropertyKey::from(to_prim_sym);
     let fcn = create_builtin_function(
-        agent,
         faux_errors,
         false,
         0_f64,
@@ -550,7 +530,6 @@ pub fn make_toprimitive_throw_obj(agent: &Agent) -> Object {
         None,
     );
     define_property_or_throw(
-        agent,
         &target,
         key,
         PotentialPropertyDescriptor::new()
@@ -566,11 +545,10 @@ pub fn make_toprimitive_throw_obj(agent: &Agent) -> Object {
 use crate::object::define_property_or_throw;
 use crate::realm::{create_realm, Realm};
 
-pub fn create_named_realm(agent: &Agent, name: &str) -> Rc<RefCell<Realm>> {
-    let r = create_realm(agent);
+pub fn create_named_realm(name: &str) -> Rc<RefCell<Realm>> {
+    let r = create_realm();
     let op = r.borrow().intrinsics.get(IntrinsicId::ObjectPrototype);
     define_property_or_throw(
-        agent,
         &op,
         "name",
         PotentialPropertyDescriptor::new().value(name).writable(false).enumerable(false).configurable(false),
@@ -579,10 +557,10 @@ pub fn create_named_realm(agent: &Agent, name: &str) -> Rc<RefCell<Realm>> {
 
     r
 }
-pub fn get_realm_name(agent: &Agent, realm: &Realm) -> String {
+pub fn get_realm_name(realm: &Realm) -> String {
     let op = realm.intrinsics.get(IntrinsicId::ObjectPrototype);
-    let name = get(agent, &op, &"name".into()).unwrap();
-    to_string(agent, name).unwrap().into()
+    let name = get(&op, &"name".into()).unwrap();
+    to_string(name).unwrap().into()
 }
 
 pub fn serr<T>(msg: &str) -> Result<T, String> {
@@ -637,8 +615,8 @@ macro_rules! tbd_function {
         #[test]
         #[should_panic(expected = "not yet implemented")]
         fn $name() {
-            let agent = test_agent();
-            super::$name(&agent, ECMAScriptValue::Undefined, None, &[]).unwrap();
+            setup_test_agent();
+            super::$name(&ECMAScriptValue::Undefined, None, &[]).unwrap();
         }
     };
 }
@@ -647,7 +625,7 @@ macro_rules! false_function {
     ( $name:ident ) => {
         #[test]
         fn $name() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make(&agent);
             assert!(!obj.o.$name());
         }
@@ -658,7 +636,7 @@ macro_rules! none_function {
     ( $name:ident ) => {
         #[test]
         fn $name() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make(&agent);
             assert!(obj.o.$name().is_none());
         }
@@ -669,7 +647,7 @@ macro_rules! default_get_prototype_of_test {
     ( $proto:ident ) => {
         #[test]
         fn get_prototype_of() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make(&agent);
             let proto = obj.o.get_prototype_of(&agent).unwrap().unwrap();
             assert_eq!(proto, agent.intrinsic(IntrinsicId::$proto));
@@ -681,9 +659,9 @@ macro_rules! default_set_prototype_of_test {
     () => {
         #[test]
         fn set_prototype_of() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make(&agent);
-            let res = obj.o.set_prototype_of(&agent, None).unwrap();
+            let res = obj.o.set_prototype_of(&None).unwrap();
             assert!(res);
             assert!(obj.o.get_prototype_of(&agent).unwrap().is_none());
         }
@@ -694,7 +672,7 @@ macro_rules! default_is_extensible_test {
     () => {
         #[test]
         fn is_extensible() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make(&agent);
             let res = obj.o.is_extensible(&agent).unwrap();
             assert!(res);
@@ -706,7 +684,7 @@ macro_rules! default_prevent_extensions_test {
     () => {
         #[test]
         fn prevent_extensions() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make(&agent);
             let res = obj.o.prevent_extensions(&agent).unwrap();
             assert!(res);
@@ -719,9 +697,9 @@ macro_rules! default_delete_test {
     () => {
         #[test]
         fn delete() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make(&agent);
-            let res = obj.o.delete(&agent, &PropertyKey::from("rust")).unwrap();
+            let res = obj.o.delete(&&PropertyKey::from("rust")).unwrap();
             assert_eq!(res, true);
         }
     };
@@ -731,7 +709,7 @@ macro_rules! default_id_test {
     () => {
         #[test]
         fn id() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make(&agent);
             let obj2 = make(&agent);
             assert_ne!(obj.o.id(), obj2.o.id());
@@ -743,9 +721,9 @@ macro_rules! default_has_property_test {
     () => {
         #[test]
         fn has_property() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make(&agent);
-            let res = obj.o.has_property(&agent, &PropertyKey::from("test_sentinel")).unwrap();
+            let res = obj.o.has_property(&&PropertyKey::from("test_sentinel")).unwrap();
             assert_eq!(res, false);
             obj.o
                 .define_own_property(
@@ -758,7 +736,7 @@ macro_rules! default_has_property_test {
                         .configurable(true),
                 )
                 .unwrap();
-            let res2 = obj.o.has_property(&agent, &PropertyKey::from("test_sentinel")).unwrap();
+            let res2 = obj.o.has_property(&&PropertyKey::from("test_sentinel")).unwrap();
             assert_eq!(res2, true);
         }
     };
@@ -768,7 +746,7 @@ macro_rules! default_is_ordinary_test {
     () => {
         #[test]
         fn is_ordinary() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make(&agent);
             assert!(obj.o.is_ordinary());
         }
@@ -780,7 +758,7 @@ macro_rules! default_get_own_property_test {
         #[test_case("test_sentinel" => Some(IdealizedPropertyDescriptor{configurable: true, enumerable: true, writable: Some(true), value: Some(ECMAScriptValue::from("present")), get: None, set: None}); "key present")]
         #[test_case("color" => None; "key not present")]
         fn get_own_property(key: &str) -> Option<IdealizedPropertyDescriptor> {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make(&agent);
             obj.o
                 .define_own_property(
@@ -789,7 +767,7 @@ macro_rules! default_get_own_property_test {
                     PotentialPropertyDescriptor::new().value("present").writable(true).enumerable(true).configurable(true),
                 )
                 .unwrap();
-            obj.o.get_own_property(&agent, &key.into()).unwrap().map(IdealizedPropertyDescriptor::from)
+            obj.o.get_own_property(& &key.into()).unwrap().map(IdealizedPropertyDescriptor::from)
         }
     }
 }
@@ -824,10 +802,10 @@ macro_rules! default_define_own_property_test {
             new_value: PotentialPropertyDescriptor,
             key: &str,
         ) -> (bool, AHashMap<PropertyKey, IdealizedPropertyDescriptor>) {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make(&agent);
 
-            let success = obj.o.define_own_property(&agent, key.into(), new_value).unwrap();
+            let success = obj.o.define_own_property(& key.into(), new_value).unwrap();
             let properties = obj
                 .o
                 .common_object_data()
@@ -847,7 +825,7 @@ macro_rules! default_get_test {
         #[test_case(|_| "friendliness".into() => ECMAScriptValue::Undefined; "doesn't exist")]
         #[test_case($key_on_proto => $val_on_proto; "from prototype")]
         fn get(make_key: impl FnOnce(&Agent) -> PropertyKey) -> ECMAScriptValue {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make(&agent);
             let key = make_key(&agent);
             obj.o
@@ -863,7 +841,7 @@ macro_rules! default_get_test {
                 .unwrap();
 
             let receiver = ECMAScriptValue::from(obj.clone());
-            obj.o.get(&agent, &key, &receiver).unwrap()
+            obj.o.get(&&key, &receiver).unwrap()
         }
     };
 }
@@ -893,10 +871,10 @@ macro_rules! default_set_test {
             new_val: impl Into<ECMAScriptValue>,
             key: impl Into<PropertyKey>,
         ) -> (bool, AHashMap<PropertyKey, IdealizedPropertyDescriptor>) {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make(&agent);
             let receiver = ECMAScriptValue::Object(obj.clone());
-            let success = obj.o.set(&agent, key.into(), new_val.into(), &receiver).unwrap();
+            let success = obj.o.set(& key.into(), new_val.into(), &receiver).unwrap();
             let properties = obj
                 .o
                 .common_object_data()
@@ -914,7 +892,7 @@ macro_rules! default_own_property_keys_test {
     () => {
         #[test]
         fn own_property_keys() {
-            let agent = test_agent();
+            setup_test_agent();
             let obj = make(&agent);
 
             let to_prim = agent.wks(WksId::ToPrimitive);

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -674,27 +674,23 @@ pub fn ordinary_to_primitive(agent: &Agent, obj: &Object, hint: ConversionHint) 
 //          objects may over-ride this behaviour by defining a @@toPrimitive method. Of the objects defined in this
 //          specification only Date objects (see 21.4.4.45) and Symbol objects (see 20.4.3.5) over-ride the default
 //          ToPrimitive behaviour. Date objects treat no hint as if the hint were string.
-pub fn to_primitive(
-    agent: &Agent,
-    input: ECMAScriptValue,
-    preferred_type: Option<ConversionHint>,
-) -> Completion<ECMAScriptValue> {
+pub fn to_primitive(input: ECMAScriptValue, preferred_type: Option<ConversionHint>) -> Completion<ECMAScriptValue> {
     if let ECMAScriptValue::Object(obj) = &input {
-        let exotic_to_prim = get_method(agent, &input, &PropertyKey::from(agent.wks(WksId::ToPrimitive)))?;
+        let exotic_to_prim = get_method(&input, &PropertyKey::from(agent.wks(WksId::ToPrimitive)))?;
         if !exotic_to_prim.is_undefined() {
             let hint = ECMAScriptValue::from(match preferred_type {
                 None => "default",
                 Some(ConversionHint::Number) => "number",
                 Some(ConversionHint::String) => "string",
             });
-            let result = call(agent, &exotic_to_prim, &input, &[hint])?;
+            let result = call(&exotic_to_prim, &input, &[hint])?;
             if !result.is_object() {
                 return Ok(result);
             }
-            return Err(create_type_error(agent, "Cannot convert object to primitive value"));
+            return Err(create_type_error("Cannot convert object to primitive value"));
         }
         let pt = preferred_type.unwrap_or(ConversionHint::Number);
-        ordinary_to_primitive(agent, obj, pt)
+        ordinary_to_primitive(obj, pt)
     } else {
         Ok(input)
     }
@@ -749,12 +745,12 @@ pub enum Numeric {
     Number(f64),
     BigInt(Rc<BigInt>),
 }
-pub fn to_numeric(agent: &Agent, value: ECMAScriptValue) -> Completion<Numeric> {
-    let prim_value = to_primitive(agent, value, Some(ConversionHint::Number))?;
+pub fn to_numeric(value: ECMAScriptValue) -> Completion<Numeric> {
+    let prim_value = to_primitive(value, Some(ConversionHint::Number))?;
     if let ECMAScriptValue::BigInt(bi) = prim_value {
         Ok(Numeric::BigInt(bi))
     } else {
-        Ok(Numeric::Number(to_number(agent, prim_value)?))
+        Ok(Numeric::Number(to_number(prim_value)?))
     }
 }
 
@@ -785,22 +781,18 @@ pub fn to_numeric(agent: &Agent, value: ECMAScriptValue) -> Completion<Numeric> 
 // |               |     1. Let primValue be ? ToPrimitive(argument, number).          |
 // |               |     2. Return ? ToNumber(primValue).                              |
 // +---------------+-------------------------------------------------------------------+
-pub fn to_number(agent: &Agent, value: impl Into<ECMAScriptValue>) -> Completion<f64> {
+pub fn to_number(value: impl Into<ECMAScriptValue>) -> Completion<f64> {
     match value.into() {
         ECMAScriptValue::Undefined => Ok(f64::NAN),
         ECMAScriptValue::Null => Ok(0_f64),
         ECMAScriptValue::Boolean(b) => Ok(if b { 1_f64 } else { 0_f64 }),
         ECMAScriptValue::Number(n) => Ok(n),
         ECMAScriptValue::String(s) => Ok(string_to_number(s)),
-        ECMAScriptValue::BigInt(_) => {
-            Err(create_type_error(agent, "BigInt values cannot be converted to Number values"))
-        }
-        ECMAScriptValue::Symbol(_) => {
-            Err(create_type_error(agent, "Symbol values cannot be converted to Number values"))
-        }
+        ECMAScriptValue::BigInt(_) => Err(create_type_error("BigInt values cannot be converted to Number values")),
+        ECMAScriptValue::Symbol(_) => Err(create_type_error("Symbol values cannot be converted to Number values")),
         ECMAScriptValue::Object(o) => {
-            let prim_value = to_primitive(agent, ECMAScriptValue::from(o), Some(ConversionHint::Number))?;
-            to_number(agent, prim_value)
+            let prim_value = to_primitive(ECMAScriptValue::from(o), Some(ConversionHint::Number))?;
+            to_number(prim_value)
         }
     }
 }
@@ -916,9 +908,9 @@ pub fn to_integer_or_infinity(agent: &Agent, argument: impl Into<ECMAScriptValue
 //      | * ToInt32(ToUint32(x)) is the same value as ToInt32(x) for all values of x. (It is to preserve this latter
 //      |   property that +∞𝔽 and -∞𝔽 are mapped to +0𝔽.)
 //      | * ToInt32 maps -0𝔽 to +0𝔽.
-fn to_core_int(agent: &Agent, modulo: f64, argument: impl Into<ECMAScriptValue>) -> Completion<f64> {
+fn to_core_int(modulo: f64, argument: impl Into<ECMAScriptValue>) -> Completion<f64> {
     Ok({
-        let number = to_number(agent, argument)?;
+        let number = to_number(argument)?;
         if !number.is_finite() || number == 0.0 {
             0.0
         } else {
@@ -936,9 +928,9 @@ fn to_core_int_agentless(modulo: f64, argument: impl Into<ECMAScriptValue>) -> a
         Ok(i % modulo)
     }
 }
-fn to_core_signed(agent: &Agent, modulo: f64, argument: impl Into<ECMAScriptValue>) -> Completion<f64> {
+fn to_core_signed(modulo: f64, argument: impl Into<ECMAScriptValue>) -> Completion<f64> {
     Ok({
-        let intval = to_core_int(agent, modulo, argument)?;
+        let intval = to_core_int(modulo, argument)?;
         if intval >= modulo / 2.0 {
             intval - modulo
         } else {
@@ -946,8 +938,8 @@ fn to_core_signed(agent: &Agent, modulo: f64, argument: impl Into<ECMAScriptValu
         }
     })
 }
-pub fn to_int32(agent: &Agent, argument: impl Into<ECMAScriptValue>) -> Completion<i32> {
-    Ok(to_core_signed(agent, 4294967296.0, argument)? as i32)
+pub fn to_int32(argument: impl Into<ECMAScriptValue>) -> Completion<i32> {
+    Ok(to_core_signed(4294967296.0, argument)? as i32)
 }
 
 // ToUint32 ( argument )
@@ -969,8 +961,8 @@ pub fn to_int32(agent: &Agent, argument: impl Into<ECMAScriptValue>) -> Completi
 //      | * ToUint32(ToInt32(x)) is the same value as ToUint32(x) for all values of x. (It is to preserve this latter
 //      |   property that +∞𝔽 and -∞𝔽 are mapped to +0𝔽.)
 //      | * ToUint32 maps -0𝔽 to +0𝔽.
-pub fn to_uint32(agent: &Agent, argument: impl Into<ECMAScriptValue>) -> Completion<u32> {
-    let i = to_core_int(agent, 4294967296.0, argument)? as i64;
+pub fn to_uint32(argument: impl Into<ECMAScriptValue>) -> Completion<u32> {
+    let i = to_core_int(4294967296.0, argument)? as i64;
     Ok((if i < 0 { i + 4294967296 } else { i }).try_into().expect("Math results in in-bounds calculation"))
 }
 pub fn to_uint32_agentless(argument: impl Into<ECMAScriptValue>) -> anyhow::Result<u32> {
@@ -988,8 +980,8 @@ pub fn to_uint32_agentless(argument: impl Into<ECMAScriptValue>) -> anyhow::Resu
 //  3. Let int be the mathematical value whose sign is the sign of number and whose magnitude is floor(abs(ℝ(number))).
 //  4. Let int16bit be int modulo 2**16.
 //  5. If int16bit ≥ 2**15, return 𝔽(int16bit - 2**16); otherwise return 𝔽(int16bit).
-pub fn to_int16(agent: &Agent, argument: impl Into<ECMAScriptValue>) -> Completion<i16> {
-    Ok(to_core_signed(agent, 65536.0, argument)? as i16)
+pub fn to_int16(argument: impl Into<ECMAScriptValue>) -> Completion<i16> {
+    Ok(to_core_signed(65536.0, argument)? as i16)
 }
 
 // ToUint16 ( argument )
@@ -1007,8 +999,8 @@ pub fn to_int16(agent: &Agent, argument: impl Into<ECMAScriptValue>) -> Completi
 //      |
 //      | * The substitution of 2**16 for 2**32 in step 4 is the only difference between ToUint32 and ToUint16.
 //      | * ToUint16 maps -0𝔽 to +0𝔽.
-pub fn to_uint16(agent: &Agent, argument: impl Into<ECMAScriptValue>) -> Completion<u16> {
-    let i = to_core_int(agent, 65536.0, argument)? as i64;
+pub fn to_uint16(argument: impl Into<ECMAScriptValue>) -> Completion<u16> {
+    let i = to_core_int(65536.0, argument)? as i64;
     Ok((if i < 0 { i + 65536 } else { i }).try_into().expect("Math results in in-bounds calculation"))
 }
 
@@ -1022,8 +1014,8 @@ pub fn to_uint16(agent: &Agent, argument: impl Into<ECMAScriptValue>) -> Complet
 //  3. Let int be the mathematical value whose sign is the sign of number and whose magnitude is floor(abs(ℝ(number))).
 //  4. Let int8bit be int modulo 2**8.
 //  5. If int8bit ≥ 2**7, return 𝔽(int8bit - 2**8); otherwise return 𝔽(int8bit).
-pub fn to_int8(agent: &Agent, argument: impl Into<ECMAScriptValue>) -> Completion<i8> {
-    Ok(to_core_signed(agent, 256.0, argument)? as i8)
+pub fn to_int8(argument: impl Into<ECMAScriptValue>) -> Completion<i8> {
+    Ok(to_core_signed(256.0, argument)? as i8)
 }
 
 // ToUint8 ( argument )
@@ -1036,8 +1028,8 @@ pub fn to_int8(agent: &Agent, argument: impl Into<ECMAScriptValue>) -> Completio
 //  3. Let int be the mathematical value whose sign is the sign of number and whose magnitude is floor(abs(ℝ(number))).
 //  4. Let int8bit be int modulo 2**8.
 //  5. Return 𝔽(int8bit).
-pub fn to_uint8(agent: &Agent, argument: impl Into<ECMAScriptValue>) -> Completion<u8> {
-    let i = to_core_int(agent, 256.0, argument)? as i64;
+pub fn to_uint8(argument: impl Into<ECMAScriptValue>) -> Completion<u8> {
+    let i = to_core_int(256.0, argument)? as i64;
     Ok((if i < 0 { i + 256 } else { i }).try_into().expect("Math results in in-bounds calculation"))
 }
 
@@ -1069,13 +1061,13 @@ pub fn to_uint8(agent: &Agent, argument: impl Into<ECMAScriptValue>) -> Completi
 // |               |      1. Let primValue be ? ToPrimitive(argument, string). |
 // |               |      2. Return ? ToString(primValue).                     |
 // +---------------+-----------------------------------------------------------+
-pub fn to_string(agent: &Agent, val: impl Into<ECMAScriptValue>) -> Completion<JSString> {
+pub fn to_string(val: impl Into<ECMAScriptValue>) -> Completion<JSString> {
     let val = val.into();
     if val.is_object() {
-        let prim_value = to_primitive(agent, val, Some(ConversionHint::String))?;
-        to_string(agent, prim_value)
+        let prim_value = to_primitive(val, Some(ConversionHint::String))?;
+        to_string(prim_value)
     } else {
-        JSString::try_from(val).map_err(|e| create_type_error(agent, e.to_string()))
+        JSString::try_from(val).map_err(|e| create_type_error(e.to_string()))
     }
 }
 
@@ -1121,7 +1113,7 @@ impl TryFrom<ECMAScriptValue> for JSString {
 // | BigInt        | Return a new BigInt object whose [[BigIntData]] internal slot is set to argument.   |
 // | Object        | Return argument.                                                                    |
 // +---------------+-------------------------------------------------------------------------------------+
-pub fn to_object(agent: &Agent, val: impl Into<ECMAScriptValue>) -> Completion<Object> {
+pub fn to_object(val: impl Into<ECMAScriptValue>) -> Completion<Object> {
     match val.into() {
         ECMAScriptValue::Null | ECMAScriptValue::Undefined => {
             Err(create_type_error(agent, "Undefined and null cannot be converted to objects"))
@@ -1144,7 +1136,7 @@ pub fn to_object(agent: &Agent, val: impl Into<ECMAScriptValue>) -> Completion<O
 //  2. If Type(key) is Symbol, then
 //      a. Return key.
 //  3. Return ! ToString(key).
-pub fn to_property_key(agent: &Agent, argument: ECMAScriptValue) -> Completion<PropertyKey> {
+pub fn to_property_key(argument: ECMAScriptValue) -> Completion<PropertyKey> {
     let key = to_primitive(agent, argument, Some(ConversionHint::String))?;
     match key {
         ECMAScriptValue::Symbol(sym) => Ok(PropertyKey::from(sym)),
@@ -1308,74 +1300,69 @@ impl ECMAScriptValue {
     }
 }
 
-impl Agent {
-    pub fn is_loosely_equal(&self, x: &ECMAScriptValue, y: &ECMAScriptValue) -> Completion<bool> {
-        match (x, y) {
-            (ECMAScriptValue::Number(_), ECMAScriptValue::Number(_))
-            | (ECMAScriptValue::BigInt(_), ECMAScriptValue::BigInt(_))
-            | (ECMAScriptValue::Undefined, ECMAScriptValue::Undefined)
-            | (ECMAScriptValue::Null, ECMAScriptValue::Null)
-            | (ECMAScriptValue::String(_), ECMAScriptValue::String(_))
-            | (ECMAScriptValue::Boolean(_), ECMAScriptValue::Boolean(_))
-            | (ECMAScriptValue::Symbol(_), ECMAScriptValue::Symbol(_))
-            | (ECMAScriptValue::Object(_), ECMAScriptValue::Object(_)) => Ok(x.is_strictly_equal(y)),
-            (ECMAScriptValue::Undefined, ECMAScriptValue::Null)
-            | (ECMAScriptValue::Null, ECMAScriptValue::Undefined) => Ok(true),
-            (ECMAScriptValue::Number(_), ECMAScriptValue::String(y)) => {
-                let new_y =
-                    ECMAScriptValue::from(to_number(self, y).expect("Strings are always convertable to numbers"));
-                self.is_loosely_equal(x, &new_y)
-            }
-            (ECMAScriptValue::String(x), ECMAScriptValue::Number(_)) => {
-                let new_x =
-                    ECMAScriptValue::from(to_number(self, x).expect("Strings are always convertable to numbers"));
-                self.is_loosely_equal(&new_x, y)
-            }
-            (ECMAScriptValue::BigInt(_), ECMAScriptValue::String(y)) => {
-                let n = String::from(y).parse::<BigInt>();
-                match n {
-                    Err(_) => Ok(false),
-                    Ok(bi) => self.is_loosely_equal(x, &bi.into()),
-                }
-            }
-            (ECMAScriptValue::String(_), ECMAScriptValue::BigInt(_)) => self.is_loosely_equal(y, x),
-            (ECMAScriptValue::Boolean(_), _) => {
-                let new_x = ECMAScriptValue::from(
-                    to_number(self, x.clone()).expect("Booleans are always convertable to numbers"),
-                );
-                self.is_loosely_equal(&new_x, y)
-            }
-            (_, ECMAScriptValue::Boolean(_)) => {
-                let new_y = ECMAScriptValue::from(
-                    to_number(self, y.clone()).expect("Booleans are always convertable to numbers"),
-                );
-                self.is_loosely_equal(x, &new_y)
-            }
-            (ECMAScriptValue::String(_), ECMAScriptValue::Object(_))
-            | (ECMAScriptValue::Number(_), ECMAScriptValue::Object(_))
-            | (ECMAScriptValue::BigInt(_), ECMAScriptValue::Object(_))
-            | (ECMAScriptValue::Symbol(_), ECMAScriptValue::Object(_)) => {
-                let new_y = to_primitive(self, y.clone(), None)?;
-                self.is_loosely_equal(x, &new_y)
-            }
-            (ECMAScriptValue::Object(_), ECMAScriptValue::String(_))
-            | (ECMAScriptValue::Object(_), ECMAScriptValue::Number(_))
-            | (ECMAScriptValue::Object(_), ECMAScriptValue::BigInt(_))
-            | (ECMAScriptValue::Object(_), ECMAScriptValue::Symbol(_)) => {
-                let new_x = to_primitive(self, x.clone(), None)?;
-                self.is_loosely_equal(&new_x, y)
-            }
-            (&ECMAScriptValue::Number(n), ECMAScriptValue::BigInt(b))
-            | (ECMAScriptValue::BigInt(b), &ECMAScriptValue::Number(n)) => {
-                Ok(n.is_finite() && n == b.to_f64().expect("BigInts always transform to floats ok"))
-            }
-            (ECMAScriptValue::Undefined, _)
-            | (ECMAScriptValue::Null, _)
-            | (ECMAScriptValue::Symbol(_), _)
-            | (_, ECMAScriptValue::Undefined)
-            | (_, ECMAScriptValue::Null)
-            | (_, ECMAScriptValue::Symbol(_)) => Ok(false),
+pub fn is_loosely_equal(x: &ECMAScriptValue, y: &ECMAScriptValue) -> Completion<bool> {
+    match (x, y) {
+        (ECMAScriptValue::Number(_), ECMAScriptValue::Number(_))
+        | (ECMAScriptValue::BigInt(_), ECMAScriptValue::BigInt(_))
+        | (ECMAScriptValue::Undefined, ECMAScriptValue::Undefined)
+        | (ECMAScriptValue::Null, ECMAScriptValue::Null)
+        | (ECMAScriptValue::String(_), ECMAScriptValue::String(_))
+        | (ECMAScriptValue::Boolean(_), ECMAScriptValue::Boolean(_))
+        | (ECMAScriptValue::Symbol(_), ECMAScriptValue::Symbol(_))
+        | (ECMAScriptValue::Object(_), ECMAScriptValue::Object(_)) => Ok(x.is_strictly_equal(y)),
+        (ECMAScriptValue::Undefined, ECMAScriptValue::Null) | (ECMAScriptValue::Null, ECMAScriptValue::Undefined) => {
+            Ok(true)
         }
+        (ECMAScriptValue::Number(_), ECMAScriptValue::String(y)) => {
+            let new_y = ECMAScriptValue::from(to_number(y).expect("Strings are always convertable to numbers"));
+            is_loosely_equal(x, &new_y)
+        }
+        (ECMAScriptValue::String(x), ECMAScriptValue::Number(_)) => {
+            let new_x = ECMAScriptValue::from(to_number(x).expect("Strings are always convertable to numbers"));
+            is_loosely_equal(&new_x, y)
+        }
+        (ECMAScriptValue::BigInt(_), ECMAScriptValue::String(y)) => {
+            let n = String::from(y).parse::<BigInt>();
+            match n {
+                Err(_) => Ok(false),
+                Ok(bi) => is_loosely_equal(x, &bi.into()),
+            }
+        }
+        (ECMAScriptValue::String(_), ECMAScriptValue::BigInt(_)) => is_loosely_equal(y, x),
+        (ECMAScriptValue::Boolean(_), _) => {
+            let new_x =
+                ECMAScriptValue::from(to_number(x.clone()).expect("Booleans are always convertable to numbers"));
+            is_loosely_equal(&new_x, y)
+        }
+        (_, ECMAScriptValue::Boolean(_)) => {
+            let new_y =
+                ECMAScriptValue::from(to_number(y.clone()).expect("Booleans are always convertable to numbers"));
+            is_loosely_equal(x, &new_y)
+        }
+        (ECMAScriptValue::String(_), ECMAScriptValue::Object(_))
+        | (ECMAScriptValue::Number(_), ECMAScriptValue::Object(_))
+        | (ECMAScriptValue::BigInt(_), ECMAScriptValue::Object(_))
+        | (ECMAScriptValue::Symbol(_), ECMAScriptValue::Object(_)) => {
+            let new_y = to_primitive(y.clone(), None)?;
+            is_loosely_equal(x, &new_y)
+        }
+        (ECMAScriptValue::Object(_), ECMAScriptValue::String(_))
+        | (ECMAScriptValue::Object(_), ECMAScriptValue::Number(_))
+        | (ECMAScriptValue::Object(_), ECMAScriptValue::BigInt(_))
+        | (ECMAScriptValue::Object(_), ECMAScriptValue::Symbol(_)) => {
+            let new_x = to_primitive(x.clone(), None)?;
+            is_loosely_equal(&new_x, y)
+        }
+        (&ECMAScriptValue::Number(n), ECMAScriptValue::BigInt(b))
+        | (ECMAScriptValue::BigInt(b), &ECMAScriptValue::Number(n)) => {
+            Ok(n.is_finite() && n == b.to_f64().expect("BigInts always transform to floats ok"))
+        }
+        (ECMAScriptValue::Undefined, _)
+        | (ECMAScriptValue::Null, _)
+        | (ECMAScriptValue::Symbol(_), _)
+        | (_, ECMAScriptValue::Undefined)
+        | (_, ECMAScriptValue::Null)
+        | (_, ECMAScriptValue::Symbol(_)) => Ok(false),
     }
 }
 

--- a/src/values/tests.rs
+++ b/src/values/tests.rs
@@ -135,7 +135,7 @@ mod ecmascript_value {
     }
     #[test]
     fn from_object_ref() {
-        let agent = test_agent();
+        setup_test_agent();
         let o = ordinary_object_create(&agent, None, &[]);
 
         let val = ECMAScriptValue::from(&o);
@@ -145,7 +145,7 @@ mod ecmascript_value {
     }
     #[test]
     fn from_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let o = ordinary_object_create(&agent, None, &[]);
         let orig_id = o.o.id();
 
@@ -167,7 +167,7 @@ mod ecmascript_value {
     #[test_case(|_| PropertyKey::String("key".into()) => "key"; "string")]
     #[test_case(|a| PropertyKey::Symbol(a.wks(WksId::ToPrimitive)) => "Symbol(Symbol.toPrimitive)"; "symbol")]
     fn from_property_key(maker: fn(&Agent) -> PropertyKey) -> String {
-        let agent = test_agent();
+        setup_test_agent();
         let key = maker(&agent);
         format!("{}", ECMAScriptValue::from(key))
     }
@@ -206,7 +206,7 @@ mod ecmascript_value {
     }
     #[test]
     fn is_symbol() {
-        let agent = test_agent();
+        setup_test_agent();
         assert_eq!(ECMAScriptValue::Undefined.is_symbol(), false);
         assert_eq!(ECMAScriptValue::from(Symbol::new(&agent, Some(JSString::from("Test Symbol")))).is_symbol(), true);
         assert_eq!(ECMAScriptValue::Null.is_symbol(), false);
@@ -219,7 +219,7 @@ mod ecmascript_value {
     }
     #[test]
     fn is_object() {
-        let agent = test_agent();
+        setup_test_agent();
         let o = ordinary_object_create(&agent, None, &[]);
         assert_eq!(ECMAScriptValue::Undefined.is_object(), false);
         assert_eq!(ECMAScriptValue::from(o).is_object(), true);
@@ -235,7 +235,7 @@ mod ecmascript_value {
     #[test]
     fn concise() {
         // Calling this on our own isn't really do-able; we need to get there via Display or Debug.
-        let agent = test_agent();
+        setup_test_agent();
         let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
         let obj = ordinary_object_create(&agent, Some(obj_proto), &[]);
         define_property_or_throw(
@@ -301,7 +301,7 @@ mod ecmascript_value {
     }
     #[test]
     fn is_array() {
-        let agent = test_agent();
+        setup_test_agent();
         let a = array_create(&agent, 0, None).unwrap();
         let v1: ECMAScriptValue = a.into();
         let v2 = ECMAScriptValue::Null;
@@ -330,7 +330,7 @@ mod ecmascript_value {
             ECMAScriptValue::Object(obj)
         } => with |s: String| assert!(Regex::new("^<Object [0-9]+>$").unwrap().is_match(&s)); "object")]
         fn complex(maker: fn(&Agent) -> ECMAScriptValue) -> String {
-            let agent = test_agent();
+            setup_test_agent();
             let val = maker(&agent);
             format!("{val}")
         }
@@ -401,7 +401,7 @@ mod ecmascript_value {
     #[test_case(object_a, object_a => true; "equal objects")]
     #[test_case(undef, symbol_b => panics "Invalid input args"; "Invalid Input")]
     fn same_value_non_numeric(make_x: ValueMaker, make_y: ValueMaker) -> bool {
-        let agent = test_agent();
+        setup_test_agent();
         let x = make_x(&agent);
         let y = make_y(&agent);
 
@@ -417,7 +417,7 @@ mod ecmascript_value {
     #[test_case(bigint_a, bigint_b => false; "different bigints")]
     #[test_case(string_a, string_a => true; "fallthru for nonnumbers")]
     fn same_value_zero(make_x: ValueMaker, make_y: ValueMaker) -> bool {
-        let agent = test_agent();
+        setup_test_agent();
         let x = make_x(&agent);
         let y = make_y(&agent);
 
@@ -433,7 +433,7 @@ mod ecmascript_value {
     #[test_case(bigint_a, bigint_b => false; "different bigints")]
     #[test_case(string_a, string_a => true; "fallthru for nonnumbers")]
     fn same_value(make_x: ValueMaker, make_y: ValueMaker) -> bool {
-        let agent = test_agent();
+        setup_test_agent();
         let x = make_x(&agent);
         let y = make_y(&agent);
 
@@ -449,7 +449,7 @@ mod ecmascript_value {
     #[test_case(bigint_a, bigint_b => false; "different bigints")]
     #[test_case(string_a, string_a => true; "fallthru for nonnumbers")]
     fn is_strictly_equal(make_x: ValueMaker, make_y: ValueMaker) -> bool {
-        let agent = test_agent();
+        setup_test_agent();
         let x = make_x(&agent);
         let y = make_y(&agent);
 
@@ -459,31 +459,31 @@ mod ecmascript_value {
 
 #[test]
 fn symbol_debug() {
-    let agent = test_agent();
+    setup_test_agent();
     assert_ne!(format!("{:?}", agent.wks(WksId::ToPrimitive)), "");
 }
 #[test]
 fn symbol_display_normal() {
-    let agent = test_agent();
+    setup_test_agent();
     let symbol = Symbol::new(&agent, Some(JSString::from("Normal")));
     assert_eq!(format!("{}", symbol), "Symbol(Normal)");
 }
 #[test]
 fn symbol_display_empty() {
-    let agent = test_agent();
+    setup_test_agent();
     let symbol = Symbol::new(&agent, None);
     assert_eq!(format!("{}", symbol), "Symbol()");
 }
 #[test]
 fn symbol_clone() {
-    let agent = test_agent();
+    setup_test_agent();
     let s1 = agent.wks(WksId::ToPrimitive);
     let s2 = s1.clone();
     assert_eq!(s1, s2);
 }
 #[test]
 fn symbol_hash() {
-    let agent = test_agent();
+    setup_test_agent();
     let s1 = agent.wks(WksId::ToPrimitive);
     let s2 = s1.clone();
     let s3 = agent.wks(WksId::Unscopables);
@@ -503,7 +503,7 @@ fn symbol_hash() {
 }
 #[test]
 fn symbol_new() {
-    let agent = test_agent();
+    setup_test_agent();
     let s1 = Symbol::new(&agent, Some(JSString::from("Symbol #1")));
     let s2 = Symbol::new(&agent, Some(JSString::from("Symbol #2")));
     let s3 = Symbol::new(&agent, Some(JSString::from("Symbol #1")));
@@ -518,7 +518,7 @@ fn symbol_new() {
 }
 #[test]
 fn symbol_description() {
-    let agent = test_agent();
+    setup_test_agent();
     let s1 = Symbol::new(&agent, Some(JSString::from("Test Symbol")));
     assert_eq!(s1.description(), Some(JSString::from("Test Symbol")));
 }
@@ -664,7 +664,7 @@ fn to_boolean_01() {
     assert_eq!(to_boolean(ECMAScriptValue::from(BigInt::from(22))), true);
     assert_eq!(to_boolean(ECMAScriptValue::from(BigInt::from(0))), false);
 
-    let agent = test_agent();
+    setup_test_agent();
     assert_eq!(to_boolean(ECMAScriptValue::from(agent.wks(WksId::ToPrimitive))), true);
     let o = ordinary_object_create(&agent, None, &[]);
     assert_eq!(to_boolean(ECMAScriptValue::from(o)), true);
@@ -691,7 +691,7 @@ mod property_key {
         assert_eq!(pk, PropertyKey::String(JSString::from("b")));
         let pk = PropertyKey::from(&JSString::from("c"));
         assert_eq!(pk, PropertyKey::String(JSString::from("c")));
-        let agent = test_agent();
+        setup_test_agent();
         let pk = PropertyKey::from(agent.wks(WksId::ToPrimitive));
         assert_eq!(pk, PropertyKey::Symbol(agent.wks(WksId::ToPrimitive)));
         let pk = PropertyKey::from(String::from("d"));
@@ -705,7 +705,7 @@ mod property_key {
     }
     #[test]
     fn display() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = agent.wks(WksId::HasInstance);
         assert_eq!(format!("{}", PropertyKey::from("tangerine")), "tangerine");
         assert_eq!(format!("{}", PropertyKey::from(sym)), "Symbol(Symbol.hasInstance)");
@@ -718,7 +718,7 @@ mod property_key {
     }
     #[test]
     fn is_array_index() {
-        let agent = test_agent();
+        setup_test_agent();
         assert_eq!(PropertyKey::from("0").is_array_index(), true);
         assert_eq!(PropertyKey::from("10").is_array_index(), true);
         assert_eq!(PropertyKey::from("0.25").is_array_index(), false);
@@ -735,7 +735,7 @@ mod property_key {
     #[test_case(|_| PropertyKey::from("alice"), |_| ECMAScriptValue::from("alice"); "string")]
     #[test_case(|a| PropertyKey::from(a.wks(WksId::ToPrimitive)), |a| ECMAScriptValue::from(a.wks(WksId::ToPrimitive)); "symbol")]
     fn into_ecmascriptvalue(make_key: fn(&Agent) -> PropertyKey, make_expected: fn(&Agent) -> ECMAScriptValue) {
-        let agent = test_agent();
+        setup_test_agent();
         let key = make_key(&agent);
         let expected = make_expected(&agent);
         assert_eq!(ECMAScriptValue::from(key), expected);
@@ -753,7 +753,7 @@ mod property_key {
 
         #[test]
         fn symbol() {
-            let agent = test_agent();
+            setup_test_agent();
             let val = ECMAScriptValue::from(agent.wks(WksId::ToPrimitive));
             let pk = PropertyKey::try_from(val).unwrap();
             assert_eq!(pk, PropertyKey::from(agent.wks(WksId::ToPrimitive)));
@@ -771,14 +771,14 @@ mod jsstring {
         #[test_case(|_| PropertyKey::from("key") => sok("key"); "string")]
         #[test_case(|a| PropertyKey::from(a.wks(WksId::ToPrimitive)) => serr("Expected String-valued property key"); "symbol")]
         fn property_key(maker: fn(&Agent) -> PropertyKey) -> Result<String, String> {
-            let agent = test_agent();
+            setup_test_agent();
             let key = maker(&agent);
             JSString::try_from(key).map_err(|e| e.to_string()).map(String::from)
         }
         #[test_case(|_| PropertyKey::from("key") => sok("key"); "string")]
         #[test_case(|a| PropertyKey::from(a.wks(WksId::ToPrimitive)) => serr("Expected String-valued property key"); "symbol")]
         fn property_key_ref(maker: fn(&Agent) -> PropertyKey) -> Result<String, String> {
-            let agent = test_agent();
+            setup_test_agent();
             let key = maker(&agent);
             JSString::try_from(&key).map_err(|e| e.to_string()).map(String::from)
         }
@@ -796,7 +796,7 @@ mod jsstring {
             ECMAScriptValue::Object(obj)
         } => serr("Object to string conversions require an agent"); "object")]
         fn ecmasript_value(maker: fn(&Agent) -> ECMAScriptValue) -> Result<String, String> {
-            let agent = test_agent();
+            setup_test_agent();
             let value = maker(&agent);
             JSString::try_from(value).map_err(|e| e.to_string()).map(String::from)
         }
@@ -830,26 +830,26 @@ mod numeric {
 
 #[test]
 fn to_numeric_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let result = to_numeric(&agent, ECMAScriptValue::from(obj)).unwrap_err();
     assert_eq!(unwind_type_error(&agent, result), "Cannot convert object to primitive value");
 }
 #[test]
 fn to_numeric_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let result = to_numeric(&agent, ECMAScriptValue::from(BigInt::from(4747474))).unwrap();
     assert_eq!(result, Numeric::BigInt(Rc::new(BigInt::from(4747474))));
 }
 #[test]
 fn to_numeric_03() {
-    let agent = test_agent();
+    setup_test_agent();
     let result = to_numeric(&agent, ECMAScriptValue::from(10)).unwrap();
     assert_eq!(result, Numeric::Number(10.0));
 }
 #[test]
 fn to_numeric_04() {
-    let agent = test_agent();
+    setup_test_agent();
     let sym = Symbol::new(&agent, None);
     let result = to_numeric(&agent, ECMAScriptValue::from(sym)).unwrap_err();
     assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
@@ -857,7 +857,7 @@ fn to_numeric_04() {
 
 #[test]
 fn to_number_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let input = ECMAScriptValue::Undefined;
 
     let result = to_number(&agent, input).unwrap();
@@ -866,7 +866,7 @@ fn to_number_01() {
 #[test]
 #[allow(clippy::float_cmp)]
 fn to_number_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let input = ECMAScriptValue::Null;
 
     let result = to_number(&agent, input).unwrap();
@@ -875,7 +875,7 @@ fn to_number_02() {
 #[test]
 #[allow(clippy::float_cmp)]
 fn to_number_03() {
-    let agent = test_agent();
+    setup_test_agent();
     let input = ECMAScriptValue::from(true);
 
     let result = to_number(&agent, input).unwrap();
@@ -884,7 +884,7 @@ fn to_number_03() {
 #[test]
 #[allow(clippy::float_cmp)]
 fn to_number_04() {
-    let agent = test_agent();
+    setup_test_agent();
     let input = ECMAScriptValue::from(false);
 
     let result = to_number(&agent, input).unwrap();
@@ -893,7 +893,7 @@ fn to_number_04() {
 #[test]
 #[allow(clippy::float_cmp)]
 fn to_number_05() {
-    let agent = test_agent();
+    setup_test_agent();
     let input = ECMAScriptValue::from(37.6);
 
     let result = to_number(&agent, input).unwrap();
@@ -901,7 +901,7 @@ fn to_number_05() {
 }
 #[test]
 fn to_number_06() {
-    let agent = test_agent();
+    setup_test_agent();
     let input = ECMAScriptValue::from("blue");
 
     let result = to_number(&agent, input).unwrap();
@@ -910,7 +910,7 @@ fn to_number_06() {
 #[test]
 #[allow(clippy::float_cmp)]
 fn to_number_07() {
-    let agent = test_agent();
+    setup_test_agent();
     let testcases = [
         ("", 0.0),
         ("1", 1.0),
@@ -934,7 +934,7 @@ fn to_number_07() {
 }
 #[test]
 fn to_number_08() {
-    let agent = test_agent();
+    setup_test_agent();
     let input = ECMAScriptValue::from(BigInt::from(10));
 
     let result = to_number(&agent, input).unwrap_err();
@@ -942,7 +942,7 @@ fn to_number_08() {
 }
 #[test]
 fn to_number_09() {
-    let agent = test_agent();
+    setup_test_agent();
     let input = ECMAScriptValue::from(Symbol::new(&agent, None));
 
     let result = to_number(&agent, input).unwrap_err();
@@ -950,7 +950,7 @@ fn to_number_09() {
 }
 #[test]
 fn to_number_10() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let input = ECMAScriptValue::from(obj);
 
@@ -959,7 +959,7 @@ fn to_number_10() {
 }
 #[test]
 fn to_number_11() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(obj_proto), &[]);
     let input = ECMAScriptValue::from(obj);
@@ -971,7 +971,7 @@ fn to_number_11() {
 #[test]
 #[allow(clippy::float_cmp)]
 fn to_integer_or_infinity_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let testcases = &[
         (f64::NAN, 0.0),
         (f64::INFINITY, f64::INFINITY),
@@ -989,7 +989,7 @@ fn to_integer_or_infinity_01() {
 }
 #[test]
 fn to_integer_or_infinity_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let sym = Symbol::new(&agent, None);
 
     let result = to_integer_or_infinity(&agent, ECMAScriptValue::from(sym)).unwrap_err();
@@ -998,50 +998,50 @@ fn to_integer_or_infinity_02() {
 
 #[test]
 fn to_string_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let result = to_string(&agent, ECMAScriptValue::Undefined).unwrap();
     assert_eq!(result, "undefined");
 }
 #[test]
 fn to_string_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let result = to_string(&agent, ECMAScriptValue::Null).unwrap();
     assert_eq!(result, "null");
 }
 #[test]
 fn to_string_03() {
-    let agent = test_agent();
+    setup_test_agent();
     let result = to_string(&agent, ECMAScriptValue::from(true)).unwrap();
     assert_eq!(result, "true");
 }
 #[test]
 fn to_string_04() {
-    let agent = test_agent();
+    setup_test_agent();
     let result = to_string(&agent, ECMAScriptValue::from(false)).unwrap();
     assert_eq!(result, "false");
 }
 #[test]
 fn to_string_05() {
-    let agent = test_agent();
+    setup_test_agent();
     let result = to_string(&agent, ECMAScriptValue::from(10)).unwrap();
     assert_eq!(result, "10");
 }
 #[test]
 fn to_string_06() {
-    let agent = test_agent();
+    setup_test_agent();
     let result = to_string(&agent, ECMAScriptValue::from("blue")).unwrap();
     assert_eq!(result, "blue");
 }
 #[test]
 fn to_string_07() {
-    let agent = test_agent();
+    setup_test_agent();
     let sym = Symbol::new(&agent, None);
     let result = to_string(&agent, ECMAScriptValue::Symbol(sym)).unwrap_err();
     assert_eq!(unwind_type_error(&agent, result), "Symbols may not be converted to strings");
 }
 #[test]
 fn to_string_08() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
     let obj = ordinary_object_create(&agent, Some(obj_proto), &[]);
     let result = to_string(&agent, ECMAScriptValue::from(obj)).unwrap();
@@ -1049,7 +1049,7 @@ fn to_string_08() {
 }
 #[test]
 fn to_string_09() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let result = to_string(&agent, ECMAScriptValue::from(obj)).unwrap_err();
     assert_eq!(unwind_type_error(&agent, result), "Cannot convert object to primitive value");
@@ -1065,7 +1065,7 @@ fn tostring_symbol(
 }
 #[test]
 fn to_string_10() {
-    let agent = test_agent();
+    setup_test_agent();
     let obj = ordinary_object_create(&agent, None, &[]);
     let badtostring = create_builtin_function(
         &agent,
@@ -1085,28 +1085,28 @@ fn to_string_10() {
 }
 #[test]
 fn to_string_11() {
-    let agent = test_agent();
+    setup_test_agent();
     let result = to_string(&agent, ECMAScriptValue::from(BigInt::from(789123))).unwrap();
     assert_eq!(result, "789123");
 }
 
 #[test]
 fn to_object_01() {
-    let agent = test_agent();
+    setup_test_agent();
     let err = to_object(&agent, ECMAScriptValue::Undefined).unwrap_err();
     let msg = unwind_type_error(&agent, err);
     assert_eq!(msg, "Undefined and null cannot be converted to objects");
 }
 #[test]
 fn to_object_02() {
-    let agent = test_agent();
+    setup_test_agent();
     let err = to_object(&agent, ECMAScriptValue::Null).unwrap_err();
     let msg = unwind_type_error(&agent, err);
     assert_eq!(msg, "Undefined and null cannot be converted to objects");
 }
 #[test]
 fn to_object_03() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_value = true;
     let result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
 
@@ -1116,7 +1116,7 @@ fn to_object_03() {
 #[test]
 #[allow(clippy::float_cmp)]
 fn to_object_04() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_value = 1337.0;
     let result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
 
@@ -1125,7 +1125,7 @@ fn to_object_04() {
 }
 #[test]
 fn to_object_05() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_value = "orange";
     let result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
 
@@ -1134,7 +1134,7 @@ fn to_object_05() {
 }
 #[test]
 fn to_object_06() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_value = agent.wks(WksId::ToPrimitive);
     let result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
     let desc = get(&agent, &result, &"description".into()).unwrap();
@@ -1143,13 +1143,13 @@ fn to_object_06() {
 #[test]
 #[should_panic(expected = "not yet implemented")] // An XFAIL. BigInt objects not yet implemented.
 fn to_object_07() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_value = BigInt::from(10);
     let _result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
 }
 #[test]
 fn to_object_08() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_value = ordinary_object_create(&agent, None, &[]);
     let id = test_value.o.id();
     let result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
@@ -1346,7 +1346,7 @@ pub fn make_test_obj_uncallable(agent: &Agent) -> Object {
 
 #[test]
 fn ordinary_to_primitive_nonoobj() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_obj = make_test_obj(&agent, FauxKind::Primitive, FauxKind::Primitive);
     let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap();
     assert_eq!(result_1, ECMAScriptValue::from(123456));
@@ -1356,7 +1356,7 @@ fn ordinary_to_primitive_nonoobj() {
 }
 #[test]
 fn ordinary_to_primitive_obj() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_obj = make_test_obj(&agent, FauxKind::Object, FauxKind::Object);
     let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap_err();
     assert_eq!(unwind_type_error(&agent, result_1), "Cannot convert object to primitive value");
@@ -1366,7 +1366,7 @@ fn ordinary_to_primitive_obj() {
 }
 #[test]
 fn ordinary_to_primitive_obj_nonobj() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_obj = make_test_obj(&agent, FauxKind::Object, FauxKind::Primitive);
     let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap();
     assert_eq!(result_1, ECMAScriptValue::from("test result"));
@@ -1376,7 +1376,7 @@ fn ordinary_to_primitive_obj_nonobj() {
 }
 #[test]
 fn ordinary_to_primitive_nonobj_obj() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_obj = make_test_obj(&agent, FauxKind::Primitive, FauxKind::Object);
     let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap();
     assert_eq!(result_1, ECMAScriptValue::from(123456));
@@ -1386,7 +1386,7 @@ fn ordinary_to_primitive_nonobj_obj() {
 }
 #[test]
 fn ordinary_to_primitive_call_errors() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_obj = make_test_obj(&agent, FauxKind::Primitive, FauxKind::Error);
     let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap();
     assert_eq!(result_1, ECMAScriptValue::from(123456));
@@ -1396,7 +1396,7 @@ fn ordinary_to_primitive_call_errors() {
 }
 #[test]
 fn ordinary_to_primitive_get_errors() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_obj = make_tostring_getter_error(&agent);
     let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap();
     assert_eq!(result_1, ECMAScriptValue::from(123456));
@@ -1406,7 +1406,7 @@ fn ordinary_to_primitive_get_errors() {
 }
 #[test]
 fn ordinary_to_primitive_uncallables() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_obj = make_test_obj_uncallable(&agent);
     let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap_err();
     assert_eq!(unwind_type_error(&agent, result_1), "Cannot convert object to primitive value");
@@ -1417,7 +1417,7 @@ fn ordinary_to_primitive_uncallables() {
 
 #[test]
 fn to_primitive_no_change() {
-    let agent = test_agent();
+    setup_test_agent();
     // Undefined
     let result = to_primitive(&agent, ECMAScriptValue::Undefined, None).unwrap();
     assert!(result.is_undefined());
@@ -1444,7 +1444,7 @@ fn to_primitive_no_change() {
 }
 #[test]
 fn to_primitive_prefer_number() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_obj = make_test_obj(&agent, FauxKind::Primitive, FauxKind::Primitive);
     let test_value = ECMAScriptValue::from(test_obj);
 
@@ -1511,7 +1511,7 @@ fn make_toprimitive_obj(
 }
 #[test]
 fn to_primitive_uses_exotics() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_obj = make_toprimitive_obj(&agent, exotic_to_prim);
     let test_value = ECMAScriptValue::from(test_obj);
 
@@ -1535,7 +1535,7 @@ fn exotic_returns_object(
 }
 #[test]
 fn to_primitive_exotic_returns_object() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_obj = make_toprimitive_obj(&agent, exotic_returns_object);
     let test_value = ECMAScriptValue::from(test_obj);
 
@@ -1552,7 +1552,7 @@ fn exotic_throws(
 }
 #[test]
 fn to_primitive_exotic_throws() {
-    let agent = test_agent();
+    setup_test_agent();
     let test_obj = make_toprimitive_obj(&agent, exotic_throws);
     let test_value = ECMAScriptValue::from(test_obj);
 
@@ -1561,7 +1561,7 @@ fn to_primitive_exotic_throws() {
 }
 #[test]
 fn to_primitive_exotic_getter_throws() {
-    let agent = test_agent();
+    setup_test_agent();
     let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
@@ -1604,7 +1604,7 @@ mod to_property_key {
     #[test_case(|_| ECMAScriptValue::from("blue") => Ok(PropertyKey::from("blue")); "string")]
     #[test_case(|a| ECMAScriptValue::from(make_tostring_getter_error(a)) => Err("Test Sentinel".to_string()); "to_primitive error")]
     fn simple(make_value: fn(&Agent) -> ECMAScriptValue) -> Result<PropertyKey, String> {
-        let agent = test_agent();
+        setup_test_agent();
         let arg = make_value(&agent);
         match to_property_key(&agent, arg) {
             Ok(key) => Ok(key),
@@ -1614,7 +1614,7 @@ mod to_property_key {
 
     #[test]
     fn symbol() {
-        let agent = test_agent();
+        setup_test_agent();
         let sym = Symbol::new(&agent, Some("test symbol".into()));
         let argument = ECMAScriptValue::from(sym.clone());
         assert_eq!(to_property_key(&agent, argument).unwrap(), PropertyKey::from(sym));
@@ -1628,7 +1628,7 @@ mod to_property_key {
 #[test_case(|_| ECMAScriptValue::from(9007199254740992.0) => Ok(9007199254740991); "over")]
 #[test_case(|a| ECMAScriptValue::from(Symbol::new(a, Some("test".into()))) => Err("Symbol values cannot be converted to Number values".to_string()); "not a number")]
 fn to_length(make_arg: fn(&Agent) -> ECMAScriptValue) -> Result<i64, String> {
-    let agent = test_agent();
+    setup_test_agent();
     let arg = make_arg(&agent);
 
     super::to_length(&agent, arg).map_err(|e| unwind_type_error(&agent, e))
@@ -1666,7 +1666,7 @@ mod to_index {
     #[test_case(ECMAScriptValue::from(-0.0) => Ok(0); "Negative zero")]
     #[test_case(ECMAScriptValue::from(BigInt::from(10_i32)) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "non-number")]
     fn f(arg: ECMAScriptValue) -> Result<i64, String> {
-        let agent = test_agent();
+        setup_test_agent();
         to_index(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
     }
 }
@@ -1685,7 +1685,7 @@ mod to_int32 {
     #[test_case(-2147483648.0 => Ok(-2147483648); "lower limit")]
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<i32, String> {
-        let agent = test_agent();
+        setup_test_agent();
         to_int32(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
     }
 }
@@ -1704,7 +1704,7 @@ mod to_uint32 {
     #[test_case(-300.0 => Ok(4294966996); "negative inputs")]
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<u32, String> {
-        let agent = test_agent();
+        setup_test_agent();
         to_uint32(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
     }
 }
@@ -1723,7 +1723,7 @@ mod to_int16 {
     #[test_case(-32768.0 => Ok(-32768); "lower limit")]
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<i16, String> {
-        let agent = test_agent();
+        setup_test_agent();
         to_int16(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
     }
 }
@@ -1742,7 +1742,7 @@ mod to_uint16 {
     #[test_case(-300.0 => Ok(65236); "negative inputs")]
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<u16, String> {
-        let agent = test_agent();
+        setup_test_agent();
         to_uint16(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
     }
 }
@@ -1761,7 +1761,7 @@ mod to_int8 {
     #[test_case(-128.0 => Ok(-128); "lower limit")]
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<i8, String> {
-        let agent = test_agent();
+        setup_test_agent();
         to_int8(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
     }
 }
@@ -1780,7 +1780,7 @@ mod to_uint8 {
     #[test_case(-200.0 => Ok(56); "negative inputs")]
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<u8, String> {
-        let agent = test_agent();
+        setup_test_agent();
         to_uint8(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
     }
 }
@@ -1840,7 +1840,7 @@ mod array_index {
         #[test_case(|_| "72x".into() => Err("Invalid array index".to_string()); "parse fail")]
         #[test_case(|_| "4294967295".into() => Err("The maximum array index is 4294967294".to_string()); "convert fail")]
         fn property_key(make_key: fn(&Agent) -> PropertyKey) -> Result<ArrayIndex, String> {
-            let agent = test_agent();
+            setup_test_agent();
             let key = make_key(&agent);
             ArrayIndex::try_from(&key).map_err(|e| e.into())
         }
@@ -1896,7 +1896,7 @@ mod is_callable {
     }
     #[test]
     fn callable() {
-        let agent = test_agent();
+        setup_test_agent();
         assert!(is_callable(&agent.intrinsic(IntrinsicId::Object).into()));
     }
 }
@@ -1909,7 +1909,7 @@ mod is_constructor {
     }
     #[test]
     fn constructor() {
-        let agent = test_agent();
+        setup_test_agent();
         assert!(is_constructor(&agent.intrinsic(IntrinsicId::Object).into()));
     }
 }
@@ -1934,7 +1934,7 @@ mod option_object {
     #[test_case(|_| ECMAScriptValue::Number(12.0) => serr("Bad type for Object/null"); "number")]
     #[test_case(object_with_marker => with validate_marker; "object")]
     fn try_from(maker: fn(&Agent) -> ECMAScriptValue) -> Result<Option<Object>, String> {
-        let agent = test_agent();
+        setup_test_agent();
         let val = maker(&agent);
         let result: anyhow::Result<Option<Object>> = val.try_into();
         result.map_err(|e| e.to_string())
@@ -2090,7 +2090,7 @@ mod agent {
     #[test_case(bigint_a, number_nan => Ok(false); "number nan right")]
     #[test_case(null, symbol_a => Ok(false); "Null & symbol")]
     fn is_loosely_equal(make_x: ValueMaker, make_y: ValueMaker) -> Result<bool, String> {
-        let agent = test_agent();
+        setup_test_agent();
         let x = make_x(&agent);
         let y = make_y(&agent);
 

--- a/src/values/tests.rs
+++ b/src/values/tests.rs
@@ -1047,7 +1047,6 @@ fn to_string_09() {
     assert_eq!(unwind_type_error(result), "Cannot convert object to primitive value");
 }
 fn tostring_symbol(
-    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -1147,7 +1146,6 @@ fn to_object_08() {
 
 // non-object number
 fn faux_makes_number(
-    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -1156,7 +1154,6 @@ fn faux_makes_number(
 }
 // non-object string
 fn faux_makes_string(
-    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -1165,7 +1162,6 @@ fn faux_makes_string(
 }
 // object value
 fn faux_makes_obj(
-    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -1176,7 +1172,6 @@ fn faux_makes_obj(
 }
 // error
 fn faux_errors(
-    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -1189,7 +1184,7 @@ enum FauxKind {
     Error,
 }
 fn make_test_obj(valueof: FauxKind, tostring: FauxKind) -> Object {
-    let realm = agent.current_realm_record().unwrap();
+    let realm = current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
     let target = ordinary_object_create(Some(object_prototype), &[]);
@@ -1242,7 +1237,7 @@ fn make_test_obj(valueof: FauxKind, tostring: FauxKind) -> Object {
 }
 pub fn make_tostring_getter_error() -> Object {
     // valueOf returns 123456; tostring is a getter that errors
-    let realm = agent.current_realm_record().unwrap();
+    let realm = current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
     let target = ordinary_object_create(Some(object_prototype), &[]);
@@ -1432,7 +1427,6 @@ fn to_primitive_prefer_number() {
     assert_eq!(result, ECMAScriptValue::from("test result"));
 }
 fn exotic_to_prim(
-    _agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -1453,7 +1447,7 @@ fn exotic_to_prim(
 fn make_toprimitive_obj(
     steps: fn(ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion<ECMAScriptValue>,
 ) -> Object {
-    let realm = agent.current_realm_record().unwrap();
+    let realm = current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
     let target = ordinary_object_create(Some(object_prototype), &[]);
@@ -1496,12 +1490,11 @@ fn to_primitive_uses_exotics() {
     assert_eq!(result, ECMAScriptValue::from("Saw string"));
 }
 fn exotic_returns_object(
-    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let realm = agent.current_realm_record().unwrap();
+    let realm = current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let target = ordinary_object_create(Some(object_prototype), &[]);
     Ok(ECMAScriptValue::from(target))
@@ -1516,7 +1509,6 @@ fn to_primitive_exotic_returns_object() {
     assert_eq!(unwind_type_error(result), "Cannot convert object to primitive value");
 }
 fn exotic_throws(
-    agent: &Agent,
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -1535,7 +1527,7 @@ fn to_primitive_exotic_throws() {
 #[test]
 fn to_primitive_exotic_getter_throws() {
     setup_test_agent();
-    let realm = agent.current_realm_record().unwrap();
+    let realm = current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
     let target = ordinary_object_create(Some(object_prototype), &[]);
@@ -2002,19 +1994,14 @@ mod agent {
     fn dead_object() -> ECMAScriptValue {
         DeadObject::object().into()
     }
-    fn returns_10(
-        _: &Agent,
-        _: ECMAScriptValue,
-        _: Option<&Object>,
-        _: &[ECMAScriptValue],
-    ) -> Completion<ECMAScriptValue> {
+    fn returns_10(_: ECMAScriptValue, _: Option<&Object>, _: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
         Ok(10.into())
     }
     fn object_10() -> ECMAScriptValue {
         let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
         let object = ordinary_object_create(Some(object_prototype), &[]);
         let to_primitive = wks(WksId::ToPrimitive);
-        let realm = agent.current_realm_record();
+        let realm = current_realm_record();
         let function_prototype = intrinsic(IntrinsicId::FunctionPrototype);
         let to_prim_func = create_builtin_function(
             returns_10,
@@ -2063,6 +2050,6 @@ mod agent {
         let x = make_x();
         let y = make_y();
 
-        agent.is_loosely_equal(&x, &y).map_err(|e| unwind_any_error(e))
+        super::is_loosely_equal(&x, &y).map_err(|e| unwind_any_error(e))
     }
 }

--- a/src/values/tests.rs
+++ b/src/values/tests.rs
@@ -1594,7 +1594,7 @@ fn to_length(make_arg: fn() -> ECMAScriptValue) -> Result<i64, String> {
     setup_test_agent();
     let arg = make_arg();
 
-    super::to_length(arg).map_err(|e| unwind_type_error(e))
+    super::to_length(arg).map_err(unwind_type_error)
 }
 
 mod canonical_numeric_index_string {
@@ -1630,7 +1630,7 @@ mod to_index {
     #[test_case(ECMAScriptValue::from(BigInt::from(10_i32)) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "non-number")]
     fn f(arg: ECMAScriptValue) -> Result<i64, String> {
         setup_test_agent();
-        to_index(arg).map_err(|e| unwind_any_error(e))
+        to_index(arg).map_err(unwind_any_error)
     }
 }
 
@@ -1649,7 +1649,7 @@ mod to_int32 {
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<i32, String> {
         setup_test_agent();
-        to_int32(arg).map_err(|e| unwind_any_error(e))
+        to_int32(arg).map_err(unwind_any_error)
     }
 }
 
@@ -1668,7 +1668,7 @@ mod to_uint32 {
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<u32, String> {
         setup_test_agent();
-        to_uint32(arg).map_err(|e| unwind_any_error(e))
+        to_uint32(arg).map_err(unwind_any_error)
     }
 }
 
@@ -1687,7 +1687,7 @@ mod to_int16 {
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<i16, String> {
         setup_test_agent();
-        to_int16(arg).map_err(|e| unwind_any_error(e))
+        to_int16(arg).map_err(unwind_any_error)
     }
 }
 
@@ -1706,7 +1706,7 @@ mod to_uint16 {
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<u16, String> {
         setup_test_agent();
-        to_uint16(arg).map_err(|e| unwind_any_error(e))
+        to_uint16(arg).map_err(unwind_any_error)
     }
 }
 
@@ -1725,7 +1725,7 @@ mod to_int8 {
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<i8, String> {
         setup_test_agent();
-        to_int8(arg).map_err(|e| unwind_any_error(e))
+        to_int8(arg).map_err(unwind_any_error)
     }
 }
 
@@ -1744,7 +1744,7 @@ mod to_uint8 {
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<u8, String> {
         setup_test_agent();
-        to_uint8(arg).map_err(|e| unwind_any_error(e))
+        to_uint8(arg).map_err(unwind_any_error)
     }
 }
 
@@ -2050,6 +2050,6 @@ mod agent {
         let x = make_x();
         let y = make_y();
 
-        super::is_loosely_equal(&x, &y).map_err(|e| unwind_any_error(e))
+        super::is_loosely_equal(&x, &y).map_err(unwind_any_error)
     }
 }

--- a/src/values/tests.rs
+++ b/src/values/tests.rs
@@ -136,7 +136,7 @@ mod ecmascript_value {
     #[test]
     fn from_object_ref() {
         setup_test_agent();
-        let o = ordinary_object_create(&agent, None, &[]);
+        let o = ordinary_object_create(None, &[]);
 
         let val = ECMAScriptValue::from(&o);
         assert!(val.is_object());
@@ -146,7 +146,7 @@ mod ecmascript_value {
     #[test]
     fn from_object() {
         setup_test_agent();
-        let o = ordinary_object_create(&agent, None, &[]);
+        let o = ordinary_object_create(None, &[]);
         let orig_id = o.o.id();
 
         let val = ECMAScriptValue::from(o);
@@ -164,11 +164,11 @@ mod ecmascript_value {
     fn from_numeric(n: Numeric) -> ECMAScriptValue {
         ECMAScriptValue::from(n)
     }
-    #[test_case(|_| PropertyKey::String("key".into()) => "key"; "string")]
-    #[test_case(|a| PropertyKey::Symbol(a.wks(WksId::ToPrimitive)) => "Symbol(Symbol.toPrimitive)"; "symbol")]
-    fn from_property_key(maker: fn(&Agent) -> PropertyKey) -> String {
+    #[test_case(|| PropertyKey::String("key".into()) => "key"; "string")]
+    #[test_case(|| PropertyKey::Symbol(wks(WksId::ToPrimitive)) => "Symbol(Symbol.toPrimitive)"; "symbol")]
+    fn from_property_key(maker: fn() -> PropertyKey) -> String {
         setup_test_agent();
-        let key = maker(&agent);
+        let key = maker();
         format!("{}", ECMAScriptValue::from(key))
     }
     #[test_case(String::from("blue") => ECMAScriptValue::String("blue".into()); "String")]
@@ -208,7 +208,7 @@ mod ecmascript_value {
     fn is_symbol() {
         setup_test_agent();
         assert_eq!(ECMAScriptValue::Undefined.is_symbol(), false);
-        assert_eq!(ECMAScriptValue::from(Symbol::new(&agent, Some(JSString::from("Test Symbol")))).is_symbol(), true);
+        assert_eq!(ECMAScriptValue::from(Symbol::new(Some(JSString::from("Test Symbol")))).is_symbol(), true);
         assert_eq!(ECMAScriptValue::Null.is_symbol(), false);
     }
     #[test]
@@ -220,7 +220,7 @@ mod ecmascript_value {
     #[test]
     fn is_object() {
         setup_test_agent();
-        let o = ordinary_object_create(&agent, None, &[]);
+        let o = ordinary_object_create(None, &[]);
         assert_eq!(ECMAScriptValue::Undefined.is_object(), false);
         assert_eq!(ECMAScriptValue::from(o).is_object(), true);
         assert_eq!(ECMAScriptValue::Null.is_object(), false);
@@ -236,61 +236,53 @@ mod ecmascript_value {
     fn concise() {
         // Calling this on our own isn't really do-able; we need to get there via Display or Debug.
         setup_test_agent();
-        let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let obj = ordinary_object_create(&agent, Some(obj_proto), &[]);
+        let obj_proto = intrinsic(IntrinsicId::ObjectPrototype);
+        let obj = ordinary_object_create(Some(obj_proto), &[]);
         define_property_or_throw(
-            &agent,
             &obj,
             PropertyKey::from("Undefined"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::Undefined), ..Default::default() },
         )
         .unwrap();
         define_property_or_throw(
-            &agent,
             &obj,
             PropertyKey::from("Null"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::Null), ..Default::default() },
         )
         .unwrap();
         define_property_or_throw(
-            &agent,
             &obj,
             PropertyKey::from("Number"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from(10.0)), ..Default::default() },
         )
         .unwrap();
         define_property_or_throw(
-            &agent,
             &obj,
             PropertyKey::from("String"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from("bob")), ..Default::default() },
         )
         .unwrap();
         define_property_or_throw(
-            &agent,
             &obj,
             PropertyKey::from("Boolean"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from(true)), ..Default::default() },
         )
         .unwrap();
         define_property_or_throw(
-            &agent,
             &obj,
             PropertyKey::from("BigInt"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from(BigInt::from(11))), ..Default::default() },
         )
         .unwrap();
-        let sym = Symbol::new(&agent, Some(JSString::from("San Francisco")));
+        let sym = Symbol::new(Some(JSString::from("San Francisco")));
         define_property_or_throw(
-            &agent,
             &obj,
             PropertyKey::from("Symbol"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from(sym)), ..Default::default() },
         )
         .unwrap();
-        let propobj = &agent.intrinsic(IntrinsicId::Boolean);
+        let propobj = &intrinsic(IntrinsicId::Boolean);
         define_property_or_throw(
-            &agent,
             &obj,
             PropertyKey::from("Object"),
             PotentialPropertyDescriptor { value: Some(ECMAScriptValue::from(propobj)), ..Default::default() },
@@ -302,11 +294,11 @@ mod ecmascript_value {
     #[test]
     fn is_array() {
         setup_test_agent();
-        let a = array_create(&agent, 0, None).unwrap();
+        let a = array_create(0, None).unwrap();
         let v1: ECMAScriptValue = a.into();
         let v2 = ECMAScriptValue::Null;
-        assert!(v1.is_array(&agent).unwrap());
-        assert!(!v2.is_array(&agent).unwrap());
+        assert!(v1.is_array().unwrap());
+        assert!(!v2.is_array().unwrap());
     }
 
     mod display {
@@ -324,68 +316,68 @@ mod ecmascript_value {
             format!("{val}")
         }
 
-        #[test_case(|a| ECMAScriptValue::Symbol(a.wks(WksId::ToPrimitive)) => "Symbol(Symbol.toPrimitive)"; "symbol")]
-        #[test_case(|a| {
-            let obj = ordinary_object_create(a, None, &[]);
+        #[test_case(|| ECMAScriptValue::Symbol(wks(WksId::ToPrimitive)) => "Symbol(Symbol.toPrimitive)"; "symbol")]
+        #[test_case(|| {
+            let obj = ordinary_object_create(None, &[]);
             ECMAScriptValue::Object(obj)
         } => with |s: String| assert!(Regex::new("^<Object [0-9]+>$").unwrap().is_match(&s)); "object")]
-        fn complex(maker: fn(&Agent) -> ECMAScriptValue) -> String {
+        fn complex(maker: fn() -> ECMAScriptValue) -> String {
             setup_test_agent();
-            let val = maker(&agent);
+            let val = maker();
             format!("{val}")
         }
     }
 
-    type ValueMaker = fn(&Agent) -> ECMAScriptValue;
-    fn undef(_: &Agent) -> ECMAScriptValue {
+    type ValueMaker = fn() -> ECMAScriptValue;
+    fn undef() -> ECMAScriptValue {
         ECMAScriptValue::Undefined
     }
-    fn null(_: &Agent) -> ECMAScriptValue {
+    fn null() -> ECMAScriptValue {
         ECMAScriptValue::Null
     }
-    fn string_a(_: &Agent) -> ECMAScriptValue {
+    fn string_a() -> ECMAScriptValue {
         ECMAScriptValue::from("A")
     }
-    fn string_b(_: &Agent) -> ECMAScriptValue {
+    fn string_b() -> ECMAScriptValue {
         ECMAScriptValue::from("B")
     }
-    fn bool_a(_: &Agent) -> ECMAScriptValue {
+    fn bool_a() -> ECMAScriptValue {
         ECMAScriptValue::from(true)
     }
-    fn bool_b(_: &Agent) -> ECMAScriptValue {
+    fn bool_b() -> ECMAScriptValue {
         ECMAScriptValue::from(false)
     }
-    fn symbol_a(agent: &Agent) -> ECMAScriptValue {
-        agent.wks(WksId::ToPrimitive).into()
+    fn symbol_a() -> ECMAScriptValue {
+        wks(WksId::ToPrimitive).into()
     }
-    fn symbol_b(agent: &Agent) -> ECMAScriptValue {
-        agent.wks(WksId::HasInstance).into()
+    fn symbol_b() -> ECMAScriptValue {
+        wks(WksId::HasInstance).into()
     }
-    fn object_a(agent: &Agent) -> ECMAScriptValue {
-        agent.intrinsic(IntrinsicId::FunctionPrototype).into()
+    fn object_a() -> ECMAScriptValue {
+        intrinsic(IntrinsicId::FunctionPrototype).into()
     }
-    fn object_b(agent: &Agent) -> ECMAScriptValue {
-        agent.intrinsic(IntrinsicId::ObjectPrototype).into()
+    fn object_b() -> ECMAScriptValue {
+        intrinsic(IntrinsicId::ObjectPrototype).into()
     }
-    fn number_10(_: &Agent) -> ECMAScriptValue {
+    fn number_10() -> ECMAScriptValue {
         10.into()
     }
-    fn number_100(_: &Agent) -> ECMAScriptValue {
+    fn number_100() -> ECMAScriptValue {
         100.into()
     }
-    fn number_zero(_: &Agent) -> ECMAScriptValue {
+    fn number_zero() -> ECMAScriptValue {
         0.into()
     }
-    fn number_neg_zero(_: &Agent) -> ECMAScriptValue {
+    fn number_neg_zero() -> ECMAScriptValue {
         (-0.0).into()
     }
-    fn number_nan(_: &Agent) -> ECMAScriptValue {
+    fn number_nan() -> ECMAScriptValue {
         f64::NAN.into()
     }
-    fn bigint_a(_: &Agent) -> ECMAScriptValue {
+    fn bigint_a() -> ECMAScriptValue {
         BigInt::from(10).into()
     }
-    fn bigint_b(_: &Agent) -> ECMAScriptValue {
+    fn bigint_b() -> ECMAScriptValue {
         BigInt::from(-1097631).into()
     }
 
@@ -402,8 +394,8 @@ mod ecmascript_value {
     #[test_case(undef, symbol_b => panics "Invalid input args"; "Invalid Input")]
     fn same_value_non_numeric(make_x: ValueMaker, make_y: ValueMaker) -> bool {
         setup_test_agent();
-        let x = make_x(&agent);
-        let y = make_y(&agent);
+        let x = make_x();
+        let y = make_y();
 
         x.same_value_non_numeric(&y)
     }
@@ -418,8 +410,8 @@ mod ecmascript_value {
     #[test_case(string_a, string_a => true; "fallthru for nonnumbers")]
     fn same_value_zero(make_x: ValueMaker, make_y: ValueMaker) -> bool {
         setup_test_agent();
-        let x = make_x(&agent);
-        let y = make_y(&agent);
+        let x = make_x();
+        let y = make_y();
 
         x.same_value_zero(&y)
     }
@@ -434,8 +426,8 @@ mod ecmascript_value {
     #[test_case(string_a, string_a => true; "fallthru for nonnumbers")]
     fn same_value(make_x: ValueMaker, make_y: ValueMaker) -> bool {
         setup_test_agent();
-        let x = make_x(&agent);
-        let y = make_y(&agent);
+        let x = make_x();
+        let y = make_y();
 
         x.same_value(&y)
     }
@@ -450,8 +442,8 @@ mod ecmascript_value {
     #[test_case(string_a, string_a => true; "fallthru for nonnumbers")]
     fn is_strictly_equal(make_x: ValueMaker, make_y: ValueMaker) -> bool {
         setup_test_agent();
-        let x = make_x(&agent);
-        let y = make_y(&agent);
+        let x = make_x();
+        let y = make_y();
 
         x.is_strictly_equal(&y)
     }
@@ -460,33 +452,33 @@ mod ecmascript_value {
 #[test]
 fn symbol_debug() {
     setup_test_agent();
-    assert_ne!(format!("{:?}", agent.wks(WksId::ToPrimitive)), "");
+    assert_ne!(format!("{:?}", wks(WksId::ToPrimitive)), "");
 }
 #[test]
 fn symbol_display_normal() {
     setup_test_agent();
-    let symbol = Symbol::new(&agent, Some(JSString::from("Normal")));
+    let symbol = Symbol::new(Some(JSString::from("Normal")));
     assert_eq!(format!("{}", symbol), "Symbol(Normal)");
 }
 #[test]
 fn symbol_display_empty() {
     setup_test_agent();
-    let symbol = Symbol::new(&agent, None);
+    let symbol = Symbol::new(None);
     assert_eq!(format!("{}", symbol), "Symbol()");
 }
 #[test]
 fn symbol_clone() {
     setup_test_agent();
-    let s1 = agent.wks(WksId::ToPrimitive);
+    let s1 = wks(WksId::ToPrimitive);
     let s2 = s1.clone();
     assert_eq!(s1, s2);
 }
 #[test]
 fn symbol_hash() {
     setup_test_agent();
-    let s1 = agent.wks(WksId::ToPrimitive);
+    let s1 = wks(WksId::ToPrimitive);
     let s2 = s1.clone();
-    let s3 = agent.wks(WksId::Unscopables);
+    let s3 = wks(WksId::Unscopables);
 
     let factory = RandomState::new();
 
@@ -504,9 +496,9 @@ fn symbol_hash() {
 #[test]
 fn symbol_new() {
     setup_test_agent();
-    let s1 = Symbol::new(&agent, Some(JSString::from("Symbol #1")));
-    let s2 = Symbol::new(&agent, Some(JSString::from("Symbol #2")));
-    let s3 = Symbol::new(&agent, Some(JSString::from("Symbol #1")));
+    let s1 = Symbol::new(Some(JSString::from("Symbol #1")));
+    let s2 = Symbol::new(Some(JSString::from("Symbol #2")));
+    let s3 = Symbol::new(Some(JSString::from("Symbol #1")));
     let s4 = s1.clone();
 
     assert_ne!(s1, s2);
@@ -519,7 +511,7 @@ fn symbol_new() {
 #[test]
 fn symbol_description() {
     setup_test_agent();
-    let s1 = Symbol::new(&agent, Some(JSString::from("Test Symbol")));
+    let s1 = Symbol::new(Some(JSString::from("Test Symbol")));
     assert_eq!(s1.description(), Some(JSString::from("Test Symbol")));
 }
 #[test]
@@ -665,8 +657,8 @@ fn to_boolean_01() {
     assert_eq!(to_boolean(ECMAScriptValue::from(BigInt::from(0))), false);
 
     setup_test_agent();
-    assert_eq!(to_boolean(ECMAScriptValue::from(agent.wks(WksId::ToPrimitive))), true);
-    let o = ordinary_object_create(&agent, None, &[]);
+    assert_eq!(to_boolean(ECMAScriptValue::from(wks(WksId::ToPrimitive))), true);
+    let o = ordinary_object_create(None, &[]);
     assert_eq!(to_boolean(ECMAScriptValue::from(o)), true);
 }
 
@@ -692,8 +684,8 @@ mod property_key {
         let pk = PropertyKey::from(&JSString::from("c"));
         assert_eq!(pk, PropertyKey::String(JSString::from("c")));
         setup_test_agent();
-        let pk = PropertyKey::from(agent.wks(WksId::ToPrimitive));
-        assert_eq!(pk, PropertyKey::Symbol(agent.wks(WksId::ToPrimitive)));
+        let pk = PropertyKey::from(wks(WksId::ToPrimitive));
+        assert_eq!(pk, PropertyKey::Symbol(wks(WksId::ToPrimitive)));
         let pk = PropertyKey::from(String::from("d"));
         assert_eq!(pk, PropertyKey::String(JSString::from("d")));
         let pk = PropertyKey::from(848183_usize);
@@ -706,7 +698,7 @@ mod property_key {
     #[test]
     fn display() {
         setup_test_agent();
-        let sym = agent.wks(WksId::HasInstance);
+        let sym = wks(WksId::HasInstance);
         assert_eq!(format!("{}", PropertyKey::from("tangerine")), "tangerine");
         assert_eq!(format!("{}", PropertyKey::from(sym)), "Symbol(Symbol.hasInstance)");
     }
@@ -730,14 +722,14 @@ mod property_key {
         assert_eq!(PropertyKey::from("4294967296").is_array_index(), false);
         assert_eq!(PropertyKey::from("010").is_array_index(), false);
         assert_eq!(PropertyKey::from("000").is_array_index(), false);
-        assert_eq!(PropertyKey::from(agent.wks(WksId::ToPrimitive)).is_array_index(), false);
+        assert_eq!(PropertyKey::from(wks(WksId::ToPrimitive)).is_array_index(), false);
     }
-    #[test_case(|_| PropertyKey::from("alice"), |_| ECMAScriptValue::from("alice"); "string")]
-    #[test_case(|a| PropertyKey::from(a.wks(WksId::ToPrimitive)), |a| ECMAScriptValue::from(a.wks(WksId::ToPrimitive)); "symbol")]
-    fn into_ecmascriptvalue(make_key: fn(&Agent) -> PropertyKey, make_expected: fn(&Agent) -> ECMAScriptValue) {
+    #[test_case(|| PropertyKey::from("alice"), || ECMAScriptValue::from("alice"); "string")]
+    #[test_case(|| PropertyKey::from(wks(WksId::ToPrimitive)), || ECMAScriptValue::from(wks(WksId::ToPrimitive)); "symbol")]
+    fn into_ecmascriptvalue(make_key: fn() -> PropertyKey, make_expected: fn() -> ECMAScriptValue) {
         setup_test_agent();
-        let key = make_key(&agent);
-        let expected = make_expected(&agent);
+        let key = make_key();
+        let expected = make_expected();
         assert_eq!(ECMAScriptValue::from(key), expected);
     }
 
@@ -754,9 +746,9 @@ mod property_key {
         #[test]
         fn symbol() {
             setup_test_agent();
-            let val = ECMAScriptValue::from(agent.wks(WksId::ToPrimitive));
+            let val = ECMAScriptValue::from(wks(WksId::ToPrimitive));
             let pk = PropertyKey::try_from(val).unwrap();
-            assert_eq!(pk, PropertyKey::from(agent.wks(WksId::ToPrimitive)));
+            assert_eq!(pk, PropertyKey::from(wks(WksId::ToPrimitive)));
         }
     }
 }
@@ -768,36 +760,36 @@ mod jsstring {
         use super::*;
         use test_case::test_case;
 
-        #[test_case(|_| PropertyKey::from("key") => sok("key"); "string")]
-        #[test_case(|a| PropertyKey::from(a.wks(WksId::ToPrimitive)) => serr("Expected String-valued property key"); "symbol")]
-        fn property_key(maker: fn(&Agent) -> PropertyKey) -> Result<String, String> {
+        #[test_case(|| PropertyKey::from("key") => sok("key"); "string")]
+        #[test_case(|| PropertyKey::from(wks(WksId::ToPrimitive)) => serr("Expected String-valued property key"); "symbol")]
+        fn property_key(maker: fn() -> PropertyKey) -> Result<String, String> {
             setup_test_agent();
-            let key = maker(&agent);
+            let key = maker();
             JSString::try_from(key).map_err(|e| e.to_string()).map(String::from)
         }
-        #[test_case(|_| PropertyKey::from("key") => sok("key"); "string")]
-        #[test_case(|a| PropertyKey::from(a.wks(WksId::ToPrimitive)) => serr("Expected String-valued property key"); "symbol")]
-        fn property_key_ref(maker: fn(&Agent) -> PropertyKey) -> Result<String, String> {
+        #[test_case(|| PropertyKey::from("key") => sok("key"); "string")]
+        #[test_case(|| PropertyKey::from(wks(WksId::ToPrimitive)) => serr("Expected String-valued property key"); "symbol")]
+        fn property_key_ref(maker: fn() -> PropertyKey) -> Result<String, String> {
             setup_test_agent();
-            let key = maker(&agent);
+            let key = maker();
             JSString::try_from(&key).map_err(|e| e.to_string()).map(String::from)
         }
 
-        #[test_case(|_| ECMAScriptValue::Undefined => sok("undefined"); "undefined")]
-        #[test_case(|_| ECMAScriptValue::Null => sok("null"); "null")]
-        #[test_case(|_| ECMAScriptValue::Boolean(true) => sok("true"); "bool true")]
-        #[test_case(|_| ECMAScriptValue::Boolean(false) => sok("false"); "bool false")]
-        #[test_case(|_| ECMAScriptValue::String("boo".into()) => sok("boo"); "string")]
-        #[test_case(|_| ECMAScriptValue::Number(3321.3) => sok("3321.3"); "number")]
-        #[test_case(|_| ECMAScriptValue::BigInt(Rc::new(BigInt::from(1000))) => sok("1000"); "bigint")]
-        #[test_case(|a| ECMAScriptValue::Symbol(a.wks(WksId::ToPrimitive)) => serr("Symbols may not be converted to strings"); "symbol")]
-        #[test_case(|a| {
-            let obj = ordinary_object_create(a, None, &[]);
+        #[test_case(|| ECMAScriptValue::Undefined => sok("undefined"); "undefined")]
+        #[test_case(|| ECMAScriptValue::Null => sok("null"); "null")]
+        #[test_case(|| ECMAScriptValue::Boolean(true) => sok("true"); "bool true")]
+        #[test_case(|| ECMAScriptValue::Boolean(false) => sok("false"); "bool false")]
+        #[test_case(|| ECMAScriptValue::String("boo".into()) => sok("boo"); "string")]
+        #[test_case(|| ECMAScriptValue::Number(3321.3) => sok("3321.3"); "number")]
+        #[test_case(|| ECMAScriptValue::BigInt(Rc::new(BigInt::from(1000))) => sok("1000"); "bigint")]
+        #[test_case(|| ECMAScriptValue::Symbol(wks(WksId::ToPrimitive)) => serr("Symbols may not be converted to strings"); "symbol")]
+        #[test_case(|| {
+            let obj = ordinary_object_create(None, &[]);
             ECMAScriptValue::Object(obj)
         } => serr("Object to string conversions require an agent"); "object")]
-        fn ecmasript_value(maker: fn(&Agent) -> ECMAScriptValue) -> Result<String, String> {
+        fn ecmasript_value(maker: fn() -> ECMAScriptValue) -> Result<String, String> {
             setup_test_agent();
-            let value = maker(&agent);
+            let value = maker();
             JSString::try_from(value).map_err(|e| e.to_string()).map(String::from)
         }
     }
@@ -831,28 +823,28 @@ mod numeric {
 #[test]
 fn to_numeric_01() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
-    let result = to_numeric(&agent, ECMAScriptValue::from(obj)).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Cannot convert object to primitive value");
+    let obj = ordinary_object_create(None, &[]);
+    let result = to_numeric(ECMAScriptValue::from(obj)).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Cannot convert object to primitive value");
 }
 #[test]
 fn to_numeric_02() {
     setup_test_agent();
-    let result = to_numeric(&agent, ECMAScriptValue::from(BigInt::from(4747474))).unwrap();
+    let result = to_numeric(ECMAScriptValue::from(BigInt::from(4747474))).unwrap();
     assert_eq!(result, Numeric::BigInt(Rc::new(BigInt::from(4747474))));
 }
 #[test]
 fn to_numeric_03() {
     setup_test_agent();
-    let result = to_numeric(&agent, ECMAScriptValue::from(10)).unwrap();
+    let result = to_numeric(ECMAScriptValue::from(10)).unwrap();
     assert_eq!(result, Numeric::Number(10.0));
 }
 #[test]
 fn to_numeric_04() {
     setup_test_agent();
-    let sym = Symbol::new(&agent, None);
-    let result = to_numeric(&agent, ECMAScriptValue::from(sym)).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
+    let sym = Symbol::new(None);
+    let result = to_numeric(ECMAScriptValue::from(sym)).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Symbol values cannot be converted to Number values");
 }
 
 #[test]
@@ -860,7 +852,7 @@ fn to_number_01() {
     setup_test_agent();
     let input = ECMAScriptValue::Undefined;
 
-    let result = to_number(&agent, input).unwrap();
+    let result = to_number(input).unwrap();
     assert!(result.is_nan());
 }
 #[test]
@@ -869,7 +861,7 @@ fn to_number_02() {
     setup_test_agent();
     let input = ECMAScriptValue::Null;
 
-    let result = to_number(&agent, input).unwrap();
+    let result = to_number(input).unwrap();
     assert_eq!(result, 0.0);
 }
 #[test]
@@ -878,7 +870,7 @@ fn to_number_03() {
     setup_test_agent();
     let input = ECMAScriptValue::from(true);
 
-    let result = to_number(&agent, input).unwrap();
+    let result = to_number(input).unwrap();
     assert_eq!(result, 1.0);
 }
 #[test]
@@ -887,7 +879,7 @@ fn to_number_04() {
     setup_test_agent();
     let input = ECMAScriptValue::from(false);
 
-    let result = to_number(&agent, input).unwrap();
+    let result = to_number(input).unwrap();
     assert_eq!(result, 0.0);
 }
 #[test]
@@ -896,7 +888,7 @@ fn to_number_05() {
     setup_test_agent();
     let input = ECMAScriptValue::from(37.6);
 
-    let result = to_number(&agent, input).unwrap();
+    let result = to_number(input).unwrap();
     assert_eq!(result, 37.6);
 }
 #[test]
@@ -904,7 +896,7 @@ fn to_number_06() {
     setup_test_agent();
     let input = ECMAScriptValue::from("blue");
 
-    let result = to_number(&agent, input).unwrap();
+    let result = to_number(input).unwrap();
     assert!(result.is_nan());
 }
 #[test]
@@ -928,7 +920,7 @@ fn to_number_07() {
     ];
 
     for (s, e) in testcases {
-        let result = to_number(&agent, ECMAScriptValue::from(s)).unwrap();
+        let result = to_number(ECMAScriptValue::from(s)).unwrap();
         assert_eq!(result, e);
     }
 }
@@ -937,34 +929,34 @@ fn to_number_08() {
     setup_test_agent();
     let input = ECMAScriptValue::from(BigInt::from(10));
 
-    let result = to_number(&agent, input).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "BigInt values cannot be converted to Number values");
+    let result = to_number(input).unwrap_err();
+    assert_eq!(unwind_type_error(result), "BigInt values cannot be converted to Number values");
 }
 #[test]
 fn to_number_09() {
     setup_test_agent();
-    let input = ECMAScriptValue::from(Symbol::new(&agent, None));
+    let input = ECMAScriptValue::from(Symbol::new(None));
 
-    let result = to_number(&agent, input).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
+    let result = to_number(input).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Symbol values cannot be converted to Number values");
 }
 #[test]
 fn to_number_10() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
+    let obj = ordinary_object_create(None, &[]);
     let input = ECMAScriptValue::from(obj);
 
-    let result = to_number(&agent, input).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Cannot convert object to primitive value");
+    let result = to_number(input).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Cannot convert object to primitive value");
 }
 #[test]
 fn to_number_11() {
     setup_test_agent();
-    let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(obj_proto), &[]);
+    let obj_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(obj_proto), &[]);
     let input = ECMAScriptValue::from(obj);
 
-    let result = to_number(&agent, input).unwrap();
+    let result = to_number(input).unwrap();
     assert!(result.is_nan());
 }
 
@@ -983,76 +975,76 @@ fn to_integer_or_infinity_01() {
     ];
 
     for (val, expected) in testcases {
-        let result = to_integer_or_infinity(&agent, ECMAScriptValue::from(*val)).unwrap();
+        let result = to_integer_or_infinity(ECMAScriptValue::from(*val)).unwrap();
         assert_eq!(result, *expected);
     }
 }
 #[test]
 fn to_integer_or_infinity_02() {
     setup_test_agent();
-    let sym = Symbol::new(&agent, None);
+    let sym = Symbol::new(None);
 
-    let result = to_integer_or_infinity(&agent, ECMAScriptValue::from(sym)).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Symbol values cannot be converted to Number values");
+    let result = to_integer_or_infinity(ECMAScriptValue::from(sym)).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Symbol values cannot be converted to Number values");
 }
 
 #[test]
 fn to_string_01() {
     setup_test_agent();
-    let result = to_string(&agent, ECMAScriptValue::Undefined).unwrap();
+    let result = to_string(ECMAScriptValue::Undefined).unwrap();
     assert_eq!(result, "undefined");
 }
 #[test]
 fn to_string_02() {
     setup_test_agent();
-    let result = to_string(&agent, ECMAScriptValue::Null).unwrap();
+    let result = to_string(ECMAScriptValue::Null).unwrap();
     assert_eq!(result, "null");
 }
 #[test]
 fn to_string_03() {
     setup_test_agent();
-    let result = to_string(&agent, ECMAScriptValue::from(true)).unwrap();
+    let result = to_string(ECMAScriptValue::from(true)).unwrap();
     assert_eq!(result, "true");
 }
 #[test]
 fn to_string_04() {
     setup_test_agent();
-    let result = to_string(&agent, ECMAScriptValue::from(false)).unwrap();
+    let result = to_string(ECMAScriptValue::from(false)).unwrap();
     assert_eq!(result, "false");
 }
 #[test]
 fn to_string_05() {
     setup_test_agent();
-    let result = to_string(&agent, ECMAScriptValue::from(10)).unwrap();
+    let result = to_string(ECMAScriptValue::from(10)).unwrap();
     assert_eq!(result, "10");
 }
 #[test]
 fn to_string_06() {
     setup_test_agent();
-    let result = to_string(&agent, ECMAScriptValue::from("blue")).unwrap();
+    let result = to_string(ECMAScriptValue::from("blue")).unwrap();
     assert_eq!(result, "blue");
 }
 #[test]
 fn to_string_07() {
     setup_test_agent();
-    let sym = Symbol::new(&agent, None);
-    let result = to_string(&agent, ECMAScriptValue::Symbol(sym)).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Symbols may not be converted to strings");
+    let sym = Symbol::new(None);
+    let result = to_string(ECMAScriptValue::Symbol(sym)).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Symbols may not be converted to strings");
 }
 #[test]
 fn to_string_08() {
     setup_test_agent();
-    let obj_proto = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(&agent, Some(obj_proto), &[]);
-    let result = to_string(&agent, ECMAScriptValue::from(obj)).unwrap();
+    let obj_proto = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(obj_proto), &[]);
+    let result = to_string(ECMAScriptValue::from(obj)).unwrap();
     assert_eq!(result, "[object Object]");
 }
 #[test]
 fn to_string_09() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
-    let result = to_string(&agent, ECMAScriptValue::from(obj)).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Cannot convert object to primitive value");
+    let obj = ordinary_object_create(None, &[]);
+    let result = to_string(ECMAScriptValue::from(obj)).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Cannot convert object to primitive value");
 }
 fn tostring_symbol(
     agent: &Agent,
@@ -1060,55 +1052,46 @@ fn tostring_symbol(
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let sym = Symbol::new(agent, None);
+    let sym = Symbol::new(None);
     Ok(ECMAScriptValue::from(sym))
 }
 #[test]
 fn to_string_10() {
     setup_test_agent();
-    let obj = ordinary_object_create(&agent, None, &[]);
-    let badtostring = create_builtin_function(
-        &agent,
-        tostring_symbol,
-        false,
-        0_f64,
-        PropertyKey::from("toString"),
-        &[],
-        None,
-        None,
-        None,
-    );
-    create_data_property(&agent, &obj, PropertyKey::from("toString"), ECMAScriptValue::from(badtostring)).unwrap();
+    let obj = ordinary_object_create(None, &[]);
+    let badtostring =
+        create_builtin_function(tostring_symbol, false, 0_f64, PropertyKey::from("toString"), &[], None, None, None);
+    create_data_property(&obj, PropertyKey::from("toString"), ECMAScriptValue::from(badtostring)).unwrap();
 
-    let result = to_string(&agent, ECMAScriptValue::from(obj)).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Symbols may not be converted to strings");
+    let result = to_string(ECMAScriptValue::from(obj)).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Symbols may not be converted to strings");
 }
 #[test]
 fn to_string_11() {
     setup_test_agent();
-    let result = to_string(&agent, ECMAScriptValue::from(BigInt::from(789123))).unwrap();
+    let result = to_string(ECMAScriptValue::from(BigInt::from(789123))).unwrap();
     assert_eq!(result, "789123");
 }
 
 #[test]
 fn to_object_01() {
     setup_test_agent();
-    let err = to_object(&agent, ECMAScriptValue::Undefined).unwrap_err();
-    let msg = unwind_type_error(&agent, err);
+    let err = to_object(ECMAScriptValue::Undefined).unwrap_err();
+    let msg = unwind_type_error(err);
     assert_eq!(msg, "Undefined and null cannot be converted to objects");
 }
 #[test]
 fn to_object_02() {
     setup_test_agent();
-    let err = to_object(&agent, ECMAScriptValue::Null).unwrap_err();
-    let msg = unwind_type_error(&agent, err);
+    let err = to_object(ECMAScriptValue::Null).unwrap_err();
+    let msg = unwind_type_error(err);
     assert_eq!(msg, "Undefined and null cannot be converted to objects");
 }
 #[test]
 fn to_object_03() {
     setup_test_agent();
     let test_value = true;
-    let result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
+    let result = to_object(ECMAScriptValue::from(test_value)).unwrap();
 
     let boolean_obj = result.o.to_boolean_obj().unwrap();
     assert_eq!(*boolean_obj.boolean_data().borrow(), test_value);
@@ -1118,7 +1101,7 @@ fn to_object_03() {
 fn to_object_04() {
     setup_test_agent();
     let test_value = 1337.0;
-    let result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
+    let result = to_object(ECMAScriptValue::from(test_value)).unwrap();
 
     let number_obj = result.o.to_number_obj().unwrap();
     assert_eq!(*number_obj.number_data().borrow(), test_value);
@@ -1127,17 +1110,17 @@ fn to_object_04() {
 fn to_object_05() {
     setup_test_agent();
     let test_value = "orange";
-    let result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
+    let result = to_object(ECMAScriptValue::from(test_value)).unwrap();
 
-    let val = to_string(&agent, result).unwrap();
+    let val = to_string(result).unwrap();
     assert_eq!(val, JSString::from(test_value));
 }
 #[test]
 fn to_object_06() {
     setup_test_agent();
-    let test_value = agent.wks(WksId::ToPrimitive);
-    let result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
-    let desc = get(&agent, &result, &"description".into()).unwrap();
+    let test_value = wks(WksId::ToPrimitive);
+    let result = to_object(ECMAScriptValue::from(test_value)).unwrap();
+    let desc = get(&result, &"description".into()).unwrap();
     assert_eq!(desc, ECMAScriptValue::from("Symbol.toPrimitive"));
 }
 #[test]
@@ -1145,14 +1128,14 @@ fn to_object_06() {
 fn to_object_07() {
     setup_test_agent();
     let test_value = BigInt::from(10);
-    let _result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
+    let _result = to_object(ECMAScriptValue::from(test_value)).unwrap();
 }
 #[test]
 fn to_object_08() {
     setup_test_agent();
-    let test_value = ordinary_object_create(&agent, None, &[]);
+    let test_value = ordinary_object_create(None, &[]);
     let id = test_value.o.id();
-    let result = to_object(&agent, ECMAScriptValue::from(test_value)).unwrap();
+    let result = to_object(ECMAScriptValue::from(test_value)).unwrap();
     assert_eq!(result.o.id(), id);
 }
 
@@ -1187,8 +1170,8 @@ fn faux_makes_obj(
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-    let obj = ordinary_object_create(agent, Some(object_prototype), &[]);
+    let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+    let obj = ordinary_object_create(Some(object_prototype), &[]);
     Ok(ECMAScriptValue::from(obj))
 }
 // error
@@ -1198,22 +1181,21 @@ fn faux_errors(
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    Err(create_type_error(agent, "Test Sentinel"))
+    Err(create_type_error("Test Sentinel"))
 }
 enum FauxKind {
     Object,
     Primitive,
     Error,
 }
-fn make_test_obj(agent: &Agent, valueof: FauxKind, tostring: FauxKind) -> Object {
+fn make_test_obj(valueof: FauxKind, tostring: FauxKind) -> Object {
     let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
-    let target = ordinary_object_create(agent, Some(object_prototype), &[]);
+    let target = ordinary_object_create(Some(object_prototype), &[]);
     let connect = |name, length, steps| {
         let key = PropertyKey::from(name);
         let fcn = create_builtin_function(
-            agent,
             steps,
             false,
             length,
@@ -1224,7 +1206,6 @@ fn make_test_obj(agent: &Agent, valueof: FauxKind, tostring: FauxKind) -> Object
             None,
         );
         define_property_or_throw(
-            agent,
             &target,
             key,
             PotentialPropertyDescriptor {
@@ -1259,15 +1240,14 @@ fn make_test_obj(agent: &Agent, valueof: FauxKind, tostring: FauxKind) -> Object
 
     target
 }
-pub fn make_tostring_getter_error(agent: &Agent) -> Object {
+pub fn make_tostring_getter_error() -> Object {
     // valueOf returns 123456; tostring is a getter that errors
     let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
-    let target = ordinary_object_create(agent, Some(object_prototype), &[]);
+    let target = ordinary_object_create(Some(object_prototype), &[]);
     let key = PropertyKey::from("valueOf");
     let fcn = create_builtin_function(
-        agent,
         faux_makes_number,
         false,
         0_f64,
@@ -1278,7 +1258,6 @@ pub fn make_tostring_getter_error(agent: &Agent) -> Object {
         None,
     );
     define_property_or_throw(
-        agent,
         &target,
         key,
         PotentialPropertyDescriptor {
@@ -1293,7 +1272,6 @@ pub fn make_tostring_getter_error(agent: &Agent) -> Object {
 
     let key = PropertyKey::from("toString");
     let tostring_getter = create_builtin_function(
-        agent,
         faux_errors,
         false,
         0_f64,
@@ -1304,7 +1282,6 @@ pub fn make_tostring_getter_error(agent: &Agent) -> Object {
         Some(JSString::from("get")),
     );
     define_property_or_throw(
-        agent,
         &target,
         key,
         PotentialPropertyDescriptor {
@@ -1318,14 +1295,13 @@ pub fn make_tostring_getter_error(agent: &Agent) -> Object {
 
     target
 }
-pub fn make_test_obj_uncallable(agent: &Agent) -> Object {
-    let realm = agent.current_realm_record().unwrap();
+pub fn make_test_obj_uncallable() -> Object {
+    let realm = current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
-    let target = ordinary_object_create(agent, Some(object_prototype), &[]);
+    let target = ordinary_object_create(Some(object_prototype), &[]);
     let connect = |name| {
         let key = PropertyKey::from(name);
         define_property_or_throw(
-            agent,
             &target,
             key,
             PotentialPropertyDescriptor {
@@ -1347,112 +1323,112 @@ pub fn make_test_obj_uncallable(agent: &Agent) -> Object {
 #[test]
 fn ordinary_to_primitive_nonoobj() {
     setup_test_agent();
-    let test_obj = make_test_obj(&agent, FauxKind::Primitive, FauxKind::Primitive);
-    let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap();
+    let test_obj = make_test_obj(FauxKind::Primitive, FauxKind::Primitive);
+    let result_1 = ordinary_to_primitive(&test_obj, ConversionHint::Number).unwrap();
     assert_eq!(result_1, ECMAScriptValue::from(123456));
 
-    let result_2 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::String).unwrap();
+    let result_2 = ordinary_to_primitive(&test_obj, ConversionHint::String).unwrap();
     assert_eq!(result_2, ECMAScriptValue::from("test result"));
 }
 #[test]
 fn ordinary_to_primitive_obj() {
     setup_test_agent();
-    let test_obj = make_test_obj(&agent, FauxKind::Object, FauxKind::Object);
-    let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result_1), "Cannot convert object to primitive value");
+    let test_obj = make_test_obj(FauxKind::Object, FauxKind::Object);
+    let result_1 = ordinary_to_primitive(&test_obj, ConversionHint::Number).unwrap_err();
+    assert_eq!(unwind_type_error(result_1), "Cannot convert object to primitive value");
 
-    let result_2 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::String).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result_2), "Cannot convert object to primitive value");
+    let result_2 = ordinary_to_primitive(&test_obj, ConversionHint::String).unwrap_err();
+    assert_eq!(unwind_type_error(result_2), "Cannot convert object to primitive value");
 }
 #[test]
 fn ordinary_to_primitive_obj_nonobj() {
     setup_test_agent();
-    let test_obj = make_test_obj(&agent, FauxKind::Object, FauxKind::Primitive);
-    let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap();
+    let test_obj = make_test_obj(FauxKind::Object, FauxKind::Primitive);
+    let result_1 = ordinary_to_primitive(&test_obj, ConversionHint::Number).unwrap();
     assert_eq!(result_1, ECMAScriptValue::from("test result"));
 
-    let result_2 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::String).unwrap();
+    let result_2 = ordinary_to_primitive(&test_obj, ConversionHint::String).unwrap();
     assert_eq!(result_2, ECMAScriptValue::from("test result"));
 }
 #[test]
 fn ordinary_to_primitive_nonobj_obj() {
     setup_test_agent();
-    let test_obj = make_test_obj(&agent, FauxKind::Primitive, FauxKind::Object);
-    let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap();
+    let test_obj = make_test_obj(FauxKind::Primitive, FauxKind::Object);
+    let result_1 = ordinary_to_primitive(&test_obj, ConversionHint::Number).unwrap();
     assert_eq!(result_1, ECMAScriptValue::from(123456));
 
-    let result_2 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::String).unwrap();
+    let result_2 = ordinary_to_primitive(&test_obj, ConversionHint::String).unwrap();
     assert_eq!(result_2, ECMAScriptValue::from(123456));
 }
 #[test]
 fn ordinary_to_primitive_call_errors() {
     setup_test_agent();
-    let test_obj = make_test_obj(&agent, FauxKind::Primitive, FauxKind::Error);
-    let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap();
+    let test_obj = make_test_obj(FauxKind::Primitive, FauxKind::Error);
+    let result_1 = ordinary_to_primitive(&test_obj, ConversionHint::Number).unwrap();
     assert_eq!(result_1, ECMAScriptValue::from(123456));
 
-    let result_2 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::String).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result_2), "Test Sentinel");
+    let result_2 = ordinary_to_primitive(&test_obj, ConversionHint::String).unwrap_err();
+    assert_eq!(unwind_type_error(result_2), "Test Sentinel");
 }
 #[test]
 fn ordinary_to_primitive_get_errors() {
     setup_test_agent();
-    let test_obj = make_tostring_getter_error(&agent);
-    let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap();
+    let test_obj = make_tostring_getter_error();
+    let result_1 = ordinary_to_primitive(&test_obj, ConversionHint::Number).unwrap();
     assert_eq!(result_1, ECMAScriptValue::from(123456));
 
-    let result_2 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::String).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result_2), "Test Sentinel");
+    let result_2 = ordinary_to_primitive(&test_obj, ConversionHint::String).unwrap_err();
+    assert_eq!(unwind_type_error(result_2), "Test Sentinel");
 }
 #[test]
 fn ordinary_to_primitive_uncallables() {
     setup_test_agent();
-    let test_obj = make_test_obj_uncallable(&agent);
-    let result_1 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::Number).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result_1), "Cannot convert object to primitive value");
+    let test_obj = make_test_obj_uncallable();
+    let result_1 = ordinary_to_primitive(&test_obj, ConversionHint::Number).unwrap_err();
+    assert_eq!(unwind_type_error(result_1), "Cannot convert object to primitive value");
 
-    let result_2 = ordinary_to_primitive(&agent, &test_obj, ConversionHint::String).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result_2), "Cannot convert object to primitive value");
+    let result_2 = ordinary_to_primitive(&test_obj, ConversionHint::String).unwrap_err();
+    assert_eq!(unwind_type_error(result_2), "Cannot convert object to primitive value");
 }
 
 #[test]
 fn to_primitive_no_change() {
     setup_test_agent();
     // Undefined
-    let result = to_primitive(&agent, ECMAScriptValue::Undefined, None).unwrap();
+    let result = to_primitive(ECMAScriptValue::Undefined, None).unwrap();
     assert!(result.is_undefined());
     // Null
-    let result = to_primitive(&agent, ECMAScriptValue::Null, None).unwrap();
+    let result = to_primitive(ECMAScriptValue::Null, None).unwrap();
     assert!(result.is_null());
     // Boolean
-    let result = to_primitive(&agent, ECMAScriptValue::from(true), None).unwrap();
+    let result = to_primitive(ECMAScriptValue::from(true), None).unwrap();
     assert_eq!(result, ECMAScriptValue::from(true));
     // Number
-    let result = to_primitive(&agent, ECMAScriptValue::from(20), None).unwrap();
+    let result = to_primitive(ECMAScriptValue::from(20), None).unwrap();
     assert_eq!(result, ECMAScriptValue::from(20));
     // String
-    let result = to_primitive(&agent, ECMAScriptValue::from("test"), None).unwrap();
+    let result = to_primitive(ECMAScriptValue::from("test"), None).unwrap();
     assert_eq!(result, ECMAScriptValue::from("test"));
     // Symbol
-    let sym = Symbol::new(&agent, Some(JSString::from("Symbolic")));
-    let result = to_primitive(&agent, ECMAScriptValue::from(sym.clone()), None).unwrap();
+    let sym = Symbol::new(Some(JSString::from("Symbolic")));
+    let result = to_primitive(ECMAScriptValue::from(sym.clone()), None).unwrap();
     assert_eq!(result, ECMAScriptValue::from(sym));
     // BigInt
     let bi = "123456789012345678901234567890".parse::<BigInt>().unwrap();
-    let result = to_primitive(&agent, ECMAScriptValue::from(bi), None).unwrap();
+    let result = to_primitive(ECMAScriptValue::from(bi), None).unwrap();
     assert_eq!(result, ECMAScriptValue::from("123456789012345678901234567890".parse::<BigInt>().unwrap()));
 }
 #[test]
 fn to_primitive_prefer_number() {
     setup_test_agent();
-    let test_obj = make_test_obj(&agent, FauxKind::Primitive, FauxKind::Primitive);
+    let test_obj = make_test_obj(FauxKind::Primitive, FauxKind::Primitive);
     let test_value = ECMAScriptValue::from(test_obj);
 
-    let result = to_primitive(&agent, test_value.clone(), None).unwrap();
+    let result = to_primitive(test_value.clone(), None).unwrap();
     assert_eq!(result, ECMAScriptValue::from(123456));
-    let result = to_primitive(&agent, test_value.clone(), Some(ConversionHint::Number)).unwrap();
+    let result = to_primitive(test_value.clone(), Some(ConversionHint::Number)).unwrap();
     assert_eq!(result, ECMAScriptValue::from(123456));
-    let result = to_primitive(&agent, test_value, Some(ConversionHint::String)).unwrap();
+    let result = to_primitive(test_value, Some(ConversionHint::String)).unwrap();
     assert_eq!(result, ECMAScriptValue::from("test result"));
 }
 fn exotic_to_prim(
@@ -1475,16 +1451,14 @@ fn exotic_to_prim(
     }
 }
 fn make_toprimitive_obj(
-    agent: &Agent,
-    steps: fn(&Agent, ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion<ECMAScriptValue>,
+    steps: fn(ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion<ECMAScriptValue>,
 ) -> Object {
     let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
-    let target = ordinary_object_create(agent, Some(object_prototype), &[]);
-    let key = PropertyKey::from(agent.wks(WksId::ToPrimitive));
+    let target = ordinary_object_create(Some(object_prototype), &[]);
+    let key = PropertyKey::from(wks(WksId::ToPrimitive));
     let fcn = create_builtin_function(
-        agent,
         steps,
         false,
         1_f64,
@@ -1495,7 +1469,6 @@ fn make_toprimitive_obj(
         None,
     );
     define_property_or_throw(
-        agent,
         &target,
         key,
         PotentialPropertyDescriptor {
@@ -1512,14 +1485,14 @@ fn make_toprimitive_obj(
 #[test]
 fn to_primitive_uses_exotics() {
     setup_test_agent();
-    let test_obj = make_toprimitive_obj(&agent, exotic_to_prim);
+    let test_obj = make_toprimitive_obj(exotic_to_prim);
     let test_value = ECMAScriptValue::from(test_obj);
 
-    let result = to_primitive(&agent, test_value.clone(), None).unwrap();
+    let result = to_primitive(test_value.clone(), None).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Saw default"));
-    let result = to_primitive(&agent, test_value.clone(), Some(ConversionHint::Number)).unwrap();
+    let result = to_primitive(test_value.clone(), Some(ConversionHint::Number)).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Saw number"));
-    let result = to_primitive(&agent, test_value, Some(ConversionHint::String)).unwrap();
+    let result = to_primitive(test_value, Some(ConversionHint::String)).unwrap();
     assert_eq!(result, ECMAScriptValue::from("Saw string"));
 }
 fn exotic_returns_object(
@@ -1530,17 +1503,17 @@ fn exotic_returns_object(
 ) -> Completion<ECMAScriptValue> {
     let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
-    let target = ordinary_object_create(agent, Some(object_prototype), &[]);
+    let target = ordinary_object_create(Some(object_prototype), &[]);
     Ok(ECMAScriptValue::from(target))
 }
 #[test]
 fn to_primitive_exotic_returns_object() {
     setup_test_agent();
-    let test_obj = make_toprimitive_obj(&agent, exotic_returns_object);
+    let test_obj = make_toprimitive_obj(exotic_returns_object);
     let test_value = ECMAScriptValue::from(test_obj);
 
-    let result = to_primitive(&agent, test_value, None).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Cannot convert object to primitive value");
+    let result = to_primitive(test_value, None).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Cannot convert object to primitive value");
 }
 fn exotic_throws(
     agent: &Agent,
@@ -1548,16 +1521,16 @@ fn exotic_throws(
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    Err(create_type_error(agent, "Test Sentinel"))
+    Err(create_type_error("Test Sentinel"))
 }
 #[test]
 fn to_primitive_exotic_throws() {
     setup_test_agent();
-    let test_obj = make_toprimitive_obj(&agent, exotic_throws);
+    let test_obj = make_toprimitive_obj(exotic_throws);
     let test_value = ECMAScriptValue::from(test_obj);
 
-    let result = to_primitive(&agent, test_value, None).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Test Sentinel");
+    let result = to_primitive(test_value, None).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Test Sentinel");
 }
 #[test]
 fn to_primitive_exotic_getter_throws() {
@@ -1565,10 +1538,9 @@ fn to_primitive_exotic_getter_throws() {
     let realm = agent.current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_proto = realm.borrow().intrinsics.function_prototype.clone();
-    let target = ordinary_object_create(&agent, Some(object_prototype), &[]);
-    let key = PropertyKey::from(agent.wks(WksId::ToPrimitive));
+    let target = ordinary_object_create(Some(object_prototype), &[]);
+    let key = PropertyKey::from(wks(WksId::ToPrimitive));
     let toprim_getter = create_builtin_function(
-        &agent,
         faux_errors,
         false,
         0_f64,
@@ -1579,7 +1551,6 @@ fn to_primitive_exotic_getter_throws() {
         Some(JSString::from("get")),
     );
     define_property_or_throw(
-        &agent,
         &target,
         key,
         PotentialPropertyDescriptor {
@@ -1592,46 +1563,46 @@ fn to_primitive_exotic_getter_throws() {
     .unwrap();
     let test_value = ECMAScriptValue::from(target);
 
-    let result = to_primitive(&agent, test_value, None).unwrap_err();
-    assert_eq!(unwind_type_error(&agent, result), "Test Sentinel");
+    let result = to_primitive(test_value, None).unwrap_err();
+    assert_eq!(unwind_type_error(result), "Test Sentinel");
 }
 
 mod to_property_key {
     use super::*;
     use test_case::test_case;
 
-    #[test_case(|_| ECMAScriptValue::Undefined => Ok(PropertyKey::from("undefined")); "undefined")]
-    #[test_case(|_| ECMAScriptValue::from("blue") => Ok(PropertyKey::from("blue")); "string")]
-    #[test_case(|a| ECMAScriptValue::from(make_tostring_getter_error(a)) => Err("Test Sentinel".to_string()); "to_primitive error")]
-    fn simple(make_value: fn(&Agent) -> ECMAScriptValue) -> Result<PropertyKey, String> {
+    #[test_case(|| ECMAScriptValue::Undefined => Ok(PropertyKey::from("undefined")); "undefined")]
+    #[test_case(|| ECMAScriptValue::from("blue") => Ok(PropertyKey::from("blue")); "string")]
+    #[test_case(|| ECMAScriptValue::from(make_tostring_getter_error()) => Err("Test Sentinel".to_string()); "to_primitive error")]
+    fn simple(make_value: fn() -> ECMAScriptValue) -> Result<PropertyKey, String> {
         setup_test_agent();
-        let arg = make_value(&agent);
-        match to_property_key(&agent, arg) {
+        let arg = make_value();
+        match to_property_key(arg) {
             Ok(key) => Ok(key),
-            Err(err) => Err(unwind_type_error(&agent, err)),
+            Err(err) => Err(unwind_type_error(err)),
         }
     }
 
     #[test]
     fn symbol() {
         setup_test_agent();
-        let sym = Symbol::new(&agent, Some("test symbol".into()));
+        let sym = Symbol::new(Some("test symbol".into()));
         let argument = ECMAScriptValue::from(sym.clone());
-        assert_eq!(to_property_key(&agent, argument).unwrap(), PropertyKey::from(sym));
+        assert_eq!(to_property_key(argument).unwrap(), PropertyKey::from(sym));
     }
 }
 
-#[test_case(|_| ECMAScriptValue::from(10.0) => Ok(10); "in range")]
-#[test_case(|_| ECMAScriptValue::from(0.0) => Ok(0); "bottom edge")]
-#[test_case(|_| ECMAScriptValue::from(-1.0) => Ok(0); "under")]
-#[test_case(|_| ECMAScriptValue::from(9007199254740991.0) => Ok(9007199254740991); "top edge")]
-#[test_case(|_| ECMAScriptValue::from(9007199254740992.0) => Ok(9007199254740991); "over")]
-#[test_case(|a| ECMAScriptValue::from(Symbol::new(a, Some("test".into()))) => Err("Symbol values cannot be converted to Number values".to_string()); "not a number")]
-fn to_length(make_arg: fn(&Agent) -> ECMAScriptValue) -> Result<i64, String> {
+#[test_case(|| ECMAScriptValue::from(10.0) => Ok(10); "in range")]
+#[test_case(|| ECMAScriptValue::from(0.0) => Ok(0); "bottom edge")]
+#[test_case(|| ECMAScriptValue::from(-1.0) => Ok(0); "under")]
+#[test_case(|| ECMAScriptValue::from(9007199254740991.0) => Ok(9007199254740991); "top edge")]
+#[test_case(|| ECMAScriptValue::from(9007199254740992.0) => Ok(9007199254740991); "over")]
+#[test_case(|| ECMAScriptValue::from(Symbol::new(Some("test".into()))) => Err("Symbol values cannot be converted to Number values".to_string()); "not a number")]
+fn to_length(make_arg: fn() -> ECMAScriptValue) -> Result<i64, String> {
     setup_test_agent();
-    let arg = make_arg(&agent);
+    let arg = make_arg();
 
-    super::to_length(&agent, arg).map_err(|e| unwind_type_error(&agent, e))
+    super::to_length(arg).map_err(|e| unwind_type_error(e))
 }
 
 mod canonical_numeric_index_string {
@@ -1667,7 +1638,7 @@ mod to_index {
     #[test_case(ECMAScriptValue::from(BigInt::from(10_i32)) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "non-number")]
     fn f(arg: ECMAScriptValue) -> Result<i64, String> {
         setup_test_agent();
-        to_index(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
+        to_index(arg).map_err(|e| unwind_any_error(e))
     }
 }
 
@@ -1686,7 +1657,7 @@ mod to_int32 {
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<i32, String> {
         setup_test_agent();
-        to_int32(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
+        to_int32(arg).map_err(|e| unwind_any_error(e))
     }
 }
 
@@ -1705,7 +1676,7 @@ mod to_uint32 {
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<u32, String> {
         setup_test_agent();
-        to_uint32(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
+        to_uint32(arg).map_err(|e| unwind_any_error(e))
     }
 }
 
@@ -1724,7 +1695,7 @@ mod to_int16 {
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<i16, String> {
         setup_test_agent();
-        to_int16(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
+        to_int16(arg).map_err(|e| unwind_any_error(e))
     }
 }
 
@@ -1743,7 +1714,7 @@ mod to_uint16 {
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<u16, String> {
         setup_test_agent();
-        to_uint16(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
+        to_uint16(arg).map_err(|e| unwind_any_error(e))
     }
 }
 
@@ -1762,7 +1733,7 @@ mod to_int8 {
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<i8, String> {
         setup_test_agent();
-        to_int8(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
+        to_int8(arg).map_err(|e| unwind_any_error(e))
     }
 }
 
@@ -1781,7 +1752,7 @@ mod to_uint8 {
     #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
     fn f(arg: impl Into<ECMAScriptValue>) -> Result<u8, String> {
         setup_test_agent();
-        to_uint8(&agent, arg).map_err(|e| unwind_any_error(&agent, e))
+        to_uint8(arg).map_err(|e| unwind_any_error(e))
     }
 }
 
@@ -1833,15 +1804,15 @@ mod array_index {
             ArrayIndex::try_from(u).map_err(|e| e.into())
         }
 
-        #[test_case(|a| a.wks(WksId::ToPrimitive).into() => Err("Symbols are not u32s".to_string()); "symbol")]
-        #[test_case(|_| "33".into() => Ok(ArrayIndex(33)); "simple")]
-        #[test_case(|_| "0".into() => Ok(ArrayIndex(0)); "zero")]
-        #[test_case(|_| "010".into() => Err("Invalid array index".to_string()); "leading zeroes")]
-        #[test_case(|_| "72x".into() => Err("Invalid array index".to_string()); "parse fail")]
-        #[test_case(|_| "4294967295".into() => Err("The maximum array index is 4294967294".to_string()); "convert fail")]
-        fn property_key(make_key: fn(&Agent) -> PropertyKey) -> Result<ArrayIndex, String> {
+        #[test_case(|| wks(WksId::ToPrimitive).into() => Err("Symbols are not u32s".to_string()); "symbol")]
+        #[test_case(|| "33".into() => Ok(ArrayIndex(33)); "simple")]
+        #[test_case(|| "0".into() => Ok(ArrayIndex(0)); "zero")]
+        #[test_case(|| "010".into() => Err("Invalid array index".to_string()); "leading zeroes")]
+        #[test_case(|| "72x".into() => Err("Invalid array index".to_string()); "parse fail")]
+        #[test_case(|| "4294967295".into() => Err("The maximum array index is 4294967294".to_string()); "convert fail")]
+        fn property_key(make_key: fn() -> PropertyKey) -> Result<ArrayIndex, String> {
             setup_test_agent();
-            let key = make_key(&agent);
+            let key = make_key();
             ArrayIndex::try_from(&key).map_err(|e| e.into())
         }
     }
@@ -1897,7 +1868,7 @@ mod is_callable {
     #[test]
     fn callable() {
         setup_test_agent();
-        assert!(is_callable(&agent.intrinsic(IntrinsicId::Object).into()));
+        assert!(is_callable(&intrinsic(IntrinsicId::Object).into()));
     }
 }
 
@@ -1910,7 +1881,7 @@ mod is_constructor {
     #[test]
     fn constructor() {
         setup_test_agent();
-        assert!(is_constructor(&agent.intrinsic(IntrinsicId::Object).into()));
+        assert!(is_constructor(&intrinsic(IntrinsicId::Object).into()));
     }
 }
 
@@ -1918,9 +1889,9 @@ mod option_object {
     use super::*;
     use test_case::test_case;
 
-    fn object_with_marker(agent: &Agent) -> ECMAScriptValue {
-        let obj = ordinary_object_create(agent, None, &[]);
-        define_property_or_throw(agent, &obj, "marker", PotentialPropertyDescriptor::new().value("sentinel")).unwrap();
+    fn object_with_marker() -> ECMAScriptValue {
+        let obj = ordinary_object_create(None, &[]);
+        define_property_or_throw(&obj, "marker", PotentialPropertyDescriptor::new().value("sentinel")).unwrap();
         ECMAScriptValue::Object(obj)
     }
     fn validate_marker(res: Result<Option<Object>, String>) {
@@ -1930,12 +1901,12 @@ mod option_object {
         assert_eq!(property, ECMAScriptValue::from("sentinel"));
     }
 
-    #[test_case(|_| ECMAScriptValue::Null => Ok(None); "null")]
-    #[test_case(|_| ECMAScriptValue::Number(12.0) => serr("Bad type for Object/null"); "number")]
+    #[test_case(|| ECMAScriptValue::Null => Ok(None); "null")]
+    #[test_case(|| ECMAScriptValue::Number(12.0) => serr("Bad type for Object/null"); "number")]
     #[test_case(object_with_marker => with validate_marker; "object")]
-    fn try_from(maker: fn(&Agent) -> ECMAScriptValue) -> Result<Option<Object>, String> {
+    fn try_from(maker: fn() -> ECMAScriptValue) -> Result<Option<Object>, String> {
         setup_test_agent();
-        let val = maker(&agent);
+        let val = maker();
         let result: anyhow::Result<Option<Object>> = val.try_into();
         result.map_err(|e| e.to_string())
     }
@@ -1967,69 +1938,69 @@ mod agent {
     use super::*;
     use test_case::test_case;
 
-    type ValueMaker = fn(&Agent) -> ECMAScriptValue;
-    fn undef(_: &Agent) -> ECMAScriptValue {
+    type ValueMaker = fn() -> ECMAScriptValue;
+    fn undef() -> ECMAScriptValue {
         ECMAScriptValue::Undefined
     }
-    fn null(_: &Agent) -> ECMAScriptValue {
+    fn null() -> ECMAScriptValue {
         ECMAScriptValue::Null
     }
-    fn string_a(_: &Agent) -> ECMAScriptValue {
+    fn string_a() -> ECMAScriptValue {
         ECMAScriptValue::from("A")
     }
-    fn string_b(_: &Agent) -> ECMAScriptValue {
+    fn string_b() -> ECMAScriptValue {
         ECMAScriptValue::from("B")
     }
-    fn string_10(_: &Agent) -> ECMAScriptValue {
+    fn string_10() -> ECMAScriptValue {
         "10".into()
     }
-    fn bool_a(_: &Agent) -> ECMAScriptValue {
+    fn bool_a() -> ECMAScriptValue {
         ECMAScriptValue::from(true)
     }
-    fn bool_b(_: &Agent) -> ECMAScriptValue {
+    fn bool_b() -> ECMAScriptValue {
         ECMAScriptValue::from(false)
     }
-    fn symbol_a(agent: &Agent) -> ECMAScriptValue {
-        agent.wks(WksId::ToPrimitive).into()
+    fn symbol_a() -> ECMAScriptValue {
+        wks(WksId::ToPrimitive).into()
     }
-    fn symbol_b(agent: &Agent) -> ECMAScriptValue {
-        agent.wks(WksId::HasInstance).into()
+    fn symbol_b() -> ECMAScriptValue {
+        wks(WksId::HasInstance).into()
     }
-    fn object_a(agent: &Agent) -> ECMAScriptValue {
-        agent.intrinsic(IntrinsicId::FunctionPrototype).into()
+    fn object_a() -> ECMAScriptValue {
+        intrinsic(IntrinsicId::FunctionPrototype).into()
     }
-    fn object_b(agent: &Agent) -> ECMAScriptValue {
-        agent.intrinsic(IntrinsicId::ObjectPrototype).into()
+    fn object_b() -> ECMAScriptValue {
+        intrinsic(IntrinsicId::ObjectPrototype).into()
     }
-    fn number_10(_: &Agent) -> ECMAScriptValue {
+    fn number_10() -> ECMAScriptValue {
         10.into()
     }
-    fn number_100(_: &Agent) -> ECMAScriptValue {
+    fn number_100() -> ECMAScriptValue {
         100.into()
     }
-    fn number_zero(_: &Agent) -> ECMAScriptValue {
+    fn number_zero() -> ECMAScriptValue {
         0.into()
     }
-    fn number_neg_zero(_: &Agent) -> ECMAScriptValue {
+    fn number_neg_zero() -> ECMAScriptValue {
         (-0.0).into()
     }
-    fn number_nan(_: &Agent) -> ECMAScriptValue {
+    fn number_nan() -> ECMAScriptValue {
         f64::NAN.into()
     }
-    fn number_inf(_: &Agent) -> ECMAScriptValue {
+    fn number_inf() -> ECMAScriptValue {
         f64::INFINITY.into()
     }
-    fn number_neg_inf(_: &Agent) -> ECMAScriptValue {
+    fn number_neg_inf() -> ECMAScriptValue {
         f64::NEG_INFINITY.into()
     }
-    fn bigint_a(_: &Agent) -> ECMAScriptValue {
+    fn bigint_a() -> ECMAScriptValue {
         BigInt::from(10).into()
     }
-    fn bigint_b(_: &Agent) -> ECMAScriptValue {
+    fn bigint_b() -> ECMAScriptValue {
         BigInt::from(-1097631).into()
     }
-    fn dead_object(agent: &Agent) -> ECMAScriptValue {
-        DeadObject::object(agent).into()
+    fn dead_object() -> ECMAScriptValue {
+        DeadObject::object().into()
     }
     fn returns_10(
         _: &Agent,
@@ -2039,14 +2010,13 @@ mod agent {
     ) -> Completion<ECMAScriptValue> {
         Ok(10.into())
     }
-    fn object_10(agent: &Agent) -> ECMAScriptValue {
-        let object_prototype = agent.intrinsic(IntrinsicId::ObjectPrototype);
-        let object = ordinary_object_create(agent, Some(object_prototype), &[]);
-        let to_primitive = agent.wks(WksId::ToPrimitive);
+    fn object_10() -> ECMAScriptValue {
+        let object_prototype = intrinsic(IntrinsicId::ObjectPrototype);
+        let object = ordinary_object_create(Some(object_prototype), &[]);
+        let to_primitive = wks(WksId::ToPrimitive);
         let realm = agent.current_realm_record();
-        let function_prototype = agent.intrinsic(IntrinsicId::FunctionPrototype);
+        let function_prototype = intrinsic(IntrinsicId::FunctionPrototype);
         let to_prim_func = create_builtin_function(
-            agent,
             returns_10,
             false,
             0_f64,
@@ -2057,7 +2027,6 @@ mod agent {
             None,
         );
         define_property_or_throw(
-            agent,
             &object,
             to_primitive,
             PotentialPropertyDescriptor::new().value(to_prim_func).writable(false).enumerable(true).configurable(true),
@@ -2091,9 +2060,9 @@ mod agent {
     #[test_case(null, symbol_a => Ok(false); "Null & symbol")]
     fn is_loosely_equal(make_x: ValueMaker, make_y: ValueMaker) -> Result<bool, String> {
         setup_test_agent();
-        let x = make_x(&agent);
-        let y = make_y(&agent);
+        let x = make_x();
+        let y = make_y();
 
-        agent.is_loosely_equal(&x, &y).map_err(|e| unwind_any_error(&agent, e))
+        agent.is_loosely_equal(&x, &y).map_err(|e| unwind_any_error(e))
     }
 }


### PR DESCRIPTION
This is essentially turning the agent data into a global object. The important part here is that globals have `'static` lifetimes, so that they can be used in async contexts. The per-thread characteristic is just fine; by the specification, agents are not shared across threads.