### PR TITLE
Fix EXTRACT_THROW. (RefCell borrow issues)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1000,14 +1000,14 @@ pub fn execute(text: &str) -> Completion<ECMAScriptValue> {
                 }
                 Insn::ExtractThrownValue => {
                     let stack_idx = agent.execution_context_stack.borrow()[index].stack.len() - 1;
-                    let completion = &agent.execution_context_stack.borrow()[index].stack[stack_idx];
-                    match completion.as_ref().unwrap_err() {
-                        AbruptCompletion::Throw { value } => {
-                            agent.execution_context_stack.borrow_mut()[index].stack[stack_idx] =
-                                Ok(value.clone().into())
+                    let errval = {
+                        let completion = &agent.execution_context_stack.borrow()[index].stack[stack_idx];
+                        match completion.as_ref().unwrap_err() {
+                            AbruptCompletion::Throw { value } => value.clone(),
+                            _ => panic!("Bad error type for ExtractThrownValue"),
                         }
-                        _ => panic!("Bad error type for ExtractThrownValue"),
-                    }
+                    };
+                    agent.execution_context_stack.borrow_mut()[index].stack[stack_idx] = Ok(errval.into());
                 }
                 Insn::ExtractArg => {
                     let ec = &mut agent.execution_context_stack.borrow_mut()[index];


### PR DESCRIPTION
With this change, the test-262 assert-false and assert-true tests pass.