### PR TITLE
Add the function stubs for `Function.prototype`

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -473,6 +473,7 @@ pub fn set_default_global_bindings() {
     // Float32Array ( . . . )
     // Float64Array ( . . . )
     // Function ( . . . )
+    constructor_property!(Function);
     // Int8Array ( . . . )
     // Int16Array ( . . . )
     // Int32Array ( . . . )

--- a/src/object_object/mod.rs
+++ b/src/object_object/mod.rs
@@ -43,7 +43,7 @@ fn object_prototype_value_of(
 //            test for those specific kinds of built-in objects. It does not provide a reliable type testing mechanism
 //            for other kinds of built-in or program defined objects. In addition, programs can use @@toStringTag in
 //            ways that will invalidate the reliability of such legacy type tests.
-fn object_prototype_to_string(
+pub fn object_prototype_to_string(
     this_value: ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],

--- a/t
+++ b/t
@@ -645,6 +645,13 @@ test_defs[BuiltInFunctionObject_own_property_keys]="BuiltInFunctionObject@Object
 test_defs[ConciseBodySource]="ConciseBodySource concise_body_source function_object"
 test_defs[ConciseParamSource]="ConciseParamSource concise_param_source function_object"
 test_defs[make_method]="make_method make_method function_object"
+test_defs[function_prototype_call]="function_prototype_call function_prototype_call function_object"
+test_defs[provision_function_intrinsic]="provision_function_intrinsic provision_function_intrinsic function_object"
+test_defs[function_constructor_function]="function_constructor_function todo::function_constructor_function function_object"
+test_defs[function_prototype_apply]="function_prototype_apply todo::function_prototype_apply function_object"
+test_defs[function_prototype_bind]="function_prototype_bind todo::function_prototype_bind function_object"
+test_defs[function_prototype_to_string]="function_prototype_to_string function_prototype_to_string function_object"
+test_defs[function_prototype_has_instance]="function_prototype_has_instance function_prototype_has_instance function_object"
 
 test_defs[JSString_index_of]="JSString::index_of jsstring::index_of strings"
 


### PR DESCRIPTION
This causes 258 different test cases to now pass, and causes 14 previously passing ones to fail. Looking at the failures, though: they should all have been failing anyway.