### PR TITLE
Add reference compilation after calls

### DIFF
--- a/src/compiler/tests.rs
+++ b/src/compiler/tests.rs
@@ -1203,8 +1203,92 @@ mod call_expression {
     #[test_case("a()(@@@)", false, &[]
                 => serr("out of range integral type conversion attempted")
                 ; "call-expression-arguments: unwind jump too far")]
-    #[test_case("a()[b]", true, &[] => panics "not yet implemented"; "expr-on-call")]
-    #[test_case("a().b", true, &[] => panics "not yet implemented"; "property-on-call")]
+    #[test_case("a()[b]", true, &[] => Ok((svec(&[
+        "STRING 0 (a)",
+        "STRICT_RESOLVE",
+        "DUP",
+        "GET_VALUE",
+        "JUMP_IF_NORMAL 4",
+        "UNWIND 1",
+        "JUMP 3",
+        "FLOAT 0 (0)",
+        "CALL",
+        "JUMP_IF_ABRUPT 18",
+        "STRING 1 (b)",
+        "STRICT_RESOLVE",
+        "GET_VALUE",
+        "JUMP_IF_NORMAL 4",
+        "UNWIND 1",
+        "JUMP 8",
+        "TO_KEY",
+        "JUMP_IF_NORMAL 4",
+        "UNWIND 1",
+        "JUMP 1",
+        "STRICT_REF"
+    ]), true, true)); "CallExpression: [ Expression ]")]
+    #[test_case("a().b[c]", true, &[] => Ok((svec(&[
+        "STRING 0 (a)",
+        "STRICT_RESOLVE",
+        "DUP",
+        "GET_VALUE",
+        "JUMP_IF_NORMAL 4",
+        "UNWIND 1",
+        "JUMP 3",
+        "FLOAT 0 (0)",
+        "CALL",
+        "JUMP_IF_ABRUPT 3",
+        "STRING 1 (b)",
+        "STRICT_REF",
+        "GET_VALUE",
+        "JUMP_IF_ABRUPT 18",
+        "STRING 2 (c)",
+        "STRICT_RESOLVE",
+        "GET_VALUE",
+        "JUMP_IF_NORMAL 4",
+        "UNWIND 1",
+        "JUMP 8",
+        "TO_KEY",
+        "JUMP_IF_NORMAL 4",
+        "UNWIND 1",
+        "JUMP 1",
+        "STRICT_REF"
+    ]), true, true)); "ce-exp; ce is ref")]
+    #[test_case("a()[b]", true, &[(Fillable::String, 0)] => serr("Out of room for strings in this compilation unit"); "ce-exp; ce fails compilation")]
+    #[test_case("a()[8n]", true, &[(Fillable::BigInt, 0)] => serr("Out of room for big ints in this compilation unit"); "ce-exp; exp fails compilation")]
+    #[test_case("a().b", true, &[] => Ok((svec(&[
+        "STRING 0 (a)",
+        "STRICT_RESOLVE",
+        "DUP",
+        "GET_VALUE",
+        "JUMP_IF_NORMAL 4",
+        "UNWIND 1",
+        "JUMP 3",
+        "FLOAT 0 (0)",
+        "CALL",
+        "JUMP_IF_ABRUPT 3",
+        "STRING 1 (b)",
+        "STRICT_REF"
+    ]), true, true)); "property-on-call")]
+    #[test_case("a().b", true, &[(Fillable::String, 0)] => serr("Out of room for strings in this compilation unit"); "ce-prop; ce fails compilation")]
+    #[test_case("a().b.c", true, &[] => Ok((svec(&[
+        "STRING 0 (a)",
+        "STRICT_RESOLVE",
+        "DUP",
+        "GET_VALUE",
+        "JUMP_IF_NORMAL 4",
+        "UNWIND 1",
+        "JUMP 3",
+        "FLOAT 0 (0)",
+        "CALL",
+        "JUMP_IF_ABRUPT 3",
+        "STRING 1 (b)",
+        "STRICT_REF",
+        "GET_VALUE",
+        "JUMP_IF_ABRUPT 3",
+        "STRING 2 (c)",
+        "STRICT_REF"
+    ]), true, true)); "ce-prop, ce is ref")]
+    #[test_case("a().b", true, &[(Fillable::String, 1)] => serr("Out of room for strings in this compilation unit"); "ce-prop; id doesn't fit")]
     #[test_case("a()`${b}`", true, &[] => panics "not yet implemented"; "template-on-call")]
     #[test_case("a().#pid", true, &[] => panics "not yet implemented"; "private-on-call")]
     fn compile(src: &str, strict: bool, what: &[(Fillable, usize)]) -> Result<(Vec<String>, bool, bool), String> {

--- a/t
+++ b/t
@@ -170,6 +170,8 @@ test_defs[CompilerTemplateLiteral]="parser::primary_expressions::TemplateLiteral
 test_defs[CompilerSubstitutionTemplate]="parser::primary_expressions::SubstitutionTemplate substitution_template compiler"
 test_defs[CompilerTemplateSpans]="parser::primary_expressions::TemplateSpans template_spans compiler"
 test_defs[CompilerTemplateMiddleList]="parser::primary_expressions::TemplateMiddleList template_middle_list compiler"
+test_defs[evaluate_property_access_with_expression_key]="evaluate_property_access_with_expression_key member_expression compiler"
+test_defs[evaluate_property_access_with_identifier_key]="evaluate_property_access_with_identifier_key member_expression compiler"
 
 test_defs[ArrowParameters]="ArrowParameters arrow_parameters parser::arrow_function_definitions"
 test_defs[ExpressionBody]="ExpressionBody expression_body parser::arrow_function_definitions"


### PR DESCRIPTION
This adds compilation and execution for the productions
* CallExpression : CallExpression . IdentifierName
* CallExpression : CallExpression [ Expression ]

(I.e.: Now I can do `Array(1,2,3).toString()`.)