### PR TITLE
Switch the function prototype to a builtin-function

### DIFF
--- a/src/realm/mod.rs
+++ b/src/realm/mod.rs
@@ -440,7 +440,16 @@ pub fn create_intrinsics(realm_rec: Rc<RefCell<Realm>>) {
     let object_prototype = immutable_prototype_exotic_object_create(None);
     realm_rec.borrow_mut().intrinsics.object_prototype = object_prototype.clone();
     // %Function.prototype%
-    let function_prototype = ordinary_object_create(Some(object_prototype.clone()), &[]);
+    let function_prototype = create_builtin_function(
+        do_nothing,
+        false,
+        0_f64,
+        PropertyKey::from(""),
+        BUILTIN_FUNCTION_SLOTS,
+        Some(realm_rec.clone()),
+        Some(object_prototype.clone()),
+        None,
+    );
     realm_rec.borrow_mut().intrinsics.function_prototype = function_prototype.clone();
     // %ThrowTypeError%
     realm_rec.borrow_mut().intrinsics.throw_type_error = create_throw_type_error_builtin(realm_rec.clone());
@@ -578,6 +587,14 @@ fn create_throw_type_error_builtin(realm: Rc<RefCell<Realm>>) -> Object {
     .unwrap();
 
     fcn
+}
+
+pub fn do_nothing(
+    _this_value: ECMAScriptValue,
+    _new_target: Option<&Object>,
+    _arguments: &[ECMAScriptValue],
+) -> Completion<ECMAScriptValue> {
+    Ok(ECMAScriptValue::Undefined)
 }
 
 fn decode_uri(


### PR DESCRIPTION
This fixes the following Test262 testcases:
  * built-ins/decodeURI/S15.1.3.1_A5.2.js
  * built-ins/decodeURIComponent/S15.1.3.2_A5.2.js
  * built-ins/encodeURI/S15.1.3.3_A5.2.js
  * built-ins/encodeURIComponent/S15.1.3.4_A5.2.js
  * built-ins/eval/length-non-configurable.js
  * built-ins/parseFloat/S15.1.2.3_A7.2.js
  * built-ins/parseInt/S15.1.2.2_A9.2.js