### PR TITLE
Add implementations for the `isNaN` and `isFinite` global functions

### DIFF
--- a/src/realm/mod.rs
+++ b/src/realm/mod.rs
@@ -622,17 +622,39 @@ fn eval(
 fn is_finite(
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
-    _arguments: &[ECMAScriptValue],
+    arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    todo!()
+    // This function is the %isFinite% intrinsic object.
+    //
+    // It performs the following steps when called:
+    //
+    //  1. Let num be ? ToNumber(number).
+    //  2. If num is not finite, return false.
+    //  3. Otherwise, return true.
+    let mut args = FuncArgs::from(arguments);
+    let number = args.next_arg();
+    let num = to_number(number)?;
+    Ok(ECMAScriptValue::from(num.is_finite()))
 }
+
 fn is_nan(
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
-    _arguments: &[ECMAScriptValue],
+    arguments: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    todo!()
+    // This function is the %isNaN% intrinsic object.
+    //
+    // It performs the following steps when called:
+    //
+    //  1. Let num be ? ToNumber(number).
+    //  2. If num is NaN, return true.
+    //  3. Otherwise, return false.
+    let mut args = FuncArgs::from(arguments);
+    let number = args.next_arg();
+    let num = to_number(number)?;
+    Ok(ECMAScriptValue::from(num.is_nan()))
 }
+
 fn parse_float(
     _this_value: ECMAScriptValue,
     _new_target: Option<&Object>,

--- a/t
+++ b/t
@@ -581,6 +581,8 @@ test_defs[ArgumentsObject_own_property_keys]="ArgumentsObject@object::ObjectInte
 test_defs[IntrinsicId]="IntrinsicId intrinsic_id realm"
 test_defs[Intrinsics]="Intrinsics intrinsics realm"
 test_defs[Realm]="Realm realm realm"
+test_defs[is_nan]="is_nan is_nan realm"
+test_defs[is_finite]="is_finite is_finite realm"
 
 test_defs[ArrayObject_own_property_keys]="ArrayObject@object::ObjectInterface::own_property_keys array_object::own_property_keys arrays"
 test_defs[ArrayObject_define_own_property]="ArrayObject@object::ObjectInterface::define_own_property array_object::define_own_property arrays"


### PR DESCRIPTION
`isNaN`, in particular, is heavily used throughout the test262 test suite.

With this change, 292 tests have switched from FAIL to PASS.