### PR TITLE
change all the `pub` to `pub(crate)`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
@@ -23,21 +23,21 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
 ]
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -57,9 +57,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -72,44 +72,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arraydeque"
@@ -119,34 +119,34 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -163,9 +163,9 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 dependencies = [
  "serde",
 ]
@@ -181,24 +181,25 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -206,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -218,27 +219,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "color-eyre"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -251,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "color-spantrace"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
 dependencies = [
  "once_cell",
  "owo-colors",
@@ -263,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "config"
@@ -301,7 +302,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "tiny-keccak",
 ]
@@ -335,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -351,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
 ]
@@ -400,9 +401,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys",
@@ -423,6 +424,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
 
 [[package]]
 name = "futures"
@@ -480,7 +487,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -555,32 +562,32 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.3+wasi-0.2.4",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
@@ -588,15 +595,15 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.11",
+ "ahash 0.8.12",
  "allocator-api2",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hashlink"
@@ -615,18 +622,18 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indenter"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -669,9 +676,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "linked-hash-map"
@@ -687,9 +694,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "minimal-lexical"
@@ -699,11 +706,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -839,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -851,6 +858,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "ordered-multimap"
@@ -864,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "3.5.0"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "pathdiff"
@@ -876,20 +889,20 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -897,24 +910,23 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -943,7 +955,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1014,9 +1026,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -1032,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1063,14 +1075,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1080,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1091,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "res"
@@ -1150,15 +1162,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
@@ -1190,14 +1202,14 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
@@ -1207,18 +1219,18 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1242,12 +1254,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "strsim"
@@ -1268,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1290,12 +1299,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1334,11 +1343,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -1349,38 +1358,36 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -1392,15 +1399,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1417,21 +1424,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.24",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
@@ -1449,16 +1456,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.6",
+ "toml_write",
+ "winnow 0.7.13",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -1472,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1492,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "sharded-slab",
  "thread_local",
@@ -1557,26 +1571,32 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.3+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.59.0"
+name = "windows-link"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -1585,14 +1605,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1602,10 +1639,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1614,10 +1663,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1626,10 +1687,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1638,10 +1711,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -1654,21 +1739,18 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
 name = "yaml-rust"
@@ -1692,40 +1774,20 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
-dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "syn 2.0.106",
 ]

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -25,19 +25,19 @@ mod agent {
 
         // All well-known symbols initialized, and different from one another.
         let symbols = [
-            agent.symbols.async_iterator_,
-            agent.symbols.has_instance_,
-            agent.symbols.is_concat_spreadable_,
-            agent.symbols.iterator_,
+            agent.symbols.async_iterator,
+            agent.symbols.has_instance,
+            agent.symbols.is_concat_spreadable,
+            agent.symbols.iterator,
             agent.symbols.match_,
-            agent.symbols.match_all_,
-            agent.symbols.replace_,
-            agent.symbols.search_,
-            agent.symbols.species_,
-            agent.symbols.split_,
-            agent.symbols.to_primitive_,
-            agent.symbols.to_string_tag_,
-            agent.symbols.unscopables_,
+            agent.symbols.match_all,
+            agent.symbols.replace,
+            agent.symbols.search,
+            agent.symbols.species,
+            agent.symbols.split,
+            agent.symbols.to_primitive,
+            agent.symbols.to_string_tag,
+            agent.symbols.unscopables,
         ];
         let num_symbols = symbols.len();
         let symbol_set = symbols.iter().collect::<AHashSet<_>>();
@@ -57,19 +57,19 @@ mod agent {
 
         // All well-known symbols initialized, and different from one another.
         let symbols = [
-            agent.symbols.async_iterator_,
-            agent.symbols.has_instance_,
-            agent.symbols.is_concat_spreadable_,
-            agent.symbols.iterator_,
+            agent.symbols.async_iterator,
+            agent.symbols.has_instance,
+            agent.symbols.is_concat_spreadable,
+            agent.symbols.iterator,
             agent.symbols.match_,
-            agent.symbols.match_all_,
-            agent.symbols.replace_,
-            agent.symbols.search_,
-            agent.symbols.species_,
-            agent.symbols.split_,
-            agent.symbols.to_primitive_,
-            agent.symbols.to_string_tag_,
-            agent.symbols.unscopables_,
+            agent.symbols.match_all,
+            agent.symbols.replace,
+            agent.symbols.search,
+            agent.symbols.species,
+            agent.symbols.split,
+            agent.symbols.to_primitive,
+            agent.symbols.to_string_tag,
+            agent.symbols.unscopables,
         ];
         let num_symbols = symbols.len();
         let symbol_set = symbols.iter().collect::<AHashSet<_>>();
@@ -912,15 +912,15 @@ mod top_level_lex_decl {
 
     fn make_class_decl() -> MakerResult {
         let cd = Maker::new("class alice {}").class_declaration();
-        (Some(cd.clone()), None, DeclPart::ClassDeclaration(cd))
+        (Some(cd.clone()), None, DeclPart::Class(cd))
     }
     fn make_lex_decl() -> MakerResult {
         let ld = Maker::new("let alice = 999;").lexical_declaration();
-        (None, Some(ld.clone()), DeclPart::LexicalDeclaration(ld))
+        (None, Some(ld.clone()), DeclPart::Lexical(ld))
     }
     fn make_func_decl() -> MakerResult {
         let fd = Maker::new("function alice(bob) { return charlie(bob); }").function_declaration();
-        (None, None, DeclPart::FunctionDeclaration(fd))
+        (None, None, DeclPart::Function(fd))
     }
     #[test_case(make_class_decl => Ok((true, false)); "class")]
     #[test_case(make_lex_decl => Ok((false, true)); "lexical")]
@@ -1021,27 +1021,27 @@ mod fcn_def {
     );
     fn decl_func() -> MakerDeclResult {
         let fd = Maker::new("function alice(bob) { return charlie(bob); }").function_declaration();
-        (Some(fd.clone()), None, None, None, DeclPart::FunctionDeclaration(fd))
+        (Some(fd.clone()), None, None, None, DeclPart::Function(fd))
     }
     fn decl_gen() -> MakerDeclResult {
         let gd = Maker::new("function *alice(bob) { return charlie(bob); }").generator_declaration();
-        (None, Some(gd.clone()), None, None, DeclPart::GeneratorDeclaration(gd))
+        (None, Some(gd.clone()), None, None, DeclPart::Generator(gd))
     }
     fn decl_async() -> MakerDeclResult {
         let afd = Maker::new("async function alice(bob) { return charlie(bob); }").async_function_declaration();
-        (None, None, Some(afd.clone()), None, DeclPart::AsyncFunctionDeclaration(afd))
+        (None, None, Some(afd.clone()), None, DeclPart::AsyncFunction(afd))
     }
     fn decl_async_gen() -> MakerDeclResult {
         let agd = Maker::new("async function *alice(bob) { return charlie(bob); }").async_generator_declaration();
-        (None, None, None, Some(agd.clone()), DeclPart::AsyncGeneratorDeclaration(agd))
+        (None, None, None, Some(agd.clone()), DeclPart::AsyncGenerator(agd))
     }
     fn decl_class() -> MakerDeclResult {
         let cls = Maker::new("class alice {}").class_declaration();
-        (None, None, None, None, DeclPart::ClassDeclaration(cls))
+        (None, None, None, None, DeclPart::Class(cls))
     }
     fn decl_lex() -> MakerDeclResult {
         let ld = Maker::new("let alice;").lexical_declaration();
-        (None, None, None, None, DeclPart::LexicalDeclaration(ld))
+        (None, None, None, None, DeclPart::Lexical(ld))
     }
     #[test_case(decl_func => Ok(true); "Function decl")]
     #[test_case(decl_gen => Ok(true); "Generator decl")]
@@ -1213,12 +1213,8 @@ mod process_error {
 
     #[test]
     fn debug() {
-        let s = format!("{:?}", ProcessError::InternalError { reason: "random reason".into() });
+        let s = format!("{:?}", ProcessError::RuntimeError { error: "random reason".into() });
         assert_ne!(s, "");
-    }
-
-    fn internal_err() -> ProcessError {
-        ProcessError::InternalError { reason: "blue".into() }
     }
 
     fn runtime_err_obj() -> ProcessError {
@@ -1246,7 +1242,7 @@ mod process_error {
             ],
         }
     }
-    #[test_case(internal_err => "blue"; "internal error")]
+    //#[test_case(internal_err => "blue"; "internal error")]
     #[test_case(runtime_err_obj => "Thrown: TypeError: test sentinel"; "error obj runtime")]
     #[test_case(runtime_err_value => "Thrown: test sentinel"; "error value runtime")]
     #[test_case(runtime_err_non_err_obj => using matches_object; "error obj but not error")]

--- a/src/bigint_object.rs
+++ b/src/bigint_object.rs
@@ -2,7 +2,7 @@ use super::*;
 use num::{BigInt, FromPrimitive, Integer};
 use std::rc::Rc;
 
-pub fn provision_big_int_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_big_int_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -260,7 +260,7 @@ fn bigint_value_of(
 }
 
 #[derive(Debug)]
-pub struct BigIntObject {
+pub(crate) struct BigIntObject {
     common: RefCell<CommonObjectData>,
     bigint_data: Rc<BigInt>,
 }
@@ -284,6 +284,7 @@ impl ObjectInterface for BigIntObject {
     fn to_bigint_object(&self) -> Option<&BigIntObject> {
         Some(self)
     }
+    #[cfg(test)]
     fn is_bigint_object(&self) -> bool {
         true
     }
@@ -398,14 +399,15 @@ impl BigIntObject {
         &self.bigint_data
     }
 
-    pub fn new(prototype: Option<Object>, value: Rc<BigInt>) -> Self {
+    pub(crate) fn new(prototype: Option<Object>, value: Rc<BigInt>) -> Self {
         Self { common: RefCell::new(CommonObjectData::new(prototype, true, BIGINT_OBJECT_SLOTS)), bigint_data: value }
     }
-    pub fn object(prototype: Option<Object>, value: Rc<BigInt>) -> Object {
+    pub(crate) fn object(prototype: Option<Object>, value: Rc<BigInt>) -> Object {
         Object { o: Rc::new(Self::new(prototype, value)) }
     }
 
-    pub fn value(&self) -> Rc<BigInt> {
+    #[cfg(test)]
+    pub(crate) fn value(&self) -> Rc<BigInt> {
         Rc::clone(&self.bigint_data)
     }
 }
@@ -459,7 +461,7 @@ fn number_to_big_int(number: f64) -> Completion<Rc<BigInt>> {
 }
 
 impl PrimitiveValue {
-    pub fn to_big_int(&self) -> Completion<Rc<BigInt>> {
+    pub(crate) fn to_big_int(&self) -> Completion<Rc<BigInt>> {
         match self {
             PrimitiveValue::Undefined
             | PrimitiveValue::Null

--- a/src/boolean_object/mod.rs
+++ b/src/boolean_object/mod.rs
@@ -2,12 +2,12 @@ use super::*;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-pub trait BooleanObjectInterface: ObjectInterface {
+pub(crate) trait BooleanObjectInterface: ObjectInterface {
     fn boolean_data(&self) -> &bool;
 }
 
 #[derive(Debug)]
-pub struct BooleanObject {
+pub(crate) struct BooleanObject {
     common: RefCell<CommonObjectData>,
     boolean_data: bool,
 }
@@ -147,10 +147,10 @@ impl BooleanObjectInterface for BooleanObject {
 }
 
 impl BooleanObject {
-    pub fn new(prototype: Option<Object>, value: bool) -> Self {
+    pub(crate) fn new(prototype: Option<Object>, value: bool) -> Self {
         Self { common: RefCell::new(CommonObjectData::new(prototype, true, BOOLEAN_OBJECT_SLOTS)), boolean_data: value }
     }
-    pub fn object(prototype: Option<Object>, value: bool) -> Object {
+    pub(crate) fn object(prototype: Option<Object>, value: bool) -> Object {
         Object { o: Rc::new(Self::new(prototype, value)) }
     }
 }
@@ -179,7 +179,7 @@ impl From<bool> for Object {
 //      b. Assert: Type(b) is Boolean.
 //      c. Return b.
 //  3. Throw a TypeError exception.
-pub fn this_boolean_value(value: &ECMAScriptValue) -> Completion<bool> {
+pub(crate) fn this_boolean_value(value: &ECMAScriptValue) -> Completion<bool> {
     match value {
         ECMAScriptValue::Boolean(b) => Ok(*b),
         ECMAScriptValue::Object(o) => {
@@ -195,7 +195,7 @@ pub fn this_boolean_value(value: &ECMAScriptValue) -> Completion<bool> {
     }
 }
 
-pub fn provision_boolean_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_boolean_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 

--- a/src/bound_function.rs
+++ b/src/bound_function.rs
@@ -26,11 +26,11 @@ use super::*;
 // +-------------------------+----------------------+-----------------------------------------------------------------+
 
 #[derive(Debug)]
-pub struct BoundFunctionObject {
+pub(crate) struct BoundFunctionObject {
     common: RefCell<CommonObjectData>,
-    pub bound_target_function: Object,
-    pub bound_this: ECMAScriptValue,
-    pub bound_arguments: Box<[ECMAScriptValue]>,
+    pub(crate) bound_target_function: Object,
+    pub(crate) bound_this: ECMAScriptValue,
+    pub(crate) bound_arguments: Box<[ECMAScriptValue]>,
 }
 
 impl<'a> From<&'a BoundFunctionObject> for &'a dyn ObjectInterface {
@@ -181,7 +181,7 @@ impl ObjectInterface for BoundFunctionObject {
 }
 
 impl BoundFunctionObject {
-    pub fn new(
+    pub(crate) fn new(
         prototype: Option<Object>,
         target_function: Object,
         bound_this: ECMAScriptValue,
@@ -204,7 +204,7 @@ impl BoundFunctionObject {
     ///     call itself follow.
     ///
     /// See also BoundFunctionCreate in [ECMA-262](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-boundfunctioncreate).
-    pub fn create(
+    pub(crate) fn create(
         target_function: Object,
         bound_this: ECMAScriptValue,
         bound_args: &[ECMAScriptValue],

--- a/src/comparison/mod.rs
+++ b/src/comparison/mod.rs
@@ -26,7 +26,7 @@ use super::*;
 // +---------------+------------------------------+
 //
 // https://tc39.es/ecma262/#sec-requireobjectcoercible
-pub fn require_object_coercible(argument: &ECMAScriptValue) -> Completion<()> {
+pub(crate) fn require_object_coercible(argument: &ECMAScriptValue) -> Completion<()> {
     match argument {
         ECMAScriptValue::Undefined | ECMAScriptValue::Null => {
             Err(create_type_error("Undefined and null are not allowed in this context"))
@@ -43,7 +43,7 @@ pub fn require_object_coercible(argument: &ECMAScriptValue) -> Completion<()> {
 //
 //  1. Assert: Type(O) is Object.
 //  2. Return ? O.[[IsExtensible]]().
-pub fn is_extensible<'a, T>(obj: T) -> Completion<bool>
+pub(crate) fn is_extensible<'a, T>(obj: T) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -60,7 +60,7 @@ where
 //  3. If floor(abs(ℝ(argument))) ≠ abs(ℝ(argument)), return false.
 //  4. Return true.
 #[expect(clippy::float_cmp)]
-pub fn is_integral_number_f64(n: f64) -> bool {
+pub(crate) fn is_integral_number_f64(n: f64) -> bool {
     if n.is_finite() {
         let magnitude = n.abs();
         magnitude.floor() == magnitude
@@ -68,7 +68,7 @@ pub fn is_integral_number_f64(n: f64) -> bool {
         false
     }
 }
-pub fn is_integral_number(argument: &ECMAScriptValue) -> bool {
+pub(crate) fn is_integral_number(argument: &ECMAScriptValue) -> bool {
     match argument {
         ECMAScriptValue::Number(n) => is_integral_number_f64(*n),
         _ => false,

--- a/src/control_abstraction/tests.rs
+++ b/src/control_abstraction/tests.rs
@@ -178,7 +178,7 @@ mod generator_prototype_next {
     }
 
     #[test]
-    pub fn multi() {
+    pub(crate) fn multi() {
         setup_test_agent();
         let (this_value, _) = list_iterator_sample();
         let mut results = vec![];
@@ -284,11 +284,7 @@ mod generator_data {
 
     #[test]
     fn debug() {
-        let item = GeneratorData {
-            generator_state: GeneratorState::Completed,
-            generator_context: None,
-            generator_brand: "Testerino".to_owned(),
-        };
+        let item = GeneratorData { state: GeneratorState::Completed, context: None, brand: "Testerino".to_owned() };
         assert_ne!(format!("{item:?}"), "");
     }
 }
@@ -336,9 +332,9 @@ mod generator_object {
 
         let go_data = o.o.to_generator_object().unwrap().generator_data.borrow();
 
-        assert_eq!(go_data.generator_state, GeneratorState::Undefined);
-        assert!(go_data.generator_context.is_none());
-        assert_eq!(go_data.generator_brand, "TestingBrand");
+        assert_eq!(go_data.state, GeneratorState::Undefined);
+        assert!(go_data.context.is_none());
+        assert_eq!(go_data.brand, "TestingBrand");
 
         let cod = o.o.common_object_data().borrow();
         assert_eq!(cod.prototype.as_ref().unwrap().clone(), gp);
@@ -431,7 +427,7 @@ mod generator_object {
         setup_test_agent();
         let obj = make(); // brand is "TestingBrand"
         let gen_obj = obj.o.to_generator_object().unwrap();
-        gen_obj.generator_data.borrow_mut().generator_state = generator_state;
+        gen_obj.generator_data.borrow_mut().state = generator_state;
 
         gen_obj.validate(desired_brand)
     }
@@ -586,7 +582,7 @@ mod generator_resume_abrupt {
         assert_eq!(unwind_any_error(item), String::from("Testing Sentinel"));
         let obj = Object::try_from(iter).unwrap();
         let r#gen = obj.o.to_generator_object().unwrap();
-        assert_eq!(r#gen.generator_data.borrow().generator_state, GeneratorState::Completed);
+        assert_eq!(r#gen.generator_data.borrow().state, GeneratorState::Completed);
     }
 
     #[test]
@@ -599,7 +595,7 @@ mod generator_resume_abrupt {
         assert_eq!(item.get(&"done".into()).unwrap(), ECMAScriptValue::from(true));
         let obj = Object::try_from(iter).unwrap();
         let r#gen = obj.o.to_generator_object().unwrap();
-        assert_eq!(r#gen.generator_data.borrow().generator_state, GeneratorState::Completed);
+        assert_eq!(r#gen.generator_data.borrow().state, GeneratorState::Completed);
     }
 
     #[test]
@@ -639,7 +635,7 @@ mod generator_resume_abrupt {
         assert_eq!(unwind_any_error(item), String::from("Testing Sentinel"));
         let obj = Object::try_from(iter).unwrap();
         let r#gen = obj.o.to_generator_object().unwrap();
-        assert_eq!(r#gen.generator_data.borrow().generator_state, GeneratorState::Completed);
+        assert_eq!(r#gen.generator_data.borrow().state, GeneratorState::Completed);
     }
 
     #[test]
@@ -653,7 +649,7 @@ mod generator_resume_abrupt {
         assert_eq!(item.get(&"value".into()).unwrap(), ECMAScriptValue::from("Token 2: [special]"));
         let obj = Object::try_from(iter).unwrap();
         let r#gen = obj.o.to_generator_object().unwrap();
-        assert_eq!(r#gen.generator_data.borrow().generator_state, GeneratorState::SuspendedYield);
+        assert_eq!(r#gen.generator_data.borrow().state, GeneratorState::SuspendedYield);
     }
 }
 
@@ -806,10 +802,10 @@ mod generator_start_from_closure {
 
         let gen_obj = r#gen.o.to_generator_object().unwrap();
         let gen_data = gen_obj.generator_data.borrow();
-        assert_eq!(gen_data.generator_brand, "");
-        assert_eq!(gen_data.generator_state, GeneratorState::SuspendedStart);
-        assert!(gen_data.generator_context.is_some());
-        let gc = gen_data.generator_context.as_ref().unwrap();
+        assert_eq!(gen_data.brand, "");
+        assert_eq!(gen_data.state, GeneratorState::SuspendedStart);
+        assert!(gen_data.context.is_some());
+        let gc = gen_data.context.as_ref().unwrap();
         assert_eq!(gc.generator.as_ref().unwrap(), &r#gen);
         assert!(gc.gen_closure.is_some());
     }
@@ -1202,7 +1198,7 @@ mod iterator_record {
         let obj = silly_this(IRNextKind::ReturnsNonObject);
         super::get_iterator(&obj, IteratorKind::Sync).unwrap()
     }
-    pub fn makes_good_ir() -> IteratorRecord {
+    pub(crate) fn makes_good_ir() -> IteratorRecord {
         let obj = silly_this(IRNextKind::ReturnsObject);
         super::get_iterator(&obj, IteratorKind::Sync).unwrap()
     }

--- a/src/cr/mod.rs
+++ b/src/cr/mod.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::ptr::addr_of;
 
 #[derive(Clone, Debug)]
-pub enum NormalCompletion {
+pub(crate) enum NormalCompletion {
     Empty,
     Value(ECMAScriptValue),
     Reference(Box<Reference>),
@@ -61,7 +61,7 @@ impl fmt::Display for NormalCompletion {
     }
 }
 #[derive(Clone, Debug, PartialEq)]
-pub enum AbruptCompletion {
+pub(crate) enum AbruptCompletion {
     Break { value: NormalCompletion, target: Option<JSString> },
     Continue { value: NormalCompletion, target: Option<JSString> },
     Return { value: ECMAScriptValue },
@@ -96,8 +96,8 @@ impl From<AbruptCompletion> for String {
     }
 }
 
-pub type Completion<T> = Result<T, AbruptCompletion>;
-pub type FullCompletion = Completion<NormalCompletion>;
+pub(crate) type Completion<T> = Result<T, AbruptCompletion>;
+pub(crate) type FullCompletion = Completion<NormalCompletion>;
 
 impl<T> From<T> for NormalCompletion
 where
@@ -256,7 +256,7 @@ impl TryFrom<NormalCompletion> for Box<Reference> {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct ThrowValue(ECMAScriptValue);
+pub(crate) struct ThrowValue(ECMAScriptValue);
 impl TryFrom<AbruptCompletion> for ThrowValue {
     type Error = anyhow::Error;
     fn try_from(value: AbruptCompletion) -> Result<Self, Self::Error> {
@@ -274,7 +274,7 @@ impl From<ThrowValue> for ECMAScriptValue {
     }
 }
 
-pub fn update_empty(completion_record: FullCompletion, old_value: NormalCompletion) -> FullCompletion {
+pub(crate) fn update_empty(completion_record: FullCompletion, old_value: NormalCompletion) -> FullCompletion {
     match completion_record {
         Ok(NormalCompletion::Empty) => Ok(old_value),
         Err(AbruptCompletion::Break { value: NormalCompletion::Empty, target }) => {

--- a/src/date_object.rs
+++ b/src/date_object.rs
@@ -6,7 +6,7 @@ use std::sync::LazyLock;
 
 use super::*;
 
-pub fn provision_date_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_date_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -199,7 +199,7 @@ pub fn provision_date_intrinsic(realm: &Rc<RefCell<Realm>>) {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
-pub struct TimeNumber {
+pub(crate) struct TimeNumber {
     // This is a floating point number that has conversion routines to/from integers designed to not generate clippy
     // warnings.
     val: f64,
@@ -292,7 +292,7 @@ impl TryFrom<TimeNumber> for u8 {
 }
 
 #[derive(Debug)]
-pub struct DateObject {
+pub(crate) struct DateObject {
     common: RefCell<CommonObjectData>,
     date_value: Cell<f64>,
 }
@@ -423,15 +423,15 @@ impl ObjectInterface for DateObject {
 }
 
 impl DateObject {
-    pub fn date_value(&self) -> f64 {
+    pub(crate) fn date_value(&self) -> f64 {
         self.date_value.get()
     }
 
-    pub fn set_date_value(&self, value: f64) {
+    pub(crate) fn set_date_value(&self, value: f64) {
         self.date_value.set(value);
     }
 
-    pub fn now_utc() -> anyhow::Result<f64> {
+    pub(crate) fn now_utc() -> anyhow::Result<f64> {
         let timestamp = time::OffsetDateTime::now_utc();
         let nanos = timestamp.unix_timestamp_nanos();
         let milliseconds = nanos / 1_000_000;
@@ -445,7 +445,7 @@ impl DateObject {
         }
     }
 
-    pub fn object(prototype: Option<Object>, value: Option<TimeNumber>) -> Object {
+    pub(crate) fn object(prototype: Option<Object>, value: Option<TimeNumber>) -> Object {
         Object { o: Rc::new(Self::new(prototype, value)) }
     }
 }

--- a/src/dtoa_r.rs
+++ b/src/dtoa_r.rs
@@ -5,7 +5,7 @@ use std::os::raw::{c_double, c_int, c_uchar};
 use std::sync::{Arc, LazyLock, Mutex};
 
 unsafe extern "C" {
-    pub fn dtoa_rust(
+    pub(crate) fn dtoa_rust(
         value: c_double,
         mode: c_int,
         ndigits: c_int,
@@ -19,13 +19,13 @@ unsafe extern "C" {
 static DTOALOCK: LazyLock<Arc<Mutex<u32>>> = LazyLock::new(|| Arc::new(Mutex::new(0)));
 
 #[derive(Debug)]
-pub struct DtoAResult {
-    pub chars: String,
-    pub decpt: i32,
-    pub sign: i8,
+pub(crate) struct DtoAResult {
+    pub(crate) chars: String,
+    pub(crate) decpt: i32,
+    pub(crate) sign: i8,
 }
 
-pub fn dtoa(value: f64) -> DtoAResult {
+pub(crate) fn dtoa(value: f64) -> DtoAResult {
     let mut decpt: c_int = 0;
     let mut sign: c_int = 0;
     let mut digits: [u8; 64] = [0; 64];
@@ -53,7 +53,7 @@ pub fn dtoa(value: f64) -> DtoAResult {
     }
 }
 
-pub fn dtoa_precise(value: f64, num_digits: i32) -> DtoAResult {
+pub(crate) fn dtoa_precise(value: f64, num_digits: i32) -> DtoAResult {
     let mut decpt: c_int = 0;
     let mut sign: c_int = 0;
     let mut digits: [u8; 110] = [0; 110];
@@ -80,7 +80,7 @@ pub fn dtoa_precise(value: f64, num_digits: i32) -> DtoAResult {
         sign: i8::try_from(sign).expect("sign should fit into an i8"),
     }
 }
-pub fn dtoa_fixed(value: f64, num_digits: i32) -> DtoAResult {
+pub(crate) fn dtoa_fixed(value: f64, num_digits: i32) -> DtoAResult {
     let mut decpt: c_int = 0;
     let mut sign: c_int = 0;
     let mut digits: [u8; 110] = [0; 110];

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -52,70 +52,74 @@ fn create_native_error_object(
     create_native_error_object_internal(message, error_constructor, proto_id, location)
 }
 
-pub fn create_type_error_object(message: impl Into<JSString>) -> Object {
+pub(crate) fn create_type_error_object(message: impl Into<JSString>) -> Object {
     let error_constructor = intrinsic(IntrinsicId::TypeError);
     create_native_error_object(message, &error_constructor, IntrinsicId::TypeErrorPrototype, None)
 }
 
-pub fn create_type_error(message: impl Into<JSString>) -> AbruptCompletion {
+pub(crate) fn create_type_error(message: impl Into<JSString>) -> AbruptCompletion {
     AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_type_error_object(message)) }
 }
 
-pub fn create_reference_error_object(message: impl Into<JSString>) -> Object {
+pub(crate) fn create_reference_error_object(message: impl Into<JSString>) -> Object {
     let cstr = intrinsic(IntrinsicId::ReferenceError);
     create_native_error_object(message, &cstr, IntrinsicId::ReferenceErrorPrototype, None)
 }
 
-pub fn create_reference_error(message: impl Into<JSString>) -> AbruptCompletion {
+pub(crate) fn create_reference_error(message: impl Into<JSString>) -> AbruptCompletion {
     AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_reference_error_object(message)) }
 }
 
-pub fn create_syntax_error_object(message: impl Into<JSString>, location: Option<Location>) -> Object {
+pub(crate) fn create_syntax_error_object(message: impl Into<JSString>, location: Option<Location>) -> Object {
     let cstr = intrinsic(IntrinsicId::SyntaxError);
     create_native_error_object(message, &cstr, IntrinsicId::SyntaxErrorPrototype, location)
 }
 
-pub fn create_syntax_error(message: impl Into<JSString>, location: Option<Location>) -> AbruptCompletion {
+pub(crate) fn create_syntax_error(message: impl Into<JSString>, location: Option<Location>) -> AbruptCompletion {
     AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_syntax_error_object(message, location)) }
 }
 
-pub fn create_range_error_object(message: impl Into<JSString>) -> Object {
+pub(crate) fn create_range_error_object(message: impl Into<JSString>) -> Object {
     let cstr = intrinsic(IntrinsicId::RangeError);
     create_native_error_object(message, &cstr, IntrinsicId::RangeErrorPrototype, None)
 }
 
-pub fn create_range_error(message: impl Into<JSString>) -> AbruptCompletion {
+pub(crate) fn create_range_error(message: impl Into<JSString>) -> AbruptCompletion {
     AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_range_error_object(message)) }
 }
 
-pub fn create_eval_error_object(message: impl Into<JSString>) -> Object {
+#[cfg(test)]
+pub(crate) fn create_eval_error_object(message: impl Into<JSString>) -> Object {
     let cstr = intrinsic(IntrinsicId::EvalError);
     create_native_error_object(message, &cstr, IntrinsicId::EvalErrorPrototype, None)
 }
 
-pub fn create_eval_error(message: impl Into<JSString>) -> AbruptCompletion {
+#[cfg(test)]
+pub(crate) fn create_eval_error(message: impl Into<JSString>) -> AbruptCompletion {
     AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_eval_error_object(message)) }
 }
 
-pub fn create_uri_error_object(message: impl Into<JSString>) -> Object {
+#[cfg(test)]
+pub(crate) fn create_uri_error_object(message: impl Into<JSString>) -> Object {
     let cstr = intrinsic(IntrinsicId::URIError);
     create_native_error_object(message, &cstr, IntrinsicId::URIErrorPrototype, None)
 }
 
-pub fn create_uri_error(message: impl Into<JSString>) -> AbruptCompletion {
+#[cfg(test)]
+pub(crate) fn create_uri_error(message: impl Into<JSString>) -> AbruptCompletion {
     AbruptCompletion::Throw { value: ECMAScriptValue::Object(create_uri_error_object(message)) }
 }
 
 #[derive(Debug)]
-pub struct ErrorObject {
+pub(crate) struct ErrorObject {
     common: RefCell<CommonObjectData>,
 }
 
 impl ErrorObject {
-    pub fn new(prototype: Option<Object>) -> Self {
+    pub(crate) fn new(prototype: Option<Object>) -> Self {
         Self { common: RefCell::new(CommonObjectData::new(prototype, true, ERROR_OBJECT_SLOTS)) }
     }
-    pub fn object(prototype: Option<Object>) -> Object {
+    pub(crate) fn object(prototype: Option<Object>) -> Object {
         Object { o: Rc::new(Self::new(prototype)) }
     }
 }
@@ -175,7 +179,7 @@ impl ObjectInterface for ErrorObject {
     }
 }
 
-pub fn provision_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -308,7 +312,7 @@ pub fn provision_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
 //             [[Configurable]]: true }.
 //          c. Perform ! DefinePropertyOrThrow(O, "message", msgDesc).
 //      4. Return O.
-pub fn error_constructor_function(
+pub(crate) fn error_constructor_function(
     this_value: &ECMAScriptValue,
     new_target: Option<&Object>,
     arguments: &[ECMAScriptValue],
@@ -329,7 +333,7 @@ pub fn error_constructor_function(
 //      7. If name is the empty String, return msg.
 //      8. If msg is the empty String, return name.
 //      9. Return the string-concatenation of name, the code unit 0x003A (COLON), the code unit 0x0020 (SPACE), and msg.
-pub fn error_prototype_tostring(
+pub(crate) fn error_prototype_tostring(
     this_value: &ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -537,56 +541,56 @@ fn uri_error_constructor_function(
     native_error_constructor_function(this_value, new_target, arguments, IntrinsicId::URIErrorPrototype)
 }
 
-pub fn provision_type_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_type_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
         provision_native_error_intrinsics(realm, "TypeError", type_error_constructor_function);
     realm.borrow_mut().intrinsics.type_error = constructor;
     realm.borrow_mut().intrinsics.type_error_prototype = prototype;
 }
-pub fn provision_eval_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_eval_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
         provision_native_error_intrinsics(realm, "EvalError", eval_error_constructor_function);
     realm.borrow_mut().intrinsics.eval_error = constructor;
     realm.borrow_mut().intrinsics.eval_error_prototype = prototype;
 }
-pub fn provision_range_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_range_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
         provision_native_error_intrinsics(realm, "RangeError", range_error_constructor_function);
     realm.borrow_mut().intrinsics.range_error = constructor;
     realm.borrow_mut().intrinsics.range_error_prototype = prototype;
 }
-pub fn provision_reference_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_reference_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
         provision_native_error_intrinsics(realm, "ReferenceError", reference_error_constructor_function);
     realm.borrow_mut().intrinsics.reference_error = constructor;
     realm.borrow_mut().intrinsics.reference_error_prototype = prototype;
 }
-pub fn provision_syntax_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_syntax_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) =
         provision_native_error_intrinsics(realm, "SyntaxError", syntax_error_constructor_function);
     realm.borrow_mut().intrinsics.syntax_error = constructor;
     realm.borrow_mut().intrinsics.syntax_error_prototype = prototype;
 }
-pub fn provision_uri_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_uri_error_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let (constructor, prototype) = provision_native_error_intrinsics(realm, "URIError", uri_error_constructor_function);
     realm.borrow_mut().intrinsics.uri_error = constructor;
     realm.borrow_mut().intrinsics.uri_error_prototype = prototype;
 }
 
 /// Transform an ECMAScript Error object into a Rust string
-pub fn unwind_any_error_value(err: ECMAScriptValue) -> String {
+pub(crate) fn unwind_any_error_value(err: ECMAScriptValue) -> String {
     to_string(err).unwrap().into()
 }
 
 /// Transform an ECMAScript Throw Completion into a Rust string
-pub fn unwind_any_error(completion: AbruptCompletion) -> String {
+pub(crate) fn unwind_any_error(completion: AbruptCompletion) -> String {
     match completion {
         AbruptCompletion::Throw { value: err } => unwind_any_error_value(err),
         _ => panic!("Improper completion for error: {completion:?}"),
     }
 }
 
-pub fn unwind_any_error_object(o: &Object) -> String {
+pub(crate) fn unwind_any_error_object(o: &Object) -> String {
     let name_prop = o.get(&"name".into()).unwrap_or(ECMAScriptValue::Undefined);
     let name = if name_prop.is_undefined() { String::from("Error") } else { name_prop.to_string() };
     let msg_prop = o.get(&"message".into()).unwrap_or(ECMAScriptValue::Undefined);

--- a/src/execution_context/tests.rs
+++ b/src/execution_context/tests.rs
@@ -4,7 +4,7 @@ use crate::tests::*;
 use test_case::test_case;
 
 impl ScriptRecord {
-    pub fn new_empty(realm: Rc<RefCell<Realm>>) -> Self {
+    pub(crate) fn new_empty(realm: Rc<RefCell<Realm>>) -> Self {
         let script = Maker::new("").script();
         ScriptRecord { realm, ecmascript_code: script, compiled: Rc::new(Chunk::new("empty")), text: String::new() }
     }

--- a/src/function_object/mod.rs
+++ b/src/function_object/mod.rs
@@ -6,26 +6,26 @@ use std::fmt;
 use std::rc::Rc;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum ConstructorKind {
+pub(crate) enum ConstructorKind {
     Base,
     Derived,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum ThisMode {
+pub(crate) enum ThisMode {
     Lexical,
     Strict,
     Global,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum ThisLexicality {
+pub(crate) enum ThisLexicality {
     LexicalThis,
     NonLexicalThis,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum ClassName {
+pub(crate) enum ClassName {
     String(JSString),
     Symbol(Symbol),
     Private(PrivateName),
@@ -96,18 +96,18 @@ impl fmt::Display for ClassName {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ClassFieldDefinitionRecord {
-    pub name: ClassName,
-    pub initializer: Option<Object>,
+pub(crate) struct ClassFieldDefinitionRecord {
+    pub(crate) name: ClassName,
+    pub(crate) initializer: Option<Object>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ClassStaticBlockDefinitionRecord {
-    pub body_function: Object,
+pub(crate) struct ClassStaticBlockDefinitionRecord {
+    pub(crate) body_function: Object,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum ClassItem {
+pub(crate) enum ClassItem {
     StaticPrivateElement(PrivateElement),
     PrivateElement(PrivateElement),
     StaticClassFieldDefinition(ClassFieldDefinitionRecord),
@@ -170,7 +170,7 @@ impl fmt::Display for ClassItem {
 }
 
 #[derive(Debug, Clone)]
-pub enum BodySource {
+pub(crate) enum BodySource {
     Function(Rc<FunctionBody>),
     Generator(Rc<GeneratorBody>),
     AsyncFunction(Rc<AsyncFunctionBody>),
@@ -180,7 +180,7 @@ pub enum BodySource {
     Initializer(Rc<Initializer>),
     ClassStaticBlockBody(Rc<ClassStaticBlockBody>),
 }
-pub struct ConciseBodySource<'a>(&'a BodySource);
+pub(crate) struct ConciseBodySource<'a>(&'a BodySource);
 impl fmt::Debug for ConciseBodySource<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
@@ -230,10 +230,10 @@ impl From<Rc<ClassStaticBlockBody>> for BodySource {
 impl From<ParsedBody> for BodySource {
     fn from(value: ParsedBody) -> Self {
         match value {
-            ParsedBody::FunctionBody(function_body) => BodySource::Function(function_body),
-            ParsedBody::GeneratorBody(generator_body) => BodySource::Generator(generator_body),
-            ParsedBody::AsyncFunctionBody(async_function_body) => BodySource::AsyncFunction(async_function_body),
-            ParsedBody::AsyncGeneratorBody(async_generator_body) => BodySource::AsyncGenerator(async_generator_body),
+            ParsedBody::Function(function_body) => BodySource::Function(function_body),
+            ParsedBody::Generator(generator_body) => BodySource::Generator(generator_body),
+            ParsedBody::AsyncFunction(async_function_body) => BodySource::AsyncFunction(async_function_body),
+            ParsedBody::AsyncGenerator(async_generator_body) => BodySource::AsyncGenerator(async_generator_body),
         }
     }
 }
@@ -296,7 +296,7 @@ impl BodySource {
     /// of the var-declared list.
     ///
     /// See [VarDeclaredNames](https://tc39.es/ecma262/#sec-static-semantics-vardeclarednames) from ECMA-262.
-    pub fn var_declared_names(&self) -> Vec<JSString> {
+    pub(crate) fn var_declared_names(&self) -> Vec<JSString> {
         match self {
             BodySource::Function(f) => f.var_declared_names(),
             BodySource::Generator(g) => g.var_declared_names(),
@@ -311,7 +311,7 @@ impl BodySource {
     /// Return a list of parse nodes for the var-style declarations contained within the children of this node.
     ///
     /// See [VarScopedDeclarations](https://tc39.es/ecma262/#sec-static-semantics-varscopeddeclarations) in ECMA-262.
-    pub fn var_scoped_declarations(&self) -> Vec<VarScopeDecl> {
+    pub(crate) fn var_scoped_declarations(&self) -> Vec<VarScopeDecl> {
         match self {
             BodySource::Function(f) => f.var_scoped_declarations(),
             BodySource::Generator(g) => g.var_scoped_declarations(),
@@ -323,7 +323,7 @@ impl BodySource {
         }
     }
 
-    pub fn lexically_declared_names(&self) -> Vec<JSString> {
+    pub(crate) fn lexically_declared_names(&self) -> Vec<JSString> {
         match self {
             BodySource::Function(f) => f.lexically_declared_names(),
             BodySource::Generator(g) => g.lexically_declared_names(),
@@ -335,7 +335,7 @@ impl BodySource {
         }
     }
 
-    pub fn lexically_scoped_declarations(&self) -> Vec<DeclPart> {
+    pub(crate) fn lexically_scoped_declarations(&self) -> Vec<DeclPart> {
         match self {
             BodySource::Function(f) => f.lexically_scoped_declarations(),
             BodySource::Generator(g) => g.lexically_scoped_declarations(),
@@ -347,7 +347,7 @@ impl BodySource {
         }
     }
 
-    pub fn contains_use_strict(&self) -> bool {
+    pub(crate) fn contains_use_strict(&self) -> bool {
         match self {
             BodySource::Function(node) => node.function_body_contains_use_strict(),
             BodySource::Generator(node) => node.function_body_contains_use_strict(),
@@ -361,7 +361,7 @@ impl BodySource {
 }
 
 #[derive(Debug, Clone)]
-pub enum ParamSource {
+pub(crate) enum ParamSource {
     FormalParameters(Rc<FormalParameters>),
     ArrowParameters(Rc<ArrowParameters>),
     AsyncArrowBinding(Rc<AsyncArrowBindingIdentifier>),
@@ -370,7 +370,7 @@ pub enum ParamSource {
     PropertySetParameterList(Rc<PropertySetParameterList>),
 }
 
-pub struct ConciseParamSource<'a>(&'a ParamSource);
+pub(crate) struct ConciseParamSource<'a>(&'a ParamSource);
 impl fmt::Debug for ConciseParamSource<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
@@ -452,18 +452,18 @@ impl TryFrom<ParamSource> for Rc<FormalParameters> {
     }
 }
 impl ParamSource {
-    pub fn expected_argument_count(&self) -> f64 {
+    pub(crate) fn expected_argument_count(&self) -> f64 {
         match self {
             ParamSource::FormalParameters(formals) => formals.expected_argument_count(),
             ParamSource::ArrowParameters(arrow) => arrow.expected_argument_count(),
-            ParamSource::AsyncArrowBinding(node) => node.expected_argument_count(),
+            ParamSource::AsyncArrowBinding(_) => 1.0,
             ParamSource::ArrowFormals(node) => node.expected_argument_count(),
             ParamSource::UniqueFormalParameters(node) => node.expected_argument_count(),
             ParamSource::PropertySetParameterList(node) => node.expected_argument_count(),
         }
     }
 
-    pub fn bound_names(&self) -> Vec<JSString> {
+    pub(crate) fn bound_names(&self) -> Vec<JSString> {
         match self {
             ParamSource::FormalParameters(formals) => formals.bound_names(),
             ParamSource::ArrowParameters(arrow) => arrow.bound_names(),
@@ -474,22 +474,22 @@ impl ParamSource {
         }
     }
 
-    pub fn is_simple_parameter_list(&self) -> bool {
+    pub(crate) fn is_simple_parameter_list(&self) -> bool {
         match self {
             ParamSource::FormalParameters(formals) => formals.is_simple_parameter_list(),
             ParamSource::ArrowParameters(arrow) => arrow.is_simple_parameter_list(),
-            ParamSource::AsyncArrowBinding(node) => node.is_simple_parameter_list(),
+            ParamSource::AsyncArrowBinding(_) => true,
             ParamSource::ArrowFormals(node) => node.is_simple_parameter_list(),
             ParamSource::UniqueFormalParameters(node) => node.is_simple_parameter_list(),
             ParamSource::PropertySetParameterList(node) => node.is_simple_parameter_list(),
         }
     }
 
-    pub fn contains_expression(&self) -> bool {
+    pub(crate) fn contains_expression(&self) -> bool {
         match self {
             ParamSource::FormalParameters(formals) => formals.contains_expression(),
             ParamSource::ArrowParameters(arrow) => arrow.contains_expression(),
-            ParamSource::AsyncArrowBinding(node) => node.contains_expression(),
+            ParamSource::AsyncArrowBinding(_) => false,
             ParamSource::ArrowFormals(node) => node.contains_expression(),
             ParamSource::UniqueFormalParameters(node) => node.contains_expression(),
             ParamSource::PropertySetParameterList(node) => node.contains_expression(),
@@ -498,15 +498,17 @@ impl ParamSource {
 }
 
 #[derive(Debug, Clone)]
-pub enum FunctionSource {
+pub(crate) enum FunctionSource {
     FunctionExpression(Rc<FunctionExpression>),
     GeneratorExpression(Rc<GeneratorExpression>),
+    #[cfg(test)]
     AsyncGeneratorExpression(Rc<AsyncGeneratorExpression>),
+    #[cfg(test)]
     AsyncFunctionExpression(Rc<AsyncFunctionExpression>),
     ArrowFunction(Rc<ArrowFunction>),
-    AsyncArrowFunction(Rc<AsyncArrowFunction>),
+    //AsyncArrowFunction(Rc<AsyncArrowFunction>),
     MethodDefinition(Rc<MethodDefinition>),
-    HoistableDeclaration(Rc<HoistableDeclaration>),
+    //HoistableDeclaration(Rc<HoistableDeclaration>),
     FieldDefinition(Rc<FieldDefinition>),
     ClassStaticBlock(Rc<ClassStaticBlock>),
     FunctionDeclaration(Rc<FunctionDeclaration>),
@@ -519,12 +521,14 @@ impl fmt::Display for FunctionSource {
         match self {
             FunctionSource::FunctionExpression(node) => node.fmt(f),
             FunctionSource::GeneratorExpression(node) => node.fmt(f),
+            #[cfg(test)]
             FunctionSource::AsyncGeneratorExpression(node) => node.fmt(f),
+            #[cfg(test)]
             FunctionSource::AsyncFunctionExpression(node) => node.fmt(f),
             FunctionSource::ArrowFunction(node) => node.fmt(f),
-            FunctionSource::AsyncArrowFunction(node) => node.fmt(f),
+            //FunctionSource::AsyncArrowFunction(node) => node.fmt(f),
             FunctionSource::MethodDefinition(node) => node.fmt(f),
-            FunctionSource::HoistableDeclaration(node) => node.fmt(f),
+            //FunctionSource::HoistableDeclaration(node) => node.fmt(f),
             FunctionSource::FieldDefinition(node) => node.fmt(f),
             FunctionSource::ClassStaticBlock(node) => node.fmt(f),
             FunctionSource::FunctionDeclaration(node) => node.fmt(f),
@@ -539,26 +543,30 @@ impl PartialEq for FunctionSource {
         match (self, other) {
             (Self::FunctionExpression(l0), Self::FunctionExpression(r0)) => Rc::ptr_eq(l0, r0),
             (Self::GeneratorExpression(l0), Self::GeneratorExpression(r0)) => Rc::ptr_eq(l0, r0),
+            #[cfg(test)]
             (Self::AsyncGeneratorExpression(l0), Self::AsyncGeneratorExpression(r0)) => Rc::ptr_eq(l0, r0),
+            #[cfg(test)]
             (Self::AsyncFunctionExpression(l0), Self::AsyncFunctionExpression(r0)) => Rc::ptr_eq(l0, r0),
             (Self::ArrowFunction(l0), Self::ArrowFunction(r0)) => Rc::ptr_eq(l0, r0),
-            (Self::AsyncArrowFunction(l0), Self::AsyncArrowFunction(r0)) => Rc::ptr_eq(l0, r0),
+            //(Self::AsyncArrowFunction(l0), Self::AsyncArrowFunction(r0)) => Rc::ptr_eq(l0, r0),
             (Self::MethodDefinition(l0), Self::MethodDefinition(r0)) => Rc::ptr_eq(l0, r0),
-            (Self::HoistableDeclaration(l0), Self::HoistableDeclaration(r0)) => Rc::ptr_eq(l0, r0),
+            //(Self::HoistableDeclaration(l0), Self::HoistableDeclaration(r0)) => Rc::ptr_eq(l0, r0),
             (Self::FieldDefinition(l0), Self::FieldDefinition(r0)) => Rc::ptr_eq(l0, r0),
             (Self::ClassStaticBlock(l0), Self::ClassStaticBlock(r0)) => Rc::ptr_eq(l0, r0),
             (Self::FunctionDeclaration(l0), Self::FunctionDeclaration(r0)) => Rc::ptr_eq(l0, r0),
             (Self::GeneratorDeclaration(l0), Self::GeneratorDeclaration(r0)) => Rc::ptr_eq(l0, r0),
             (Self::GeneratorMethod(l0), Self::GeneratorMethod(r0)) => Rc::ptr_eq(l0, r0),
+            #[cfg(test)]
+            (   Self::AsyncGeneratorExpression(_)
+                | Self::AsyncFunctionExpression(_), _
+            ) => false,
             (
                 Self::FunctionExpression(_)
                 | Self::GeneratorExpression(_)
-                | Self::AsyncGeneratorExpression(_)
-                | Self::AsyncFunctionExpression(_)
                 | Self::ArrowFunction(_)
-                | Self::AsyncArrowFunction(_)
+                //| Self::AsyncArrowFunction(_)
                 | Self::MethodDefinition(_)
-                | Self::HoistableDeclaration(_)
+                //| Self::HoistableDeclaration(_)
                 | Self::FieldDefinition(_)
                 | Self::ClassStaticBlock(_)
                 | Self::FunctionDeclaration(_)
@@ -705,22 +713,22 @@ impl TryFrom<FunctionSource> for Rc<MethodDefinition> {
     }
 }
 
-pub struct FunctionObjectData {
-    pub environment: Rc<dyn EnvironmentRecord>,
+pub(crate) struct FunctionObjectData {
+    pub(crate) environment: Rc<dyn EnvironmentRecord>,
     private_environment: Option<Rc<RefCell<PrivateEnvironmentRecord>>>,
     formal_parameters: ParamSource,
     ecmascript_code: BodySource,
     compiled: Rc<Chunk>,
-    pub constructor_kind: ConstructorKind,
-    pub realm: Rc<RefCell<Realm>>,
+    pub(crate) constructor_kind: ConstructorKind,
+    pub(crate) realm: Rc<RefCell<Realm>>,
     script_or_module: Option<ScriptOrModule>,
-    pub this_mode: ThisMode,
+    pub(crate) this_mode: ThisMode,
     strict: bool,
-    pub home_object: Option<Object>,
-    pub source_text: String,
-    pub fields: Vec<ClassFieldDefinitionRecord>,
-    pub private_methods: Vec<PrivateElement>,
-    pub class_field_initializer_name: Option<ClassName>,
+    pub(crate) home_object: Option<Object>,
+    pub(crate) source_text: String,
+    pub(crate) fields: Vec<ClassFieldDefinitionRecord>,
+    pub(crate) private_methods: Vec<PrivateElement>,
+    pub(crate) class_field_initializer_name: Option<ClassName>,
     is_class_constructor: bool,
     is_constructor: bool,
 }
@@ -749,7 +757,7 @@ impl fmt::Debug for FunctionObjectData {
 }
 
 #[derive(Debug)]
-pub struct FunctionObject {
+pub(crate) struct FunctionObject {
     common: RefCell<CommonObjectData>,
     function_data: RefCell<FunctionObjectData>,
 }
@@ -760,7 +768,7 @@ impl<'a> From<&'a FunctionObject> for &'a dyn ObjectInterface {
     }
 }
 
-pub trait CallableObject: ObjectInterface {
+pub(crate) trait CallableObject: ObjectInterface {
     fn call(&self, self_object: &Object, this_argument: &ECMAScriptValue, arguments_list: &[ECMAScriptValue]);
     fn construct(&self, self_object: &Object, arguments_list: &[ECMAScriptValue], new_target: &Object);
     fn end_evaluation(&self, result: FullCompletion);
@@ -1015,7 +1023,7 @@ impl CallableObject for FunctionObject {
     }
 }
 
-pub fn initialize_instance_elements(this_argument: &Object, constructor: &Object) -> Completion<()> {
+pub(crate) fn initialize_instance_elements(this_argument: &Object, constructor: &Object) -> Completion<()> {
     // InitializeInstanceElements ( O, constructor )
     // The abstract operation InitializeInstanceElements takes arguments O (an Object) and constructor (an ECMAScript
     // function object) and returns either a normal completion containing unused or a throw completion. It performs the
@@ -1062,7 +1070,7 @@ impl FunctionInterface for FunctionObject {
 
 impl FunctionObject {
     #[expect(clippy::too_many_arguments)]
-    pub fn new(
+    pub(crate) fn new(
         prototype: Option<Object>,
         environment: Rc<dyn EnvironmentRecord>,
         private_environment: Option<Rc<RefCell<PrivateEnvironmentRecord>>>,
@@ -1106,7 +1114,7 @@ impl FunctionObject {
     }
 
     #[expect(clippy::too_many_arguments)]
-    pub fn object(
+    pub(crate) fn object(
         prototype: Option<Object>,
         environment: Rc<dyn EnvironmentRecord>,
         private_environment: Option<Rc<RefCell<PrivateEnvironmentRecord>>>,
@@ -1154,7 +1162,7 @@ impl FunctionObject {
 /// The function being called is `func`, and any target for New expressions is in `new_target`.
 ///
 /// See [PrepareForOrdinaryCall](https://tc39.es/ecma262/#sec-prepareforordinarycall) from ECMA-262.
-pub fn prepare_for_ordinary_call(func: &Object, new_target: Option<Object>) {
+pub(crate) fn prepare_for_ordinary_call(func: &Object, new_target: Option<Object>) {
     // PrepareForOrdinaryCall ( F, newTarget )
     //
     // The abstract operation PrepareForOrdinaryCall takes arguments F (a function object) and newTarget (an Object
@@ -1294,7 +1302,7 @@ fn ordinary_call_evaluate_body(func: &Object, args: &[ECMAScriptValue]) {
     ec_push(Ok(args.len().into()));
 }
 
-pub fn nameify(src: &str, limit: usize) -> String {
+pub(crate) fn nameify(src: &str, limit: usize) -> String {
     let minimized = src.trim().split(|c: char| c.is_whitespace()).filter(|x| !x.is_empty()).join(" ");
     let (always_shown, maybe_shown): (Vec<_>, Vec<_>) =
         minimized.chars().enumerate().partition(|&(idx, _)| idx < limit - 3);
@@ -1330,7 +1338,7 @@ pub fn nameify(src: &str, limit: usize) -> String {
 //              i. Optionally, set F.[[InitialName]] to name.
 //      6. Return ! DefinePropertyOrThrow(F, "name", PropertyDescriptor { [[Value]]: name, [[Writable]]: false,
 //         [[Enumerable]]: false, [[Configurable]]: true }).
-pub fn set_function_name(func: &Object, name: FunctionName, prefix: Option<JSString>) {
+pub(crate) fn set_function_name(func: &Object, name: FunctionName, prefix: Option<JSString>) {
     let name_before_prefix = match name {
         FunctionName::String(s) => s,
         FunctionName::PrivateName(pn) => pn.description,
@@ -1377,7 +1385,7 @@ pub fn set_function_name(func: &Object, name: FunctionName, prefix: Option<JSStr
 //      1. Assert: F is an extensible object that does not have a "length" own property.
 //      2. Return ! DefinePropertyOrThrow(F, "length", PropertyDescriptor { [[Value]]: 𝔽(length), [[Writable]]: false,
 //         [[Enumerable]]: false, [[Configurable]]: true }).
-pub fn set_function_length(func: &Object, length: f64) {
+pub(crate) fn set_function_length(func: &Object, length: f64) {
     define_property_or_throw(
         func,
         "length",
@@ -1399,7 +1407,7 @@ pub fn set_function_length(func: &Object, length: f64) {
 //      let second_arg = args.next_arg();
 // etc. If the args are there, you get them, if the arguments array is short, then you get undefined.
 // args.remaining() returns an iterator over the "rest" of the args (since "next_arg" won't tell if you've "gotten to the end")
-pub struct FuncArgs<'a> {
+pub(crate) struct FuncArgs<'a> {
     iterator: std::slice::Iter<'a, ECMAScriptValue>,
     count: usize,
 }
@@ -1410,22 +1418,22 @@ impl<'a> From<&'a [ECMAScriptValue]> for FuncArgs<'a> {
     }
 }
 impl<'a> FuncArgs<'a> {
-    pub fn next_arg(&mut self) -> ECMAScriptValue {
+    pub(crate) fn next_arg(&mut self) -> ECMAScriptValue {
         self.iterator.next().cloned().unwrap_or(ECMAScriptValue::Undefined)
     }
-    pub fn count(&self) -> usize {
+    pub(crate) fn count(&self) -> usize {
         self.count
     }
-    pub fn remaining(&mut self) -> &mut std::slice::Iter<'a, ECMAScriptValue> {
+    pub(crate) fn remaining(&mut self) -> &mut std::slice::Iter<'a, ECMAScriptValue> {
         &mut self.iterator
     }
-    pub fn next_if_exists(&mut self) -> Option<ECMAScriptValue> {
+    pub(crate) fn next_if_exists(&mut self) -> Option<ECMAScriptValue> {
         self.iterator.next().cloned()
     }
 }
 
 #[derive(Debug, Clone)]
-pub enum FunctionName {
+pub(crate) enum FunctionName {
     String(JSString),
     Symbol(Symbol),
     PrivateName(PrivateName),
@@ -1526,16 +1534,17 @@ impl TryFrom<NormalCompletion> for FunctionName {
     }
 }
 
-pub type BuiltInFcn = Box<dyn Fn(&ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion<ECMAScriptValue>>;
+pub(crate) type BuiltInFcn =
+    Box<dyn Fn(&ECMAScriptValue, Option<&Object>, &[ECMAScriptValue]) -> Completion<ECMAScriptValue>>;
 
-pub struct BuiltInFunctionData {
-    pub realm: Rc<RefCell<Realm>>,
-    pub initial_name: Option<FunctionName>,
-    pub steps: BuiltInFcn,
-    pub constructor_kind: Option<ConstructorKind>,
-    pub fields: Vec<ClassFieldDefinitionRecord>,
-    pub private_methods: Vec<PrivateElement>,
-    pub source_text: Option<String>,
+pub(crate) struct BuiltInFunctionData {
+    pub(crate) realm: Rc<RefCell<Realm>>,
+    pub(crate) initial_name: Option<FunctionName>,
+    pub(crate) steps: BuiltInFcn,
+    pub(crate) constructor_kind: Option<ConstructorKind>,
+    pub(crate) fields: Vec<ClassFieldDefinitionRecord>,
+    pub(crate) private_methods: Vec<PrivateElement>,
+    pub(crate) source_text: Option<String>,
 }
 
 impl fmt::Debug for BuiltInFunctionData {
@@ -1553,7 +1562,7 @@ impl fmt::Debug for BuiltInFunctionData {
 }
 
 impl BuiltInFunctionData {
-    pub fn new(
+    pub(crate) fn new(
         realm: Rc<RefCell<Realm>>,
         initial_name: Option<FunctionName>,
         steps: BuiltInFcn,
@@ -1572,7 +1581,7 @@ impl BuiltInFunctionData {
 }
 
 #[derive(Debug)]
-pub struct BuiltInFunctionObject {
+pub(crate) struct BuiltInFunctionObject {
     common: RefCell<CommonObjectData>,
     builtin_data: RefCell<BuiltInFunctionData>,
 }
@@ -1590,7 +1599,7 @@ impl BuiltinFunctionInterface for BuiltInFunctionObject {
 }
 
 impl BuiltInFunctionObject {
-    pub fn new(
+    pub(crate) fn new(
         prototype: Option<Object>,
         extensible: bool,
         realm: Rc<RefCell<Realm>>,
@@ -1604,7 +1613,7 @@ impl BuiltInFunctionObject {
         }
     }
 
-    pub fn object(
+    pub(crate) fn object(
         prototype: Option<Object>,
         extensible: bool,
         realm: Rc<RefCell<Realm>>,
@@ -1616,7 +1625,7 @@ impl BuiltInFunctionObject {
     }
 }
 
-pub trait BuiltinFunctionInterface: CallableObject {
+pub(crate) trait BuiltinFunctionInterface: CallableObject {
     fn builtin_function_data(&self) -> &RefCell<BuiltInFunctionData>;
 }
 
@@ -1783,7 +1792,7 @@ impl CallableObject for BuiltInFunctionObject {
 // Each built-in function defined in this specification is created by calling the CreateBuiltinFunction abstract
 // operation.
 #[expect(clippy::too_many_arguments)]
-pub fn create_builtin_function(
+pub(crate) fn create_builtin_function(
     behavior: BuiltInFcn,
     constructor_kind: Option<ConstructorKind>,
     length: f64,
@@ -1803,7 +1812,7 @@ pub fn create_builtin_function(
 }
 
 impl FunctionDeclaration {
-    pub fn instantiate_function_object(
+    pub(crate) fn instantiate_function_object(
         self: &Rc<Self>,
         env: Rc<dyn EnvironmentRecord>,
         private_env: Option<Rc<RefCell<PrivateEnvironmentRecord>>>,
@@ -1884,7 +1893,7 @@ impl FunctionDeclaration {
 }
 
 impl GeneratorDeclaration {
-    pub fn instantiate_function_object(
+    pub(crate) fn instantiate_function_object(
         self: &Rc<Self>,
         env: Rc<dyn EnvironmentRecord>,
         private_env: Option<Rc<RefCell<PrivateEnvironmentRecord>>>,
@@ -1979,7 +1988,7 @@ impl GeneratorDeclaration {
 
 impl AsyncFunctionDeclaration {
     #[expect(unused_variables, clippy::needless_pass_by_value)]
-    pub fn instantiate_function_object(
+    pub(crate) fn instantiate_function_object(
         self: &Rc<Self>,
         env: Rc<dyn EnvironmentRecord>,
         private_env: Option<Rc<RefCell<PrivateEnvironmentRecord>>>,
@@ -1992,7 +2001,7 @@ impl AsyncFunctionDeclaration {
 
 impl AsyncGeneratorDeclaration {
     #[expect(unused_variables, clippy::needless_pass_by_value)]
-    pub fn instantiate_function_object(
+    pub(crate) fn instantiate_function_object(
         self: &Rc<Self>,
         env: Rc<dyn EnvironmentRecord>,
         private_env: Option<Rc<RefCell<PrivateEnvironmentRecord>>>,
@@ -2007,7 +2016,7 @@ impl AsyncGeneratorDeclaration {
 ///
 /// See [OrdinaryFunctionCreate](https://tc39.es/ecma262/#sec-ordinaryfunctioncreate) from ECMA-262.
 #[expect(clippy::too_many_arguments)]
-pub fn ordinary_function_create(
+pub(crate) fn ordinary_function_create(
     function_prototype: Object,
     source_text: &str,
     parameter_list: ParamSource,
@@ -2096,7 +2105,7 @@ pub fn ordinary_function_create(
 /// Transform a function object into a constructor
 ///
 /// See [MakeConstructor](https://tc39.es/ecma262/#sec-makeconstructor) from ECMA-262.
-pub fn make_constructor(func: &Object, args: Option<(bool, Object)>) {
+pub(crate) fn make_constructor(func: &Object, args: Option<(bool, Object)>) {
     // MakeConstructor ( F [ , writablePrototype [ , prototype ] ] )
     //
     // The abstract operation MakeConstructor takes argument F (an ECMAScript function object or a built-in function
@@ -2197,7 +2206,7 @@ fn function_prototype_call(
     }
 }
 
-pub fn provision_function_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_function_intrinsic(realm: &Rc<RefCell<Realm>>) {
     //let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -2323,14 +2332,14 @@ fn function_constructor_function(
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum FunctionKind {
+pub(crate) enum FunctionKind {
     Normal,
     Generator,
-    Async,
-    AsyncGenerator,
+    //Async,
+    //AsyncGenerator,
 }
 
-pub fn create_dynamic_function(
+pub(crate) fn create_dynamic_function(
     constructor: &Object,
     new_target: Option<&Object>,
     kind: FunctionKind,
@@ -2341,8 +2350,8 @@ pub fn create_dynamic_function(
     let (prefix, fallback_proto) = match kind {
         FunctionKind::Normal => ("function", IntrinsicId::FunctionPrototype),
         FunctionKind::Generator => ("function*", IntrinsicId::GeneratorFunctionPrototype),
-        FunctionKind::Async => ("async function", IntrinsicId::AsyncFunctionPrototype),
-        FunctionKind::AsyncGenerator => ("async function*", IntrinsicId::AsyncGeneratorFunctionPrototype),
+        //FunctionKind::Async => ("async function", IntrinsicId::AsyncFunctionPrototype),
+        //FunctionKind::AsyncGenerator => ("async function*", IntrinsicId::AsyncGeneratorFunctionPrototype),
     };
     let parameter_strings = parameter_args.iter().map(|v| to_string(v.clone())).collect::<Result<Vec<_>, _>>()?;
     let body_string = to_string(body_arg.clone())?;
@@ -2372,8 +2381,8 @@ pub fn create_dynamic_function(
         match kind {
             FunctionKind::Normal => ParseGoal::FormalParameters(YieldAllowed::No, AwaitAllowed::No),
             FunctionKind::Generator => ParseGoal::FormalParameters(YieldAllowed::Yes, AwaitAllowed::No),
-            FunctionKind::Async => ParseGoal::FormalParameters(YieldAllowed::No, AwaitAllowed::Yes),
-            FunctionKind::AsyncGenerator => ParseGoal::FormalParameters(YieldAllowed::Yes, AwaitAllowed::Yes),
+            //FunctionKind::Async => ParseGoal::FormalParameters(YieldAllowed::No, AwaitAllowed::Yes),
+            //FunctionKind::AsyncGenerator => ParseGoal::FormalParameters(YieldAllowed::Yes, AwaitAllowed::Yes),
         },
         false,
         false,
@@ -2392,8 +2401,8 @@ pub fn create_dynamic_function(
         match kind {
             FunctionKind::Normal => ParseGoal::FunctionBody(YieldAllowed::No, AwaitAllowed::No),
             FunctionKind::Generator => ParseGoal::GeneratorBody,
-            FunctionKind::Async => ParseGoal::AsyncFunctionBody,
-            FunctionKind::AsyncGenerator => ParseGoal::AsyncGeneratorBody,
+            //FunctionKind::Async => ParseGoal::AsyncFunctionBody,
+            //FunctionKind::AsyncGenerator => ParseGoal::AsyncGeneratorBody,
         },
         false,
         false,
@@ -2403,10 +2412,10 @@ pub fn create_dynamic_function(
         Err(mut errs) => {
             return Err(AbruptCompletion::Throw { value: ECMAScriptValue::Object(errs.swap_remove(0)) });
         }
-        Ok(ParsedBody::FunctionBody(fb)) => BodySource::from(fb),
-        Ok(ParsedBody::GeneratorBody(gb)) => BodySource::from(gb),
-        Ok(ParsedBody::AsyncFunctionBody(afb)) => BodySource::from(afb),
-        Ok(ParsedBody::AsyncGeneratorBody(agb)) => BodySource::from(agb),
+        Ok(ParsedBody::Function(fb)) => BodySource::from(fb),
+        Ok(ParsedBody::Generator(gb)) => BodySource::from(gb),
+        Ok(ParsedBody::AsyncFunction(afb)) => BodySource::from(afb),
+        Ok(ParsedBody::AsyncGenerator(agb)) => BodySource::from(agb),
     };
     let body_contains_use_strict = body.contains_use_strict();
     let function_expression = parse_text(
@@ -2414,8 +2423,8 @@ pub fn create_dynamic_function(
         match kind {
             FunctionKind::Normal => ParseGoal::FunctionExpression,
             FunctionKind::Generator => ParseGoal::GeneratorExpression,
-            FunctionKind::Async => ParseGoal::AsyncFunctionExpression,
-            FunctionKind::AsyncGenerator => ParseGoal::AsyncGeneratorExpression,
+            //FunctionKind::Async => ParseGoal::AsyncFunctionExpression,
+            //FunctionKind::AsyncGenerator => ParseGoal::AsyncGeneratorExpression,
         },
         body_contains_use_strict,
         false,
@@ -2426,10 +2435,12 @@ pub fn create_dynamic_function(
         Err(mut errs) => {
             return Err(AbruptCompletion::Throw { value: ECMAScriptValue::Object(errs.swap_remove(0)) });
         }
-        Ok(ParsedFunctionExpression::FunctionExpression(fe)) => FunctionSource::FunctionExpression(fe),
-        Ok(ParsedFunctionExpression::GeneratorExpression(ge)) => FunctionSource::GeneratorExpression(ge),
-        Ok(ParsedFunctionExpression::AsyncFunctionExpression(afe)) => FunctionSource::AsyncFunctionExpression(afe),
-        Ok(ParsedFunctionExpression::AsyncGeneratorExpression(age)) => FunctionSource::AsyncGeneratorExpression(age),
+        Ok(ParsedFunctionExpression::Function(fe)) => FunctionSource::FunctionExpression(fe),
+        Ok(ParsedFunctionExpression::Generator(ge)) => FunctionSource::GeneratorExpression(ge),
+        #[cfg(test)]
+        Ok(ParsedFunctionExpression::AsyncFunction(afe)) => FunctionSource::AsyncFunctionExpression(afe),
+        #[cfg(test)]
+        Ok(ParsedFunctionExpression::AsyncGenerator(age)) => FunctionSource::AsyncGeneratorExpression(age),
     };
     let proto = new_target.get_prototype_from_constructor(fallback_proto)?;
     let env = current_realm.borrow().global_env.clone().expect("There should be a global environment");
@@ -2447,9 +2458,9 @@ pub fn create_dynamic_function(
     let body = ParsedBody::try_from(body).expect("body should be a function body");
     let source_tree = SourceTree { text: source_text.clone(), ast: parsed_body };
     let compilation_status = match &body {
-        ParsedBody::FunctionBody(fb) => fb.compile_body(&mut compiled, &source_tree, &function_data),
-        ParsedBody::GeneratorBody(gb) => gb.evaluate_generator_body(&mut compiled, &source_tree, &function_data),
-        ParsedBody::AsyncFunctionBody(_) | ParsedBody::AsyncGeneratorBody(_) => {
+        ParsedBody::Function(fb) => fb.compile_body(&mut compiled, &source_tree, &function_data),
+        ParsedBody::Generator(gb) => gb.evaluate_generator_body(&mut compiled, &source_tree, &function_data),
+        ParsedBody::AsyncFunction(_) | ParsedBody::AsyncGenerator(_) => {
             compiled.op(Insn::ToDo);
             Ok(AbruptResult::Never)
         }
@@ -2491,22 +2502,21 @@ pub fn create_dynamic_function(
                     .configurable(false),
             )
             .unwrap();
-        }
-        FunctionKind::Async => {}
-        FunctionKind::AsyncGenerator => {
-            let prototype =
-                ordinary_object_create(Some(intrinsic(IntrinsicId::AsyncGeneratorFunctionPrototypePrototype)));
-            define_property_or_throw(
-                &f,
-                "prototype",
-                PotentialPropertyDescriptor::new()
-                    .value(prototype)
-                    .writable(true)
-                    .enumerable(false)
-                    .configurable(false),
-            )
-            .unwrap();
-        }
+        } //FunctionKind::Async => {}
+          //FunctionKind::AsyncGenerator => {
+          //    let prototype =
+          //        ordinary_object_create(Some(intrinsic(IntrinsicId::AsyncGeneratorFunctionPrototypePrototype)));
+          //    define_property_or_throw(
+          //        &f,
+          //        "prototype",
+          //        PotentialPropertyDescriptor::new()
+          //            .value(prototype)
+          //            .writable(true)
+          //            .enumerable(false)
+          //            .configurable(false),
+          //    )
+          //    .unwrap();
+          //}
     }
     Ok(f)
 }
@@ -2703,7 +2713,7 @@ fn function_prototype_has_instance(
     ordinary_has_instance(this_value, &v).map(ECMAScriptValue::from)
 }
 
-pub fn make_method(f: &dyn FunctionInterface, home_object: Object) {
+pub(crate) fn make_method(f: &dyn FunctionInterface, home_object: Object) {
     // MakeMethod ( F, homeObject )
     // The abstract operation MakeMethod takes arguments F (an ECMAScript function object) and homeObject (an Object)
     // and returns UNUSED. It configures F as a method. It performs the following steps when called:
@@ -2713,7 +2723,7 @@ pub fn make_method(f: &dyn FunctionInterface, home_object: Object) {
     f.function_data().borrow_mut().home_object = Some(home_object);
 }
 
-pub fn make_class_constructor(f: &Object) {
+pub(crate) fn make_class_constructor(f: &Object) {
     // MakeClassConstructor ( F )
     // The abstract operation MakeClassConstructor takes argument F (an ECMAScript function object) and returns unused.
     // It performs the following steps when called:
@@ -2735,7 +2745,7 @@ pub fn make_class_constructor(f: &Object) {
     }
 }
 
-pub fn get_super_constructor() -> Result<ECMAScriptValue, InternalRuntimeError> {
+pub(crate) fn get_super_constructor() -> Result<ECMAScriptValue, InternalRuntimeError> {
     // GetSuperConstructor ( )
     // The abstract operation GetSuperConstructor takes no arguments and returns an ECMAScript language value. It
     // performs the following steps when called:

--- a/src/function_object/tests.rs
+++ b/src/function_object/tests.rs
@@ -2336,9 +2336,9 @@ mod function_source {
     #[test_case(&FunctionSource::AsyncGeneratorExpression(Maker::new("async function *(){}").async_generator_expression()) => "async function * ( ) { }"; "AsyncGeneratorExpression")]
     #[test_case(&FunctionSource::AsyncFunctionExpression(Maker::new("async function (){}").async_function_expression()) => "async function ( ) { }"; "AsyncFunctionExpression")]
     #[test_case(&FunctionSource::ArrowFunction(Maker::new("() => 10").arrow_function()) => "( ) => 10"; "ArrowFunction")]
-    #[test_case(&FunctionSource::AsyncArrowFunction(Maker::new("async () => 10").async_arrow_function()) => "async ( ) => 10"; "AsyncArrowFunction")]
+    //#[test_case(&FunctionSource::AsyncArrowFunction(Maker::new("async () => 10").async_arrow_function()) => "async ( ) => 10"; "AsyncArrowFunction")]
     #[test_case(&FunctionSource::MethodDefinition(Maker::new("a(){}").method_definition()) => "a ( ) { }"; "MethodDefinition")]
-    #[test_case(&FunctionSource::HoistableDeclaration(Maker::new("function foo(){}").hoistable_declaration()) => "function foo ( ) { }"; "HoistableDeclaration")]
+    //#[test_case(&FunctionSource::HoistableDeclaration(Maker::new("function foo(){}").hoistable_declaration()) => "function foo ( ) { }"; "HoistableDeclaration")]
     #[test_case(&FunctionSource::FieldDefinition(Maker::new("a").field_definition()) => "a"; "FieldDefinition")]
     #[test_case(&FunctionSource::ClassStaticBlock(Maker::new("static{}").class_static_block()) => "static { }"; "ClassStaticBlock")]
     fn display_fmt(item: &FunctionSource) -> String {
@@ -2434,14 +2434,14 @@ mod function_source {
         => true;
         "ArrowFunction ; equal"
     )]
-    #[test_case(
-        || {
-            let fs = FunctionSource::AsyncArrowFunction(Maker::new("async x => x").async_arrow_function());
-            (fs.clone(), fs)
-        }
-        => true;
-        "AsyncArrowFunction ; equal"
-    )]
+    //#[test_case(
+    //    || {
+    //        let fs = FunctionSource::AsyncArrowFunction(Maker::new("async x => x").async_arrow_function());
+    //        (fs.clone(), fs)
+    //    }
+    //    => true;
+    //    "AsyncArrowFunction ; equal"
+    //)]
     #[test_case(
         || {
             let fs = FunctionSource::MethodDefinition(Maker::new("a(){}").method_definition());
@@ -2450,14 +2450,14 @@ mod function_source {
         => true;
         "MethodDefinition ; equal"
     )]
-    #[test_case(
-        || {
-            let fs = FunctionSource::HoistableDeclaration(Maker::new("function a(){}").hoistable_declaration());
-            (fs.clone(), fs)
-        }
-        => true;
-        "HoistableDeclaration ; equal"
-    )]
+    //#[test_case(
+    //    || {
+    //        let fs = FunctionSource::HoistableDeclaration(Maker::new("function a(){}").hoistable_declaration());
+    //        (fs.clone(), fs)
+    //    }
+    //    => true;
+    //    "HoistableDeclaration ; equal"
+    //)]
     #[test_case(
         || {
             let fs = FunctionSource::FieldDefinition(Maker::new("a").field_definition());
@@ -2662,8 +2662,8 @@ fn make_constructor(
 
 #[test_case(|| (intrinsic(IntrinsicId::Object), None, FunctionKind::Normal, vec![], ECMAScriptValue::Undefined) => sok("function anonymous(\n) {\nundefined\n}"); "simple arguments")]
 #[test_case(|| (intrinsic(IntrinsicId::Object), None, FunctionKind::Generator, vec![], ECMAScriptValue::Undefined) => sok("function* anonymous(\n) {\nundefined\n}"); "generator: simple arguments")]
-#[test_case(|| (intrinsic(IntrinsicId::Object), None, FunctionKind::Async, vec![], ECMAScriptValue::Undefined) => sok("async function anonymous(\n) {\nundefined\n}"); "async: simple arguments")]
-#[test_case(|| (intrinsic(IntrinsicId::Object), None, FunctionKind::AsyncGenerator, vec![], ECMAScriptValue::Undefined) => sok("async function* anonymous(\n) {\nundefined\n}"); "async generator: simple arguments")]
+//#[test_case(|| (intrinsic(IntrinsicId::Object), None, FunctionKind::Async, vec![], ECMAScriptValue::Undefined) => sok("async function anonymous(\n) {\nundefined\n}"); "async: simple arguments")]
+//#[test_case(|| (intrinsic(IntrinsicId::Object), None, FunctionKind::AsyncGenerator, vec![], ECMAScriptValue::Undefined) => sok("async function* anonymous(\n) {\nundefined\n}"); "async generator: simple arguments")]
 #[test_case(|| (intrinsic(IntrinsicId::Object), None, FunctionKind::Normal, vec![ECMAScriptValue::from(wks(WksId::ToStringTag))], ECMAScriptValue::Undefined) => serr("TypeError: Symbols may not be converted to strings"); "bad parameters")]
 #[test_case(|| (intrinsic(IntrinsicId::Object), None, FunctionKind::Normal, vec![], ECMAScriptValue::from(wks(WksId::ToStringTag))) => serr("TypeError: Symbols may not be converted to strings"); "bad body")]
 #[test_case(|| (intrinsic(IntrinsicId::Object), None, FunctionKind::Normal, vec![ECMAScriptValue::from("a"), ECMAScriptValue::from("second")], ECMAScriptValue::Undefined) => sok("function anonymous(a,second\n) {\nundefined\n}"); "func with params")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,6 @@
 #![allow(clippy::wildcard_imports)]
 #![expect(clippy::doc_markdown)]
 #![expect(clippy::float_cmp)]
-#![expect(clippy::missing_errors_doc)]
-#![expect(clippy::missing_panics_doc)]
-#![expect(clippy::module_name_repetitions)]
-#![expect(clippy::must_use_candidate)]
 #![expect(clippy::similar_names)]
 #![expect(clippy::single_match_else)]
 #![expect(clippy::too_many_lines)]
@@ -46,40 +42,40 @@ mod strings;
 mod symbol_object;
 mod values;
 
-pub use crate::agent::*;
-pub use crate::arguments_object::*;
-pub use crate::arrays::*;
-pub use crate::bigint_object::*;
-pub use crate::boolean_object::*;
-pub use crate::bound_function::*;
-pub use crate::chunk::*;
-pub use crate::comparison::*;
-pub use crate::compiler::*;
-pub use crate::control_abstraction::*;
-pub use crate::cr::*;
-pub use crate::date_object::*;
-pub use crate::dtoa_r::*;
-pub use crate::environment_record::*;
-pub use crate::errors::*;
-pub use crate::execution_context::*;
-pub use crate::function_object::*;
-pub use crate::map::*;
-pub use crate::math::*;
-pub use crate::number_object::*;
-pub use crate::object::*;
-pub use crate::object_object::*;
-pub use crate::parser::*;
-pub use crate::prettyprint::*;
-pub use crate::proxy_object::*;
-pub use crate::realm::*;
-pub use crate::reference::*;
-pub use crate::reflect::*;
-pub use crate::regexp::*;
-pub use crate::scanner::*;
-pub use crate::string_object::*;
-pub use crate::strings::*;
-pub use crate::symbol_object::*;
-pub use crate::values::*;
+pub(crate) use crate::agent::*;
+pub(crate) use crate::arguments_object::*;
+pub(crate) use crate::arrays::*;
+pub(crate) use crate::bigint_object::*;
+pub(crate) use crate::boolean_object::*;
+pub(crate) use crate::bound_function::*;
+pub(crate) use crate::chunk::*;
+pub(crate) use crate::comparison::*;
+pub(crate) use crate::compiler::*;
+pub(crate) use crate::control_abstraction::*;
+pub(crate) use crate::cr::*;
+pub(crate) use crate::date_object::*;
+pub(crate) use crate::dtoa_r::*;
+pub(crate) use crate::environment_record::*;
+pub(crate) use crate::errors::*;
+pub(crate) use crate::execution_context::*;
+pub(crate) use crate::function_object::*;
+pub(crate) use crate::map::*;
+pub(crate) use crate::math::*;
+pub(crate) use crate::number_object::*;
+pub(crate) use crate::object::*;
+pub(crate) use crate::object_object::*;
+pub(crate) use crate::parser::*;
+pub(crate) use crate::prettyprint::*;
+pub(crate) use crate::proxy_object::*;
+pub(crate) use crate::realm::*;
+pub(crate) use crate::reference::*;
+pub(crate) use crate::reflect::*;
+pub(crate) use crate::regexp::*;
+pub(crate) use crate::scanner::*;
+pub(crate) use crate::string_object::*;
+pub(crate) use crate::strings::*;
+pub(crate) use crate::symbol_object::*;
+pub(crate) use crate::values::*;
 
 use std::cell::RefCell;
 use std::env;
@@ -191,5 +187,5 @@ fn main() {
 }
 
 #[cfg(test)]
-#[expect(hidden_glob_reexports)]
+//#[expect(hidden_glob_reexports)]
 mod tests;

--- a/src/map.rs
+++ b/src/map.rs
@@ -21,7 +21,7 @@ use super::*;
 /// used as a Map key and whose second element is the value to associate with that key.
 ///
 /// See [AddEntriesFromIterable](https://tc39.es/ecma262/#sec-add-entries-from-iterable) in ECMA-262.
-pub fn add_entries_from_iterable(
+pub(crate) fn add_entries_from_iterable(
     target: &ECMAScriptValue,
     iterable: &ECMAScriptValue,
     adder: &ECMAScriptValue,
@@ -90,7 +90,7 @@ pub fn add_entries_from_iterable(
     }
 }
 
-pub fn provision_map_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_map_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -326,7 +326,7 @@ struct MapInternals {
 }
 
 #[derive(Debug)]
-pub struct MapObject {
+pub(crate) struct MapObject {
     common: RefCell<CommonObjectData>,
     map_data: RefCell<MapInternals>,
 }
@@ -470,7 +470,7 @@ impl MapObject {
         }
     }
 
-    pub fn object(prototype: Option<Object>) -> Object {
+    pub(crate) fn object(prototype: Option<Object>) -> Object {
         Object { o: Rc::new(Self::new(prototype)) }
     }
 }
@@ -840,7 +840,7 @@ fn map_prototype_values(
 
 impl ECMAScriptValue {
     #[must_use]
-    pub fn canonicalize_keyed_collection_key(self) -> Self {
+    pub(crate) fn canonicalize_keyed_collection_key(self) -> Self {
         // CanonicalizeKeyedCollectionKey ( key )
         // The abstract operation CanonicalizeKeyedCollectionKey takes argument key (an ECMAScript language value) and
         // returns an ECMAScript language value. It performs the following steps when called:

--- a/src/math.rs
+++ b/src/math.rs
@@ -2,7 +2,7 @@ use super::*;
 use rand::prelude::*;
 use std::f64;
 
-pub fn provision_math_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_math_intrinsic(realm: &Rc<RefCell<Realm>>) {
     // The Math object:
     //
     //  * is %Math%.

--- a/src/number_object/mod.rs
+++ b/src/number_object/mod.rs
@@ -3,12 +3,12 @@ use num::ToPrimitive;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-pub trait NumberObjectInterface: ObjectInterface {
+pub(crate) trait NumberObjectInterface: ObjectInterface {
     fn number_data(&self) -> &f64;
 }
 
 #[derive(Debug)]
-pub struct NumberObject {
+pub(crate) struct NumberObject {
     common: RefCell<CommonObjectData>,
     number_data: f64,
 }
@@ -148,15 +148,15 @@ impl NumberObjectInterface for NumberObject {
 }
 
 impl NumberObject {
-    pub fn new(prototype: Option<Object>, number: f64) -> Self {
+    pub(crate) fn new(prototype: Option<Object>, number: f64) -> Self {
         Self { common: RefCell::new(CommonObjectData::new(prototype, true, NUMBER_OBJECT_SLOTS)), number_data: number }
     }
-    pub fn object(prototype: Option<Object>, number: f64) -> Object {
+    pub(crate) fn object(prototype: Option<Object>, number: f64) -> Object {
         Object { o: Rc::new(Self::new(prototype, number)) }
     }
 }
 
-pub fn provision_number_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_number_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -901,7 +901,7 @@ fn number_prototype_to_precision(
     ))
 }
 
-pub fn next_double(dbl: f64) -> f64 {
+pub(crate) fn next_double(dbl: f64) -> f64 {
     // Copied from the V8 source
     // Returns the next greater double. Returns +infinity on input +infinity.
     // double NextDouble() const {
@@ -954,7 +954,7 @@ fn double_exponent(dbl: f64) -> i32 {
 #[expect(clippy::float_cmp)]
 #[expect(unused_assignments)] // Remove this when the Condition B panic is removed
 #[expect(unreachable_code)] // Remove this when the Condition B panic is removed
-pub fn double_to_radix_string(val: f64, radix: u32) -> String {
+pub(crate) fn double_to_radix_string(val: f64, radix: u32) -> String {
     const KBUFFERSIZE: usize = 2200;
 
     // This code is pretty blatantly grabbed from v8 source, and rewritten in rust.

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -7,19 +7,19 @@ use std::fmt::{self, Debug};
 use std::rc::Rc;
 
 #[derive(Debug, PartialEq, Clone, Default)]
-pub struct DataProperty {
-    pub value: ECMAScriptValue,
-    pub writable: bool,
+pub(crate) struct DataProperty {
+    pub(crate) value: ECMAScriptValue,
+    pub(crate) writable: bool,
 }
 
 #[derive(Debug, PartialEq, Clone, Default)]
-pub struct AccessorProperty {
-    pub get: ECMAScriptValue,
-    pub set: ECMAScriptValue,
+pub(crate) struct AccessorProperty {
+    pub(crate) get: ECMAScriptValue,
+    pub(crate) set: ECMAScriptValue,
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub enum PropertyKind {
+pub(crate) enum PropertyKind {
     Data(DataProperty),
     Accessor(AccessorProperty),
 }
@@ -31,14 +31,14 @@ impl Default for PropertyKind {
 }
 
 #[derive(Debug, PartialEq, Clone, Default)]
-pub struct PropertyDescriptor {
-    pub property: PropertyKind,
-    pub enumerable: bool,
-    pub configurable: bool,
-    pub spot: usize,
+pub(crate) struct PropertyDescriptor {
+    pub(crate) property: PropertyKind,
+    pub(crate) enumerable: bool,
+    pub(crate) configurable: bool,
+    pub(crate) spot: usize,
 }
 
-pub struct ConcisePropertyDescriptor<'a>(&'a PropertyDescriptor);
+pub(crate) struct ConcisePropertyDescriptor<'a>(&'a PropertyDescriptor);
 impl fmt::Debug for ConcisePropertyDescriptor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{{ ")?;
@@ -65,11 +65,11 @@ impl<'a> From<&'a PropertyDescriptor> for ConcisePropertyDescriptor<'a> {
     }
 }
 
-pub struct DataDescriptor {
-    pub value: ECMAScriptValue,
-    pub writable: bool,
-    pub enumerable: bool,
-    pub configurable: bool,
+pub(crate) struct DataDescriptor {
+    pub(crate) value: ECMAScriptValue,
+    pub(crate) writable: bool,
+    pub(crate) enumerable: bool,
+    pub(crate) configurable: bool,
 }
 
 impl TryFrom<PropertyDescriptor> for DataDescriptor {
@@ -87,7 +87,7 @@ impl TryFrom<PropertyDescriptor> for DataDescriptor {
     }
 }
 
-pub trait DescriptorKind {
+pub(crate) trait DescriptorKind {
     fn is_data_descriptor(&self) -> bool;
     fn is_accessor_descriptor(&self) -> bool;
     fn is_generic_descriptor(&self) -> bool;
@@ -119,57 +119,57 @@ impl DescriptorKind for PropertyDescriptor {
 }
 
 #[derive(Debug, Default, PartialEq, Clone)]
-pub struct PotentialPropertyDescriptor {
-    pub value: Option<ECMAScriptValue>,
-    pub writable: Option<bool>,
-    pub get: Option<ECMAScriptValue>,
-    pub set: Option<ECMAScriptValue>,
-    pub enumerable: Option<bool>,
-    pub configurable: Option<bool>,
+pub(crate) struct PotentialPropertyDescriptor {
+    pub(crate) value: Option<ECMAScriptValue>,
+    pub(crate) writable: Option<bool>,
+    pub(crate) get: Option<ECMAScriptValue>,
+    pub(crate) set: Option<ECMAScriptValue>,
+    pub(crate) enumerable: Option<bool>,
+    pub(crate) configurable: Option<bool>,
 }
 
 impl PotentialPropertyDescriptor {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         PotentialPropertyDescriptor::default()
     }
 
     #[must_use]
-    pub fn value(mut self, value: impl Into<ECMAScriptValue>) -> Self {
+    pub(crate) fn value(mut self, value: impl Into<ECMAScriptValue>) -> Self {
         self.value = Some(value.into());
         self
     }
 
     #[must_use]
-    pub fn writable(mut self, writable: bool) -> Self {
+    pub(crate) fn writable(mut self, writable: bool) -> Self {
         self.writable = Some(writable);
         self
     }
 
     #[must_use]
-    pub fn enumerable(mut self, enumerable: bool) -> Self {
+    pub(crate) fn enumerable(mut self, enumerable: bool) -> Self {
         self.enumerable = Some(enumerable);
         self
     }
 
     #[must_use]
-    pub fn configurable(mut self, configurable: bool) -> Self {
+    pub(crate) fn configurable(mut self, configurable: bool) -> Self {
         self.configurable = Some(configurable);
         self
     }
 
     #[must_use]
-    pub fn get(mut self, get: impl Into<ECMAScriptValue>) -> Self {
+    pub(crate) fn get(mut self, get: impl Into<ECMAScriptValue>) -> Self {
         self.get = Some(get.into());
         self
     }
 
     #[must_use]
-    pub fn set(mut self, set: impl Into<ECMAScriptValue>) -> Self {
+    pub(crate) fn set(mut self, set: impl Into<ECMAScriptValue>) -> Self {
         self.set = Some(set.into());
         self
     }
 
-    pub fn complete(self) -> PropertyDescriptor {
+    pub(crate) fn complete(self) -> PropertyDescriptor {
         PropertyDescriptor {
             property: if self.is_accessor_descriptor() {
                 PropertyKind::Accessor(AccessorProperty {
@@ -332,7 +332,7 @@ fn fpd(d: PotentialPropertyDescriptor) -> Object {
     }
     obj
 }
-pub fn from_property_descriptor<T>(desc: Option<T>) -> Option<Object>
+pub(crate) fn from_property_descriptor<T>(desc: Option<T>) -> Option<Object>
 where
     T: Into<PotentialPropertyDescriptor>,
 {
@@ -383,7 +383,7 @@ fn get_pd_prop(obj: &Object, key: impl Into<PropertyKey>) -> Completion<Option<E
 fn get_pd_bool(obj: &Object, key: &str) -> Completion<Option<bool>> {
     Ok(get_pd_prop(obj, key)?.map(to_boolean))
 }
-pub fn to_property_descriptor(obj: &ECMAScriptValue) -> Completion<PotentialPropertyDescriptor> {
+pub(crate) fn to_property_descriptor(obj: &ECMAScriptValue) -> Completion<PotentialPropertyDescriptor> {
     match obj {
         ECMAScriptValue::Object(obj) => {
             let enumerable = get_pd_bool(obj, "enumerable")?;
@@ -416,7 +416,7 @@ pub fn to_property_descriptor(obj: &ECMAScriptValue) -> Completion<PotentialProp
 // called:
 //
 //  1. Return O.[[Prototype]].
-pub fn ordinary_get_prototype_of<'a, T>(o: T) -> Option<Object>
+pub(crate) fn ordinary_get_prototype_of<'a, T>(o: T) -> Option<Object>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -448,7 +448,7 @@ where
 //
 // NOTE     The loop in step 8 guarantees that there will be no circularities in any prototype chain that only includes
 //          objects that use the ordinary object definitions for [[GetPrototypeOf]] and [[SetPrototypeOf]].
-pub fn ordinary_set_prototype_of<'a, T>(o: T, val: Option<Object>) -> bool
+pub(crate) fn ordinary_set_prototype_of<'a, T>(o: T, val: Option<Object>) -> bool
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -485,7 +485,7 @@ fn ospo_internal(obj: &dyn ObjectInterface, val: Option<Object>) -> bool {
 // called:
 //
 //  1. Return O.[[Extensible]].
-pub fn ordinary_is_extensible<'a, T>(o: T) -> bool
+pub(crate) fn ordinary_is_extensible<'a, T>(o: T) -> bool
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -501,7 +501,7 @@ where
 //
 //  1. Set O.[[Extensible]] to false.
 //  2. Return true.
-pub fn ordinary_prevent_extensions<'a, T>(o: T) -> bool
+pub(crate) fn ordinary_prevent_extensions<'a, T>(o: T) -> bool
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -530,7 +530,7 @@ where
 //  7. Set D.[[Enumerable]] to the value of X's [[Enumerable]] attribute.
 //  8. Set D.[[Configurable]] to the value of X's [[Configurable]] attribute.
 //  9. Return D.
-pub fn ordinary_get_own_property<'a, T>(o: T, key: &PropertyKey) -> Option<PropertyDescriptor>
+pub(crate) fn ordinary_get_own_property<'a, T>(o: T, key: &PropertyKey) -> Option<PropertyDescriptor>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -547,7 +547,7 @@ where
 //  1. Let current be ? O.[[GetOwnProperty]](P).
 //  2. Let extensible be ? IsExtensible(O).
 //  3. Return ValidateAndApplyPropertyDescriptor(O, P, extensible, Desc, current).
-pub fn ordinary_define_own_property<'a, T>(
+pub(crate) fn ordinary_define_own_property<'a, T>(
     o: T,
     p: impl Into<PropertyKey>,
     desc: impl Into<PotentialPropertyDescriptor>,
@@ -772,7 +772,7 @@ fn internal_validate_and_apply_property_descriptor(
 ///
 /// See [IsCompatiblePropertyDescriptor](https://tc39.es/ecma262/#sec-iscompatiblepropertydescriptor) in
 /// ECMA-262.
-pub fn is_compatible_property_descriptor(
+pub(crate) fn is_compatible_property_descriptor(
     extensible: bool,
     desc: PotentialPropertyDescriptor,
     current: Option<&PropertyDescriptor>,
@@ -793,7 +793,7 @@ pub fn is_compatible_property_descriptor(
 //  5. If parent is not null, then
 //      a. Return ? parent.[[HasProperty]](P).
 //  6. Return false.
-pub fn ordinary_has_property<'a, T>(o: T, p: &PropertyKey) -> Completion<bool>
+pub(crate) fn ordinary_has_property<'a, T>(o: T, p: &PropertyKey) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -829,7 +829,7 @@ fn ohp_internal(obj: &dyn ObjectInterface, p: &PropertyKey) -> Completion<bool> 
 //  6. Let getter be desc.[[Get]].
 //  7. If getter is undefined, return undefined.
 //  8. Return ? Call(getter, Receiver).
-pub fn ordinary_get<'a, T>(o: T, p: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue>
+pub(crate) fn ordinary_get<'a, T>(o: T, p: &PropertyKey, receiver: &ECMAScriptValue) -> Completion<ECMAScriptValue>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -866,7 +866,7 @@ fn og_internal(obj: &dyn ObjectInterface, p: &PropertyKey, receiver: &ECMAScript
 ///
 /// See [OrdinarySet](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ordinaryset) in
 /// ECMA-262.
-pub fn ordinary_set<'a, T>(
+pub(crate) fn ordinary_set<'a, T>(
     o: T,
     p: impl Into<PropertyKey>,
     v: impl Into<ECMAScriptValue>,
@@ -926,7 +926,7 @@ fn os_internal(
 //  6. If setter is undefined, return false.
 //  7. Perform ? Call(setter, Receiver, « V »).
 //  8. Return true.
-pub fn ordinary_set_with_own_descriptor<'a, T>(
+pub(crate) fn ordinary_set_with_own_descriptor<'a, T>(
     o: T,
     p: impl Into<PropertyKey>,
     v: impl Into<ECMAScriptValue>,
@@ -1015,7 +1015,7 @@ fn ordinary_set_with_own_descriptor_internal(
 //      a. Remove the own property with name P from O.
 //      b. Return true.
 //  5. Return false.
-pub fn ordinary_delete<'a, T>(o: T, p: &PropertyKey) -> Completion<bool>
+pub(crate) fn ordinary_delete<'a, T>(o: T, p: &PropertyKey) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -1046,7 +1046,7 @@ fn ordinary_delete_internal(obj: &dyn ObjectInterface, p: &PropertyKey) -> Compl
 //  4. For each own property key P of O such that Type(P) is Symbol, in ascending chronological order of property creation, do
 //      a. Add P as the last element of keys.
 //  5. Return keys.
-pub fn ordinary_own_property_keys<'a, T>(o: T) -> Vec<PropertyKey>
+pub(crate) fn ordinary_own_property_keys<'a, T>(o: T) -> Vec<PropertyKey>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -1083,27 +1083,27 @@ fn ordinary_own_property_keys_internal(obj: &dyn ObjectInterface) -> Vec<Propert
     }
     keys
 }
-pub fn array_index_key(item: &PropertyKey) -> u32 {
+pub(crate) fn array_index_key(item: &PropertyKey) -> u32 {
     match item {
         PropertyKey::String(s) => String::from_utf16_lossy(s.as_slice()).parse::<u32>().unwrap(),
         PropertyKey::Symbol(_) => unreachable!(),
     }
 }
 
-pub const ARRAY_TAG: &str = "Array";
-pub const OBJECT_TAG: &str = "Object";
-pub const NUMBER_TAG: &str = "Number";
-pub const BOOLEAN_TAG: &str = "Boolean";
-pub const STRING_TAG: &str = "String";
-pub const ARGUMENTS_TAG: &str = "Arguments";
-pub const DATE_TAG: &str = "Date";
-pub const REGEXP_TAG: &str = "RegExp";
-pub const FUNCTION_TAG: &str = "Function";
-pub const ERROR_TAG: &str = "Error";
-pub const MAP_TAG: &str = "Map";
+pub(crate) const ARRAY_TAG: &str = "Array";
+pub(crate) const OBJECT_TAG: &str = "Object";
+pub(crate) const NUMBER_TAG: &str = "Number";
+pub(crate) const BOOLEAN_TAG: &str = "Boolean";
+pub(crate) const STRING_TAG: &str = "String";
+pub(crate) const ARGUMENTS_TAG: &str = "Arguments";
+pub(crate) const DATE_TAG: &str = "Date";
+pub(crate) const REGEXP_TAG: &str = "RegExp";
+pub(crate) const FUNCTION_TAG: &str = "Function";
+pub(crate) const ERROR_TAG: &str = "Error";
+pub(crate) const MAP_TAG: &str = "Map";
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum ObjectTag {
+pub(crate) enum ObjectTag {
     Array,
     Object,
     Number,
@@ -1138,7 +1138,7 @@ impl fmt::Display for ObjectTag {
     }
 }
 
-pub trait ObjectInterface: Debug {
+pub(crate) trait ObjectInterface: Debug {
     fn common_object_data(&self) -> &RefCell<CommonObjectData>;
     fn uses_ordinary_get_prototype_of(&self) -> bool; // True if implements ordinary defintion of GetPrototypeOf
     fn id(&self) -> usize {
@@ -1190,6 +1190,7 @@ pub trait ObjectInterface: Debug {
         None
     }
     /// True if this object has no special behavior and no additional slots
+    #[cfg(test)]
     fn is_plain_object(&self) -> bool {
         false
     }
@@ -1202,9 +1203,11 @@ pub trait ObjectInterface: Debug {
     fn is_string_object(&self) -> bool {
         false
     }
+    #[cfg(test)]
     fn is_date_object(&self) -> bool {
         false
     }
+    #[cfg(test)]
     fn is_regexp_object(&self) -> bool {
         false
     }
@@ -1214,15 +1217,19 @@ pub trait ObjectInterface: Debug {
     fn is_array_object(&self) -> bool {
         false
     }
+    #[cfg(test)]
     fn to_array_object(&self) -> Option<&ArrayObject> {
         None
     }
+    #[cfg(test)]
     fn is_proxy_object(&self) -> bool {
         false
     }
+    #[cfg(test)]
     fn is_symbol_object(&self) -> bool {
         false
     }
+    #[cfg(test)]
     fn is_generator_object(&self) -> bool {
         false
     }
@@ -1232,6 +1239,7 @@ pub trait ObjectInterface: Debug {
     fn to_bigint_object(&self) -> Option<&BigIntObject> {
         None
     }
+    #[cfg(test)]
     fn is_bigint_object(&self) -> bool {
         false
     }
@@ -1252,22 +1260,22 @@ pub trait ObjectInterface: Debug {
     fn own_property_keys(&self) -> Completion<Vec<PropertyKey>>;
 }
 
-pub trait FunctionInterface: CallableObject {
+pub(crate) trait FunctionInterface: CallableObject {
     fn function_data(&self) -> &RefCell<FunctionObjectData>;
 }
 
-pub struct CommonObjectData {
-    pub properties: AHashMap<PropertyKey, PropertyDescriptor>,
-    pub prototype: Option<Object>,
-    pub extensible: bool,
-    pub next_spot: usize,
-    pub objid: usize,
-    pub slots: Vec<InternalSlotName>,
-    pub private_elements: Vec<Rc<PrivateElement>>,
+pub(crate) struct CommonObjectData {
+    pub(crate) properties: AHashMap<PropertyKey, PropertyDescriptor>,
+    pub(crate) prototype: Option<Object>,
+    pub(crate) extensible: bool,
+    pub(crate) next_spot: usize,
+    pub(crate) objid: usize,
+    pub(crate) slots: Vec<InternalSlotName>,
+    pub(crate) private_elements: Vec<Rc<PrivateElement>>,
 }
 
 impl CommonObjectData {
-    pub fn new(prototype: Option<Object>, extensible: bool, slots: &[InternalSlotName]) -> Self {
+    pub(crate) fn new(prototype: Option<Object>, extensible: bool, slots: &[InternalSlotName]) -> Self {
         Self {
             properties: AHashMap::default(),
             prototype,
@@ -1294,7 +1302,7 @@ impl fmt::Debug for CommonObjectData {
     }
 }
 
-pub struct ConciseObject<'a>(&'a Object);
+pub(crate) struct ConciseObject<'a>(&'a Object);
 impl fmt::Debug for ConciseObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.concise(f)
@@ -1305,7 +1313,7 @@ impl<'a> From<&'a Object> for ConciseObject<'a> {
         Self(source)
     }
 }
-pub struct ConciseOptionalObject<'a>(&'a Option<Object>);
+pub(crate) struct ConciseOptionalObject<'a>(&'a Option<Object>);
 impl fmt::Debug for ConciseOptionalObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0.as_ref() {
@@ -1355,6 +1363,7 @@ impl ObjectInterface for OrdinaryObject {
     fn uses_ordinary_get_prototype_of(&self) -> bool {
         true
     }
+    #[cfg(test)]
     fn is_plain_object(&self) -> bool {
         true
     }
@@ -1474,8 +1483,8 @@ impl ObjectInterface for OrdinaryObject {
 }
 
 #[derive(Clone, Debug)]
-pub struct Object {
-    pub o: Rc<dyn ObjectInterface>,
+pub(crate) struct Object {
+    pub(crate) o: Rc<dyn ObjectInterface>,
 }
 
 impl PartialEq for Object {
@@ -1530,10 +1539,10 @@ impl fmt::Display for Object {
 }
 
 impl OrdinaryObject {
-    pub fn new(prototype: Option<Object>, extensible: bool) -> Self {
+    pub(crate) fn new(prototype: Option<Object>, extensible: bool) -> Self {
         Self { data: RefCell::new(CommonObjectData::new(prototype, extensible, ORDINARY_OBJECT_SLOTS)) }
     }
-    pub fn object(prototype: Option<Object>, extensible: bool) -> Object {
+    pub(crate) fn object(prototype: Option<Object>, extensible: bool) -> Object {
         Object { o: Rc::new(Self::new(prototype, extensible)) }
     }
 }
@@ -1542,14 +1551,14 @@ impl Object {
     fn new(prototype: Option<Object>, extensible: bool) -> Self {
         OrdinaryObject::object(prototype, extensible)
     }
-    pub fn concise(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    pub(crate) fn concise(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.which_intrinsic() {
             None => write!(f, "<Object {}>", self.o.id()),
             Some(int) => write!(f, "<%{int:?}%>"),
         }
     }
 
-    pub fn which_intrinsic(&self) -> Option<IntrinsicId> {
+    pub(crate) fn which_intrinsic(&self) -> Option<IntrinsicId> {
         let realm_ref = current_realm_record()?;
         let realm = realm_ref.borrow();
         realm.intrinsics.which(self)
@@ -1566,7 +1575,7 @@ impl Object {
     //      b. Let target be argument.[[ProxyTarget]].
     //      c. Return ? IsArray(target).
     //  4. Return false.
-    pub fn is_array(&self) -> Completion<bool> {
+    pub(crate) fn is_array(&self) -> Completion<bool> {
         if self.o.is_array_object() {
             Ok(true)
         } else {
@@ -1580,7 +1589,8 @@ impl Object {
         }
     }
 
-    pub fn is_typed_array(&self) -> bool {
+    #[expect(clippy::unused_self)]
+    pub(crate) fn is_typed_array(&self) -> bool {
         false
     }
 
@@ -1592,7 +1602,11 @@ impl Object {
     ///
     /// See [CreateDataProperty](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-createdataproperty) in
     /// ECMA-262.
-    pub fn create_data_property(&self, p: impl Into<PropertyKey>, v: impl Into<ECMAScriptValue>) -> Completion<bool> {
+    pub(crate) fn create_data_property(
+        &self,
+        p: impl Into<PropertyKey>,
+        v: impl Into<ECMAScriptValue>,
+    ) -> Completion<bool> {
         // Implementation in an internal function, to separate type conversion from the logic, for easier coverage
         // testing.
         self.internal_cdp(p.into(), v.into())
@@ -1627,7 +1641,7 @@ impl Object {
     /// See
     /// [CreateDataPropertyOrThrow](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-createdatapropertyorthrow)
     /// in ECMA-262.
-    pub fn create_data_property_or_throw(
+    pub(crate) fn create_data_property_or_throw(
         &self,
         p: impl Into<PropertyKey>,
         v: impl Into<ECMAScriptValue>,
@@ -1658,7 +1672,7 @@ impl Object {
     /// This uses all of the object's prototype chain, and calls accessor functions, unlike GetOwnProperty.
     ///
     /// See [Get](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-get-o-p) in ECMA-262.
-    pub fn get(&self, key: &PropertyKey) -> Completion<ECMAScriptValue> {
+    pub(crate) fn get(&self, key: &PropertyKey) -> Completion<ECMAScriptValue> {
         // Get ( O, P )
         //
         // The abstract operation Get takes arguments O (an Object) and P (a property key). It is used to retrieve the value of
@@ -1671,16 +1685,12 @@ impl Object {
         self.o.get(key, &receiver)
     }
 
-    pub fn is_constructor(&self) -> bool {
+    pub(crate) fn is_constructor(&self) -> bool {
         self.o.to_constructable().is_some()
     }
 
-    pub fn is_error_object(&self) -> bool {
+    pub(crate) fn is_error_object(&self) -> bool {
         self.o.kind() == ObjectTag::Error
-    }
-
-    pub fn date_value(&self) -> Option<f64> {
-        self.o.to_date_obj().map(DateObject::date_value)
     }
 }
 
@@ -1703,7 +1713,7 @@ impl Object {
 //          overriding some or all of that object's internal methods. In order to encapsulate exotic object creation,
 //          the object's essential internal methods are never modified outside those operations.
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum InternalSlotName {
+pub(crate) enum InternalSlotName {
     Prototype,
     Extensible,
     BooleanData,
@@ -1753,21 +1763,21 @@ pub enum InternalSlotName {
     OriginalFlags,
     RegExpRecord,
     RegExpMatcher,
-
-    Nonsense, // For testing purposes, for the time being.
+    //Nonsense, // For testing purposes, for the time being.
 }
-pub const ORDINARY_OBJECT_SLOTS: &[InternalSlotName] = &[InternalSlotName::Prototype, InternalSlotName::Extensible];
-pub const BOOLEAN_OBJECT_SLOTS: &[InternalSlotName] =
+pub(crate) const ORDINARY_OBJECT_SLOTS: &[InternalSlotName] =
+    &[InternalSlotName::Prototype, InternalSlotName::Extensible];
+pub(crate) const BOOLEAN_OBJECT_SLOTS: &[InternalSlotName] =
     &[InternalSlotName::Prototype, InternalSlotName::Extensible, InternalSlotName::BooleanData];
-pub const ERROR_OBJECT_SLOTS: &[InternalSlotName] =
+pub(crate) const ERROR_OBJECT_SLOTS: &[InternalSlotName] =
     &[InternalSlotName::Prototype, InternalSlotName::Extensible, InternalSlotName::ErrorData];
-pub const BUILTIN_FUNCTION_SLOTS: &[InternalSlotName] = &[
+pub(crate) const BUILTIN_FUNCTION_SLOTS: &[InternalSlotName] = &[
     InternalSlotName::Prototype,
     InternalSlotName::Extensible,
     InternalSlotName::InitialName,
     InternalSlotName::Realm,
 ];
-pub const FUNCTION_OBJECT_SLOTS: &[InternalSlotName] = &[
+pub(crate) const FUNCTION_OBJECT_SLOTS: &[InternalSlotName] = &[
     InternalSlotName::Prototype,
     InternalSlotName::Extensible,
     InternalSlotName::Realm,
@@ -1786,37 +1796,38 @@ pub const FUNCTION_OBJECT_SLOTS: &[InternalSlotName] = &[
     InternalSlotName::ClassFieldInitializerName,
     InternalSlotName::IsClassConstructor,
 ];
-pub const BOUND_FUNCTION_OBJECT_SLOTS: &[InternalSlotName] =
+pub(crate) const BOUND_FUNCTION_OBJECT_SLOTS: &[InternalSlotName] =
     &[InternalSlotName::BoundTargetFunction, InternalSlotName::BoundThis, InternalSlotName::BoundArguments];
-pub const NUMBER_OBJECT_SLOTS: &[InternalSlotName] =
+pub(crate) const NUMBER_OBJECT_SLOTS: &[InternalSlotName] =
     &[InternalSlotName::Prototype, InternalSlotName::Extensible, InternalSlotName::NumberData];
-pub const BIGINT_OBJECT_SLOTS: &[InternalSlotName] =
+pub(crate) const BIGINT_OBJECT_SLOTS: &[InternalSlotName] =
     &[InternalSlotName::Prototype, InternalSlotName::Extensible, InternalSlotName::BigIntData];
-pub const ARRAY_OBJECT_SLOTS: &[InternalSlotName] =
+pub(crate) const ARRAY_OBJECT_SLOTS: &[InternalSlotName] =
     &[InternalSlotName::Prototype, InternalSlotName::Extensible, InternalSlotName::ArrayMarker];
-pub const SYMBOL_OBJECT_SLOTS: &[InternalSlotName] =
+pub(crate) const SYMBOL_OBJECT_SLOTS: &[InternalSlotName] =
     &[InternalSlotName::Prototype, InternalSlotName::Extensible, InternalSlotName::SymbolData];
-pub const ARGUMENTS_OBJECT_SLOTS: &[InternalSlotName] =
+pub(crate) const ARGUMENTS_OBJECT_SLOTS: &[InternalSlotName] =
     &[InternalSlotName::Prototype, InternalSlotName::Extensible, InternalSlotName::ParameterMap];
-pub const STRING_OBJECT_SLOTS: &[InternalSlotName] =
+pub(crate) const STRING_OBJECT_SLOTS: &[InternalSlotName] =
     &[InternalSlotName::Prototype, InternalSlotName::Extensible, InternalSlotName::StringData];
-pub const GENERATOR_OBJECT_SLOTS: &[InternalSlotName] = &[
+pub(crate) const GENERATOR_OBJECT_SLOTS: &[InternalSlotName] = &[
     InternalSlotName::Prototype,
     InternalSlotName::Extensible,
     InternalSlotName::GeneratorState,
     InternalSlotName::GeneratorContext,
     InternalSlotName::GeneratorBrand,
 ];
-pub const FOR_IN_ITERATOR_SLOTS: &[InternalSlotName] = &[
+pub(crate) const FOR_IN_ITERATOR_SLOTS: &[InternalSlotName] = &[
     InternalSlotName::Object,
     InternalSlotName::ObjectWasVisited,
     InternalSlotName::VisitedKeys,
     InternalSlotName::RemainingKeys,
 ];
-pub const PROXY_OBJECT_SLOTS: &[InternalSlotName] = &[InternalSlotName::ProxyTarget, InternalSlotName::ProxyHandler];
-pub const DATE_OBJECT_SLOTS: &[InternalSlotName] =
+pub(crate) const PROXY_OBJECT_SLOTS: &[InternalSlotName] =
+    &[InternalSlotName::ProxyTarget, InternalSlotName::ProxyHandler];
+pub(crate) const DATE_OBJECT_SLOTS: &[InternalSlotName] =
     &[InternalSlotName::Prototype, InternalSlotName::Extensible, InternalSlotName::DateValue];
-pub const REGEXP_OBJECT_SLOTS: &[InternalSlotName] = &[
+pub(crate) const REGEXP_OBJECT_SLOTS: &[InternalSlotName] = &[
     InternalSlotName::Prototype,
     InternalSlotName::Extensible,
     InternalSlotName::OriginalSource,
@@ -1833,7 +1844,7 @@ impl ECMAScriptValue {
     /// without needing to do the to-object conversion.
     ///
     /// See [GetV](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-get) from ECMA-262.
-    pub fn get(&self, p: &PropertyKey) -> Completion<ECMAScriptValue> {
+    pub(crate) fn get(&self, p: &PropertyKey) -> Completion<ECMAScriptValue> {
         // GetV ( V, P )
         //
         // The abstract operation GetV takes arguments V (an ECMAScript language value) and P (a property key). It is
@@ -1853,7 +1864,7 @@ impl Object {
     /// Set the value of a specific property for an object
     ///
     /// See [Set](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-set-o-p-v-throw) in ECMA-262.
-    pub fn set(
+    pub(crate) fn set(
         &self,
         propkey: impl Into<PropertyKey>,
         value: impl Into<ECMAScriptValue>,
@@ -1892,7 +1903,7 @@ impl Object {
 ///
 /// See [DefinePropertyOrThrow](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-definepropertyorthrow)
 /// from the ECMA-262 spec.
-pub fn define_property_or_throw(
+pub(crate) fn define_property_or_throw(
     obj: &Object,
     p: impl Into<PropertyKey>,
     desc: PotentialPropertyDescriptor,
@@ -1924,7 +1935,7 @@ fn internal_define_property_or_throw(
 }
 
 impl Object {
-    pub fn delete_property_or_throw(&self, p: &PropertyKey) -> Completion<()> {
+    pub(crate) fn delete_property_or_throw(&self, p: &PropertyKey) -> Completion<()> {
         // DeletePropertyOrThrow ( O, P )
         // The abstract operation DeletePropertyOrThrow takes arguments O (an Object) and P (a property key) and
         // returns either a normal completion containing unused or a throw completion. It is used to remove a
@@ -1951,7 +1962,7 @@ impl Object {
 //  4. If IsCallable(func) is false, throw a TypeError exception.
 //  5. Return func.
 impl ECMAScriptValue {
-    pub fn get_method(&self, key: &PropertyKey) -> Completion<ECMAScriptValue> {
+    pub(crate) fn get_method(&self, key: &PropertyKey) -> Completion<ECMAScriptValue> {
         let func = self.get(key)?;
         if func.is_undefined() || func.is_null() {
             Ok(ECMAScriptValue::Undefined)
@@ -1963,7 +1974,7 @@ impl ECMAScriptValue {
     }
 }
 impl Object {
-    pub fn get_method(&self, key: &PropertyKey) -> Completion<ECMAScriptValue> {
+    pub(crate) fn get_method(&self, key: &PropertyKey) -> Completion<ECMAScriptValue> {
         let func = self.get(key)?;
         if func.is_undefined() || func.is_null() {
             Ok(ECMAScriptValue::Undefined)
@@ -1985,11 +1996,11 @@ impl Object {
 //  1. Assert: Type(O) is Object.
 //  2. Assert: IsPropertyKey(P) is true.
 //  3. Return ? O.[[HasProperty]](P).
-pub fn has_property(obj: &Object, p: &PropertyKey) -> Completion<bool> {
+pub(crate) fn has_property(obj: &Object, p: &PropertyKey) -> Completion<bool> {
     obj.has_property(p)
 }
 impl Object {
-    pub fn has_property(&self, p: &PropertyKey) -> Completion<bool> {
+    pub(crate) fn has_property(&self, p: &PropertyKey) -> Completion<bool> {
         self.o.has_property(p)
     }
 }
@@ -2006,7 +2017,7 @@ impl Object {
 //  4. If desc is undefined, return false.
 //  5. Return true.
 impl Object {
-    pub fn has_own_property(&self, p: &PropertyKey) -> Completion<bool> {
+    pub(crate) fn has_own_property(&self, p: &PropertyKey) -> Completion<bool> {
         Ok(self.o.get_own_property(p)?.is_some())
     }
 }
@@ -2022,14 +2033,14 @@ impl Object {
 //  1. If argumentsList is not present, set argumentsList to a new empty List.
 //  2. If IsCallable(F) is false, throw a TypeError exception.
 //  3. Return ? F.[[Call]](V, argumentsList).
-pub fn to_callable(val: &ECMAScriptValue) -> Option<&dyn CallableObject> {
+pub(crate) fn to_callable(val: &ECMAScriptValue) -> Option<&dyn CallableObject> {
     match val {
         ECMAScriptValue::Object(obj) => obj.o.to_callable_obj(),
         _ => None,
     }
 }
 
-pub fn call(
+pub(crate) fn call(
     func: &ECMAScriptValue,
     this_value: &ECMAScriptValue,
     args: &[ECMAScriptValue],
@@ -2037,7 +2048,7 @@ pub fn call(
     tailable_call(func, this_value, args, false)
 }
 
-pub fn tailable_call(
+pub(crate) fn tailable_call(
     func: &ECMAScriptValue,
     this_value: &ECMAScriptValue,
     args: &[ECMAScriptValue],
@@ -2052,7 +2063,7 @@ pub fn tailable_call(
     }
 }
 
-pub fn initiate_call(
+pub(crate) fn initiate_call(
     func: &ECMAScriptValue,
     this_value: &ECMAScriptValue,
     args: &[ECMAScriptValue],
@@ -2076,7 +2087,7 @@ pub fn initiate_call(
     }
 }
 
-pub fn complete_call(func: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
+pub(crate) fn complete_call(func: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
     let callable = to_callable(func).unwrap();
     callable.complete_call()
 }
@@ -2096,22 +2107,19 @@ pub fn complete_call(func: &ECMAScriptValue) -> Completion<ECMAScriptValue> {
 //    5. Return ? F.[[Construct]](argumentsList, newTarget).
 //
 // NOTE     If newTarget is not present, this operation is equivalent to: new F(...argumentsList)
-pub fn construct(func: &Object, args: &[ECMAScriptValue], new_target: Option<&Object>) -> Completion<ECMAScriptValue> {
+pub(crate) fn construct(
+    func: &Object,
+    args: &[ECMAScriptValue],
+    new_target: Option<&Object>,
+) -> Completion<ECMAScriptValue> {
     initiate_construct(func, args, new_target);
     complete_call(&ECMAScriptValue::from(func))
 }
 
-pub fn initiate_construct(func: &Object, args: &[ECMAScriptValue], new_target: Option<&Object>) {
+pub(crate) fn initiate_construct(func: &Object, args: &[ECMAScriptValue], new_target: Option<&Object>) {
     let nt = new_target.unwrap_or(func);
     let cstr = func.o.to_constructable().unwrap();
     cstr.construct(func, args, nt);
-}
-
-pub fn to_constructor(val: &ECMAScriptValue) -> Option<&dyn CallableObject> {
-    match val {
-        ECMAScriptValue::Object(obj) => obj.o.to_constructable(),
-        _ => None,
-    }
 }
 
 // SetIntegrityLevel ( O, level )
@@ -2139,11 +2147,11 @@ pub fn to_constructor(val: &ECMAScriptValue) -> Option<&dyn CallableObject> {
 //
 // https://tc39.es/ecma262/#sec-setintegritylevel
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
-pub enum IntegrityLevel {
+pub(crate) enum IntegrityLevel {
     Sealed,
     Frozen,
 }
-pub fn set_integrity_level(o: &Object, level: IntegrityLevel) -> Completion<bool> {
+pub(crate) fn set_integrity_level(o: &Object, level: IntegrityLevel) -> Completion<bool> {
     let status = o.o.prevent_extensions()?;
     if !status {
         return Ok(false);
@@ -2168,7 +2176,7 @@ pub fn set_integrity_level(o: &Object, level: IntegrityLevel) -> Completion<bool
     Ok(true)
 }
 
-pub fn test_integrity_level(o: &Object, level: IntegrityLevel) -> Completion<bool> {
+pub(crate) fn test_integrity_level(o: &Object, level: IntegrityLevel) -> Completion<bool> {
     // TestIntegrityLevel ( O, level )
     // The abstract operation TestIntegrityLevel takes arguments O (an Object) and level (sealed or frozen)
     // and returns either a normal completion containing a Boolean or a throw completion. It is used to
@@ -2216,7 +2224,7 @@ pub fn test_integrity_level(o: &Object, level: IntegrityLevel) -> Completion<boo
 //      a. Perform ! CreateDataPropertyOrThrow(array, ! ToString(𝔽(n)), e).
 //      b. Set n to n + 1.
 //  4. Return array.
-pub fn create_array_from_list(elements: &[ECMAScriptValue]) -> Object {
+pub(crate) fn create_array_from_list(elements: &[ECMAScriptValue]) -> Object {
     let array = array_create(0.0, None).unwrap();
     for (n, e) in elements.iter().enumerate() {
         let key = PropertyKey::from(u64::try_from(n).unwrap());
@@ -2229,7 +2237,7 @@ pub fn create_array_from_list(elements: &[ECMAScriptValue]) -> Object {
 ///
 /// See [LengthOfArrayLike](https://tc39.es/ecma262/#sec-lengthofarraylike) from ECMA-262.
 impl Object {
-    pub fn length_of_array_like(&self) -> Completion<f64> {
+    pub(crate) fn length_of_array_like(&self) -> Completion<f64> {
         // LengthOfArrayLike ( obj )
         //
         // The abstract operation LengthOfArrayLike takes argument obj (an Object) and returns either a normal
@@ -2243,7 +2251,7 @@ impl Object {
     }
 }
 
-pub fn create_list_from_array_like(
+pub(crate) fn create_list_from_array_like(
     obj: ECMAScriptValue,
     element_types: Option<&[ValueKind]>,
 ) -> Completion<Vec<ECMAScriptValue>> {
@@ -2305,13 +2313,13 @@ pub fn create_list_from_array_like(
 //  3. Let func be ? GetV(V, P).
 //  4. Return ? Call(func, V, argumentsList).
 impl ECMAScriptValue {
-    pub fn invoke(&self, p: &PropertyKey, arguments_list: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
+    pub(crate) fn invoke(&self, p: &PropertyKey, arguments_list: &[ECMAScriptValue]) -> Completion<ECMAScriptValue> {
         let func = self.get(p)?;
         call(&func, self, arguments_list)
     }
 }
 
-pub fn ordinary_has_instance(c: &ECMAScriptValue, o: &ECMAScriptValue) -> Completion<bool> {
+pub(crate) fn ordinary_has_instance(c: &ECMAScriptValue, o: &ECMAScriptValue) -> Completion<bool> {
     // OrdinaryHasInstance ( C, O )
     //
     // The abstract operation OrdinaryHasInstance takes arguments C (an ECMAScript language value) and O and returns
@@ -2385,7 +2393,7 @@ pub fn ordinary_has_instance(c: &ECMAScriptValue, o: &ECMAScriptValue) -> Comple
 //  4. Return properties.
 //
 // https://tc39.es/ecma262/#sec-enumerableownpropertynames
-pub fn enumerable_own_properties(obj: &Object, kind: KeyValueKind) -> Completion<Vec<ECMAScriptValue>> {
+pub(crate) fn enumerable_own_properties(obj: &Object, kind: KeyValueKind) -> Completion<Vec<ECMAScriptValue>> {
     let own_keys = obj.o.own_property_keys()?;
     let mut properties: Vec<ECMAScriptValue> = vec![];
     for key in own_keys {
@@ -2427,7 +2435,7 @@ pub fn enumerable_own_properties(obj: &Object, kind: KeyValueKind) -> Completion
 //          to create an ordinary object, and not an exotic one. Thus, within this specification, it is not called by
 //          any algorithm that subsequently modifies the internal methods of the object in ways that would make the
 //          result non-ordinary. Operations that create exotic objects invoke MakeBasicObject directly.
-pub fn ordinary_object_create(proto: Option<Object>) -> Object {
+pub(crate) fn ordinary_object_create(proto: Option<Object>) -> Object {
     Object::new(proto, true)
 }
 
@@ -2445,7 +2453,7 @@ pub fn ordinary_object_create(proto: Option<Object>) -> Object {
 //  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
 //  3. Return ! OrdinaryObjectCreate(proto, internalSlotsList).
 impl Object {
-    pub fn ordinary_create_from_constructor(
+    pub(crate) fn ordinary_create_from_constructor(
         &self,
         intrinsic_default_proto: IntrinsicId,
         factory: impl FnOnce(Option<Object>) -> Object,
@@ -2474,7 +2482,7 @@ impl Object {
 // NOTE     If constructor does not supply a [[Prototype]] value, the default value that is used is obtained from the
 //          realm of the constructor function rather than from the running execution context.
 impl Object {
-    pub fn get_prototype_from_constructor(&self, intrinsic_default_proto: IntrinsicId) -> Completion<Object> {
+    pub(crate) fn get_prototype_from_constructor(&self, intrinsic_default_proto: IntrinsicId) -> Completion<Object> {
         let proto = self.get(&PropertyKey::from("prototype"))?;
         match proto {
             ECMAScriptValue::Object(obj) => Ok(obj),
@@ -2488,7 +2496,7 @@ impl Object {
 }
 
 #[derive(Debug)]
-pub struct DeadObject {
+pub(crate) struct DeadObject {
     objid: usize,
 }
 impl ObjectInterface for DeadObject {
@@ -2538,7 +2546,7 @@ impl ObjectInterface for DeadObject {
 }
 
 impl DeadObject {
-    pub fn object() -> Object {
+    pub(crate) fn object() -> Object {
         Object { o: Rc::new(Self { objid: next_object_id() }) }
     }
 }
@@ -2552,7 +2560,7 @@ impl DeadObject {
 //  2. Let current be ? O.[[GetPrototypeOf]]().
 //  3. If SameValue(V, current) is true, return true.
 //  4. Return false.
-pub fn set_immutable_prototype<'a, T>(o: T, val: Option<&Object>) -> Completion<bool>
+pub(crate) fn set_immutable_prototype<'a, T>(o: T, val: Option<&Object>) -> Completion<bool>
 where
     T: Into<&'a dyn ObjectInterface>,
 {
@@ -2564,7 +2572,7 @@ fn set_immutable_prototype_internal(obj: &dyn ObjectInterface, val: Option<&Obje
 }
 
 #[derive(Debug)]
-pub struct ImmutablePrototypeExoticObject {
+pub(crate) struct ImmutablePrototypeExoticObject {
     data: RefCell<CommonObjectData>,
 }
 
@@ -2697,16 +2705,16 @@ impl ObjectInterface for ImmutablePrototypeExoticObject {
 }
 
 impl ImmutablePrototypeExoticObject {
-    pub fn new(prototype: Option<Object>) -> Self {
+    pub(crate) fn new(prototype: Option<Object>) -> Self {
         Self { data: RefCell::new(CommonObjectData::new(prototype, true, ORDINARY_OBJECT_SLOTS)) }
     }
 
-    pub fn object(prototype: Option<Object>) -> Object {
+    pub(crate) fn object(prototype: Option<Object>) -> Object {
         Object { o: Rc::new(ImmutablePrototypeExoticObject::new(prototype)) }
     }
 }
 
-pub fn immutable_prototype_exotic_object_create(proto: Option<&Object>) -> Object {
+pub(crate) fn immutable_prototype_exotic_object_create(proto: Option<&Object>) -> Object {
     ImmutablePrototypeExoticObject::object(proto.cloned())
 }
 
@@ -2729,7 +2737,7 @@ pub fn immutable_prototype_exotic_object_create(proto: Option<&Object>) -> Objec
 // NOTE     Step 5 will only be reached if obj is a non-standard function exotic object that does not have a [[Realm]]
 //          internal slot.
 impl Object {
-    pub fn get_function_realm(&self) -> Completion<Rc<RefCell<Realm>>> {
+    pub(crate) fn get_function_realm(&self) -> Completion<Rc<RefCell<Realm>>> {
         match self.o.to_function_obj() {
             Some(f) => Ok(f.function_data().borrow().realm.clone()),
             _ => {
@@ -2779,7 +2787,7 @@ impl Object {
 //      a. Let entry be that PrivateElement.
 //      b. Return entry.
 //  2. Return empty.
-pub fn private_element_find(o: &Object, p: &PrivateName) -> Option<Rc<PrivateElement>> {
+pub(crate) fn private_element_find(o: &Object, p: &PrivateName) -> Option<Rc<PrivateElement>> {
     let cod = o.o.common_object_data().borrow();
     let item = cod.private_elements.iter().find(|&item| item.key == *p);
     item.cloned()
@@ -2793,7 +2801,7 @@ pub fn private_element_find(o: &Object, p: &PrivateName) -> Option<Rc<PrivateEle
 //  1. Let entry be ! PrivateElementFind(O, P).
 //  2. If entry is not empty, throw a TypeError exception.
 //  3. Append PrivateElement { [[Key]]: P, [[Kind]]: field, [[Value]]: value } to O.[[PrivateElements]].
-pub fn private_field_add(obj: &Object, p: PrivateName, value: ECMAScriptValue) -> Completion<()> {
+pub(crate) fn private_field_add(obj: &Object, p: PrivateName, value: ECMAScriptValue) -> Completion<()> {
     let entry = private_element_find(obj, &p);
     match entry {
         Some(_) => Err(create_type_error("PrivateName already defined")),
@@ -2820,7 +2828,7 @@ pub fn private_field_add(obj: &Object, p: PrivateName, value: ECMAScriptValue) -
 //
 // NOTE: The values for private methods and accessors are shared across instances. This step does not create a new copy
 // of the method or accessor.
-pub fn private_method_or_accessor_add(obj: &Object, method: PrivateElement) -> Completion<()> {
+pub(crate) fn private_method_or_accessor_add(obj: &Object, method: PrivateElement) -> Completion<()> {
     if private_element_find(obj, &method.key).is_some() {
         Err(create_type_error("PrivateName already defined"))
     } else {
@@ -2829,7 +2837,7 @@ pub fn private_method_or_accessor_add(obj: &Object, method: PrivateElement) -> C
     }
 }
 
-pub fn define_field(obj: &Object, field: &ClassFieldDefinitionRecord) -> Completion<()> {
+pub(crate) fn define_field(obj: &Object, field: &ClassFieldDefinitionRecord) -> Completion<()> {
     // DefineField ( receiver, fieldRecord )
     // The abstract operation DefineField takes arguments receiver (an Object) and fieldRecord (a ClassFieldDefinition
     // Record) and returns either a normal completion containing unused or a throw completion. It performs the following
@@ -2876,7 +2884,7 @@ pub fn define_field(obj: &Object, field: &ClassFieldDefinitionRecord) -> Complet
 //  5. If entry.[[Get]] is undefined, throw a TypeError exception.
 //  6. Let getter be entry.[[Get]].
 //  7. Return ? Call(getter, O).
-pub fn private_get(obj: &Object, pn: &PrivateName) -> Completion<ECMAScriptValue> {
+pub(crate) fn private_get(obj: &Object, pn: &PrivateName) -> Completion<ECMAScriptValue> {
     match private_element_find(obj, pn) {
         None => Err(create_type_error("PrivateName not defined")),
         Some(pe) => match &pe.kind {
@@ -2906,7 +2914,7 @@ pub fn private_get(obj: &Object, pn: &PrivateName) -> Completion<ECMAScriptValue
 //      b. If entry.[[Set]] is undefined, throw a TypeError exception.
 //      c. Let setter be entry.[[Set]].
 //      d. Perform ? Call(setter, O, « value »).
-pub fn private_set(obj: &Object, pn: &PrivateName, v: ECMAScriptValue) -> Completion<()> {
+pub(crate) fn private_set(obj: &Object, pn: &PrivateName, v: ECMAScriptValue) -> Completion<()> {
     match private_element_find(obj, pn) {
         None => Err(create_type_error("PrivateName not defined")),
         Some(pe) => match &pe.kind {
@@ -2928,7 +2936,7 @@ impl Object {
     /// Copy enumerable data properties from a source to a target, potentially excluding some
     ///
     /// See [CopyDataProperties](https://tc39.es/ecma262/#sec-copydataproperties) in ECMA-262.
-    pub fn copy_data_properties(&self, source: ECMAScriptValue, excluded: &[PropertyKey]) -> Completion<()> {
+    pub(crate) fn copy_data_properties(&self, source: ECMAScriptValue, excluded: &[PropertyKey]) -> Completion<()> {
         // CopyDataProperties ( target, source, excludedItems )
         // The abstract operation CopyDataProperties takes arguments target (an Object), source (an ECMAScript language
         // value), and excludedItems (a List of property keys) and returns either a normal completion containing UNUSED

--- a/src/object/objtests.rs
+++ b/src/object/objtests.rs
@@ -4611,25 +4611,6 @@ mod define_property_or_throw {
     }
 }
 
-#[test_case(|| ECMAScriptValue::from(99) => None; "not a constructor")]
-#[test_case(
-    || {
-        let cstr = intrinsic(IntrinsicId::Object);
-        cstr.set("sentinel", "test response", true).unwrap();
-        ECMAScriptValue::from(cstr)
-    }
-    => Some("test response".to_string());
-    "constructor object")]
-#[test_case(|| intrinsic(IntrinsicId::ObjectPrototype).into() => None; "object but not cstr")]
-fn to_constructor(make_val: impl FnOnce() -> ECMAScriptValue) -> Option<String> {
-    setup_test_agent();
-    let val = make_val();
-    super::to_constructor(&val).map(|cstr| {
-        let key = PropertyKey::from("sentinel");
-        cstr.get(&key, &val).unwrap().test_result_string()
-    })
-}
-
 mod ordinary_object {
     use super::*;
 

--- a/src/object_object/mod.rs
+++ b/src/object_object/mod.rs
@@ -43,7 +43,7 @@ fn object_prototype_value_of(
 //            test for those specific kinds of built-in objects. It does not provide a reliable type testing mechanism
 //            for other kinds of built-in or program defined objects. In addition, programs can use @@toStringTag in
 //            ways that will invalidate the reliability of such legacy type tests.
-pub fn object_prototype_to_string(
+pub(crate) fn object_prototype_to_string(
     this_value: &ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -68,7 +68,7 @@ pub fn object_prototype_to_string(
     Ok(ECMAScriptValue::from(result_vec))
 }
 
-pub fn provision_object_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_object_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 

--- a/src/parser/additive_operators/tests.rs
+++ b/src/parser/additive_operators/tests.rs
@@ -18,7 +18,6 @@ mod additive_expression {
         pretty_check(&*ae, "AdditiveExpression: a", &["MultiplicativeExpression: a"]);
         concise_check(&*ae, "IdentifierName: a", &[]);
         assert_ne!(format!("{ae:?}"), "");
-        assert_eq!(ae.is_function_definition(), false);
     }
     #[test]
     fn parse_02() {
@@ -28,7 +27,6 @@ mod additive_expression {
         pretty_check(&*ae, "AdditiveExpression: a + b", &["AdditiveExpression: a", "MultiplicativeExpression: b"]);
         concise_check(&*ae, "AdditiveExpression: a + b", &["IdentifierName: a", "Punctuator: +", "IdentifierName: b"]);
         assert_ne!(format!("{ae:?}"), "");
-        assert_eq!(ae.is_function_definition(), false);
     }
     #[test]
     fn parse_03() {
@@ -38,7 +36,6 @@ mod additive_expression {
         pretty_check(&*ae, "AdditiveExpression: a - b", &["AdditiveExpression: a", "MultiplicativeExpression: b"]);
         concise_check(&*ae, "AdditiveExpression: a - b", &["IdentifierName: a", "Punctuator: -", "IdentifierName: b"]);
         assert_ne!(format!("{ae:?}"), "");
-        assert_eq!(ae.is_function_definition(), false);
     }
     #[test]
     fn parse_04() {
@@ -48,7 +45,6 @@ mod additive_expression {
         pretty_check(&*ae, "AdditiveExpression: a", &["MultiplicativeExpression: a"]);
         concise_check(&*ae, "IdentifierName: a", &[]);
         assert_ne!(format!("{ae:?}"), "");
-        assert_eq!(ae.is_function_definition(), false);
     }
     #[test]
     fn parse_05() {
@@ -182,12 +178,12 @@ mod additive_expression {
         Maker::new(src).additive_expression().assignment_target_type(strict)
     }
 
-    #[test_case("a+b" => false; "additive")]
-    #[test_case("13" => false; "fall-thru, not named func")]
-    #[test_case("function bob(){}" => true; "fall-thru, named")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).additive_expression().is_named_function()
-    }
+    //#[test_case("a+b" => false; "additive")]
+    //#[test_case("13" => false; "fall-thru, not named func")]
+    //#[test_case("function bob(){}" => true; "fall-thru, named")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).additive_expression().is_named_function()
+    //}
 
     #[test_case("\nblue" => Location { starting_line: 2, starting_column: 1, span: Span{ starting_index: 1, length: 4 } }; "fall-thru")]
     #[test_case("/* x */ a   +\n(p-l)" => Location { starting_line: 1, starting_column: 9, span: Span{ starting_index: 8, length: 11 } }; "add")]

--- a/src/parser/assignment_operators/tests.rs
+++ b/src/parser/assignment_operators/tests.rs
@@ -130,34 +130,6 @@ mod assignment_expression {
         Ok((scanner, pretty_elements, concise_elements))
     }
 
-    #[test_case("a" => false; "Fall-thru (identifier)")]
-    #[test_case("function (){}" => true; "Fall-thru (function exp)")]
-    #[test_case("yield a" => false; "YieldExpression")]
-    #[test_case("a=>a" => true; "ArrowFunction")]
-    #[test_case("async a=>a" => true; "AsyncArrowFunction")]
-    #[test_case("a=b" => false; "LeftHandSideExpression = AssignmentExpression (assignment)")]
-    #[test_case("a*=b" => false; "LeftHandSideExpression *= AssignmentExpression (multiply)")]
-    #[test_case("a/=b" => false; "LeftHandSideExpression /= AssignmentExpression (divide)")]
-    #[test_case("a%=b" => false; "LeftHandSideExpression %= AssignmentExpression (modulo)")]
-    #[test_case("a+=b" => false; "LeftHandSideExpression += AssignmentExpression (add)")]
-    #[test_case("a-=b" => false; "LeftHandSideExpression -= AssignmentExpression (subtract)")]
-    #[test_case("a<<=b" => false; "LeftHandSideExpression <<= AssignmentExpression (lshift)")]
-    #[test_case("a>>=b" => false; "LeftHandSideExpression >>= AssignmentExpression (rshift)")]
-    #[test_case("a>>>=b" => false; "LeftHandSideExpression >>>= AssignmentExpression (urshift)")]
-    #[test_case("a&=b" => false; "LeftHandSideExpression &= AssignmentExpression (bitwise and)")]
-    #[test_case("a^=b" => false; "LeftHandSideExpression ^= AssignmentExpression (bitwise xor)")]
-    #[test_case("a|=b" => false; "LeftHandSideExpression |= AssignmentExpression (bitwise or)")]
-    #[test_case("a&&=b" => false; "LeftHandSideExpression &&= AssignmentExpression (logical and)")]
-    #[test_case("a||=b" => false; "LeftHandSideExpression ||= AssignmentExpression (logical or)")]
-    #[test_case("a??=b" => false; "LeftHandSideExpression ??= AssignmentExpression (coalesce)")]
-    #[test_case("[a]=[1]" => false; "AssignmentPattern = AssignmentExpression")]
-    fn is_function_definition(src: &str) -> bool {
-        AssignmentExpression::parse(&mut newparser(src), Scanner::new(), true, true, true)
-            .unwrap()
-            .0
-            .is_function_definition()
-    }
-
     #[test_case("a", true => ATTKind::Simple; "Fall-thru (identifier)")]
     #[test_case("function (){}", true => ATTKind::Invalid; "Fall-thru (function exp)")]
     #[test_case("yield a", true => ATTKind::Invalid; "YieldExpression")]
@@ -341,7 +313,7 @@ mod assignment_expression {
     #[test_case("package", true => sset(&[PACKAGE_NOT_ALLOWED]); "Fall-thru (identifier)")]
     #[test_case("yield package", true => sset(&[PACKAGE_NOT_ALLOWED]); "YieldExpression")]
     #[test_case("package=>interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "ArrowFunction")]
-    #[test_case("async package=>interface", true => panics "not yet implemented"; "AsyncArrowFunction")]
+    #[test_case("async package=>interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "AsyncArrowFunction")]
     #[test_case("package=interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "LeftHandSideExpression = AssignmentExpression (assignment)")]
     #[test_case("package*=interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "LeftHandSideExpression *= AssignmentExpression (multiply)")]
     #[test_case("package/=interface", true => sset(&[PACKAGE_NOT_ALLOWED, INTERFACE_NOT_ALLOWED]); "LeftHandSideExpression /= AssignmentExpression (divide)")]
@@ -428,60 +400,60 @@ mod assignment_expression {
             .contains_arguments()
     }
 
-    #[test_case("function blue(){}" => false; "named function")]
-    #[test_case("function (){}" => true; "anonymous function")]
-    #[test_case("function *a(){}" => false; "named generator")]
-    #[test_case("function *(){}" => true; "anonymous generator")]
-    #[test_case("async function blue(){}" => false; "async named function")]
-    #[test_case("async function (){}" => true; "async anonymous function")]
-    #[test_case("async function *a(){}" => false; "async named generator")]
-    #[test_case("async function *(){}" => true; "async anonymous generator")]
-    #[test_case("class {}" => true; "anonymous class")]
-    #[test_case("class a{}" => false; "named class")]
-    #[test_case("x => x*2" => true; "arrow function")]
-    #[test_case("async x => x + 3" => true; "async arrow function")]
-    #[test_case("10" => false; "literal")]
-    #[test_case("(function *(){})" => true; "parenthesized function expr")]
-    fn is_anonymous_function_definition(src: &str) -> bool {
-        Maker::new(src).assignment_expression().is_anonymous_function_definition()
-    }
+    //#[test_case("function blue(){}" => false; "named function")]
+    //#[test_case("function (){}" => true; "anonymous function")]
+    //#[test_case("function *a(){}" => false; "named generator")]
+    //#[test_case("function *(){}" => true; "anonymous generator")]
+    //#[test_case("async function blue(){}" => false; "async named function")]
+    //#[test_case("async function (){}" => true; "async anonymous function")]
+    //#[test_case("async function *a(){}" => false; "async named generator")]
+    //#[test_case("async function *(){}" => true; "async anonymous generator")]
+    //#[test_case("class {}" => true; "anonymous class")]
+    //#[test_case("class a{}" => false; "named class")]
+    //#[test_case("x => x*2" => true; "arrow function")]
+    //#[test_case("async x => x + 3" => true; "async arrow function")]
+    //#[test_case("10" => false; "literal")]
+    //#[test_case("(function *(){})" => true; "parenthesized function expr")]
+    //fn is_anonymous_function_definition(src: &str) -> bool {
+    //    Maker::new(src).assignment_expression().is_anonymous_function_definition()
+    //}
 
-    #[test_case("function blue(){}" => true; "named function")]
-    #[test_case("function (){}" => false; "anonymous function")]
-    #[test_case("function *a(){}" => true; "named generator")]
-    #[test_case("function *(){}" => false; "anonymous generator")]
-    #[test_case("async function blue(){}" => true; "async named function")]
-    #[test_case("async function (){}" => false; "async anonymous function")]
-    #[test_case("async function *a(){}" => true; "async named generator")]
-    #[test_case("async function *(){}" => false; "async anonymous generator")]
-    #[test_case("class {}" => false; "anonymous class")]
-    #[test_case("class a{}" => true; "named class")]
-    #[test_case("x => x*2" => false; "arrow function")]
-    #[test_case("async x => x + 3" => false; "async arrow function")]
-    #[test_case("10" => false; "literal")]
-    #[test_case("(function *(){})" => false; "parenthesized function expr")]
-    #[test_case("a+b" => false; "additive")]
-    #[test_case("a^b" => false; "bitwise xor")]
-    #[test_case("a&b" => false; "bitwise and")]
-    #[test_case("a|b" => false; "bitwise or")]
-    #[test_case("a??b" => false; "coalesce")]
-    #[test_case("a||b" => false; "logical or")]
-    #[test_case("a&&b" => false; "logical and")]
-    #[test_case("a<<b" => false; "shift expr")]
-    #[test_case("(a,b)" => false; "comma")]
-    #[test_case("a==b" => false; "equality")]
-    #[test_case("a**b" => false; "exponent")]
-    #[test_case("a.b" => false; "member")]
-    #[test_case("a()" => false; "call")]
-    #[test_case("new a" => false; "new expr")]
-    #[test_case("a*b" => false; "multiplicative")]
-    #[test_case("a<b" => false; "relational")]
-    #[test_case("-a" => false; "unary expr")]
-    #[test_case("a++" => false; "update expr")]
-    #[test_case("a?b:c" => false; "conditional")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).assignment_expression().is_named_function()
-    }
+    //#[test_case("function blue(){}" => true; "named function")]
+    //#[test_case("function (){}" => false; "anonymous function")]
+    //#[test_case("function *a(){}" => true; "named generator")]
+    //#[test_case("function *(){}" => false; "anonymous generator")]
+    //#[test_case("async function blue(){}" => true; "async named function")]
+    //#[test_case("async function (){}" => false; "async anonymous function")]
+    //#[test_case("async function *a(){}" => true; "async named generator")]
+    //#[test_case("async function *(){}" => false; "async anonymous generator")]
+    //#[test_case("class {}" => false; "anonymous class")]
+    //#[test_case("class a{}" => true; "named class")]
+    //#[test_case("x => x*2" => false; "arrow function")]
+    //#[test_case("async x => x + 3" => false; "async arrow function")]
+    //#[test_case("10" => false; "literal")]
+    //#[test_case("(function *(){})" => false; "parenthesized function expr")]
+    //#[test_case("a+b" => false; "additive")]
+    //#[test_case("a^b" => false; "bitwise xor")]
+    //#[test_case("a&b" => false; "bitwise and")]
+    //#[test_case("a|b" => false; "bitwise or")]
+    //#[test_case("a??b" => false; "coalesce")]
+    //#[test_case("a||b" => false; "logical or")]
+    //#[test_case("a&&b" => false; "logical and")]
+    //#[test_case("a<<b" => false; "shift expr")]
+    //#[test_case("(a,b)" => false; "comma")]
+    //#[test_case("a==b" => false; "equality")]
+    //#[test_case("a**b" => false; "exponent")]
+    //#[test_case("a.b" => false; "member")]
+    //#[test_case("a()" => false; "call")]
+    //#[test_case("new a" => false; "new expr")]
+    //#[test_case("a*b" => false; "multiplicative")]
+    //#[test_case("a<b" => false; "relational")]
+    //#[test_case("-a" => false; "unary expr")]
+    //#[test_case("a++" => false; "update expr")]
+    //#[test_case("a?b:c" => false; "conditional")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).assignment_expression().is_named_function()
+    //}
 
     #[test_case(" 12" => Location { starting_line: 1, starting_column: 2, span: Span { starting_index: 1, length: 2 } }; "fall-thru")]
     #[test_case(" yield 12" => Location { starting_line: 1, starting_column: 2, span: Span { starting_index: 1, length: 8 } }; "yield expression")]
@@ -517,22 +489,6 @@ mod assignment_expression {
 mod assignment_operator {
     use super::*;
     use test_case::test_case;
-
-    #[test_case(AssignmentOperator::Multiply => false; "Multiply")]
-    #[test_case(AssignmentOperator::Divide => false; "Divide")]
-    #[test_case(AssignmentOperator::Modulo => false; "Modulo")]
-    #[test_case(AssignmentOperator::Add => false; "Add")]
-    #[test_case(AssignmentOperator::Subtract => false; "Subtract")]
-    #[test_case(AssignmentOperator::LeftShift => false; "LeftShift")]
-    #[test_case(AssignmentOperator::SignedRightShift => false; "SignedRightShift")]
-    #[test_case(AssignmentOperator::UnsignedRightShift => false; "UnsignedRightShift")]
-    #[test_case(AssignmentOperator::BitwiseAnd => false; "BitwiseAnd")]
-    #[test_case(AssignmentOperator::BitwiseXor => false; "BitwiseXor")]
-    #[test_case(AssignmentOperator::BitwiseOr => false; "BitwiseOr")]
-    #[test_case(AssignmentOperator::Exponentiate => false; "Exponentiate")]
-    fn contains(op: AssignmentOperator) -> bool {
-        op.contains(ParseNodeKind::This)
-    }
 
     #[test]
     fn debug() {
@@ -703,11 +659,6 @@ mod assignment_pattern {
     #[test_case(" [x,y,z]" => Location { starting_line: 1, starting_column: 2, span: Span{ starting_index: 1, length: 7 } }; "array pattern")]
     fn location(src: &str) -> Location {
         Maker::new(src).assignment_pattern().location()
-    }
-
-    #[test_case("[]" => true; "is a pattern")]
-    fn is_destructuring(src: &str) -> bool {
-        Maker::new(src).assignment_pattern().is_destructuring()
     }
 }
 

--- a/src/parser/async_arrow_function_definitions/tests.rs
+++ b/src/parser/async_arrow_function_definitions/tests.rs
@@ -245,7 +245,6 @@ fn async_arrow_function_test_all_private_identifiers_valid(src: &str) -> bool {
 }
 
 #[test]
-#[should_panic(expected = "not yet implemented")]
 fn async_arrow_function_test_early_errors() {
     AsyncArrowFunction::parse(&mut newparser("async x => x"), Scanner::new(), true, true, true)
         .unwrap()
@@ -350,7 +349,6 @@ fn async_concise_body_test_all_private_identifiers_valid(src: &str) -> bool {
 }
 
 #[test]
-#[should_panic(expected = "not yet implemented")]
 fn async_concise_body_test_early_errors() {
     AsyncConciseBody::parse(&mut newparser("x"), Scanner::new(), true).unwrap().0.early_errors(&mut vec![], true);
 }
@@ -396,14 +394,8 @@ fn async_arrow_binding_identifier_test_conciseerrors_1() {
     let (item, _) = AsyncArrowBindingIdentifier::parse(&mut newparser("identifier"), Scanner::new(), false).unwrap();
     concise_error_validate(&*item);
 }
-#[test]
-fn async_arrow_binding_identifier_test_contains_01() {
-    let (item, _) = AsyncArrowBindingIdentifier::parse(&mut newparser("identifier"), Scanner::new(), true).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
-}
 
 #[test]
-#[should_panic(expected = "not yet implemented")]
 fn async_arrow_binding_identifier_test_early_errors() {
     AsyncArrowBindingIdentifier::parse(&mut newparser("x"), Scanner::new(), true)
         .unwrap()
@@ -470,32 +462,6 @@ fn cceaaah_test_conciseerrors_1() {
             .unwrap();
     concise_error_validate(&*item);
 }
-#[test]
-fn cceaaah_test_contains_01() {
-    let (item, _) =
-        CoverCallExpressionAndAsyncArrowHead::parse(&mut newparser("this.a(10)"), Scanner::new(), true, true).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), true);
-}
-#[test]
-fn cceaaah_test_contains_02() {
-    let (item, _) =
-        CoverCallExpressionAndAsyncArrowHead::parse(&mut newparser("big[30]()"), Scanner::new(), true, true).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), true);
-}
-#[test]
-fn cceaaah_test_contains_03() {
-    let (item, _) =
-        CoverCallExpressionAndAsyncArrowHead::parse(&mut newparser("a()"), Scanner::new(), true, true).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
-}
-#[test]
-#[should_panic(expected = "not yet implemented")]
-fn cceaaah_test_early_errors() {
-    CoverCallExpressionAndAsyncArrowHead::parse(&mut newparser("x()"), Scanner::new(), true, true)
-        .unwrap()
-        .0
-        .early_errors(&mut vec![], true);
-}
 
 // ASYNC ARROW HEAD
 #[test]
@@ -545,7 +511,6 @@ fn async_arrow_head_test_all_private_identifiers_valid(src: &str) -> bool {
     item.all_private_identifiers_valid(&[JSString::from("#valid")])
 }
 #[test]
-#[should_panic(expected = "not yet implemented")]
 fn async_arrow_head_test_early_errors() {
     AsyncArrowHead::parse(&mut newparser("async(a)"), Scanner::new()).unwrap().0.early_errors(&mut vec![], true);
 }

--- a/src/parser/async_function_definitions/mod.rs
+++ b/src/parser/async_function_definitions/mod.rs
@@ -8,7 +8,7 @@ use std::io::Write;
 //      async [no LineTerminator here] function BindingIdentifier[?Yield, ?Await] ( FormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
 //      [+Default] async [no LineTerminator here] function ( FormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
 #[derive(Debug)]
-pub struct AsyncFunctionDeclaration {
+pub(crate) struct AsyncFunctionDeclaration {
     ident: Option<Rc<BindingIdentifier>>,
     params: Rc<FormalParameters>,
     body: Rc<AsyncFunctionBody>,
@@ -69,7 +69,7 @@ impl PrettyPrint for AsyncFunctionDeclaration {
 
 impl AsyncFunctionDeclaration {
     // AsyncFunctionDeclaration's only parent is HoistableDeclaration. It doesn't need to be cached.
-    pub fn parse(
+    pub(crate) fn parse(
         parser: &mut Parser,
         scanner: Scanner,
         yield_flag: bool,
@@ -77,10 +77,10 @@ impl AsyncFunctionDeclaration {
         default_flag: bool,
     ) -> ParseResult<Self> {
         let (async_loc, after_async) =
-            scan_for_keyword(scanner, parser.source, ScanGoal::InputElementRegExp, Keyword::Async)?;
+            scan_for_keyword(scanner, parser.source, InputElementGoal::RegExp, Keyword::Async)?;
         no_line_terminator(after_async, parser.source)?;
         let (_, after_function) =
-            scan_for_keyword(after_async, parser.source, ScanGoal::InputElementDiv, Keyword::Function)?;
+            scan_for_keyword(after_async, parser.source, InputElementGoal::Div, Keyword::Function)?;
         let (ident, after_bi) = match BindingIdentifier::parse(parser, after_function, yield_flag, await_flag) {
             Err(e) => {
                 if default_flag {
@@ -91,38 +91,33 @@ impl AsyncFunctionDeclaration {
             }
             Ok((node, scan)) => Ok((Some(node), scan)),
         }?;
-        let (_, after_lp) = scan_for_punct(after_bi, parser.source, ScanGoal::InputElementDiv, Punctuator::LeftParen)?;
+        let (_, after_lp) = scan_for_punct(after_bi, parser.source, InputElementGoal::Div, Punctuator::LeftParen)?;
         let (params, after_params) = FormalParameters::parse(parser, after_lp, false, true);
-        let (_, after_rp) =
-            scan_for_punct(after_params, parser.source, ScanGoal::InputElementDiv, Punctuator::RightParen)?;
-        let (_, after_lb) = scan_for_punct(after_rp, parser.source, ScanGoal::InputElementDiv, Punctuator::LeftBrace)?;
+        let (_, after_rp) = scan_for_punct(after_params, parser.source, InputElementGoal::Div, Punctuator::RightParen)?;
+        let (_, after_lb) = scan_for_punct(after_rp, parser.source, InputElementGoal::Div, Punctuator::LeftBrace)?;
         let (body, after_body) = AsyncFunctionBody::parse(parser, after_lb);
         let (rb_loc, after_rb) =
-            scan_for_punct(after_body, parser.source, ScanGoal::InputElementDiv, Punctuator::RightBrace)?;
+            scan_for_punct(after_body, parser.source, InputElementGoal::Div, Punctuator::RightBrace)?;
         let location = async_loc.merge(&rb_loc);
         Ok((Rc::new(AsyncFunctionDeclaration { ident, params, body, location }), after_rb))
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         self.location
     }
 
-    pub fn bound_names(&self) -> Vec<JSString> {
+    pub(crate) fn bound_names(&self) -> Vec<JSString> {
         vec![self.bound_name()]
     }
 
-    pub fn bound_name(&self) -> JSString {
+    pub(crate) fn bound_name(&self) -> JSString {
         match &self.ident {
             None => JSString::from("*default*"),
             Some(node) => node.bound_name(),
         }
     }
 
-    pub fn contains(&self, _: ParseNodeKind) -> bool {
-        false
-    }
-
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -142,7 +137,7 @@ impl AsyncFunctionDeclaration {
     /// See [Early Errors for Async Function Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-async-function-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         // AsyncFunctionDeclaration :
         //     async function BindingIdentifier ( FormalParameters ) { AsyncFunctionBody }
@@ -236,12 +231,8 @@ impl AsyncFunctionDeclaration {
         // And done.
     }
 
-    pub fn is_constant_declaration(&self) -> bool {
-        false
-    }
-
     #[expect(unused_variables)]
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         todo!()
     }
@@ -250,10 +241,10 @@ impl AsyncFunctionDeclaration {
 // AsyncFunctionExpression :
 //      async [no LineTerminator here] function BindingIdentifier[~Yield, +Await]opt ( FormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
 #[derive(Debug)]
-pub struct AsyncFunctionExpression {
-    pub ident: Option<Rc<BindingIdentifier>>,
-    pub params: Rc<FormalParameters>,
-    pub body: Rc<AsyncFunctionBody>,
+pub(crate) struct AsyncFunctionExpression {
+    pub(crate) ident: Option<Rc<BindingIdentifier>>,
+    pub(crate) params: Rc<FormalParameters>,
+    pub(crate) body: Rc<AsyncFunctionBody>,
     location: Location,
 }
 
@@ -309,45 +300,34 @@ impl PrettyPrint for AsyncFunctionExpression {
     }
 }
 
-impl IsFunctionDefinition for AsyncFunctionExpression {
-    fn is_function_definition(&self) -> bool {
-        true
-    }
-}
-
 impl AsyncFunctionExpression {
     // AsyncFunctionExpression's only parent is PrimaryExpression. It doesn't need caching.
-    pub fn parse(parser: &mut Parser, scanner: Scanner) -> ParseResult<Self> {
+    pub(crate) fn parse(parser: &mut Parser, scanner: Scanner) -> ParseResult<Self> {
         let (async_loc, after_async) =
-            scan_for_keyword(scanner, parser.source, ScanGoal::InputElementRegExp, Keyword::Async)?;
+            scan_for_keyword(scanner, parser.source, InputElementGoal::RegExp, Keyword::Async)?;
         no_line_terminator(after_async, parser.source)?;
         let (_, after_function) =
-            scan_for_keyword(after_async, parser.source, ScanGoal::InputElementDiv, Keyword::Function)?;
+            scan_for_keyword(after_async, parser.source, InputElementGoal::Div, Keyword::Function)?;
         let (ident, after_bi) = match BindingIdentifier::parse(parser, after_function, false, true) {
             Err(_) => (None, after_function),
             Ok((node, scan)) => (Some(node), scan),
         };
-        let (_, after_lp) = scan_for_punct(after_bi, parser.source, ScanGoal::InputElementDiv, Punctuator::LeftParen)?;
+        let (_, after_lp) = scan_for_punct(after_bi, parser.source, InputElementGoal::Div, Punctuator::LeftParen)?;
         let (params, after_params) = FormalParameters::parse(parser, after_lp, false, true);
-        let (_, after_rp) =
-            scan_for_punct(after_params, parser.source, ScanGoal::InputElementDiv, Punctuator::RightParen)?;
-        let (_, after_lb) = scan_for_punct(after_rp, parser.source, ScanGoal::InputElementDiv, Punctuator::LeftBrace)?;
+        let (_, after_rp) = scan_for_punct(after_params, parser.source, InputElementGoal::Div, Punctuator::RightParen)?;
+        let (_, after_lb) = scan_for_punct(after_rp, parser.source, InputElementGoal::Div, Punctuator::LeftBrace)?;
         let (body, after_body) = AsyncFunctionBody::parse(parser, after_lb);
         let (rb_loc, after_rb) =
-            scan_for_punct(after_body, parser.source, ScanGoal::InputElementDiv, Punctuator::RightBrace)?;
+            scan_for_punct(after_body, parser.source, InputElementGoal::Div, Punctuator::RightBrace)?;
         let location = async_loc.merge(&rb_loc);
         Ok((Rc::new(AsyncFunctionExpression { ident, params, body, location }), after_rb))
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         self.location
     }
 
-    pub fn contains(&self, _: ParseNodeKind) -> bool {
-        false
-    }
-
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -367,7 +347,7 @@ impl AsyncFunctionExpression {
     /// See [Early Errors for Async Function Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-async-function-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  AsyncFunctionExpression :
         //      async function BindingIdentifier[opt] ( FormalParameters ) { AsyncFunctionBody }
@@ -458,11 +438,11 @@ impl AsyncFunctionExpression {
         self.body.early_errors(errs, strict_function);
     }
 
-    pub fn is_named_function(&self) -> bool {
+    pub(crate) fn is_named_function(&self) -> bool {
         self.ident.is_some()
     }
     #[expect(unused_variables)]
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         todo!()
     }
 }
@@ -470,7 +450,7 @@ impl AsyncFunctionExpression {
 // AsyncMethod[Yield, Await] :
 //      async [no LineTerminator here] ClassElementName[?Yield, ?Await] ( UniqueFormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
 #[derive(Debug)]
-pub struct AsyncMethod {
+pub(crate) struct AsyncMethod {
     ident: Rc<ClassElementName>,
     params: Rc<UniqueFormalParameters>,
     body: Rc<AsyncFunctionBody>,
@@ -523,44 +503,48 @@ impl PrettyPrint for AsyncMethod {
 
 impl AsyncMethod {
     // No caching required. Parent: MethodDefinition
-    pub fn parse(parser: &mut Parser, scanner: Scanner, yield_flag: bool, await_flag: bool) -> ParseResult<Self> {
+    pub(crate) fn parse(
+        parser: &mut Parser,
+        scanner: Scanner,
+        yield_flag: bool,
+        await_flag: bool,
+    ) -> ParseResult<Self> {
         let (async_loc, after_async) =
-            scan_for_keyword(scanner, parser.source, ScanGoal::InputElementRegExp, Keyword::Async)?;
+            scan_for_keyword(scanner, parser.source, InputElementGoal::RegExp, Keyword::Async)?;
         no_line_terminator(after_async, parser.source)?;
         let (ident, after_ident) = ClassElementName::parse(parser, after_async, yield_flag, await_flag)?;
-        let (_, after_lp) =
-            scan_for_punct(after_ident, parser.source, ScanGoal::InputElementDiv, Punctuator::LeftParen)?;
+        let (_, after_lp) = scan_for_punct(after_ident, parser.source, InputElementGoal::Div, Punctuator::LeftParen)?;
         let (params, after_params) = UniqueFormalParameters::parse(parser, after_lp, false, true);
-        let (_, after_rp) =
-            scan_for_punct(after_params, parser.source, ScanGoal::InputElementDiv, Punctuator::RightParen)?;
-        let (_, after_lb) = scan_for_punct(after_rp, parser.source, ScanGoal::InputElementDiv, Punctuator::LeftBrace)?;
+        let (_, after_rp) = scan_for_punct(after_params, parser.source, InputElementGoal::Div, Punctuator::RightParen)?;
+        let (_, after_lb) = scan_for_punct(after_rp, parser.source, InputElementGoal::Div, Punctuator::LeftBrace)?;
         let (body, after_body) = AsyncFunctionBody::parse(parser, after_lb);
         let (rb_loc, after_rb) =
-            scan_for_punct(after_body, parser.source, ScanGoal::InputElementDiv, Punctuator::RightBrace)?;
+            scan_for_punct(after_body, parser.source, InputElementGoal::Div, Punctuator::RightBrace)?;
         let location = async_loc.merge(&rb_loc);
         Ok((Rc::new(AsyncMethod { ident, params, body, location }), after_rb))
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         self.location
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    #[cfg(test)]
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         self.ident.contains(kind) || self.params.contains(kind) || self.body.contains(kind)
     }
 
-    pub fn computed_property_contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn computed_property_contains(&self, kind: ParseNodeKind) -> bool {
         self.ident.computed_property_contains(kind)
     }
 
-    pub fn private_bound_identifier(&self) -> Option<JSString> {
+    pub(crate) fn private_bound_identifier(&self) -> Option<JSString> {
         // Static Semantics: PrivateBoundIdentifiers
         // AsyncMethod : async ClassElementName ( UniqueFormalParameters ) { AsyncFunctionBody }
         //  1. Return PrivateBoundIdentifiers of ClassElementName.
         self.ident.private_bound_identifier()
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -576,14 +560,14 @@ impl AsyncMethod {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. Return ContainsArguments of ClassElementName.
         self.ident.contains_arguments()
     }
 
-    pub fn has_direct_super(&self) -> bool {
+    pub(crate) fn has_direct_super(&self) -> bool {
         // Static Semantics: HasDirectSuper
         //      The syntax-directed operation HasDirectSuper takes no arguments.
         // AsyncMethod : async ClassElementName ( UniqueFormalParameters ) { AsyncFunctionBody }
@@ -602,7 +586,7 @@ impl AsyncMethod {
     /// See [Early Errors for Async Function Definitions][1] from ECMA-262.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-async-function-definitions-static-semantics-early-errors
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  AsyncMethod : async ClassElementName ( UniqueFormalParameters ) { AsyncFunctionBody }
         //  * It is a Syntax Error if FunctionBodyContainsUseStrict of AsyncFunctionBody is true and
@@ -640,7 +624,7 @@ impl AsyncMethod {
         self.body.early_errors(errs, strict_func);
     }
 
-    pub fn prop_name(&self) -> Option<JSString> {
+    pub(crate) fn prop_name(&self) -> Option<JSString> {
         // Static Semantics: PropName
         // The syntax-directed operation PropName takes no arguments and returns a String or empty.
         //      AsyncMethod : async ClassElementName ( UniqueFormalParameters ) { AsyncFunctionBody }
@@ -649,7 +633,7 @@ impl AsyncMethod {
     }
 
     #[expect(unused_variables)]
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         todo!()
     }
@@ -658,7 +642,7 @@ impl AsyncMethod {
 // AsyncFunctionBody :
 //      FunctionBody[~Yield, +Await]
 #[derive(Debug)]
-pub struct AsyncFunctionBody(pub Rc<FunctionBody>);
+pub(crate) struct AsyncFunctionBody(pub(crate) Rc<FunctionBody>);
 
 impl fmt::Display for AsyncFunctionBody {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -686,11 +670,11 @@ impl PrettyPrint for AsyncFunctionBody {
 
 impl AsyncFunctionBody {
     fn parse_core(parser: &mut Parser, scanner: Scanner) -> (Rc<Self>, Scanner) {
-        let (fb, after_fb) = FunctionBody::parse(parser, scanner, false, true, FunctionBodyParent::AsyncBody);
+        let (fb, after_fb) = FunctionBody::parse(parser, scanner, false, true, FunctionBodyParent::Async);
         (Rc::new(AsyncFunctionBody(fb)), after_fb)
     }
 
-    pub fn parse(parser: &mut Parser, scanner: Scanner) -> (Rc<Self>, Scanner) {
+    pub(crate) fn parse(parser: &mut Parser, scanner: Scanner) -> (Rc<Self>, Scanner) {
         match parser.async_function_body_cache.get(&scanner) {
             Some(result) => result.clone(),
             None => {
@@ -701,15 +685,15 @@ impl AsyncFunctionBody {
         }
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         self.0.location()
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         self.0.contains(kind)
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -723,7 +707,7 @@ impl AsyncFunctionBody {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -733,21 +717,21 @@ impl AsyncFunctionBody {
         self.0.contains_arguments()
     }
 
-    pub fn function_body_contains_use_strict(&self) -> bool {
+    pub(crate) fn function_body_contains_use_strict(&self) -> bool {
         // Static Semantics: FunctionBodyContainsUseStrict
         // AsyncFunctionBody : FunctionBody
         //  1. Return FunctionBodyContainsUseStrict of FunctionBody.
         self.0.function_body_contains_use_strict()
     }
 
-    pub fn lexically_declared_names(&self) -> Vec<JSString> {
+    pub(crate) fn lexically_declared_names(&self) -> Vec<JSString> {
         // Static Semantics: LexicallyDeclaredNames
         //      AsyncFunctionBody : FunctionBody
         //  1. Return LexicallyDeclaredNames of FunctionBody.
         self.0.lexically_declared_names()
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         self.0.early_errors(errs, strict);
     }
 
@@ -757,31 +741,31 @@ impl AsyncFunctionBody {
     /// of the var-declared list.
     ///
     /// See [VarDeclaredNames](https://tc39.es/ecma262/#sec-static-semantics-vardeclarednames) from ECMA-262.
-    pub fn var_declared_names(&self) -> Vec<JSString> {
+    pub(crate) fn var_declared_names(&self) -> Vec<JSString> {
         self.0.var_declared_names()
     }
 
     /// Return a list of parse nodes for the var-style declarations contained within the children of this node.
     ///
     /// See [VarScopedDeclarations](https://tc39.es/ecma262/#sec-static-semantics-varscopeddeclarations) in ECMA-262.
-    pub fn var_scoped_declarations(&self) -> Vec<VarScopeDecl> {
+    pub(crate) fn var_scoped_declarations(&self) -> Vec<VarScopeDecl> {
         self.0.var_scoped_declarations()
     }
 
-    pub fn lexically_scoped_declarations(&self) -> Vec<DeclPart> {
+    pub(crate) fn lexically_scoped_declarations(&self) -> Vec<DeclPart> {
         self.0.lexically_scoped_declarations()
     }
 
-    #[expect(unused_variables)]
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
-        todo!()
-    }
+    //#[expect(unused_variables)]
+    //pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    //    todo!()
+    //}
 }
 
 // AwaitExpression[Yield] :
 //      await UnaryExpression[?Yield, +Await]
 #[derive(Debug)]
-pub struct AwaitExpression {
+pub(crate) struct AwaitExpression {
     exp: Rc<UnaryExpression>,
     location: Location,
 }
@@ -815,23 +799,23 @@ impl PrettyPrint for AwaitExpression {
 
 impl AwaitExpression {
     // No caching required. Parent: UnaryExpression
-    pub fn parse(parser: &mut Parser, scanner: Scanner, yield_flag: bool) -> ParseResult<Self> {
+    pub(crate) fn parse(parser: &mut Parser, scanner: Scanner, yield_flag: bool) -> ParseResult<Self> {
         let (await_loc, after_await) =
-            scan_for_keyword(scanner, parser.source, ScanGoal::InputElementRegExp, Keyword::Await)?;
+            scan_for_keyword(scanner, parser.source, InputElementGoal::RegExp, Keyword::Await)?;
         let (exp, after_ue) = UnaryExpression::parse(parser, after_await, yield_flag, true)?;
         let location = await_loc.merge(&exp.location());
         Ok((Rc::new(AwaitExpression { exp, location }), after_ue))
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         self.location
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         kind == ParseNodeKind::AwaitExpression || { self.exp.contains(kind) }
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -841,7 +825,7 @@ impl AwaitExpression {
         self.exp.all_private_identifiers_valid(names)
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         self.exp.early_errors(errs, strict);
     }
 
@@ -849,7 +833,7 @@ impl AwaitExpression {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -860,7 +844,7 @@ impl AwaitExpression {
     }
 
     #[expect(unused_variables)]
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         todo!()
     }

--- a/src/parser/async_function_definitions/tests.rs
+++ b/src/parser/async_function_definitions/tests.rs
@@ -191,30 +191,6 @@ fn async_function_declaration_test_conciseerrors_2() {
     concise_error_validate(&*item);
 }
 #[test]
-fn async_function_declaration_test_contains_01() {
-    let (item, _) = AsyncFunctionDeclaration::parse(
-        &mut newparser("async function bob() { return 11; }"),
-        Scanner::new(),
-        true,
-        true,
-        true,
-    )
-    .unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
-}
-#[test]
-fn async_function_declaration_test_contains_02() {
-    let (item, _) = AsyncFunctionDeclaration::parse(
-        &mut newparser("async function () { return 10; }"),
-        Scanner::new(),
-        true,
-        true,
-        true,
-    )
-    .unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
-}
-#[test]
 fn async_function_declaration_test_bound_names_01() {
     let (item, _) = AsyncFunctionDeclaration::parse(
         &mut newparser("async function a() { return 10; }"),
@@ -296,11 +272,6 @@ mod async_function_declaration {
     fn bound_name(src: &str) -> String {
         Maker::new(src).async_function_declaration().bound_name().into()
     }
-
-    #[test_case("async function foo () {}" => false; "typical")]
-    fn is_constant_declaration(src: &str) -> bool {
-        Maker::new(src).async_function_declaration().is_constant_declaration()
-    }
 }
 
 // ASYNC FUNCTION EXPRESSION
@@ -332,7 +303,6 @@ fn async_function_expression_test_01() {
         ],
     );
     assert_ne!(format!("{node:?}"), "");
-    assert!(node.is_function_definition());
 }
 #[test]
 fn async_function_expression_test_02() {
@@ -361,7 +331,6 @@ fn async_function_expression_test_02() {
         ],
     );
     assert_ne!(format!("{node:?}"), "");
-    assert!(node.is_function_definition());
 }
 #[test]
 fn async_function_expression_test_err_01() {
@@ -446,18 +415,6 @@ fn async_function_expression_test_conciseerrors_2() {
     )
     .unwrap();
     concise_error_validate(&*item);
-}
-#[test]
-fn async_function_expression_test_contains_01() {
-    let (item, _) =
-        AsyncFunctionExpression::parse(&mut newparser("async function bob() { return 11; }"), Scanner::new()).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
-}
-#[test]
-fn async_function_expression_test_contains_02() {
-    let (item, _) =
-        AsyncFunctionExpression::parse(&mut newparser("async function () { return 10; }"), Scanner::new()).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
 }
 #[test_case("async function x(arg=item.#valid){}" => true; "Params valid")]
 #[test_case("async function x(arg) { arg.#valid(); }" => true; "Body valid")]

--- a/src/parser/async_generator_function_definitions/tests.rs
+++ b/src/parser/async_generator_function_definitions/tests.rs
@@ -254,7 +254,6 @@ fn async_generator_declaration_test_01() {
         ],
     );
     assert_ne!(format!("{node:?}"), "");
-    assert!(node.is_function_definition());
 }
 #[test]
 fn async_generator_declaration_test_02() {
@@ -285,7 +284,6 @@ fn async_generator_declaration_test_02() {
         ],
     );
     assert_ne!(format!("{node:?}"), "");
-    assert!(node.is_function_definition());
 }
 #[test]
 fn async_generator_declaration_test_03() {
@@ -471,30 +469,6 @@ fn async_generator_declaration_test_conciseerrors_2() {
     concise_error_validate(&*item);
 }
 #[test]
-fn async_generator_declaration_test_contains_01() {
-    let (item, _) = AsyncGeneratorDeclaration::parse(
-        &mut newparser("async function * a(b=10) { return 10; }"),
-        Scanner::new(),
-        true,
-        true,
-        true,
-    )
-    .unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
-}
-#[test]
-fn async_generator_declaration_test_contains_02() {
-    let (item, _) = AsyncGeneratorDeclaration::parse(
-        &mut newparser("async function * (b=10) { return 10; }"),
-        Scanner::new(),
-        true,
-        true,
-        true,
-    )
-    .unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
-}
-#[test]
 fn async_generator_declaration_test_bound_names_01() {
     let (item, _) = AsyncGeneratorDeclaration::parse(
         &mut newparser("async function * a() { return; }"),
@@ -575,11 +549,6 @@ mod async_generator_declaration {
     fn bound_name(src: &str) -> String {
         Maker::new(src).async_generator_declaration().bound_name().into()
     }
-
-    #[test_case("async function *foo () {}" => false; "typical")]
-    fn is_constant_declaration(src: &str) -> bool {
-        Maker::new(src).async_generator_declaration().is_constant_declaration()
-    }
 }
 
 // ASYNC GENERATOR EXPRESSION
@@ -608,7 +577,6 @@ fn async_generator_expression_test_01() {
         ],
     );
     assert_ne!(format!("{node:?}"), "");
-    assert!(node.is_function_definition());
 }
 #[test]
 fn async_generator_expression_test_02() {
@@ -634,7 +602,6 @@ fn async_generator_expression_test_02() {
         ],
     );
     assert_ne!(format!("{node:?}"), "");
-    assert!(node.is_function_definition());
 }
 #[test]
 fn async_generator_expression_test_03() {
@@ -760,20 +727,6 @@ fn async_generator_expression_test_conciseerrors_2() {
     )
     .unwrap();
     concise_error_validate(&*item);
-}
-#[test]
-fn async_generator_expression_test_contains_01() {
-    let (item, _) =
-        AsyncGeneratorExpression::parse(&mut newparser("async function * a(b=10) { return 10; }"), Scanner::new())
-            .unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
-}
-#[test]
-fn async_generator_expression_test_contains_02() {
-    let (item, _) =
-        AsyncGeneratorExpression::parse(&mut newparser("async function * (b=10) { return 10; }"), Scanner::new())
-            .unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
 }
 #[test_case("async function *f(arg=item.#valid){}" => true; "Params valid")]
 #[test_case("async function *f(arg){item.#valid;}" => true; "Body valid")]

--- a/src/parser/binary_bitwise_operators/tests.rs
+++ b/src/parser/binary_bitwise_operators/tests.rs
@@ -18,7 +18,6 @@ mod bitwise_and_expression {
         pretty_check(&*pn, "BitwiseANDExpression: a", &["EqualityExpression: a"]);
         concise_check(&*pn, "IdentifierName: a", &[]);
         assert_ne!(format!("{pn:?}"), "");
-        assert_eq!(pn.is_function_definition(), false);
     }
     #[test]
     fn parse_02() {
@@ -33,7 +32,6 @@ mod bitwise_and_expression {
             &["IdentifierName: a", "Punctuator: &", "IdentifierName: b"],
         );
         assert_ne!(format!("{pn:?}"), "");
-        assert_eq!(pn.is_function_definition(), false);
     }
     #[test]
     fn parse_03() {
@@ -44,7 +42,6 @@ mod bitwise_and_expression {
         pretty_check(&*pn, "BitwiseANDExpression: a", &["EqualityExpression: a"]);
         concise_check(&*pn, "IdentifierName: a", &[]);
         assert_ne!(format!("{pn:?}"), "");
-        assert_eq!(pn.is_function_definition(), false);
     }
     #[test]
     fn parse_04() {
@@ -154,12 +151,12 @@ mod bitwise_and_expression {
         Maker::new(src).bitwise_and_expression().assignment_target_type(strict)
     }
 
-    #[test_case("a&b" => false; "bitwise and")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).bitwise_and_expression().is_named_function()
-    }
+    //#[test_case("a&b" => false; "bitwise and")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).bitwise_and_expression().is_named_function()
+    //}
 
     #[test_case("  a&b" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "bitwise and")]
     #[test_case("  998" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "literal")]
@@ -176,7 +173,6 @@ fn bitwise_xor_expression_test_01() {
     pretty_check(&*pn, "BitwiseXORExpression: a", &["BitwiseANDExpression: a"]);
     concise_check(&*pn, "IdentifierName: a", &[]);
     assert_ne!(format!("{pn:?}"), "");
-    assert_eq!(pn.is_function_definition(), false);
 }
 #[test]
 fn bitwise_xor_expression_test_02() {
@@ -186,7 +182,6 @@ fn bitwise_xor_expression_test_02() {
     pretty_check(&*pn, "BitwiseXORExpression: a ^ b", &["BitwiseXORExpression: a", "BitwiseANDExpression: b"]);
     concise_check(&*pn, "BitwiseXORExpression: a ^ b", &["IdentifierName: a", "Punctuator: ^", "IdentifierName: b"]);
     assert_ne!(format!("{pn:?}"), "");
-    assert_eq!(pn.is_function_definition(), false);
 }
 #[test]
 fn bitwise_xor_expression_test_03() {
@@ -196,7 +191,6 @@ fn bitwise_xor_expression_test_03() {
     pretty_check(&*pn, "BitwiseXORExpression: a", &["BitwiseANDExpression: a"]);
     concise_check(&*pn, "IdentifierName: a", &[]);
     assert_ne!(format!("{pn:?}"), "");
-    assert_eq!(pn.is_function_definition(), false);
 }
 #[test]
 fn bitwise_xor_expression_test_04() {
@@ -305,12 +299,12 @@ mod bitwise_xor_expression {
         Maker::new(src).bitwise_xor_expression().assignment_target_type(strict)
     }
 
-    #[test_case("a^b" => false; "bitwise xor")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).bitwise_xor_expression().is_named_function()
-    }
+    //#[test_case("a^b" => false; "bitwise xor")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).bitwise_xor_expression().is_named_function()
+    //}
 
     #[test_case("  a^b" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "bitwise xor")]
     #[test_case("  998" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "literal")]
@@ -327,7 +321,6 @@ fn bitwise_or_expression_test_01() {
     pretty_check(&*pn, "BitwiseORExpression: a", &["BitwiseXORExpression: a"]);
     concise_check(&*pn, "IdentifierName: a", &[]);
     assert_ne!(format!("{pn:?}"), "");
-    assert_eq!(pn.is_function_definition(), false);
 }
 #[test]
 fn bitwise_or_expression_test_02() {
@@ -337,7 +330,6 @@ fn bitwise_or_expression_test_02() {
     pretty_check(&*pn, "BitwiseORExpression: a | b", &["BitwiseORExpression: a", "BitwiseXORExpression: b"]);
     concise_check(&*pn, "BitwiseORExpression: a | b", &["IdentifierName: a", "Punctuator: |", "IdentifierName: b"]);
     assert_ne!(format!("{pn:?}"), "");
-    assert_eq!(pn.is_function_definition(), false);
 }
 #[test]
 fn bitwise_or_expression_test_03() {
@@ -347,7 +339,6 @@ fn bitwise_or_expression_test_03() {
     pretty_check(&*pn, "BitwiseORExpression: a", &["BitwiseXORExpression: a"]);
     concise_check(&*pn, "IdentifierName: a", &[]);
     assert_ne!(format!("{pn:?}"), "");
-    assert_eq!(pn.is_function_definition(), false);
 }
 #[test]
 fn bitwise_or_expression_test_cache_01() {
@@ -462,12 +453,12 @@ mod bitwise_or_expression {
         Maker::new(src).bitwise_or_expression().assignment_target_type(strict)
     }
 
-    #[test_case("a|b" => false; "bitwise or")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).bitwise_or_expression().is_named_function()
-    }
+    //#[test_case("a|b" => false; "bitwise or")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).bitwise_or_expression().is_named_function()
+    //}
 
     #[test_case("  a|b" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "bitwise or")]
     #[test_case("  998" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "literal")]

--- a/src/parser/binary_logical_operators/tests.rs
+++ b/src/parser/binary_logical_operators/tests.rs
@@ -19,7 +19,6 @@ mod logical_and_expression {
         pretty_check(&*pn, "LogicalANDExpression: a", &["BitwiseORExpression: a"]);
         concise_check(&*pn, "IdentifierName: a", &[]);
         assert_ne!(format!("{pn:?}"), "");
-        assert_eq!(pn.is_function_definition(), false);
     }
     #[test]
     fn parse_02() {
@@ -34,7 +33,6 @@ mod logical_and_expression {
             &["IdentifierName: a", "Punctuator: &&", "IdentifierName: b"],
         );
         assert_ne!(format!("{pn:?}"), "");
-        assert_eq!(pn.is_function_definition(), false);
     }
     #[test]
     fn parse_03() {
@@ -45,7 +43,6 @@ mod logical_and_expression {
         pretty_check(&*pn, "LogicalANDExpression: a", &["BitwiseORExpression: a"]);
         concise_check(&*pn, "IdentifierName: a", &[]);
         assert_ne!(format!("{pn:?}"), "");
-        assert_eq!(pn.is_function_definition(), false);
     }
     #[test]
     fn prettyerrors_1() {
@@ -156,13 +153,6 @@ mod logical_and_expression {
         Maker::new(src).logical_and_expression().assignment_target_type(strict)
     }
 
-    #[test_case("a&&b" => false; "logical and")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).logical_and_expression().is_named_function()
-    }
-
     #[test_case("  a&&b" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 4 }}; "logical and")]
     #[test_case("  998" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "literal")]
     fn location(src: &str) -> Location {
@@ -183,7 +173,6 @@ mod logical_or_expression {
         pretty_check(&*pn, "LogicalORExpression: a", &["LogicalANDExpression: a"]);
         concise_check(&*pn, "IdentifierName: a", &[]);
         assert_ne!(format!("{pn:?}"), "");
-        assert_eq!(pn.is_function_definition(), false);
     }
     #[test]
     fn parse_02() {
@@ -198,7 +187,6 @@ mod logical_or_expression {
             &["IdentifierName: a", "Punctuator: ||", "IdentifierName: b"],
         );
         assert_ne!(format!("{pn:?}"), "");
-        assert_eq!(pn.is_function_definition(), false);
     }
     #[test]
     fn parse_03() {
@@ -209,7 +197,6 @@ mod logical_or_expression {
         pretty_check(&*pn, "LogicalORExpression: a", &["LogicalANDExpression: a"]);
         concise_check(&*pn, "IdentifierName: a", &[]);
         assert_ne!(format!("{pn:?}"), "");
-        assert_eq!(pn.is_function_definition(), false);
     }
     #[test]
     fn prettyerrors_1() {
@@ -316,12 +303,12 @@ mod logical_or_expression {
         Maker::new(src).logical_or_expression().assignment_target_type(strict)
     }
 
-    #[test_case("a||b" => false; "logical or")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).logical_or_expression().is_named_function()
-    }
+    //#[test_case("a||b" => false; "logical or")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).logical_or_expression().is_named_function()
+    //}
 
     #[test_case("  a||b" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 4 }}; "logical or")]
     #[test_case("  998" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "literal")]
@@ -574,7 +561,6 @@ fn short_circuit_expression_test_01() {
     pretty_check(&*pn, "ShortCircuitExpression: a ?? b", &["CoalesceExpression: a ?? b"]);
     concise_check(&*pn, "CoalesceExpression: a ?? b", &["IdentifierName: a", "Punctuator: ??", "IdentifierName: b"]);
     assert_ne!(format!("{pn:?}"), "");
-    assert_eq!(pn.is_function_definition(), false);
 }
 #[test]
 fn short_circuit_expression_test_02() {
@@ -584,7 +570,6 @@ fn short_circuit_expression_test_02() {
     pretty_check(&*pn, "ShortCircuitExpression: 6", &["LogicalORExpression: 6"]);
     concise_check(&*pn, "Numeric: 6", &[]);
     assert_ne!(format!("{pn:?}"), "");
-    assert_eq!(pn.is_function_definition(), false);
 }
 #[test]
 fn short_circuit_expression_test_03() {
@@ -697,12 +682,12 @@ mod short_circuit_expression {
         Maker::new(src).short_circuit_expression().assignment_target_type(strict)
     }
 
-    #[test_case("a??b" => false; "expr")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).short_circuit_expression().is_named_function()
-    }
+    //#[test_case("a??b" => false; "expr")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).short_circuit_expression().is_named_function()
+    //}
 
     #[test_case("  a??b" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 4 }}; "coelesce")]
     #[test_case("  998" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "literal")]

--- a/src/parser/bitwise_shift_operators/tests.rs
+++ b/src/parser/bitwise_shift_operators/tests.rs
@@ -15,7 +15,6 @@ fn shift_expression_test_01() {
     pretty_check(&*se, "ShiftExpression: a", &["AdditiveExpression: a"]);
     concise_check(&*se, "IdentifierName: a", &[]);
     assert_ne!(format!("{se:?}"), "");
-    assert_eq!(se.is_function_definition(), false);
 }
 #[test]
 fn shift_expression_test_02() {
@@ -25,7 +24,6 @@ fn shift_expression_test_02() {
     pretty_check(&*se, "ShiftExpression: a << b", &["ShiftExpression: a", "AdditiveExpression: b"]);
     concise_check(&*se, "ShiftExpression: a << b", &["IdentifierName: a", "Punctuator: <<", "IdentifierName: b"]);
     assert_ne!(format!("{se:?}"), "");
-    assert_eq!(se.is_function_definition(), false);
 }
 #[test]
 fn shift_expression_test_03() {
@@ -35,7 +33,6 @@ fn shift_expression_test_03() {
     pretty_check(&*se, "ShiftExpression: a >> b", &["ShiftExpression: a", "AdditiveExpression: b"]);
     concise_check(&*se, "ShiftExpression: a >> b", &["IdentifierName: a", "Punctuator: >>", "IdentifierName: b"]);
     assert_ne!(format!("{se:?}"), "");
-    assert_eq!(se.is_function_definition(), false);
 }
 #[test]
 fn shift_expression_test_04() {
@@ -45,7 +42,6 @@ fn shift_expression_test_04() {
     pretty_check(&*se, "ShiftExpression: a >>> b", &["ShiftExpression: a", "AdditiveExpression: b"]);
     concise_check(&*se, "ShiftExpression: a >>> b", &["IdentifierName: a", "Punctuator: >>>", "IdentifierName: b"]);
     assert_ne!(format!("{se:?}"), "");
-    assert_eq!(se.is_function_definition(), false);
 }
 #[test]
 fn shift_expression_test_05() {
@@ -61,7 +57,6 @@ fn shift_expression_test_06() {
     let (se, scanner) = check(ShiftExpression::parse(&mut newparser("a >>> @"), Scanner::new(), false, false));
     chk_scan(&scanner, 1);
     assert!(matches!(&*se, ShiftExpression::AdditiveExpression(_)));
-    assert_eq!(se.is_function_definition(), false);
 }
 #[test]
 fn shift_expression_test_prettyerrors_1() {
@@ -234,12 +229,12 @@ mod shift_expression {
         Maker::new(src).shift_expression().assignment_target_type(strict)
     }
 
-    #[test_case("a<<b" => false; "expr")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).shift_expression().is_named_function()
-    }
+    //#[test_case("a<<b" => false; "expr")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).shift_expression().is_named_function()
+    //}
 
     #[test_case("  a<<b" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 4 }}; "shl")]
     #[test_case("  a>>b" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 4 }}; "sshr")]

--- a/src/parser/break_statement/tests.rs
+++ b/src/parser/break_statement/tests.rs
@@ -93,16 +93,6 @@ fn break_statement_test_contains_undefined_break_target_02() {
     assert_eq!(item.contains_undefined_break_target(&[]), false);
     assert_eq!(item.contains_undefined_break_target(&[JSString::from("label")]), false);
 }
-#[test]
-fn break_statement_test_contains_01() {
-    let (item, _) = BreakStatement::parse(&mut newparser("break label;"), Scanner::new(), true, true).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
-}
-#[test]
-fn break_statement_test_contains_02() {
-    let (item, _) = BreakStatement::parse(&mut newparser("break;"), Scanner::new(), true, true).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
-}
 mod break_statement {
     use super::*;
     use test_case::test_case;

--- a/src/parser/class_definitions/tests.rs
+++ b/src/parser/class_definitions/tests.rs
@@ -160,11 +160,6 @@ mod class_declaration {
     fn bound_name(src: &str) -> String {
         Maker::new(src).class_declaration().bound_name().into()
     }
-
-    #[test_case("class x {}" => false; "typical")]
-    fn is_constant_declaration(src: &str) -> bool {
-        Maker::new(src).class_declaration().is_constant_declaration()
-    }
 }
 
 // CLASS EXPRESSION
@@ -175,7 +170,6 @@ fn class_expression_test_01() {
     pretty_check(&*node, "ClassExpression: class a { }", &["BindingIdentifier: a", "ClassTail: { }"]);
     concise_check(&*node, "ClassExpression: class a { }", &["Keyword: class", "IdentifierName: a", "ClassTail: { }"]);
     assert_ne!(format!("{node:?}"), "");
-    assert!(node.is_function_definition());
 }
 #[test]
 fn class_expression_test_02() {
@@ -184,7 +178,6 @@ fn class_expression_test_02() {
     pretty_check(&*node, "ClassExpression: class { }", &["ClassTail: { }"]);
     concise_check(&*node, "ClassExpression: class { }", &["Keyword: class", "ClassTail: { }"]);
     assert_ne!(format!("{node:?}"), "");
-    assert!(node.is_function_definition());
 }
 #[test]
 fn class_expression_test_err_01() {
@@ -1506,11 +1499,6 @@ mod class_static_block {
     #[test_case("static {", "‘}’ expected", 9; "Missing Trailing Brace")]
     fn err(src: &str, expected_error: &str, err_column: u32) {
         check_err(ClassStaticBlock::parse(&mut newparser(src), Scanner::new()), expected_error, 1, err_column);
-    }
-    #[test]
-    fn contains() {
-        let (node, _) = check(ClassStaticBlock::parse(&mut newparser("static { 0; }"), Scanner::new()));
-        assert_eq!(node.contains(), false);
     }
     #[test]
     fn prettyerrors() {

--- a/src/parser/comma_operator/tests.rs
+++ b/src/parser/comma_operator/tests.rs
@@ -1,4 +1,3 @@
-#![expect(clippy::bool_assert_comparison)]
 use super::testhelp::*;
 use super::*;
 use crate::prettyprint::pp_testhelp::*;
@@ -15,7 +14,6 @@ fn expression_test_01() {
     pretty_check(&*se, "Expression: a", &["AssignmentExpression: a"]);
     concise_check(&*se, "IdentifierName: a", &[]);
     assert_ne!(format!("{se:?}"), "");
-    assert_eq!(se.is_function_definition(), false);
 }
 #[test]
 fn expression_test_02() {
@@ -25,7 +23,6 @@ fn expression_test_02() {
     pretty_check(&*se, "Expression: a , b", &["Expression: a", "AssignmentExpression: b"]);
     concise_check(&*se, "Expression: a , b", &["IdentifierName: a", "Punctuator: ,", "IdentifierName: b"]);
     assert_ne!(format!("{se:?}"), "");
-    assert_eq!(se.is_function_definition(), false);
 }
 #[test]
 fn expression_test_cache_01() {
@@ -127,12 +124,12 @@ mod expression {
         Maker::new(src).expression().contains(target)
     }
 
-    #[test_case("a,b" => false; "comma")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).expression().is_named_function()
-    }
+    //#[test_case("a,b" => false; "comma")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).expression().is_named_function()
+    //}
 
     #[test_case("  a,b" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "comma")]
     #[test_case("  998" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "literal")]

--- a/src/parser/conditional_operator/tests.rs
+++ b/src/parser/conditional_operator/tests.rs
@@ -15,7 +15,6 @@ fn conditional_expression_test_01() {
     pretty_check(&*se, "ConditionalExpression: a", &["ShortCircuitExpression: a"]);
     concise_check(&*se, "IdentifierName: a", &[]);
     assert_ne!(format!("{se:?}"), "");
-    assert_eq!(se.is_function_definition(), false);
 }
 #[test]
 fn conditional_expression_test_02() {
@@ -34,7 +33,6 @@ fn conditional_expression_test_02() {
         &["IdentifierName: a", "Punctuator: ?", "IdentifierName: b", "Punctuator: :", "IdentifierName: c"],
     );
     assert_ne!(format!("{se:?}"), "");
-    assert_eq!(se.is_function_definition(), false);
 }
 #[test]
 fn conditional_expression_test_03() {
@@ -170,12 +168,12 @@ mod conditional_expression {
         Maker::new(src).conditional_expression().assignment_target_type(strict)
     }
 
-    #[test_case("a?b:c" => false; "conditional")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).conditional_expression().is_named_function()
-    }
+    //#[test_case("a?b:c" => false; "conditional")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).conditional_expression().is_named_function()
+    //}
 
     #[test_case("  a?b:c" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 5 }}; "conditional")]
     #[test_case("  998" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "literal")]

--- a/src/parser/continue_statement/tests.rs
+++ b/src/parser/continue_statement/tests.rs
@@ -1,4 +1,3 @@
-#![expect(clippy::bool_assert_comparison)]
 use super::testhelp::*;
 use super::*;
 use crate::prettyprint::pp_testhelp::*;
@@ -98,16 +97,6 @@ fn continue_statement_test_conciseerrors_1() {
 fn continue_statement_test_conciseerrors_2() {
     let (item, _) = ContinueStatement::parse(&mut newparser("continue label;"), Scanner::new(), false, false).unwrap();
     concise_error_validate(&*item);
-}
-#[test]
-fn continue_statement_test_contains_01() {
-    let (item, _) = ContinueStatement::parse(&mut newparser("continue label;"), Scanner::new(), true, true).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
-}
-#[test]
-fn continue_statement_test_contains_02() {
-    let (item, _) = ContinueStatement::parse(&mut newparser("continue;"), Scanner::new(), true, true).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
 }
 #[test_case("continue x;" => (false, true); "continue x;")]
 #[test_case("continue;" => (false, false); "continue;")]

--- a/src/parser/debugger_statement/mod.rs
+++ b/src/parser/debugger_statement/mod.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 // DebuggerStatement :
 //      debugger ;
 #[derive(Debug)]
-pub struct DebuggerStatement {
+pub(crate) struct DebuggerStatement {
     location: Location,
 }
 
@@ -38,24 +38,15 @@ impl PrettyPrint for DebuggerStatement {
 
 impl DebuggerStatement {
     // no need to cache
-    pub fn parse(parser: &mut Parser, scanner: Scanner) -> ParseResult<Self> {
+    pub(crate) fn parse(parser: &mut Parser, scanner: Scanner) -> ParseResult<Self> {
         let (deb_loc, after_deb) =
-            scan_for_keyword(scanner, parser.source, ScanGoal::InputElementRegExp, Keyword::Debugger)?;
-        let (semi_loc, after_semi) = scan_for_auto_semi(after_deb, parser.source, ScanGoal::InputElementDiv)?;
+            scan_for_keyword(scanner, parser.source, InputElementGoal::RegExp, Keyword::Debugger)?;
+        let (semi_loc, after_semi) = scan_for_auto_semi(after_deb, parser.source, InputElementGoal::Div)?;
         Ok((Rc::new(DebuggerStatement { location: deb_loc.merge(&semi_loc) }), after_semi))
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         self.location
-    }
-
-    pub fn contains(&self, _kind: ParseNodeKind) -> bool {
-        false
-    }
-
-    pub fn body_containing_location(&self, _: &Location) -> Option<ContainingBody> {
-        // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
-        None
     }
 }
 

--- a/src/parser/debugger_statement/tests.rs
+++ b/src/parser/debugger_statement/tests.rs
@@ -1,4 +1,3 @@
-#![expect(clippy::bool_assert_comparison)]
 use super::testhelp::*;
 use super::*;
 use crate::prettyprint::pp_testhelp::*;
@@ -41,11 +40,6 @@ mod debugger_statement {
     fn conciseerrors_1() {
         let (item, _) = DebuggerStatement::parse(&mut newparser("debugger;"), Scanner::new()).unwrap();
         concise_error_validate(&*item);
-    }
-    #[test]
-    fn contains_01() {
-        let (item, _) = DebuggerStatement::parse(&mut newparser("debugger;"), Scanner::new()).unwrap();
-        assert_eq!(item.contains(ParseNodeKind::Literal), false);
     }
 
     #[test_case("   debugger;" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 9 } }; "typical")]

--- a/src/parser/declarations_and_variables/tests.rs
+++ b/src/parser/declarations_and_variables/tests.rs
@@ -167,12 +167,6 @@ mod let_or_const {
     use super::*;
     use test_case::test_case;
 
-    #[test]
-    fn contains() {
-        let item = LetOrConst::Let;
-        assert_eq!(item.contains(ParseNodeKind::Literal), false);
-    }
-
     #[test_case(LetOrConst::Let => false; "kwd let")]
     #[test_case(LetOrConst::Const => true; "kwd const")]
     fn is_constant_declaration(which: LetOrConst) -> bool {
@@ -398,7 +392,6 @@ mod lexical_binding {
 
     #[test_case("a=1", ParseNodeKind::Literal => true; "binding with literal initializer contains literal")]
     #[test_case("a", ParseNodeKind::Literal => false; "binding with no init does not contain literal")]
-    #[test_case("a", ParseNodeKind::IdentifierName => true; "binding contains identifier")]
     #[test_case("a=b", ParseNodeKind::Literal => false; "binding with izer containing no literals")]
     #[test_case("[a=0]=[z]", ParseNodeKind::Literal => true; "complex pattern binding with literal")]
     #[test_case("[a]=[0]", ParseNodeKind::Literal => true; "pattern binding with literal initializer")]
@@ -1487,11 +1480,6 @@ fn binding_rest_property_test_bound_names_01() {
     let (item, _) = BindingRestProperty::parse(&mut newparser("...a"), Scanner::new(), true, true).unwrap();
     assert_eq!(item.bound_names(), &["a"]);
 }
-#[test]
-fn binding_rest_property_test_contains_01() {
-    let (item, _) = BindingRestProperty::parse(&mut newparser("...a"), Scanner::new(), true, true).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
-}
 mod binding_rest_property {
     use super::*;
     use test_case::test_case;
@@ -2239,7 +2227,6 @@ mod single_name_binding {
     }
 
     #[test_case("a", ParseNodeKind::Literal => false; "name doesn't have literal")]
-    #[test_case("a", ParseNodeKind::IdentifierName => true; "name has name")]
     #[test_case("a=0", ParseNodeKind::Literal => true; "name has literal initializer")]
     #[test_case("a=x", ParseNodeKind::Literal => false; "name doesn't have literal initializer")]
     fn contains(src: &str, kind: ParseNodeKind) -> bool {

--- a/src/parser/empty_statement/mod.rs
+++ b/src/parser/empty_statement/mod.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 // EmptyStatement :
 //      ;
 #[derive(Debug)]
-pub struct EmptyStatement {
+pub(crate) struct EmptyStatement {
     location: Location,
 }
 
@@ -34,23 +34,14 @@ impl PrettyPrint for EmptyStatement {
 }
 
 impl EmptyStatement {
-    pub fn parse(parser: &mut Parser, scanner: Scanner) -> ParseResult<Self> {
+    pub(crate) fn parse(parser: &mut Parser, scanner: Scanner) -> ParseResult<Self> {
         let (semi_loc, after_semi) =
-            scan_for_punct(scanner, parser.source, ScanGoal::InputElementRegExp, Punctuator::Semicolon)?;
+            scan_for_punct(scanner, parser.source, InputElementGoal::RegExp, Punctuator::Semicolon)?;
         Ok((Rc::new(EmptyStatement { location: semi_loc }), after_semi))
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         self.location
-    }
-
-    pub fn contains(&self, _kind: ParseNodeKind) -> bool {
-        false
-    }
-
-    pub fn body_containing_location(&self, _: &Location) -> Option<ContainingBody> {
-        // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
-        None
     }
 }
 

--- a/src/parser/empty_statement/tests.rs
+++ b/src/parser/empty_statement/tests.rs
@@ -1,4 +1,3 @@
-#![expect(clippy::bool_assert_comparison)]
 use super::testhelp::*;
 use super::*;
 use crate::prettyprint::pp_testhelp::*;
@@ -29,11 +28,6 @@ mod empty_statement {
     fn conciseerrors_1() {
         let (item, _) = EmptyStatement::parse(&mut newparser(";"), Scanner::new()).unwrap();
         concise_error_validate(&*item);
-    }
-    #[test]
-    fn contains_01() {
-        let (item, _) = EmptyStatement::parse(&mut newparser(";"), Scanner::new()).unwrap();
-        assert_eq!(item.contains(ParseNodeKind::Literal), false);
     }
 
     #[test_case("   ;" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 1 } }; "typical")]

--- a/src/parser/equality_operators/mod.rs
+++ b/src/parser/equality_operators/mod.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 //      EqualityExpression[?In, ?Yield, ?Await] === RelationalExpression[?In, ?Yield, ?Await]
 //      EqualityExpression[?In, ?Yield, ?Await] !== RelationalExpression[?In, ?Yield, ?Await]
 #[derive(Debug)]
-pub enum EqualityExpression {
+pub(crate) enum EqualityExpression {
     RelationalExpression(Rc<RelationalExpression>),
     Equal(Rc<EqualityExpression>, Rc<RelationalExpression>),
     NotEqual(Rc<EqualityExpression>, Rc<RelationalExpression>),
@@ -73,17 +73,8 @@ impl PrettyPrint for EqualityExpression {
     }
 }
 
-impl IsFunctionDefinition for EqualityExpression {
-    fn is_function_definition(&self) -> bool {
-        match self {
-            EqualityExpression::RelationalExpression(re) => re.is_function_definition(),
-            _ => false,
-        }
-    }
-}
-
 impl EqualityExpression {
-    pub fn parse(
+    pub(crate) fn parse(
         parser: &mut Parser,
         scanner: Scanner,
         in_flag: bool,
@@ -94,7 +85,7 @@ impl EqualityExpression {
         let mut current = Rc::new(EqualityExpression::RelationalExpression(re1));
         let mut current_scanner = after_re1;
         loop {
-            let (op_token, _, after_op) = scan_token(&current_scanner, parser.source, ScanGoal::InputElementDiv);
+            let (op_token, _, after_op) = scan_token(&current_scanner, parser.source, InputElementGoal::Div);
             let make_ee = match op_token {
                 Token::Punctuator(Punctuator::EqEq) => EqualityExpression::Equal,
                 Token::Punctuator(Punctuator::BangEq) => EqualityExpression::NotEqual,
@@ -118,7 +109,7 @@ impl EqualityExpression {
         Ok((current, current_scanner))
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         match self {
             EqualityExpression::RelationalExpression(exp) => exp.location(),
             EqualityExpression::Equal(left, right)
@@ -128,7 +119,7 @@ impl EqualityExpression {
         }
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         match self {
             EqualityExpression::RelationalExpression(n) => n.contains(kind),
             EqualityExpression::Equal(l, r)
@@ -138,14 +129,14 @@ impl EqualityExpression {
         }
     }
 
-    pub fn as_string_literal(&self) -> Option<StringToken> {
+    pub(crate) fn as_string_literal(&self) -> Option<StringToken> {
         match self {
             EqualityExpression::RelationalExpression(n) => n.as_string_literal(),
             _ => None,
         }
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -167,7 +158,7 @@ impl EqualityExpression {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -183,7 +174,7 @@ impl EqualityExpression {
         }
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
             EqualityExpression::RelationalExpression(n) => n.early_errors(errs, strict),
             EqualityExpression::Equal(l, r)
@@ -196,7 +187,7 @@ impl EqualityExpression {
         }
     }
 
-    pub fn is_strictly_deletable(&self) -> bool {
+    pub(crate) fn is_strictly_deletable(&self) -> bool {
         match self {
             EqualityExpression::RelationalExpression(node) => node.is_strictly_deletable(),
             _ => true,
@@ -206,21 +197,21 @@ impl EqualityExpression {
     /// Whether an expression can be assigned to. `Simple` or `Invalid`.
     ///
     /// See [AssignmentTargetType](https://tc39.es/ecma262/#sec-static-semantics-assignmenttargettype) from ECMA-262.
-    pub fn assignment_target_type(&self, strict: bool) -> ATTKind {
+    pub(crate) fn assignment_target_type(&self, strict: bool) -> ATTKind {
         match self {
             EqualityExpression::RelationalExpression(re) => re.assignment_target_type(strict),
             _ => ATTKind::Invalid,
         }
     }
 
-    pub fn is_named_function(&self) -> bool {
-        match self {
-            EqualityExpression::RelationalExpression(node) => node.is_named_function(),
-            _ => false,
-        }
-    }
+    //pub(crate) fn is_named_function(&self) -> bool {
+    //    match self {
+    //        EqualityExpression::RelationalExpression(node) => node.is_named_function(),
+    //        _ => false,
+    //    }
+    //}
 
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         if self.location().contains(location) {
             match self {
@@ -237,7 +228,7 @@ impl EqualityExpression {
         }
     }
 
-    pub fn has_call_in_tail_position(&self, location: &Location) -> bool {
+    pub(crate) fn has_call_in_tail_position(&self, location: &Location) -> bool {
         // Static Semantics: HasCallInTailPosition
         // The syntax-directed operation HasCallInTailPosition takes argument call (a CallExpression Parse Node, a
         // MemberExpression Parse Node, or an OptionalChain Parse Node) and returns a Boolean.

--- a/src/parser/equality_operators/tests.rs
+++ b/src/parser/equality_operators/tests.rs
@@ -18,7 +18,6 @@ mod equality_expression {
         pretty_check(&*se, "EqualityExpression: a", &["RelationalExpression: a"]);
         concise_check(&*se, "IdentifierName: a", &[]);
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_02() {
@@ -33,7 +32,6 @@ mod equality_expression {
             &["IdentifierName: a", "Punctuator: ==", "IdentifierName: b"],
         );
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_03() {
@@ -48,7 +46,6 @@ mod equality_expression {
             &["IdentifierName: a", "Punctuator: !=", "IdentifierName: b"],
         );
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_04() {
@@ -63,7 +60,6 @@ mod equality_expression {
             &["IdentifierName: a", "Punctuator: ===", "IdentifierName: b"],
         );
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_05() {
@@ -78,7 +74,6 @@ mod equality_expression {
             &["IdentifierName: a", "Punctuator: !==", "IdentifierName: b"],
         );
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_06() {
@@ -98,7 +93,6 @@ mod equality_expression {
         pretty_check(&*se, "EqualityExpression: a", &["RelationalExpression: a"]);
         concise_check(&*se, "IdentifierName: a", &[]);
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn prettyerrors_1() {
@@ -308,12 +302,12 @@ mod equality_expression {
         Maker::new(src).equality_expression().assignment_target_type(strict)
     }
 
-    #[test_case("a==b" => false; "expr")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).equality_expression().is_named_function()
-    }
+    //#[test_case("a==b" => false; "expr")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).equality_expression().is_named_function()
+    //}
 
     #[test_case("  a==b" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 4 }}; "eq")]
     #[test_case("  a===b" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 5 }}; "seq")]

--- a/src/parser/exponentiation_operator/tests.rs
+++ b/src/parser/exponentiation_operator/tests.rs
@@ -18,7 +18,6 @@ mod exponentiation_expression {
         pretty_check(&*se, "ExponentiationExpression: a", &["UnaryExpression: a"]);
         concise_check(&*se, "IdentifierName: a", &[]);
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_02() {
@@ -33,7 +32,6 @@ mod exponentiation_expression {
             &["IdentifierName: a", "Punctuator: **", "IdentifierName: b"],
         );
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_03() {
@@ -53,7 +51,6 @@ mod exponentiation_expression {
         pretty_check(&*se, "ExponentiationExpression: a", &["UnaryExpression: a"]);
         concise_check(&*se, "IdentifierName: a", &[]);
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn prettyerrors_1() {
@@ -159,12 +156,12 @@ mod exponentiation_expression {
         Maker::new(src).exponentiation_expression().assignment_target_type(strict)
     }
 
-    #[test_case("a**b" => false; "expr")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).exponentiation_expression().is_named_function()
-    }
+    //#[test_case("a**b" => false; "expr")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).exponentiation_expression().is_named_function()
+    //}
 
     #[test_case("  a**b" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 4 }}; "power")]
     #[test_case("  998" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "literal")]

--- a/src/parser/expression_statement/mod.rs
+++ b/src/parser/expression_statement/mod.rs
@@ -6,8 +6,8 @@ use std::io::Write;
 // ExpressionStatement[Yield, Await] :
 //      [lookahead ∉ { {, function, async [no LineTerminator here] function, class, let [ }] Expression[+In, ?Yield, ?Await] ;
 #[derive(Debug)]
-pub struct ExpressionStatement {
-    pub exp: Rc<Expression>,
+pub(crate) struct ExpressionStatement {
+    pub(crate) exp: Rc<Expression>,
     location: Location,
 }
 
@@ -38,19 +38,24 @@ impl PrettyPrint for ExpressionStatement {
 }
 
 impl ExpressionStatement {
-    pub fn parse(parser: &mut Parser, scanner: Scanner, yield_flag: bool, await_flag: bool) -> ParseResult<Self> {
-        let (first_token, _, after_token) = scan_token(&scanner, parser.source, ScanGoal::InputElementRegExp);
+    pub(crate) fn parse(
+        parser: &mut Parser,
+        scanner: Scanner,
+        yield_flag: bool,
+        await_flag: bool,
+    ) -> ParseResult<Self> {
+        let (first_token, _, after_token) = scan_token(&scanner, parser.source, InputElementGoal::RegExp);
         let invalid = match first_token {
             Token::Punctuator(Punctuator::LeftBrace) => true,
             Token::Identifier(id) if id.matches(Keyword::Function) => true,
             Token::Identifier(id) if id.matches(Keyword::Class) => true,
             Token::Identifier(id) if id.matches(Keyword::Let) => {
-                let (second_token, _, _) = scan_token(&after_token, parser.source, ScanGoal::InputElementRegExp);
+                let (second_token, _, _) = scan_token(&after_token, parser.source, InputElementGoal::RegExp);
                 second_token.matches_punct(Punctuator::LeftBracket)
             }
             Token::Identifier(id) if id.matches(Keyword::Async) => {
                 if no_line_terminator(after_token, parser.source).is_ok() {
-                    let (second_token, _, _) = scan_token(&after_token, parser.source, ScanGoal::InputElementRegExp);
+                    let (second_token, _, _) = scan_token(&after_token, parser.source, InputElementGoal::RegExp);
                     matches!(second_token, Token::Identifier(xx) if xx.matches(Keyword::Function))
                 } else {
                     false
@@ -63,25 +68,25 @@ impl ExpressionStatement {
             Err(ParseError::new(PECode::ParseNodeExpected(ParseNodeKind::ExpressionStatement), scanner))
         } else {
             let (exp, after_exp) = Expression::parse(parser, scanner, true, yield_flag, await_flag)?;
-            let (semi_loc, after_semi) = scan_for_auto_semi(after_exp, parser.source, ScanGoal::InputElementRegExp)?;
+            let (semi_loc, after_semi) = scan_for_auto_semi(after_exp, parser.source, InputElementGoal::RegExp)?;
             let location = exp.location().merge(&semi_loc);
             Ok((Rc::new(ExpressionStatement { exp, location }), after_semi))
         }
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         self.location
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         kind == ParseNodeKind::Expression || self.exp.contains(kind)
     }
 
-    pub fn as_string_literal(&self) -> Option<StringToken> {
+    pub(crate) fn as_string_literal(&self) -> Option<StringToken> {
         self.exp.as_string_literal()
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -95,7 +100,7 @@ impl ExpressionStatement {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -105,11 +110,11 @@ impl ExpressionStatement {
         self.exp.contains_arguments()
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         self.exp.early_errors(errs, strict);
     }
 
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         if self.location().contains(location) { self.exp.body_containing_location(location) } else { None }
     }

--- a/src/parser/generator_function_definitions/tests.rs
+++ b/src/parser/generator_function_definitions/tests.rs
@@ -369,13 +369,6 @@ fn generator_declaration_test_bound_names_02() {
         GeneratorDeclaration::parse(&mut newparser("function * () {}"), Scanner::new(), true, true, true).unwrap();
     assert_eq!(item.bound_names(), &["*default*"]);
 }
-#[test]
-fn generator_declaration_test_contains_01() {
-    let (item, _) =
-        GeneratorDeclaration::parse(&mut newparser("function * a(x=0) {0;}"), Scanner::new(), true, true, true)
-            .unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
-}
 #[test_case("function *a(b=c.#valid){}" => true; "params valid")]
 #[test_case("function *a(){b.#valid;}" => true; "body valid")]
 #[test_case("function *a(b=c.#invalid){}" => false; "params invalid")]
@@ -430,11 +423,6 @@ mod generator_declaration {
     fn bound_name(src: &str) -> String {
         Maker::new(src).generator_declaration().bound_name().into()
     }
-
-    #[test_case("function *x() {}" => false; "typical")]
-    fn is_constant_declaration(src: &str) -> bool {
-        Maker::new(src).generator_declaration().is_constant_declaration()
-    }
 }
 
 // GENERATOR EXPRESSION
@@ -461,7 +449,6 @@ fn generator_expression_test_01() {
         ],
     );
     assert_ne!(format!("{node:?}"), "");
-    assert!(node.is_function_definition());
 }
 #[test]
 fn generator_expression_test_02() {
@@ -474,7 +461,6 @@ fn generator_expression_test_02() {
         &["Keyword: function", "Punctuator: *", "Punctuator: (", "Punctuator: )", "Punctuator: {", "Punctuator: }"],
     );
     assert_ne!(format!("{node:?}"), "");
-    assert!(node.is_function_definition());
 }
 #[test]
 fn generator_expression_test_03() {
@@ -557,11 +543,6 @@ fn generator_expression_test_conciseerrors_2() {
     )
     .unwrap();
     concise_error_validate(&*item);
-}
-#[test]
-fn generator_expression_test_contains_01() {
-    let (item, _) = GeneratorExpression::parse(&mut newparser("function * a(x=0) {0;}"), Scanner::new()).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
 }
 #[test_case("function *a(b=c.#valid){}" => true; "params valid")]
 #[test_case("function *a(){b.#valid;}" => true; "body valid")]

--- a/src/parser/identifiers/tests.rs
+++ b/src/parser/identifiers/tests.rs
@@ -1,4 +1,3 @@
-#![expect(clippy::bool_assert_comparison)]
 use super::testhelp::*;
 use super::*;
 use crate::prettyprint::pp_testhelp::*;
@@ -395,7 +394,6 @@ fn identifier_reference_test_simple_success() {
     let idref = idref_create("identifier");
     assert!(matches!(*idref, IdentifierReference::Identifier { .. }));
     assert_eq!(idref.string_value(), "identifier");
-    assert_eq!(idref.contains(ParseNodeKind::Super), false);
     pretty_check(&*idref, "IdentifierReference: identifier", &["Identifier: identifier"]);
     concise_check(&*idref, "IdentifierName: identifier", &[]);
 }
@@ -404,7 +402,6 @@ fn identifier_reference_test_yield() {
     let idref = idref_create("yield");
     assert!(matches!(*idref, IdentifierReference::Yield { .. }));
     assert_eq!(idref.string_value(), "yield");
-    assert_eq!(idref.contains(ParseNodeKind::Super), false);
     pretty_check(&*idref, "IdentifierReference: yield", &[]);
     concise_check(&*idref, "Keyword: yield", &[]);
 }
@@ -418,7 +415,6 @@ fn identifier_reference_test_await() {
     let idref = idref_create("await");
     assert!(matches!(*idref, IdentifierReference::Await { .. }));
     assert_eq!(idref.string_value(), "await");
-    assert_eq!(idref.contains(ParseNodeKind::Super), false);
     pretty_check(&*idref, "IdentifierReference: await", &[]);
     concise_check(&*idref, "Keyword: await", &[]);
 }
@@ -623,7 +619,6 @@ fn bid_allflags(text: &str) {
             };
             assert!((yield_flag && yflag) || (!yield_flag && !yflag));
             assert!((await_flag && aflag) || (!await_flag && !aflag));
-            assert_eq!(bid.contains(ParseNodeKind::Super), false);
         }
     }
 }
@@ -886,7 +881,6 @@ fn label_identifier_test_normal_noyield_noawait() {
     chk_scan(&scanner, 2);
     assert!(matches!(*lid, LabelIdentifier::Identifier { .. }));
     assert_eq!(lid.string_value(), "id");
-    assert_eq!(lid.contains(ParseNodeKind::Super), false);
     pretty_check(&*lid, "LabelIdentifier: id", &["Identifier: id"]);
     concise_check(&*lid, "IdentifierName: id", &[]);
     assert_ne!(format!("{lid:?}"), "");
@@ -897,7 +891,6 @@ fn label_identifier_test_normal_yield_noawait() {
     chk_scan(&scanner, 2);
     assert!(matches!(*lid, LabelIdentifier::Identifier { .. }));
     assert_eq!(lid.string_value(), "id");
-    assert_eq!(lid.contains(ParseNodeKind::Super), false);
     pretty_check(&*lid, "LabelIdentifier: id", &["Identifier: id"]);
     concise_check(&*lid, "IdentifierName: id", &[]);
     assert_ne!(format!("{lid:?}"), "");
@@ -908,7 +901,6 @@ fn label_identifier_test_normal_noyield_await() {
     chk_scan(&scanner, 2);
     assert!(matches!(*lid, LabelIdentifier::Identifier { .. }));
     assert_eq!(lid.string_value(), "id");
-    assert_eq!(lid.contains(ParseNodeKind::Super), false);
     pretty_check(&*lid, "LabelIdentifier: id", &["Identifier: id"]);
     concise_check(&*lid, "IdentifierName: id", &[]);
     assert_ne!(format!("{lid:?}"), "");
@@ -919,7 +911,6 @@ fn label_identifier_test_normal_yield_await() {
     chk_scan(&scanner, 2);
     assert!(matches!(*lid, LabelIdentifier::Identifier { .. }));
     assert_eq!(lid.string_value(), "id");
-    assert_eq!(lid.contains(ParseNodeKind::Super), false);
     pretty_check(&*lid, "LabelIdentifier: id", &["Identifier: id"]);
     concise_check(&*lid, "IdentifierName: id", &[]);
     assert_ne!(format!("{lid:?}"), "");
@@ -930,7 +921,6 @@ fn label_identifier_test_yield_noyield_noawait() {
     chk_scan(&scanner, 5);
     assert!(matches!(*lid, LabelIdentifier::Yield { .. }));
     assert_eq!(lid.string_value(), "yield");
-    assert_eq!(lid.contains(ParseNodeKind::Super), false);
     pretty_check(&*lid, "LabelIdentifier: yield", &[]);
     concise_check(&*lid, "Keyword: yield", &[]);
     assert_ne!(format!("{lid:?}"), "");
@@ -949,7 +939,6 @@ fn label_identifier_test_yield_noyield_await() {
     chk_scan(&scanner, 5);
     assert!(matches!(*lid, LabelIdentifier::Yield { .. }));
     assert_eq!(lid.string_value(), "yield");
-    assert_eq!(lid.contains(ParseNodeKind::Super), false);
     pretty_check(&*lid, "LabelIdentifier: yield", &[]);
     concise_check(&*lid, "Keyword: yield", &[]);
     assert_ne!(format!("{lid:?}"), "");
@@ -968,7 +957,6 @@ fn label_identifier_test_await_noyield_noawait() {
     chk_scan(&scanner, 5);
     assert!(matches!(*lid, LabelIdentifier::Await { .. }));
     assert_eq!(lid.string_value(), "await");
-    assert_eq!(lid.contains(ParseNodeKind::Super), false);
     pretty_check(&*lid, "LabelIdentifier: await", &[]);
     concise_check(&*lid, "Keyword: await", &[]);
     assert_ne!(format!("{lid:?}"), "");
@@ -979,7 +967,6 @@ fn label_identifier_test_await_yield_noawait() {
     chk_scan(&scanner, 5);
     assert!(matches!(*lid, LabelIdentifier::Await { .. }));
     assert_eq!(lid.string_value(), "await");
-    assert_eq!(lid.contains(ParseNodeKind::Super), false);
     pretty_check(&*lid, "LabelIdentifier: await", &[]);
     concise_check(&*lid, "Keyword: await", &[]);
     assert_ne!(format!("{lid:?}"), "");

--- a/src/parser/iteration_statements/mod.rs
+++ b/src/parser/iteration_statements/mod.rs
@@ -9,7 +9,7 @@ use std::io::Write;
 //      ForStatement[?Yield, ?Await, ?Return]
 //      ForInOfStatement[?Yield, ?Await, ?Return]
 #[derive(Debug)]
-pub enum IterationStatement {
+pub(crate) enum IterationStatement {
     DoWhile(Rc<DoWhileStatement>),
     While(Rc<WhileStatement>),
     For(Rc<ForStatement>),
@@ -56,7 +56,7 @@ impl PrettyPrint for IterationStatement {
 }
 
 impl IterationStatement {
-    pub fn parse(
+    pub(crate) fn parse(
         parser: &mut Parser,
         scanner: Scanner,
         yield_flag: bool,
@@ -84,7 +84,7 @@ impl IterationStatement {
             })
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         match self {
             IterationStatement::DoWhile(node) => node.location(),
             IterationStatement::While(node) => node.location(),
@@ -93,7 +93,7 @@ impl IterationStatement {
         }
     }
 
-    pub fn var_declared_names(&self) -> Vec<JSString> {
+    pub(crate) fn var_declared_names(&self) -> Vec<JSString> {
         match self {
             IterationStatement::DoWhile(node) => node.var_declared_names(),
             IterationStatement::While(node) => node.var_declared_names(),
@@ -102,7 +102,7 @@ impl IterationStatement {
         }
     }
 
-    pub fn contains_undefined_break_target(&self, label_set: &[JSString]) -> bool {
+    pub(crate) fn contains_undefined_break_target(&self, label_set: &[JSString]) -> bool {
         match self {
             IterationStatement::DoWhile(node) => node.contains_undefined_break_target(label_set),
             IterationStatement::While(node) => node.contains_undefined_break_target(label_set),
@@ -111,7 +111,7 @@ impl IterationStatement {
         }
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         match self {
             IterationStatement::DoWhile(node) => node.contains(kind),
             IterationStatement::While(node) => node.contains(kind),
@@ -120,7 +120,7 @@ impl IterationStatement {
         }
     }
 
-    pub fn contains_duplicate_labels(&self, label_set: &[JSString]) -> bool {
+    pub(crate) fn contains_duplicate_labels(&self, label_set: &[JSString]) -> bool {
         match self {
             IterationStatement::DoWhile(node) => node.contains_duplicate_labels(label_set),
             IterationStatement::While(node) => node.contains_duplicate_labels(label_set),
@@ -129,7 +129,7 @@ impl IterationStatement {
         }
     }
 
-    pub fn contains_undefined_continue_target(&self, iteration_set: &[JSString]) -> bool {
+    pub(crate) fn contains_undefined_continue_target(&self, iteration_set: &[JSString]) -> bool {
         match self {
             IterationStatement::DoWhile(node) => node.contains_undefined_continue_target(iteration_set),
             IterationStatement::While(node) => node.contains_undefined_continue_target(iteration_set),
@@ -138,7 +138,7 @@ impl IterationStatement {
         }
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -157,7 +157,7 @@ impl IterationStatement {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -172,7 +172,7 @@ impl IterationStatement {
         }
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
         match self {
             IterationStatement::DoWhile(node) => node.early_errors(errs, strict, within_switch),
             IterationStatement::While(node) => node.early_errors(errs, strict, within_switch),
@@ -184,7 +184,7 @@ impl IterationStatement {
     /// Return a list of parse nodes for the var-style declarations contained within the children of this node.
     ///
     /// See [VarScopedDeclarations](https://tc39.es/ecma262/#sec-static-semantics-varscopeddeclarations) in ECMA-262.
-    pub fn var_scoped_declarations(&self) -> Vec<VarScopeDecl> {
+    pub(crate) fn var_scoped_declarations(&self) -> Vec<VarScopeDecl> {
         match self {
             IterationStatement::DoWhile(node) => node.var_scoped_declarations(),
             IterationStatement::While(node) => node.var_scoped_declarations(),
@@ -193,7 +193,7 @@ impl IterationStatement {
         }
     }
 
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         if self.location().contains(location) {
             match self {
@@ -211,7 +211,7 @@ impl IterationStatement {
         }
     }
 
-    pub fn has_call_in_tail_position(&self, location: &Location) -> bool {
+    pub(crate) fn has_call_in_tail_position(&self, location: &Location) -> bool {
         // Static Semantics: HasCallInTailPosition
         // The syntax-directed operation HasCallInTailPosition takes argument call (a CallExpression Parse Node, a
         // MemberExpression Parse Node, or an OptionalChain Parse Node) and returns a Boolean.
@@ -235,9 +235,9 @@ impl IterationStatement {
 // DoWhileStatement[Yield, Await, Return] :
 //      do Statement[?Yield, ?Await, ?Return] while ( Expression[+In, ?Yield, ?Await] ) ;
 #[derive(Debug)]
-pub struct DoWhileStatement {
-    pub stmt: Rc<Statement>,
-    pub exp: Rc<Expression>,
+pub(crate) struct DoWhileStatement {
+    pub(crate) stmt: Rc<Statement>,
+    pub(crate) exp: Rc<Expression>,
     location: Location,
 }
 
@@ -274,54 +274,51 @@ impl PrettyPrint for DoWhileStatement {
 }
 
 impl DoWhileStatement {
-    pub fn parse(
+    pub(crate) fn parse(
         parser: &mut Parser,
         scanner: Scanner,
         yield_flag: bool,
         await_flag: bool,
         return_flag: bool,
     ) -> ParseResult<Self> {
-        let (do_loc, after_do) = scan_for_keyword(scanner, parser.source, ScanGoal::InputElementRegExp, Keyword::Do)?;
+        let (do_loc, after_do) = scan_for_keyword(scanner, parser.source, InputElementGoal::RegExp, Keyword::Do)?;
         let (stmt, after_stmt) = Statement::parse(parser, after_do, yield_flag, await_flag, return_flag)?;
-        let (_, after_while) =
-            scan_for_keyword(after_stmt, parser.source, ScanGoal::InputElementRegExp, Keyword::While)?;
-        let (_, after_open) =
-            scan_for_punct(after_while, parser.source, ScanGoal::InputElementDiv, Punctuator::LeftParen)?;
+        let (_, after_while) = scan_for_keyword(after_stmt, parser.source, InputElementGoal::RegExp, Keyword::While)?;
+        let (_, after_open) = scan_for_punct(after_while, parser.source, InputElementGoal::Div, Punctuator::LeftParen)?;
         let (exp, after_exp) = Expression::parse(parser, after_open, true, yield_flag, await_flag)?;
-        let (_, after_close) =
-            scan_for_punct(after_exp, parser.source, ScanGoal::InputElementDiv, Punctuator::RightParen)?;
+        let (_, after_close) = scan_for_punct(after_exp, parser.source, InputElementGoal::Div, Punctuator::RightParen)?;
         let (semi_loc, after_semi) =
-            scan_for_punct(after_close, parser.source, ScanGoal::InputElementRegExp, Punctuator::Semicolon)
+            scan_for_punct(after_close, parser.source, InputElementGoal::RegExp, Punctuator::Semicolon)
                 .unwrap_or((Location::from(after_close), after_close));
         let location = do_loc.merge(&semi_loc);
         Ok((Rc::new(DoWhileStatement { stmt, exp, location }), after_semi))
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         self.location
     }
 
-    pub fn var_declared_names(&self) -> Vec<JSString> {
+    pub(crate) fn var_declared_names(&self) -> Vec<JSString> {
         self.stmt.var_declared_names()
     }
 
-    pub fn contains_undefined_break_target(&self, label_set: &[JSString]) -> bool {
+    pub(crate) fn contains_undefined_break_target(&self, label_set: &[JSString]) -> bool {
         self.stmt.contains_undefined_break_target(label_set)
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         self.stmt.contains(kind) || self.exp.contains(kind)
     }
 
-    pub fn contains_duplicate_labels(&self, label_set: &[JSString]) -> bool {
+    pub(crate) fn contains_duplicate_labels(&self, label_set: &[JSString]) -> bool {
         self.stmt.contains_duplicate_labels(label_set)
     }
 
-    pub fn contains_undefined_continue_target(&self, iteration_set: &[JSString]) -> bool {
+    pub(crate) fn contains_undefined_continue_target(&self, iteration_set: &[JSString]) -> bool {
         self.stmt.contains_undefined_continue_target(iteration_set, &[])
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -335,7 +332,7 @@ impl DoWhileStatement {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -345,7 +342,7 @@ impl DoWhileStatement {
         self.stmt.contains_arguments() || self.exp.contains_arguments()
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
         self.stmt.early_errors(errs, strict, true, within_switch);
         self.exp.early_errors(errs, strict);
     }
@@ -353,11 +350,11 @@ impl DoWhileStatement {
     /// Return a list of parse nodes for the var-style declarations contained within the children of this node.
     ///
     /// See [VarScopedDeclarations](https://tc39.es/ecma262/#sec-static-semantics-varscopeddeclarations) in ECMA-262.
-    pub fn var_scoped_declarations(&self) -> Vec<VarScopeDecl> {
+    pub(crate) fn var_scoped_declarations(&self) -> Vec<VarScopeDecl> {
         self.stmt.var_scoped_declarations()
     }
 
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         if self.location().contains(location) {
             self.exp.body_containing_location(location).or_else(|| self.stmt.body_containing_location(location))
@@ -366,7 +363,7 @@ impl DoWhileStatement {
         }
     }
 
-    pub fn has_call_in_tail_position(&self, location: &Location) -> bool {
+    pub(crate) fn has_call_in_tail_position(&self, location: &Location) -> bool {
         // Static Semantics: HasCallInTailPosition
         // The syntax-directed operation HasCallInTailPosition takes argument call (a CallExpression Parse Node, a
         // MemberExpression Parse Node, or an OptionalChain Parse Node) and returns a Boolean.
@@ -385,9 +382,9 @@ impl DoWhileStatement {
 // WhileStatement[Yield, Await, Return] :
 //      while ( Expression[+In, ?Yield, ?Await] ) Statement[?Yield, ?Await, ?Return]
 #[derive(Debug)]
-pub struct WhileStatement {
-    pub exp: Rc<Expression>,
-    pub stmt: Rc<Statement>,
+pub(crate) struct WhileStatement {
+    pub(crate) exp: Rc<Expression>,
+    pub(crate) stmt: Rc<Statement>,
     location: Location,
 }
 
@@ -422,7 +419,7 @@ impl PrettyPrint for WhileStatement {
 }
 
 impl WhileStatement {
-    pub fn parse(
+    pub(crate) fn parse(
         parser: &mut Parser,
         scanner: Scanner,
         yield_flag: bool,
@@ -430,42 +427,40 @@ impl WhileStatement {
         return_flag: bool,
     ) -> ParseResult<Self> {
         let (while_loc, after_while) =
-            scan_for_keyword(scanner, parser.source, ScanGoal::InputElementRegExp, Keyword::While)?;
-        let (_, after_open) =
-            scan_for_punct(after_while, parser.source, ScanGoal::InputElementDiv, Punctuator::LeftParen)?;
+            scan_for_keyword(scanner, parser.source, InputElementGoal::RegExp, Keyword::While)?;
+        let (_, after_open) = scan_for_punct(after_while, parser.source, InputElementGoal::Div, Punctuator::LeftParen)?;
         let (exp, after_exp) = Expression::parse(parser, after_open, true, yield_flag, await_flag)?;
-        let (_, after_close) =
-            scan_for_punct(after_exp, parser.source, ScanGoal::InputElementDiv, Punctuator::RightParen)?;
+        let (_, after_close) = scan_for_punct(after_exp, parser.source, InputElementGoal::Div, Punctuator::RightParen)?;
         let (stmt, after_stmt) = Statement::parse(parser, after_close, yield_flag, await_flag, return_flag)?;
         let location = while_loc.merge(&stmt.location());
         Ok((Rc::new(WhileStatement { exp, stmt, location }), after_stmt))
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         self.location
     }
 
-    pub fn var_declared_names(&self) -> Vec<JSString> {
+    pub(crate) fn var_declared_names(&self) -> Vec<JSString> {
         self.stmt.var_declared_names()
     }
 
-    pub fn contains_undefined_break_target(&self, label_set: &[JSString]) -> bool {
+    pub(crate) fn contains_undefined_break_target(&self, label_set: &[JSString]) -> bool {
         self.stmt.contains_undefined_break_target(label_set)
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         self.exp.contains(kind) || self.stmt.contains(kind)
     }
 
-    pub fn contains_duplicate_labels(&self, label_set: &[JSString]) -> bool {
+    pub(crate) fn contains_duplicate_labels(&self, label_set: &[JSString]) -> bool {
         self.stmt.contains_duplicate_labels(label_set)
     }
 
-    pub fn contains_undefined_continue_target(&self, iteration_set: &[JSString]) -> bool {
+    pub(crate) fn contains_undefined_continue_target(&self, iteration_set: &[JSString]) -> bool {
         self.stmt.contains_undefined_continue_target(iteration_set, &[])
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -479,7 +474,7 @@ impl WhileStatement {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -489,7 +484,7 @@ impl WhileStatement {
         self.exp.contains_arguments() || self.stmt.contains_arguments()
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
         self.exp.early_errors(errs, strict);
         self.stmt.early_errors(errs, strict, true, within_switch);
     }
@@ -497,11 +492,11 @@ impl WhileStatement {
     /// Return a list of parse nodes for the var-style declarations contained within the children of this node.
     ///
     /// See [VarScopedDeclarations](https://tc39.es/ecma262/#sec-static-semantics-varscopeddeclarations) in ECMA-262.
-    pub fn var_scoped_declarations(&self) -> Vec<VarScopeDecl> {
+    pub(crate) fn var_scoped_declarations(&self) -> Vec<VarScopeDecl> {
         self.stmt.var_scoped_declarations()
     }
 
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         if self.location().contains(location) {
             self.exp.body_containing_location(location).or_else(|| self.stmt.body_containing_location(location))
@@ -510,7 +505,7 @@ impl WhileStatement {
         }
     }
 
-    pub fn has_call_in_tail_position(&self, location: &Location) -> bool {
+    pub(crate) fn has_call_in_tail_position(&self, location: &Location) -> bool {
         // Static Semantics: HasCallInTailPosition
         // The syntax-directed operation HasCallInTailPosition takes argument call (a CallExpression Parse Node, a
         // MemberExpression Parse Node, or an OptionalChain Parse Node) and returns a Boolean.
@@ -531,7 +526,7 @@ impl WhileStatement {
 //      for ( var VariableDeclarationList[~In, ?Yield, ?Await] ; Expression[+In, ?Yield, ?Await]opt ; Expression[+In, ?Yield, ?Await]opt ) Statement[?Yield, ?Await, ?Return]
 //      for ( LexicalDeclaration[~In, ?Yield, ?Await] Expression[+In, ?Yield, ?Await]opt ; Expression[+In, ?Yield, ?Await]opt ) Statement[?Yield, ?Await, ?Return]
 #[derive(Debug)]
-pub enum ForStatement {
+pub(crate) enum ForStatement {
     For(Option<Rc<Expression>>, Option<Rc<Expression>>, Option<Rc<Expression>>, Rc<Statement>, Location),
     ForVar(Rc<VariableDeclarationList>, Option<Rc<Expression>>, Option<Rc<Expression>>, Rc<Statement>, Location),
     ForLex(Rc<LexicalDeclaration>, Option<Rc<Expression>>, Option<Rc<Expression>>, Rc<Statement>, Location),
@@ -661,38 +656,36 @@ impl PrettyPrint for ForStatement {
 }
 
 impl ForStatement {
-    pub fn parse(
+    pub(crate) fn parse(
         parser: &mut Parser,
         scanner: Scanner,
         yield_flag: bool,
         await_flag: bool,
         return_flag: bool,
     ) -> ParseResult<Self> {
-        let (for_loc, after_for) =
-            scan_for_keyword(scanner, parser.source, ScanGoal::InputElementRegExp, Keyword::For)?;
-        let (_, after_open) =
-            scan_for_punct(after_for, parser.source, ScanGoal::InputElementDiv, Punctuator::LeftParen)?;
+        let (for_loc, after_for) = scan_for_keyword(scanner, parser.source, InputElementGoal::RegExp, Keyword::For)?;
+        let (_, after_open) = scan_for_punct(after_for, parser.source, InputElementGoal::Div, Punctuator::LeftParen)?;
         Err(ParseError::new(PECode::ForStatementDefinitionError, after_open))
             .otherwise(|| {
                 // for ( var VariableDeclarationList ; Expression ; Expression ) Statement
                 let (_, after_var) =
-                    scan_for_keyword(after_open, parser.source, ScanGoal::InputElementRegExp, Keyword::Var)?;
+                    scan_for_keyword(after_open, parser.source, InputElementGoal::RegExp, Keyword::Var)?;
                 let (vdl, after_vdl) =
                     VariableDeclarationList::parse(parser, after_var, false, yield_flag, await_flag)?;
                 let (_, after_init) =
-                    scan_for_punct(after_vdl, parser.source, ScanGoal::InputElementDiv, Punctuator::Semicolon)?;
+                    scan_for_punct(after_vdl, parser.source, InputElementGoal::Div, Punctuator::Semicolon)?;
                 let (exp1, after_exp1) = match Expression::parse(parser, after_init, true, yield_flag, await_flag) {
                     Err(_) => (None, after_init),
                     Ok((node, scan)) => (Some(node), scan),
                 };
                 let (_, after_test) =
-                    scan_for_punct(after_exp1, parser.source, ScanGoal::InputElementDiv, Punctuator::Semicolon)?;
+                    scan_for_punct(after_exp1, parser.source, InputElementGoal::Div, Punctuator::Semicolon)?;
                 let (exp2, after_exp2) = match Expression::parse(parser, after_test, true, yield_flag, await_flag) {
                     Err(_) => (None, after_test),
                     Ok((node, scan)) => (Some(node), scan),
                 };
                 let (_, after_close) =
-                    scan_for_punct(after_exp2, parser.source, ScanGoal::InputElementDiv, Punctuator::RightParen)?;
+                    scan_for_punct(after_exp2, parser.source, InputElementGoal::Div, Punctuator::RightParen)?;
                 let (stmt, after_stmt) = Statement::parse(parser, after_close, yield_flag, await_flag, return_flag)?;
                 let location = for_loc.merge(&stmt.location());
                 Ok((Rc::new(ForStatement::ForVar(vdl, exp1, exp2, stmt, location)), after_stmt))
@@ -705,22 +698,22 @@ impl ForStatement {
                     Err(_) => (None, after_lex),
                 };
                 let (_, after_test) =
-                    scan_for_punct(after_exp1, parser.source, ScanGoal::InputElementDiv, Punctuator::Semicolon)?;
+                    scan_for_punct(after_exp1, parser.source, InputElementGoal::Div, Punctuator::Semicolon)?;
                 let (exp2, after_exp2) = match Expression::parse(parser, after_test, true, yield_flag, await_flag) {
                     Ok((node, scan)) => (Some(node), scan),
                     Err(_) => (None, after_test),
                 };
                 let (_, after_close) =
-                    scan_for_punct(after_exp2, parser.source, ScanGoal::InputElementDiv, Punctuator::RightParen)?;
+                    scan_for_punct(after_exp2, parser.source, InputElementGoal::Div, Punctuator::RightParen)?;
                 let (stmt, after_stmt) = Statement::parse(parser, after_close, yield_flag, await_flag, return_flag)?;
                 let location = for_loc.merge(&stmt.location());
                 Ok((Rc::new(ForStatement::ForLex(lex, exp1, exp2, stmt, location)), after_stmt))
             })
             .otherwise(|| {
                 // for ( Expression ; Expression ; Expression ) Statement
-                let (lookahead1, _, after_1) = scan_token(&after_open, parser.source, ScanGoal::InputElementRegExp);
+                let (lookahead1, _, after_1) = scan_token(&after_open, parser.source, InputElementGoal::RegExp);
                 if lookahead1.matches_keyword(Keyword::Let) {
-                    let (lookahead2, _, _) = scan_token(&after_1, parser.source, ScanGoal::InputElementRegExp);
+                    let (lookahead2, _, _) = scan_token(&after_1, parser.source, InputElementGoal::RegExp);
                     if lookahead2.matches_punct(Punctuator::LeftBracket) {
                         // We return an error here, and stop processing, but it will never be seen by our callers
                         // because the error from the Lexical Binding parse happens first, and takes precedence.
@@ -732,26 +725,26 @@ impl ForStatement {
                     Err(_) => (None, after_open),
                 };
                 let (_, after_semi1) =
-                    scan_for_punct(after_init, parser.source, ScanGoal::InputElementDiv, Punctuator::Semicolon)?;
+                    scan_for_punct(after_init, parser.source, InputElementGoal::Div, Punctuator::Semicolon)?;
                 let (test, after_test) = match Expression::parse(parser, after_semi1, true, yield_flag, await_flag) {
                     Ok((node, scan)) => (Some(node), scan),
                     Err(_) => (None, after_semi1),
                 };
                 let (_, after_semi2) =
-                    scan_for_punct(after_test, parser.source, ScanGoal::InputElementDiv, Punctuator::Semicolon)?;
+                    scan_for_punct(after_test, parser.source, InputElementGoal::Div, Punctuator::Semicolon)?;
                 let (inc, after_inc) = match Expression::parse(parser, after_semi2, true, yield_flag, await_flag) {
                     Ok((node, scan)) => (Some(node), scan),
                     Err(_) => (None, after_semi2),
                 };
                 let (_, after_close) =
-                    scan_for_punct(after_inc, parser.source, ScanGoal::InputElementDiv, Punctuator::RightParen)?;
+                    scan_for_punct(after_inc, parser.source, InputElementGoal::Div, Punctuator::RightParen)?;
                 let (stmt, after_stmt) = Statement::parse(parser, after_close, yield_flag, await_flag, return_flag)?;
                 let location = for_loc.merge(&stmt.location());
                 Ok((Rc::new(ForStatement::For(init, test, inc, stmt, location)), after_stmt))
             })
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         match self {
             ForStatement::For(_, _, _, _, location)
             | ForStatement::ForVar(_, _, _, _, location)
@@ -759,7 +752,7 @@ impl ForStatement {
         }
     }
 
-    pub fn var_declared_names(&self) -> Vec<JSString> {
+    pub(crate) fn var_declared_names(&self) -> Vec<JSString> {
         match self {
             ForStatement::ForVar(v, _, _, s, _) => {
                 let mut names = v.bound_names();
@@ -770,7 +763,7 @@ impl ForStatement {
         }
     }
 
-    pub fn contains_undefined_break_target(&self, label_set: &[JSString]) -> bool {
+    pub(crate) fn contains_undefined_break_target(&self, label_set: &[JSString]) -> bool {
         match self {
             ForStatement::For(_, _, _, s, _)
             | ForStatement::ForVar(_, _, _, s, _)
@@ -778,7 +771,7 @@ impl ForStatement {
         }
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         match self {
             ForStatement::For(opt1, opt2, opt3, s, _) => {
                 opt1.as_ref().is_some_and(|n| n.contains(kind))
@@ -801,7 +794,7 @@ impl ForStatement {
         }
     }
 
-    pub fn contains_duplicate_labels(&self, label_set: &[JSString]) -> bool {
+    pub(crate) fn contains_duplicate_labels(&self, label_set: &[JSString]) -> bool {
         match self {
             ForStatement::For(_, _, _, s, _)
             | ForStatement::ForVar(_, _, _, s, _)
@@ -809,7 +802,7 @@ impl ForStatement {
         }
     }
 
-    pub fn contains_undefined_continue_target(&self, iteration_set: &[JSString]) -> bool {
+    pub(crate) fn contains_undefined_continue_target(&self, iteration_set: &[JSString]) -> bool {
         match self {
             ForStatement::For(_, _, _, s, _)
             | ForStatement::ForVar(_, _, _, s, _)
@@ -817,7 +810,7 @@ impl ForStatement {
         }
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -850,7 +843,7 @@ impl ForStatement {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -880,7 +873,7 @@ impl ForStatement {
         }
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
         // Static Semantics: Early Errors
         if let ForStatement::ForLex(lex, _, _, stmt, _) = self {
             // ForStatement : for ( LexicalDeclaration Expression[opt] ; Expression[opt] ) Statement
@@ -927,7 +920,7 @@ impl ForStatement {
     /// Return a list of parse nodes for the var-style declarations contained within the children of this node.
     ///
     /// See [VarScopedDeclarations](https://tc39.es/ecma262/#sec-static-semantics-varscopeddeclarations) in ECMA-262.
-    pub fn var_scoped_declarations(&self) -> Vec<VarScopeDecl> {
+    pub(crate) fn var_scoped_declarations(&self) -> Vec<VarScopeDecl> {
         match self {
             ForStatement::For(_, _, _, s, _) | ForStatement::ForLex(_, _, _, s, _) => s.var_scoped_declarations(),
             ForStatement::ForVar(vd, _, _, s, _) => {
@@ -938,7 +931,7 @@ impl ForStatement {
         }
     }
 
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         if self.location().contains(location) {
             match self {
@@ -966,7 +959,7 @@ impl ForStatement {
         }
     }
 
-    pub fn has_call_in_tail_position(&self, location: &Location) -> bool {
+    pub(crate) fn has_call_in_tail_position(&self, location: &Location) -> bool {
         // Static Semantics: HasCallInTailPosition
         // The syntax-directed operation HasCallInTailPosition takes argument call (a CallExpression Parse Node, a
         // MemberExpression Parse Node, or an OptionalChain Parse Node) and returns a Boolean.
@@ -997,7 +990,7 @@ impl ForStatement {
 //      [+Await] for await ( var ForBinding[?Yield, ?Await] of AssignmentExpression[+In, ?Yield, ?Await] ) Statement[?Yield, ?Await, ?Return]
 //      [+Await] for await ( ForDeclaration[?Yield, ?Await] of AssignmentExpression[+In, ?Yield, ?Await] ) Statement[?Yield, ?Await, ?Return]
 #[derive(Debug)]
-pub enum ForInOfStatement {
+pub(crate) enum ForInOfStatement {
     In(Rc<LeftHandSideExpression>, Rc<Expression>, Rc<Statement>, Location),
     DestructuringIn(Rc<AssignmentPattern>, Rc<Expression>, Rc<Statement>, Location),
     VarIn(Rc<ForBinding>, Rc<Expression>, Rc<Statement>, Location),
@@ -1164,49 +1157,41 @@ impl PrettyPrint for ForInOfStatement {
 }
 
 impl ForInOfStatement {
-    pub fn parse(
+    pub(crate) fn parse(
         parser: &mut Parser,
         scanner: Scanner,
         yield_flag: bool,
         await_flag: bool,
         return_flag: bool,
     ) -> ParseResult<Self> {
-        let (for_loc, after_for) =
-            scan_for_keyword(scanner, parser.source, ScanGoal::InputElementRegExp, Keyword::For)?;
+        let (for_loc, after_for) = scan_for_keyword(scanner, parser.source, InputElementGoal::RegExp, Keyword::For)?;
         let (await_seen, after_await) = if await_flag {
-            match scan_for_keyword(after_for, parser.source, ScanGoal::InputElementDiv, Keyword::Await) {
+            match scan_for_keyword(after_for, parser.source, InputElementGoal::Div, Keyword::Await) {
                 Ok((_, scan)) => (true, scan),
                 Err(_) => (false, after_for),
             }
         } else {
             (false, after_for)
         };
-        let (_, after_open) =
-            scan_for_punct(after_await, parser.source, ScanGoal::InputElementDiv, Punctuator::LeftParen)?;
+        let (_, after_open) = scan_for_punct(after_await, parser.source, InputElementGoal::Div, Punctuator::LeftParen)?;
         Err(ParseError::new(PECode::ForInOfDefinitionError, after_open))
             .otherwise(|| {
                 // for var
                 let (_, after_var) =
-                    scan_for_keyword(after_open, parser.source, ScanGoal::InputElementRegExp, Keyword::Var)?;
+                    scan_for_keyword(after_open, parser.source, InputElementGoal::RegExp, Keyword::Var)?;
                 let (for_binding, after_fb) = ForBinding::parse(parser, after_var, yield_flag, await_flag)?;
                 let (kwd, _, after_kwd) = if await_seen {
-                    let (loc, scan) =
-                        scan_for_keyword(after_fb, parser.source, ScanGoal::InputElementRegExp, Keyword::Of)?;
+                    let (loc, scan) = scan_for_keyword(after_fb, parser.source, InputElementGoal::RegExp, Keyword::Of)?;
                     (Keyword::Of, loc, scan)
                 } else {
-                    scan_for_keywords(
-                        after_fb,
-                        parser.source,
-                        ScanGoal::InputElementRegExp,
-                        &[Keyword::Of, Keyword::In],
-                    )?
+                    scan_for_keywords(after_fb, parser.source, InputElementGoal::RegExp, &[Keyword::Of, Keyword::In])?
                 };
                 match kwd {
                     Keyword::Of => {
                         let (ae, after_ae) =
                             AssignmentExpression::parse(parser, after_kwd, true, yield_flag, await_flag)?;
                         let (_, after_close) =
-                            scan_for_punct(after_ae, parser.source, ScanGoal::InputElementDiv, Punctuator::RightParen)?;
+                            scan_for_punct(after_ae, parser.source, InputElementGoal::Div, Punctuator::RightParen)?;
                         let (stmt, after_stmt) =
                             Statement::parse(parser, after_close, yield_flag, await_flag, return_flag)?;
                         let location = for_loc.merge(&stmt.location());
@@ -1218,12 +1203,8 @@ impl ForInOfStatement {
                     }
                     _ => {
                         let (exp, after_exp) = Expression::parse(parser, after_kwd, true, yield_flag, await_flag)?;
-                        let (_, after_close) = scan_for_punct(
-                            after_exp,
-                            parser.source,
-                            ScanGoal::InputElementDiv,
-                            Punctuator::RightParen,
-                        )?;
+                        let (_, after_close) =
+                            scan_for_punct(after_exp, parser.source, InputElementGoal::Div, Punctuator::RightParen)?;
                         let (stmt, after_stmt) =
                             Statement::parse(parser, after_close, yield_flag, await_flag, return_flag)?;
                         let location = for_loc.merge(&stmt.location());
@@ -1236,22 +1217,17 @@ impl ForInOfStatement {
                 let (decl, after_decl) = ForDeclaration::parse(parser, after_open, yield_flag, await_flag)?;
                 let (kwd, _, after_kwd) = if await_seen {
                     let (loc, scan) =
-                        scan_for_keyword(after_decl, parser.source, ScanGoal::InputElementRegExp, Keyword::Of)?;
+                        scan_for_keyword(after_decl, parser.source, InputElementGoal::RegExp, Keyword::Of)?;
                     (Keyword::Of, loc, scan)
                 } else {
-                    scan_for_keywords(
-                        after_decl,
-                        parser.source,
-                        ScanGoal::InputElementRegExp,
-                        &[Keyword::Of, Keyword::In],
-                    )?
+                    scan_for_keywords(after_decl, parser.source, InputElementGoal::RegExp, &[Keyword::Of, Keyword::In])?
                 };
                 match kwd {
                     Keyword::Of => {
                         let (ae, after_ae) =
                             AssignmentExpression::parse(parser, after_kwd, true, yield_flag, await_flag)?;
                         let (_, after_close) =
-                            scan_for_punct(after_ae, parser.source, ScanGoal::InputElementDiv, Punctuator::RightParen)?;
+                            scan_for_punct(after_ae, parser.source, InputElementGoal::Div, Punctuator::RightParen)?;
                         let (stmt, after_stmt) =
                             Statement::parse(parser, after_close, yield_flag, await_flag, return_flag)?;
                         let location = for_loc.merge(&stmt.location());
@@ -1263,12 +1239,8 @@ impl ForInOfStatement {
                     }
                     _ => {
                         let (exp, after_exp) = Expression::parse(parser, after_kwd, true, yield_flag, await_flag)?;
-                        let (_, after_close) = scan_for_punct(
-                            after_exp,
-                            parser.source,
-                            ScanGoal::InputElementDiv,
-                            Punctuator::RightParen,
-                        )?;
+                        let (_, after_close) =
+                            scan_for_punct(after_exp, parser.source, InputElementGoal::Div, Punctuator::RightParen)?;
                         let (stmt, after_stmt) =
                             Statement::parse(parser, after_close, yield_flag, await_flag, return_flag)?;
                         let location = for_loc.merge(&stmt.location());
@@ -1278,10 +1250,10 @@ impl ForInOfStatement {
             })
             .otherwise(|| {
                 // for ( LHS in/of ... )
-                let (lookahead1, _, after_lh1) = scan_token(&after_open, parser.source, ScanGoal::InputElementRegExp);
+                let (lookahead1, _, after_lh1) = scan_token(&after_open, parser.source, InputElementGoal::RegExp);
                 if lookahead1.matches_keyword(Keyword::Let)
                     && (await_seen || {
-                        let (lookahead2, _, _) = scan_token(&after_lh1, parser.source, ScanGoal::InputElementDiv);
+                        let (lookahead2, _, _) = scan_token(&after_lh1, parser.source, InputElementGoal::Div);
                         lookahead2.matches_punct(Punctuator::LeftBracket)
                     })
                 {
@@ -1291,22 +1263,17 @@ impl ForInOfStatement {
                 let (lhs, after_lhs) = LeftHandSideExpression::parse(parser, after_open, yield_flag, await_flag)?;
                 let (kwd, _, after_kwd) = if await_seen {
                     let (loc, scan) =
-                        scan_for_keyword(after_lhs, parser.source, ScanGoal::InputElementRegExp, Keyword::Of)?;
+                        scan_for_keyword(after_lhs, parser.source, InputElementGoal::RegExp, Keyword::Of)?;
                     (Keyword::Of, loc, scan)
                 } else {
-                    scan_for_keywords(
-                        after_lhs,
-                        parser.source,
-                        ScanGoal::InputElementRegExp,
-                        &[Keyword::Of, Keyword::In],
-                    )?
+                    scan_for_keywords(after_lhs, parser.source, InputElementGoal::RegExp, &[Keyword::Of, Keyword::In])?
                 };
                 match kwd {
                     Keyword::Of => {
                         let (ae, after_ae) =
                             AssignmentExpression::parse(parser, after_kwd, true, yield_flag, await_flag)?;
                         let (_, after_close) =
-                            scan_for_punct(after_ae, parser.source, ScanGoal::InputElementDiv, Punctuator::RightParen)?;
+                            scan_for_punct(after_ae, parser.source, InputElementGoal::Div, Punctuator::RightParen)?;
                         let (stmt, after_stmt) =
                             Statement::parse(parser, after_close, yield_flag, await_flag, return_flag)?;
                         let location = for_loc.merge(&stmt.location());
@@ -1330,12 +1297,8 @@ impl ForInOfStatement {
                     }
                     _ => {
                         let (exp, after_exp) = Expression::parse(parser, after_kwd, true, yield_flag, await_flag)?;
-                        let (_, after_close) = scan_for_punct(
-                            after_exp,
-                            parser.source,
-                            ScanGoal::InputElementDiv,
-                            Punctuator::RightParen,
-                        )?;
+                        let (_, after_close) =
+                            scan_for_punct(after_exp, parser.source, InputElementGoal::Div, Punctuator::RightParen)?;
                         let (stmt, after_stmt) =
                             Statement::parse(parser, after_close, yield_flag, await_flag, return_flag)?;
                         let location = for_loc.merge(&stmt.location());
@@ -1352,7 +1315,7 @@ impl ForInOfStatement {
             })
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         match self {
             ForInOfStatement::In(_, _, _, location)
             | ForInOfStatement::DestructuringIn(_, _, _, location)
@@ -1369,7 +1332,7 @@ impl ForInOfStatement {
         }
     }
 
-    pub fn var_declared_names(&self) -> Vec<JSString> {
+    pub(crate) fn var_declared_names(&self) -> Vec<JSString> {
         match self {
             ForInOfStatement::In(_, _, s, _)
             | ForInOfStatement::DestructuringIn(_, _, s, _)
@@ -1390,7 +1353,7 @@ impl ForInOfStatement {
         }
     }
 
-    pub fn contains_undefined_break_target(&self, label_set: &[JSString]) -> bool {
+    pub(crate) fn contains_undefined_break_target(&self, label_set: &[JSString]) -> bool {
         match self {
             ForInOfStatement::In(_, _, s, _)
             | ForInOfStatement::DestructuringIn(_, _, s, _)
@@ -1407,7 +1370,7 @@ impl ForInOfStatement {
         }
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         match self {
             ForInOfStatement::In(lhs, e, s, _) => lhs.contains(kind) || e.contains(kind) || s.contains(kind),
             ForInOfStatement::DestructuringIn(lhs, e, s, _) => {
@@ -1430,7 +1393,7 @@ impl ForInOfStatement {
         }
     }
 
-    pub fn contains_duplicate_labels(&self, label_set: &[JSString]) -> bool {
+    pub(crate) fn contains_duplicate_labels(&self, label_set: &[JSString]) -> bool {
         match self {
             ForInOfStatement::In(_, _, s, _)
             | ForInOfStatement::DestructuringIn(_, _, s, _)
@@ -1447,7 +1410,7 @@ impl ForInOfStatement {
         }
     }
 
-    pub fn contains_undefined_continue_target(&self, iteration_set: &[JSString]) -> bool {
+    pub(crate) fn contains_undefined_continue_target(&self, iteration_set: &[JSString]) -> bool {
         match self {
             ForInOfStatement::In(_, _, s, _)
             | ForInOfStatement::DestructuringIn(_, _, s, _)
@@ -1464,7 +1427,7 @@ impl ForInOfStatement {
         }
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -1519,7 +1482,7 @@ impl ForInOfStatement {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -1554,7 +1517,7 @@ impl ForInOfStatement {
         }
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, within_switch: bool) {
         // Static Semantics: Early Errors
         match self {
             ForInOfStatement::LexIn(fd, _, stmt, ..)
@@ -1641,7 +1604,7 @@ impl ForInOfStatement {
     /// Return a list of parse nodes for the var-style declarations contained within the children of this node.
     ///
     /// See [VarScopedDeclarations](https://tc39.es/ecma262/#sec-static-semantics-varscopeddeclarations) in ECMA-262.
-    pub fn var_scoped_declarations(&self) -> Vec<VarScopeDecl> {
+    pub(crate) fn var_scoped_declarations(&self) -> Vec<VarScopeDecl> {
         match self {
             ForInOfStatement::In(_, _, s, _)
             | ForInOfStatement::DestructuringIn(_, _, s, _)
@@ -1662,13 +1625,69 @@ impl ForInOfStatement {
         }
     }
 
-    #[expect(unused_variables)]
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
-        todo!()
+        if self.location().contains(location) {
+            match self {
+                ForInOfStatement::In(left_hand_side_expression, expression, statement, _) => left_hand_side_expression
+                    .body_containing_location(location)
+                    .or_else(|| expression.body_containing_location(location))
+                    .or_else(|| statement.body_containing_location(location)),
+                ForInOfStatement::DestructuringIn(assignment_pattern, expression, statement, _) => assignment_pattern
+                    .body_containing_location(location)
+                    .or_else(|| expression.body_containing_location(location))
+                    .or_else(|| statement.body_containing_location(location)),
+                ForInOfStatement::VarIn(for_binding, expression, statement, _) => for_binding
+                    .body_containing_location(location)
+                    .or_else(|| expression.body_containing_location(location))
+                    .or_else(|| statement.body_containing_location(location)),
+                ForInOfStatement::LexIn(for_declaration, expression, statement, _) => for_declaration
+                    .body_containing_location(location)
+                    .or_else(|| expression.body_containing_location(location))
+                    .or_else(|| statement.body_containing_location(location)),
+                ForInOfStatement::Of(left_hand_side_expression, assignment_expression, statement, _) => {
+                    left_hand_side_expression
+                        .body_containing_location(location)
+                        .or_else(|| assignment_expression.body_containing_location(location))
+                        .or_else(|| statement.body_containing_location(location))
+                }
+                ForInOfStatement::DestructuringOf(assignment_pattern, assignment_expression, statement, _) => {
+                    assignment_pattern
+                        .body_containing_location(location)
+                        .or_else(|| assignment_expression.body_containing_location(location))
+                        .or_else(|| statement.body_containing_location(location))
+                }
+                ForInOfStatement::VarOf(for_binding, assignment_expression, statement, _) => for_binding
+                    .body_containing_location(location)
+                    .or_else(|| assignment_expression.body_containing_location(location))
+                    .or_else(|| statement.body_containing_location(location)),
+                ForInOfStatement::LexOf(for_declaration, assignment_expression, statement, _) => for_declaration
+                    .body_containing_location(location)
+                    .or_else(|| assignment_expression.body_containing_location(location))
+                    .or_else(|| statement.body_containing_location(location)),
+                #[expect(unused_variables)]
+                ForInOfStatement::AwaitOf(left_hand_side_expression, assignment_expression, statement, _) => {
+                    todo!()
+                }
+                #[expect(unused_variables)]
+                ForInOfStatement::DestructuringAwaitOf(assignment_pattern, assignment_expression, statement, _) => {
+                    todo!()
+                }
+                #[expect(unused_variables)]
+                ForInOfStatement::AwaitVarOf(for_binding, assignment_expression, statement, _) => {
+                    todo!()
+                }
+                #[expect(unused_variables)]
+                ForInOfStatement::AwaitLexOf(for_declaration, assignment_expression, statement, _) => {
+                    todo!()
+                }
+            }
+        } else {
+            None
+        }
     }
 
-    pub fn has_call_in_tail_position(&self, location: &Location) -> bool {
+    pub(crate) fn has_call_in_tail_position(&self, location: &Location) -> bool {
         // Static Semantics: HasCallInTailPosition
         // The syntax-directed operation HasCallInTailPosition takes argument call (a CallExpression Parse Node, a
         // MemberExpression Parse Node, or an OptionalChain Parse Node) and returns a Boolean.
@@ -1745,9 +1764,9 @@ where
 // ForDeclaration[Yield, Await] :
 //      LetOrConst ForBinding[?Yield, ?Await]
 #[derive(Debug)]
-pub struct ForDeclaration {
-    pub loc: LetOrConst,
-    pub binding: Rc<ForBinding>,
+pub(crate) struct ForDeclaration {
+    pub(crate) loc: LetOrConst,
+    pub(crate) binding: Rc<ForBinding>,
     location: Location,
 }
 
@@ -1780,9 +1799,14 @@ impl PrettyPrint for ForDeclaration {
 }
 
 impl ForDeclaration {
-    pub fn parse(parser: &mut Parser, scanner: Scanner, yield_flag: bool, await_flag: bool) -> ParseResult<Self> {
+    pub(crate) fn parse(
+        parser: &mut Parser,
+        scanner: Scanner,
+        yield_flag: bool,
+        await_flag: bool,
+    ) -> ParseResult<Self> {
         let (tok, tok_loc, after_tok) =
-            scan_for_keywords(scanner, parser.source, ScanGoal::InputElementRegExp, &[Keyword::Let, Keyword::Const])?;
+            scan_for_keywords(scanner, parser.source, InputElementGoal::RegExp, &[Keyword::Let, Keyword::Const])?;
         let loc = match tok {
             Keyword::Let => LetOrConst::Let,
             _ => LetOrConst::Const,
@@ -1792,15 +1816,15 @@ impl ForDeclaration {
         Ok((Rc::new(ForDeclaration { loc, binding, location }), after_binding))
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         self.location
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
-        self.loc.contains(kind) || self.binding.contains(kind)
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
+        self.binding.contains(kind)
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -1814,7 +1838,7 @@ impl ForDeclaration {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -1824,15 +1848,15 @@ impl ForDeclaration {
         self.binding.contains_arguments()
     }
 
-    pub fn bound_names(&self) -> Vec<JSString> {
+    pub(crate) fn bound_names(&self) -> Vec<JSString> {
         self.binding.bound_names()
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         self.binding.early_errors(errs, strict);
     }
 
-    pub fn is_destructuring(&self) -> bool {
+    pub(crate) fn is_destructuring(&self) -> bool {
         // Static Semantics: IsDestructuring
         // The syntax-directed operation IsDestructuring takes no arguments and returns a Boolean. It is
         // defined piecewise over the following productions:
@@ -1842,10 +1866,9 @@ impl ForDeclaration {
         self.binding.is_destructuring()
     }
 
-    #[expect(unused_variables)]
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
-        todo!()
+        if self.location().contains(location) { self.binding.body_containing_location(location) } else { None }
     }
 }
 
@@ -1853,7 +1876,7 @@ impl ForDeclaration {
 //      BindingIdentifier[?Yield, ?Await]
 //      BindingPattern[?Yield, ?Await]
 #[derive(Debug)]
-pub enum ForBinding {
+pub(crate) enum ForBinding {
     Identifier(Rc<BindingIdentifier>),
     Pattern(Rc<BindingPattern>),
 }
@@ -1904,7 +1927,12 @@ impl ForBinding {
             })
     }
 
-    pub fn parse(parser: &mut Parser, scanner: Scanner, yield_flag: bool, await_flag: bool) -> ParseResult<Self> {
+    pub(crate) fn parse(
+        parser: &mut Parser,
+        scanner: Scanner,
+        yield_flag: bool,
+        await_flag: bool,
+    ) -> ParseResult<Self> {
         let key = YieldAwaitKey { scanner, yield_flag, await_flag };
         match parser.for_binding_cache.get(&key) {
             Some(result) => result.clone(),
@@ -1916,28 +1944,28 @@ impl ForBinding {
         }
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         match self {
             ForBinding::Identifier(node) => node.location(),
             ForBinding::Pattern(node) => node.location(),
         }
     }
 
-    pub fn bound_names(&self) -> Vec<JSString> {
+    pub(crate) fn bound_names(&self) -> Vec<JSString> {
         match self {
             ForBinding::Identifier(node) => node.bound_names(),
             ForBinding::Pattern(node) => node.bound_names(),
         }
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         match self {
-            ForBinding::Identifier(node) => node.contains(kind),
+            ForBinding::Identifier(_) => false,
             ForBinding::Pattern(node) => node.contains(kind),
         }
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -1954,7 +1982,7 @@ impl ForBinding {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -1967,14 +1995,14 @@ impl ForBinding {
         }
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ForBinding::Identifier(id) => id.early_errors(errs, strict),
             ForBinding::Pattern(pat) => pat.early_errors(errs, strict),
         }
     }
 
-    pub fn is_destructuring(&self) -> bool {
+    pub(crate) fn is_destructuring(&self) -> bool {
         // Static Semantics: IsDestructuring
         // The syntax-directed operation IsDestructuring takes no arguments and returns a Boolean. It is
         // defined piecewise over the following productions:
@@ -1992,10 +2020,16 @@ impl ForBinding {
         }
     }
 
-    #[expect(unused_variables)]
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
-        todo!()
+        if self.location().contains(location) {
+            match self {
+                ForBinding::Identifier(_) => None,
+                ForBinding::Pattern(binding_pattern) => binding_pattern.body_containing_location(location),
+            }
+        } else {
+            None
+        }
     }
 }
 

--- a/src/parser/left_hand_side_expressions/tests.rs
+++ b/src/parser/left_hand_side_expressions/tests.rs
@@ -16,7 +16,6 @@ fn member_expression_test_primary_expression() {
     assert_ne!(format!("{me:?}"), "");
     pretty_check(&*me, "MemberExpression: a", &["PrimaryExpression: a"]);
     concise_check(&*me, "IdentifierName: a", &[]);
-    assert_eq!(me.is_function_definition(), false);
 }
 #[test]
 fn member_expression_test_meta_property() {
@@ -27,7 +26,6 @@ fn member_expression_test_meta_property() {
     assert_ne!(format!("{me:?}"), "");
     pretty_check(&*me, "MemberExpression: new . target", &["MetaProperty: new . target"]);
     concise_check(&*me, "MetaProperty: new . target", &["Keyword: new", "Punctuator: .", "Keyword: target"]);
-    assert_eq!(me.is_function_definition(), false);
 }
 #[test]
 fn member_expression_test_super_property() {
@@ -38,7 +36,6 @@ fn member_expression_test_super_property() {
     assert_ne!(format!("{me:?}"), "");
     pretty_check(&*me, "MemberExpression: super . ior", &["SuperProperty: super . ior"]);
     concise_check(&*me, "SuperProperty: super . ior", &["Keyword: super", "Punctuator: .", "IdentifierName: ior"]);
-    assert_eq!(me.is_function_definition(), false);
 }
 #[test]
 fn member_expression_test_new_me_args() {
@@ -58,7 +55,6 @@ fn member_expression_test_new_me_args() {
         "MemberExpression: new shoes ( 'red' , 'leather' )",
         &["Keyword: new", "IdentifierName: shoes", "Arguments: ( 'red' , 'leather' )"],
     );
-    assert_eq!(me.is_function_definition(), false);
 }
 #[test]
 fn member_expression_test_me_expression() {
@@ -73,7 +69,6 @@ fn member_expression_test_me_expression() {
         "MemberExpression: bill [ a ]",
         &["IdentifierName: bill", "Punctuator: [", "IdentifierName: a", "Punctuator: ]"],
     );
-    assert_eq!(me.is_function_definition(), false);
 }
 #[test]
 fn member_expression_test_me_ident() {
@@ -88,7 +83,6 @@ fn member_expression_test_me_ident() {
         "MemberExpression: alice . name",
         &["IdentifierName: alice", "Punctuator: .", "IdentifierName: name"],
     );
-    assert_eq!(me.is_function_definition(), false);
 }
 #[test]
 fn member_expression_test_me_private() {
@@ -103,7 +97,6 @@ fn member_expression_test_me_private() {
         "MemberExpression: alice . #name",
         &["IdentifierName: alice", "Punctuator: .", "PrivateIdentifier: #name"],
     );
-    assert_eq!(me.is_function_definition(), false);
 }
 #[test]
 fn member_expression_test_me_template() {
@@ -118,7 +111,6 @@ fn member_expression_test_me_template() {
         "MemberExpression: alice `${ a }`",
         &["IdentifierName: alice", "SubstitutionTemplate: `${ a }`"],
     );
-    assert_eq!(me.is_function_definition(), false);
 }
 #[test]
 fn member_expression_test_errs_01() {
@@ -445,31 +437,31 @@ mod member_expression {
         Maker::new(src).member_expression().assignment_target_type(strict)
     }
 
-    #[test_case("a[b]" => false; "brackets")]
-    #[test_case("a.b" => false; "property id")]
-    #[test_case("a`${b}`" => false; "template")]
-    #[test_case("super.a" => false; "super prop")]
-    #[test_case("new.target" => false; "meta")]
-    #[test_case("new a(b)" => false; "new me")]
-    #[test_case("a.#b" => false; "private id")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).member_expression().is_named_function()
-    }
+    //#[test_case("a[b]" => false; "brackets")]
+    //#[test_case("a.b" => false; "property id")]
+    //#[test_case("a`${b}`" => false; "template")]
+    //#[test_case("super.a" => false; "super prop")]
+    //#[test_case("new.target" => false; "meta")]
+    //#[test_case("new a(b)" => false; "new me")]
+    //#[test_case("a.#b" => false; "private id")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).member_expression().is_named_function()
+    //}
 
-    #[test_case("a[b]" => false; "brackets")]
-    #[test_case("a.b" => false; "property id")]
-    #[test_case("a`${b}`" => false; "template")]
-    #[test_case("super.a" => false; "super prop")]
-    #[test_case("new.target" => false; "meta")]
-    #[test_case("new a(b)" => false; "new me")]
-    #[test_case("a.#b" => false; "private id")]
-    #[test_case("beetle" => true; "id")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_identifier_ref(src: &str) -> bool {
-        Maker::new(src).member_expression().is_identifier_ref()
-    }
+    //#[test_case("a[b]" => false; "brackets")]
+    //#[test_case("a.b" => false; "property id")]
+    //#[test_case("a`${b}`" => false; "template")]
+    //#[test_case("super.a" => false; "super prop")]
+    //#[test_case("new.target" => false; "meta")]
+    //#[test_case("new a(b)" => false; "new me")]
+    //#[test_case("a.#b" => false; "private id")]
+    //#[test_case("beetle" => true; "id")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_identifier_ref(src: &str) -> bool {
+    //    Maker::new(src).member_expression().is_identifier_ref()
+    //}
 
     #[test_case("a[b]" => None; "brackets")]
     #[test_case("a.b" => None; "property id")]
@@ -543,7 +535,7 @@ fn super_property_test_nomatch() {
 #[test]
 fn super_property_test_bad_ident() {
     let r = SuperProperty::parse(&mut newparser("super.*"), Scanner::new(), false, false);
-    check_err(r, "IdentifierName expected", 1, 7);
+    check_err(r, "identifier name expected", 1, 7);
 }
 #[test]
 fn super_property_test_bad_expression() {
@@ -910,7 +902,7 @@ fn argument_list_test_dots_ae() {
 fn argument_list_test_al_ae() {
     let (al, scanner) = check(ArgumentList::parse(&mut newparser("ab,aba"), Scanner::new(), false, false));
     chk_scan(&scanner, 6);
-    assert!(matches!(*al, ArgumentList::ArgumentList(..)));
+    assert!(matches!(*al, ArgumentList::List(..)));
     assert_ne!(format!("{al:?}"), "");
     pretty_check(&*al, "ArgumentList: ab , aba", &["ArgumentList: ab", "AssignmentExpression: aba"]);
     concise_check(&*al, "ArgumentList: ab , aba", &["IdentifierName: ab", "Punctuator: ,", "IdentifierName: aba"]);
@@ -919,7 +911,7 @@ fn argument_list_test_al_ae() {
 fn argument_list_test_al_dots_ae() {
     let (al, scanner) = check(ArgumentList::parse(&mut newparser("ab,...aba"), Scanner::new(), false, false));
     chk_scan(&scanner, 9);
-    assert!(matches!(*al, ArgumentList::ArgumentListDots(..)));
+    assert!(matches!(*al, ArgumentList::ListDots(..)));
     assert_ne!(format!("{al:?}"), "");
     pretty_check(&*al, "ArgumentList: ab , ... aba", &["ArgumentList: ab", "AssignmentExpression: aba"]);
     concise_check(
@@ -1114,7 +1106,6 @@ mod new_expression {
         assert_ne!(format!("{ne:?}"), "");
         pretty_check(&*ne, "NewExpression: true", &["MemberExpression: true"]);
         concise_check(&*ne, "Keyword: true", &[]);
-        assert_eq!(ne.is_function_definition(), false);
     }
     #[test]
     fn new() {
@@ -1124,7 +1115,6 @@ mod new_expression {
         assert_ne!(format!("{ne:?}"), "");
         pretty_check(&*ne, "NewExpression: new bob", &["NewExpression: bob"]);
         concise_check(&*ne, "NewExpression: new bob", &["Keyword: new", "IdentifierName: bob"]);
-        assert_eq!(ne.is_function_definition(), false);
     }
     #[test]
     fn new_me() {
@@ -1138,7 +1128,6 @@ mod new_expression {
             "MemberExpression: new bob ( )",
             &["Keyword: new", "IdentifierName: bob", "Arguments: ( )"],
         );
-        assert_eq!(ne.is_function_definition(), false);
     }
     #[test]
     fn nomatch() {
@@ -1254,19 +1243,19 @@ mod new_expression {
         Maker::new(src).new_expression().location()
     }
 
-    #[test_case("new a" => false; "new exp")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).new_expression().is_named_function()
-    }
+    //#[test_case("new a" => false; "new exp")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).new_expression().is_named_function()
+    //}
 
-    #[test_case("idref" => true; "Id Ref")]
-    #[test_case("10" => false; "literal")]
-    #[test_case("new a" => false; "other new expr")]
-    fn is_identifier_ref(src: &str) -> bool {
-        Maker::new(src).new_expression().is_identifier_ref()
-    }
+    //#[test_case("idref" => true; "Id Ref")]
+    //#[test_case("10" => false; "literal")]
+    //#[test_case("new a" => false; "other new expr")]
+    //fn is_identifier_ref(src: &str) -> bool {
+    //    Maker::new(src).new_expression().is_identifier_ref()
+    //}
 
     #[test_case("idref" => ssome("idref"); "Id Ref")]
     #[test_case("10" => None; "literal")]
@@ -1573,7 +1562,7 @@ mod call_expression {
         let (ce, scanner) =
             check(CallExpression::parse(&mut newparser("blue(pop)(snap)(10)(20)"), Scanner::new(), false, false));
         chk_scan(&scanner, 23);
-        assert!(matches!(*ce, CallExpression::CallExpressionArguments(..)));
+        assert!(matches!(*ce, CallExpression::CallThenArguments(..)));
         assert_ne!(format!("{ce:?}"), "");
         pretty_check(
             &*ce,
@@ -1591,7 +1580,7 @@ mod call_expression {
         let (ce, scanner) =
             check(CallExpression::parse(&mut newparser("blue(pop)(snap)(10)(++)"), Scanner::new(), false, false));
         chk_scan(&scanner, 19);
-        assert!(matches!(*ce, CallExpression::CallExpressionArguments(..)));
+        assert!(matches!(*ce, CallExpression::CallThenArguments(..)));
         assert_ne!(format!("{ce:?}"), "");
     }
     #[test]
@@ -1599,7 +1588,7 @@ mod call_expression {
         let (ce, scanner) =
             check(CallExpression::parse(&mut newparser("blue(pop)[snap]"), Scanner::new(), false, false));
         chk_scan(&scanner, 15);
-        assert!(matches!(*ce, CallExpression::CallExpressionExpression(..)));
+        assert!(matches!(*ce, CallExpression::CallThenExpression(..)));
         assert_ne!(format!("{ce:?}"), "");
         pretty_check(
             &*ce,
@@ -1617,7 +1606,7 @@ mod call_expression {
         let (ce, scanner) =
             check(CallExpression::parse(&mut newparser("blue(pop).snap"), Scanner::new(), false, false));
         chk_scan(&scanner, 14);
-        assert!(matches!(*ce, CallExpression::CallExpressionIdentifierName(..)));
+        assert!(matches!(*ce, CallExpression::CallThenName(..)));
         assert_ne!(format!("{ce:?}"), "");
         pretty_check(&*ce, "CallExpression: blue ( pop ) . snap", &["CallExpression: blue ( pop )"]);
         concise_check(
@@ -1631,7 +1620,7 @@ mod call_expression {
         let (ce, scanner) =
             check(CallExpression::parse(&mut newparser("blue(pop).#snap"), Scanner::new(), false, false));
         chk_scan(&scanner, 15);
-        assert!(matches!(*ce, CallExpression::CallExpressionPrivateId(..)));
+        assert!(matches!(*ce, CallExpression::CallThenPrivateId(..)));
         assert_ne!(format!("{ce:?}"), "");
         pretty_check(&*ce, "CallExpression: blue ( pop ) . #snap", &["CallExpression: blue ( pop )"]);
         concise_check(
@@ -1645,7 +1634,7 @@ mod call_expression {
         let (ce, scanner) =
             check(CallExpression::parse(&mut newparser("blue(pop)`snap`"), Scanner::new(), false, false));
         chk_scan(&scanner, 15);
-        assert!(matches!(*ce, CallExpression::CallExpressionTemplateLiteral(..)));
+        assert!(matches!(*ce, CallExpression::CallThenTemplateLiteral(..)));
         assert_ne!(format!("{ce:?}"), "");
         pretty_check(
             &*ce,
@@ -2641,7 +2630,6 @@ mod left_hand_side_expression {
         assert_ne!(format!("{lhs:?}"), "");
         pretty_check(&*lhs, "LeftHandSideExpression: a", &["NewExpression: a"]);
         concise_check(&*lhs, "IdentifierName: a", &[]);
-        assert_eq!(lhs.is_function_definition(), false);
     }
     #[test]
     fn parse_02() {
@@ -2650,7 +2638,6 @@ mod left_hand_side_expression {
         assert!(matches!(*lhs, LeftHandSideExpression::Call(_)));
         pretty_check(&*lhs, "LeftHandSideExpression: a ( )", &["CallExpression: a ( )"]);
         concise_check(&*lhs, "CallMemberExpression: a ( )", &["IdentifierName: a", "Arguments: ( )"]);
-        assert_eq!(lhs.is_function_definition(), false);
     }
     #[test]
     fn parse_03() {
@@ -2660,7 +2647,6 @@ mod left_hand_side_expression {
         assert!(matches!(*lhs, LeftHandSideExpression::Optional(_)));
         pretty_check(&*lhs, "LeftHandSideExpression: a ( ) ?. b", &["OptionalExpression: a ( ) ?. b"]);
         concise_check(&*lhs, "OptionalExpression: a ( ) ?. b", &["CallMemberExpression: a ( )", "OptionalChain: ?. b"]);
-        assert_eq!(lhs.is_function_definition(), false);
     }
     #[test]
     fn prettyerrors_1() {
@@ -2795,31 +2781,31 @@ mod left_hand_side_expression {
         Maker::new(src).left_hand_side_expression().assignment_target_type(strict)
     }
 
-    #[test_case("idref" => true; "Id Ref")]
-    #[test_case("this" => false; "this kwd")]
-    #[test_case("10" => false; "literal")]
-    #[test_case("[10, 11, 12]" => false; "array literal")]
-    #[test_case("{ a: 12 }" => false; "object literal")]
-    #[test_case("function a(){}" => false; "function expression")]
-    #[test_case("function *a(){}" => false; "generator expression")]
-    #[test_case("async function () {}" => false; "async func expr")]
-    #[test_case("async function *(){}" => false; "async gen expr")]
-    #[test_case("/abcd/" => false; "regex literal")]
-    #[test_case("`template`" => false; "template literal")]
-    #[test_case("(id)" => false; "parentheszied expr")]
-    #[test_case("a[0]" => false; "expression member access")]
-    #[test_case("a.a" => false; "name member access")]
-    #[test_case("a`${b}`" => false; "tagged template")]
-    #[test_case("super.a" => false; "super prop")]
-    #[test_case("new.target" => false; "meta prop")]
-    #[test_case("new a()" => false; "new expr")]
-    #[test_case("a.#b" => false; "private member access")]
-    #[test_case("new a" => false; "other new expr")]
-    #[test_case("a()" => false; "call")]
-    #[test_case("a?.b" => false; "optional")]
-    fn is_identifier_ref(src: &str) -> bool {
-        Maker::new(src).left_hand_side_expression().is_identifier_ref()
-    }
+    //#[test_case("idref" => true; "Id Ref")]
+    //#[test_case("this" => false; "this kwd")]
+    //#[test_case("10" => false; "literal")]
+    //#[test_case("[10, 11, 12]" => false; "array literal")]
+    //#[test_case("{ a: 12 }" => false; "object literal")]
+    //#[test_case("function a(){}" => false; "function expression")]
+    //#[test_case("function *a(){}" => false; "generator expression")]
+    //#[test_case("async function () {}" => false; "async func expr")]
+    //#[test_case("async function *(){}" => false; "async gen expr")]
+    //#[test_case("/abcd/" => false; "regex literal")]
+    //#[test_case("`template`" => false; "template literal")]
+    //#[test_case("(id)" => false; "parentheszied expr")]
+    //#[test_case("a[0]" => false; "expression member access")]
+    //#[test_case("a.a" => false; "name member access")]
+    //#[test_case("a`${b}`" => false; "tagged template")]
+    //#[test_case("super.a" => false; "super prop")]
+    //#[test_case("new.target" => false; "meta prop")]
+    //#[test_case("new a()" => false; "new expr")]
+    //#[test_case("a.#b" => false; "private member access")]
+    //#[test_case("new a" => false; "other new expr")]
+    //#[test_case("a()" => false; "call")]
+    //#[test_case("a?.b" => false; "optional")]
+    //fn is_identifier_ref(src: &str) -> bool {
+    //    Maker::new(src).left_hand_side_expression().is_identifier_ref()
+    //}
 
     #[test_case("idref" => ssome("idref"); "Id Ref")]
     #[test_case("this" => None; "this kwd")]
@@ -2854,13 +2840,13 @@ mod left_hand_side_expression {
         Maker::new(src).left_hand_side_expression().location()
     }
 
-    #[test_case("1" => false; "literal")]
-    #[test_case("a()" => false; "call expression")]
-    #[test_case("a?.b" => false; "optional expression")]
-    #[test_case("function bob(){}" => true; "function")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).left_hand_side_expression().is_named_function()
-    }
+    //#[test_case("1" => false; "literal")]
+    //#[test_case("a()" => false; "call expression")]
+    //#[test_case("a?.b" => false; "optional expression")]
+    //#[test_case("function bob(){}" => true; "function")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).left_hand_side_expression().is_named_function()
+    //}
 
     #[test_case("1" => false; "literal")]
     #[test_case("[a]" => true; "destructuring")]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10,44 +10,47 @@ use std::fmt;
 use std::rc::Rc;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
-pub enum YieldAllowed {
+pub(crate) enum YieldAllowed {
     Yes,
     #[default]
     No,
 }
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
-pub enum AwaitAllowed {
+pub(crate) enum AwaitAllowed {
     Yes,
     #[default]
     No,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Default)]
-pub enum ParseGoal {
+pub(crate) enum ParseGoal {
     #[default]
     Script,
     Module,
     FormalParameters(YieldAllowed, AwaitAllowed),
     FunctionBody(YieldAllowed, AwaitAllowed),
     GeneratorBody,
-    AsyncFunctionBody,
-    AsyncGeneratorBody,
     FunctionExpression,
     GeneratorExpression,
+    // These are all as-yet-to-be-used, so I'm hiding them behind #[cfg(test)] for the time being
+    #[cfg(test)]
+    AsyncFunctionBody,
+    #[cfg(test)]
+    AsyncGeneratorBody,
+    #[cfg(test)]
     AsyncFunctionExpression,
+    #[cfg(test)]
     AsyncGeneratorExpression,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
-pub enum ParseNodeKind {
+pub(crate) enum ParseNodeKind {
     ArrowFunction,
     AssignmentExpression,
     AssignmentOperator,
     AssignmentPattern,
     AsyncArrowFunction,
     AsyncConciseBody,
-    AsyncFunctionBody,
-    AsyncGeneratorBody,
     AwaitExpression,
     BindingElement,
     BindingPattern,
@@ -57,10 +60,8 @@ pub enum ParseNodeKind {
     BreakStatement,
     CallExpression,
     CatchParameter,
-    ClassBody,
     ClassElement,
     ClassElementName,
-    ClassHeritage,
     ConciseBody,
     ConditionalExpression,
     ContinueStatement,
@@ -73,9 +74,7 @@ pub enum ParseNodeKind {
     ExpressionBody,
     ExpressionStatement,
     ForBinding,
-    GeneratorBody,
     HoistableDeclaration,
-    IdentifierName,
     IfStatement,
     IterationStatement,
     LabelledItem,
@@ -95,7 +94,6 @@ pub enum ParseNodeKind {
     RegularExpression,
     RelationalExpression,
     ReturnStatement,
-    ScriptBody,
     Statement,
     StatementList,
     StatementListItem,
@@ -116,6 +114,17 @@ pub enum ParseNodeKind {
     VariableStatement,
     WithStatement,
     YieldExpression,
+
+    // Still unused, these are getting hidden behind #[cfg(test)], if in the tests, else commented out
+    // AsyncFunctionBody,
+    // AsyncGeneratorBody,
+    #[cfg(test)]
+    ClassBody,
+    #[cfg(test)]
+    ClassHeritage,
+    //GeneratorBody,
+    #[cfg(test)]
+    ScriptBody,
 }
 impl fmt::Display for ParseNodeKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -126,8 +135,8 @@ impl fmt::Display for ParseNodeKind {
             ParseNodeKind::AssignmentPattern => "AssignmentPattern",
             ParseNodeKind::AsyncArrowFunction => "AsyncArrowFunction",
             ParseNodeKind::AsyncConciseBody => "AsyncConciseBody",
-            ParseNodeKind::AsyncFunctionBody => "AsyncFunctionBody",
-            ParseNodeKind::AsyncGeneratorBody => "AsyncGeneratorBody",
+            //ParseNodeKind::AsyncFunctionBody => "AsyncFunctionBody",
+            //ParseNodeKind::AsyncGeneratorBody => "AsyncGeneratorBody",
             ParseNodeKind::AwaitExpression => "AwaitExpression",
             ParseNodeKind::BindingElement => "BindingElement",
             ParseNodeKind::BindingPattern => "BindingPattern",
@@ -137,9 +146,11 @@ impl fmt::Display for ParseNodeKind {
             ParseNodeKind::BreakStatement => "BreakStatement",
             ParseNodeKind::CallExpression => "CallExpression",
             ParseNodeKind::CatchParameter => "CatchParameter",
+            #[cfg(test)]
             ParseNodeKind::ClassBody => "ClassBody",
             ParseNodeKind::ClassElement => "ClassElement",
             ParseNodeKind::ClassElementName => "ClassElementName",
+            #[cfg(test)]
             ParseNodeKind::ClassHeritage => "ClassHeritage",
             ParseNodeKind::ConciseBody => "ConciseBody",
             ParseNodeKind::ConditionalExpression => "ConditionalExpression",
@@ -153,9 +164,8 @@ impl fmt::Display for ParseNodeKind {
             ParseNodeKind::ExpressionBody => "ExpressionBody",
             ParseNodeKind::ExpressionStatement => "ExpressionStatement",
             ParseNodeKind::ForBinding => "ForBinding",
-            ParseNodeKind::GeneratorBody => "GeneratorBody",
+            //ParseNodeKind::GeneratorBody => "GeneratorBody",
             ParseNodeKind::HoistableDeclaration => "HoistableDeclaration",
-            ParseNodeKind::IdentifierName => "IdentifierName",
             ParseNodeKind::IfStatement => "IfStatement",
             ParseNodeKind::IterationStatement => "IterationStatement",
             ParseNodeKind::LabelledItem => "LabelledItem",
@@ -175,6 +185,7 @@ impl fmt::Display for ParseNodeKind {
             ParseNodeKind::RegularExpression => "RegularExpression",
             ParseNodeKind::RelationalExpression => "RelationalExpression",
             ParseNodeKind::ReturnStatement => "ReturnStatement",
+            #[cfg(test)]
             ParseNodeKind::ScriptBody => "ScriptBody",
             ParseNodeKind::Statement => "Statement",
             ParseNodeKind::StatementList => "StatementList",
@@ -201,14 +212,14 @@ impl fmt::Display for ParseNodeKind {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-pub struct YieldAwaitKey {
+pub(crate) struct YieldAwaitKey {
     scanner: Scanner,
     yield_flag: bool,
     await_flag: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-pub struct YieldAwaitTaggedKey {
+pub(crate) struct YieldAwaitTaggedKey {
     scanner: Scanner,
     yield_flag: bool,
     await_flag: bool,
@@ -216,42 +227,42 @@ pub struct YieldAwaitTaggedKey {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-pub struct InYieldAwaitKey {
+pub(crate) struct InYieldAwaitKey {
     scanner: Scanner,
     in_flag: bool,
     yield_flag: bool,
     await_flag: bool,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-pub struct InKey {
-    scanner: Scanner,
-    in_flag: bool,
-}
+//#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+//pub(crate) struct InKey {
+//    scanner: Scanner,
+//    in_flag: bool,
+//}
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-pub struct InAwaitKey {
+pub(crate) struct InAwaitKey {
     scanner: Scanner,
     in_flag: bool,
     await_flag: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-pub struct YieldAwaitReturnKey {
+pub(crate) struct YieldAwaitReturnKey {
     scanner: Scanner,
     yield_flag: bool,
     await_flag: bool,
     return_flag: bool,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-pub struct YieldKey {
-    scanner: Scanner,
-    yield_flag: bool,
-}
+//#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+//pub(crate) struct YieldKey {
+//    scanner: Scanner,
+//    yield_flag: bool,
+//}
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-pub struct YieldAwaitDefaultKey {
+pub(crate) struct YieldAwaitDefaultKey {
     scanner: Scanner,
     yield_flag: bool,
     await_flag: bool,
@@ -261,77 +272,80 @@ pub struct YieldAwaitDefaultKey {
 type ParseResult<T> = Result<(Rc<T>, Scanner), ParseError>;
 
 #[derive(Default)]
-pub struct Parser<'a> {
-    pub source: &'a str,
-    pub direct: bool,
-    pub goal: ParseGoal,
-    pub arguments_cache: AHashMap<YieldAwaitKey, ParseResult<Arguments>, RandomState>,
-    pub arrow_formal_parameters_cache: AHashMap<YieldAwaitKey, ParseResult<ArrowFormalParameters>, RandomState>,
-    pub assignment_expression_cache: AHashMap<InYieldAwaitKey, ParseResult<AssignmentExpression>, RandomState>,
-    pub async_function_body_cache: AHashMap<Scanner, (Rc<AsyncFunctionBody>, Scanner), RandomState>,
-    pub async_generator_body_cache: AHashMap<Scanner, (Rc<AsyncGeneratorBody>, Scanner), RandomState>,
-    pub binding_element_cache: AHashMap<YieldAwaitKey, ParseResult<BindingElement>, RandomState>,
-    pub binding_identifier_cache: AHashMap<YieldAwaitKey, ParseResult<BindingIdentifier>, RandomState>,
-    pub binding_pattern_cache: AHashMap<YieldAwaitKey, ParseResult<BindingPattern>, RandomState>,
-    pub binding_rest_element_cache: AHashMap<YieldAwaitKey, ParseResult<BindingRestElement>, RandomState>,
-    pub binding_rest_property_cache: AHashMap<YieldAwaitKey, ParseResult<BindingRestProperty>, RandomState>,
-    pub bitwise_or_expression_cache: AHashMap<InYieldAwaitKey, ParseResult<BitwiseORExpression>, RandomState>,
-    pub block_cache: AHashMap<YieldAwaitReturnKey, ParseResult<Block>, RandomState>,
-    pub call_expression_cache: AHashMap<YieldAwaitKey, ParseResult<CallExpression>, RandomState>,
-    pub catch_parameter_cache: AHashMap<YieldAwaitKey, ParseResult<CatchParameter>, RandomState>,
-    pub class_tail_cache: AHashMap<YieldAwaitKey, ParseResult<ClassTail>, RandomState>,
-    pub coalesce_expression_cache: AHashMap<InYieldAwaitKey, ParseResult<CoalesceExpression>, RandomState>,
-    pub cover_call_expression_and_async_arrow_head_cache:
+pub(crate) struct Parser<'a> {
+    pub(crate) source: &'a str,
+    pub(crate) direct: bool,
+    pub(crate) goal: ParseGoal,
+    pub(crate) arguments_cache: AHashMap<YieldAwaitKey, ParseResult<Arguments>, RandomState>,
+    pub(crate) arrow_formal_parameters_cache: AHashMap<YieldAwaitKey, ParseResult<ArrowFormalParameters>, RandomState>,
+    pub(crate) assignment_expression_cache: AHashMap<InYieldAwaitKey, ParseResult<AssignmentExpression>, RandomState>,
+    pub(crate) async_function_body_cache: AHashMap<Scanner, (Rc<AsyncFunctionBody>, Scanner), RandomState>,
+    pub(crate) async_generator_body_cache: AHashMap<Scanner, (Rc<AsyncGeneratorBody>, Scanner), RandomState>,
+    pub(crate) binding_element_cache: AHashMap<YieldAwaitKey, ParseResult<BindingElement>, RandomState>,
+    pub(crate) binding_identifier_cache: AHashMap<YieldAwaitKey, ParseResult<BindingIdentifier>, RandomState>,
+    pub(crate) binding_pattern_cache: AHashMap<YieldAwaitKey, ParseResult<BindingPattern>, RandomState>,
+    pub(crate) binding_rest_element_cache: AHashMap<YieldAwaitKey, ParseResult<BindingRestElement>, RandomState>,
+    pub(crate) binding_rest_property_cache: AHashMap<YieldAwaitKey, ParseResult<BindingRestProperty>, RandomState>,
+    pub(crate) bitwise_or_expression_cache: AHashMap<InYieldAwaitKey, ParseResult<BitwiseORExpression>, RandomState>,
+    pub(crate) block_cache: AHashMap<YieldAwaitReturnKey, ParseResult<Block>, RandomState>,
+    pub(crate) call_expression_cache: AHashMap<YieldAwaitKey, ParseResult<CallExpression>, RandomState>,
+    pub(crate) catch_parameter_cache: AHashMap<YieldAwaitKey, ParseResult<CatchParameter>, RandomState>,
+    pub(crate) class_tail_cache: AHashMap<YieldAwaitKey, ParseResult<ClassTail>, RandomState>,
+    pub(crate) coalesce_expression_cache: AHashMap<InYieldAwaitKey, ParseResult<CoalesceExpression>, RandomState>,
+    pub(crate) cover_call_expression_and_async_arrow_head_cache:
         AHashMap<YieldAwaitKey, ParseResult<CoverCallExpressionAndAsyncArrowHead>, RandomState>,
-    pub cpeaapl_cache:
+    pub(crate) cpeaapl_cache:
         AHashMap<YieldAwaitKey, ParseResult<CoverParenthesizedExpressionAndArrowParameterList>, RandomState>,
-    pub elision_cache: AHashMap<Scanner, ParseResult<Elisions>, RandomState>,
-    pub expression_body_cache: AHashMap<InAwaitKey, ParseResult<ExpressionBody>, RandomState>,
-    pub expression_cache: AHashMap<InYieldAwaitKey, ParseResult<Expression>, RandomState>,
-    pub for_binding_cache: AHashMap<YieldAwaitKey, ParseResult<ForBinding>, RandomState>,
-    pub formal_parameter_cache: AHashMap<YieldAwaitKey, ParseResult<FormalParameter>, RandomState>,
-    pub formal_parameters_cache: AHashMap<YieldAwaitKey, (Rc<FormalParameters>, Scanner), RandomState>,
-    pub function_body_cache: AHashMap<YieldAwaitKey, (Rc<FunctionBody>, Scanner), RandomState>,
-    pub function_declaration_cache: AHashMap<YieldAwaitDefaultKey, ParseResult<FunctionDeclaration>, RandomState>,
-    pub generator_body_cache: AHashMap<Scanner, (Rc<GeneratorBody>, Scanner), RandomState>,
-    pub identifier_cache: AHashMap<Scanner, ParseResult<Identifier>, RandomState>,
-    pub identifier_reference_cache: AHashMap<YieldAwaitKey, ParseResult<IdentifierReference>, RandomState>,
-    pub initializer_cache: AHashMap<InYieldAwaitKey, ParseResult<Initializer>, RandomState>,
-    pub label_identifier_cache: AHashMap<YieldAwaitKey, ParseResult<LabelIdentifier>, RandomState>,
-    pub lexical_declaration_cache: AHashMap<InYieldAwaitKey, ParseResult<LexicalDeclaration>, RandomState>,
-    pub lhs_cache: AHashMap<YieldAwaitKey, ParseResult<LeftHandSideExpression>, RandomState>,
-    pub lpn_cache: AHashMap<Scanner, ParseResult<LiteralPropertyName>, RandomState>,
-    pub member_expression_cache: AHashMap<YieldAwaitKey, ParseResult<MemberExpression>, RandomState>,
-    pub meta_property_cache: AHashMap<Scanner, ParseResult<MetaProperty>, RandomState>,
-    pub method_definition_cache: AHashMap<YieldAwaitKey, ParseResult<MethodDefinition>, RandomState>,
-    pub property_name_cache: AHashMap<YieldAwaitKey, ParseResult<PropertyName>, RandomState>,
-    pub single_name_binding_cache: AHashMap<YieldAwaitKey, ParseResult<SingleNameBinding>, RandomState>,
-    pub statement_cache: AHashMap<YieldAwaitReturnKey, ParseResult<Statement>, RandomState>,
-    pub statement_list_cache: AHashMap<YieldAwaitReturnKey, ParseResult<StatementList>, RandomState>,
-    pub template_literal_cache: AHashMap<YieldAwaitTaggedKey, ParseResult<TemplateLiteral>, RandomState>,
-    pub unary_expression_cache: AHashMap<YieldAwaitKey, ParseResult<UnaryExpression>, RandomState>,
-    pub unique_formal_parameters_cache: AHashMap<YieldAwaitKey, (Rc<UniqueFormalParameters>, Scanner), RandomState>,
-    pub update_expression_cache: AHashMap<YieldAwaitKey, ParseResult<UpdateExpression>, RandomState>,
-    pub variable_declaration_list_cache: AHashMap<InYieldAwaitKey, ParseResult<VariableDeclarationList>, RandomState>,
+    pub(crate) elision_cache: AHashMap<Scanner, ParseResult<Elisions>, RandomState>,
+    pub(crate) expression_body_cache: AHashMap<InAwaitKey, ParseResult<ExpressionBody>, RandomState>,
+    pub(crate) expression_cache: AHashMap<InYieldAwaitKey, ParseResult<Expression>, RandomState>,
+    pub(crate) for_binding_cache: AHashMap<YieldAwaitKey, ParseResult<ForBinding>, RandomState>,
+    pub(crate) formal_parameter_cache: AHashMap<YieldAwaitKey, ParseResult<FormalParameter>, RandomState>,
+    pub(crate) formal_parameters_cache: AHashMap<YieldAwaitKey, (Rc<FormalParameters>, Scanner), RandomState>,
+    pub(crate) function_body_cache: AHashMap<YieldAwaitKey, (Rc<FunctionBody>, Scanner), RandomState>,
+    pub(crate) function_declaration_cache:
+        AHashMap<YieldAwaitDefaultKey, ParseResult<FunctionDeclaration>, RandomState>,
+    pub(crate) generator_body_cache: AHashMap<Scanner, (Rc<GeneratorBody>, Scanner), RandomState>,
+    pub(crate) identifier_cache: AHashMap<Scanner, ParseResult<Identifier>, RandomState>,
+    pub(crate) identifier_reference_cache: AHashMap<YieldAwaitKey, ParseResult<IdentifierReference>, RandomState>,
+    pub(crate) initializer_cache: AHashMap<InYieldAwaitKey, ParseResult<Initializer>, RandomState>,
+    pub(crate) label_identifier_cache: AHashMap<YieldAwaitKey, ParseResult<LabelIdentifier>, RandomState>,
+    pub(crate) lexical_declaration_cache: AHashMap<InYieldAwaitKey, ParseResult<LexicalDeclaration>, RandomState>,
+    pub(crate) lhs_cache: AHashMap<YieldAwaitKey, ParseResult<LeftHandSideExpression>, RandomState>,
+    //pub(crate) lpn_cache: AHashMap<Scanner, ParseResult<LiteralPropertyName>, RandomState>,
+    pub(crate) member_expression_cache: AHashMap<YieldAwaitKey, ParseResult<MemberExpression>, RandomState>,
+    //pub(crate) meta_property_cache: AHashMap<Scanner, ParseResult<MetaProperty>, RandomState>,
+    pub(crate) method_definition_cache: AHashMap<YieldAwaitKey, ParseResult<MethodDefinition>, RandomState>,
+    pub(crate) property_name_cache: AHashMap<YieldAwaitKey, ParseResult<PropertyName>, RandomState>,
+    pub(crate) single_name_binding_cache: AHashMap<YieldAwaitKey, ParseResult<SingleNameBinding>, RandomState>,
+    pub(crate) statement_cache: AHashMap<YieldAwaitReturnKey, ParseResult<Statement>, RandomState>,
+    pub(crate) statement_list_cache: AHashMap<YieldAwaitReturnKey, ParseResult<StatementList>, RandomState>,
+    pub(crate) template_literal_cache: AHashMap<YieldAwaitTaggedKey, ParseResult<TemplateLiteral>, RandomState>,
+    pub(crate) unary_expression_cache: AHashMap<YieldAwaitKey, ParseResult<UnaryExpression>, RandomState>,
+    pub(crate) unique_formal_parameters_cache:
+        AHashMap<YieldAwaitKey, (Rc<UniqueFormalParameters>, Scanner), RandomState>,
+    pub(crate) update_expression_cache: AHashMap<YieldAwaitKey, ParseResult<UpdateExpression>, RandomState>,
+    pub(crate) variable_declaration_list_cache:
+        AHashMap<InYieldAwaitKey, ParseResult<VariableDeclarationList>, RandomState>,
 }
 
 impl<'a> Parser<'a> {
-    pub fn new(source: &'a str, direct: bool, goal: ParseGoal) -> Self {
+    pub(crate) fn new(source: &'a str, direct: bool, goal: ParseGoal) -> Self {
         Self { source, direct, goal, ..Default::default() }
     }
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Copy, Clone, Default)]
-pub struct Span {
-    pub starting_index: usize,
-    pub length: usize,
+pub(crate) struct Span {
+    pub(crate) starting_index: usize,
+    pub(crate) length: usize,
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Copy, Clone)]
-pub struct Location {
-    pub starting_line: u32,
-    pub starting_column: u32,
-    pub span: Span,
+pub(crate) struct Location {
+    pub(crate) starting_line: u32,
+    pub(crate) starting_column: u32,
+    pub(crate) span: Span,
 }
 
 impl Default for Location {
@@ -380,7 +394,7 @@ impl Ord for Location {
 
 impl Location {
     #[must_use]
-    pub fn merge(&self, other: &Self) -> Self {
+    pub(crate) fn merge(&self, other: &Self) -> Self {
         assert!(self.span.starting_index <= other.span.starting_index + other.span.length);
         Location {
             starting_line: self.starting_line,
@@ -392,14 +406,14 @@ impl Location {
         }
     }
 
-    pub fn contains(&self, other: &Self) -> bool {
+    pub(crate) fn contains(&self, other: &Self) -> bool {
         self.span.starting_index <= other.span.starting_index
             && (self.span.starting_index + self.span.length) >= (other.span.starting_index + other.span.length)
     }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Default)]
-pub enum PECode {
+pub(crate) enum PECode {
     #[default]
     Generic,
     EoFExpected,
@@ -425,6 +439,7 @@ pub enum PECode {
     ImproperExpression,
     DeclarationOrStatementExpected,
     ParseNodeExpected(ParseNodeKind),
+    IdentifierNameExpected,
     OpenOrIdentExpected,
     ForStatementDefinitionError,
     ForInOfDefinitionError,
@@ -473,6 +488,7 @@ impl fmt::Display for PECode {
             PECode::ImproperExpression => f.write_str("Improper Expression"),
             PECode::DeclarationOrStatementExpected => f.write_str("Declaration or Statement expected"),
             PECode::ParseNodeExpected(pn) => write!(f, "{pn} expected"),
+            PECode::IdentifierNameExpected => f.write_str("identifier name expected"),
             PECode::OpenOrIdentExpected => f.write_str("‘[’, ‘{’, or an identifier expected"),
             PECode::ForStatementDefinitionError => f.write_str("‘var’, LexicalDeclaration, or Expression expected"),
             PECode::ForInOfDefinitionError => f.write_str("‘let’, ‘var’, or a LeftHandSideExpression expected"),
@@ -483,7 +499,7 @@ impl fmt::Display for PECode {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct ParseError {
+pub(crate) struct ParseError {
     code: PECode,
     location: Location,
 }
@@ -494,13 +510,13 @@ impl fmt::Display for ParseError {
 }
 impl Error for ParseError {}
 impl ParseError {
-    pub fn compare(left: &ParseError, right: &ParseError) -> Ordering {
+    pub(crate) fn compare(left: &ParseError, right: &ParseError) -> Ordering {
         left.location.cmp(&right.location)
     }
-    pub fn new(code: PECode, location: impl Into<Location>) -> Self {
+    pub(crate) fn new(code: PECode, location: impl Into<Location>) -> Self {
         Self { code, location: location.into() }
     }
-    pub fn compare_option(left: Option<&Self>, right: Option<&Self>) -> Ordering {
+    pub(crate) fn compare_option(left: Option<&Self>, right: Option<&Self>) -> Ordering {
         let location_left = left.map(|pe| &pe.location);
         let location_right = right.map(|pe| &pe.location);
 
@@ -522,7 +538,7 @@ impl ParseError {
 //    parse_first_kind(parse_args)
 //       .otherwise(|| parse_second_kind(parse_args))
 //       .otherwise(|| parse_third_kind(parse_args))
-pub trait Otherwise<T, E> {
+pub(crate) trait Otherwise<T, E> {
     fn otherwise<O>(self, f: O) -> Result<T, E>
     where
         O: FnOnce() -> Result<T, E>;
@@ -537,20 +553,16 @@ impl<T> Otherwise<T, ParseError> for Result<T, ParseError> {
     }
 }
 
-pub trait IsFunctionDefinition {
-    fn is_function_definition(&self) -> bool;
-}
-
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub enum ATTKind {
+pub(crate) enum ATTKind {
     Invalid,
     Simple,
 }
 
-pub fn scan_for_punct(
+pub(crate) fn scan_for_punct(
     scanner: Scanner,
     src: &str,
-    goal: ScanGoal,
+    goal: InputElementGoal,
     punct: Punctuator,
 ) -> Result<(Location, Scanner), ParseError> {
     let (tok, token_loc, after_tok) = scan_token(&scanner, src, goal);
@@ -561,10 +573,10 @@ pub fn scan_for_punct(
     }
 }
 
-pub fn scan_for_punct_set(
+pub(crate) fn scan_for_punct_set(
     scanner: Scanner,
     src: &str,
-    goal: ScanGoal,
+    goal: InputElementGoal,
     punct_set: &[Punctuator],
 ) -> Result<(Punctuator, Location, Scanner), ParseError> {
     let (tok, tok_loc, after_tok) = scan_token(&scanner, src, goal);
@@ -575,7 +587,11 @@ pub fn scan_for_punct_set(
     }
 }
 
-pub fn scan_for_auto_semi(scanner: Scanner, src: &str, goal: ScanGoal) -> Result<(Location, Scanner), ParseError> {
+pub(crate) fn scan_for_auto_semi(
+    scanner: Scanner,
+    src: &str,
+    goal: InputElementGoal,
+) -> Result<(Location, Scanner), ParseError> {
     let (tok, tok_loc, after_tok) = scan_token(&scanner, src, goal);
     if tok.matches_punct(Punctuator::Semicolon) {
         Ok((tok_loc, after_tok))
@@ -586,10 +602,10 @@ pub fn scan_for_auto_semi(scanner: Scanner, src: &str, goal: ScanGoal) -> Result
     }
 }
 
-pub fn scan_for_keyword(
+pub(crate) fn scan_for_keyword(
     scanner: Scanner,
     src: &str,
-    goal: ScanGoal,
+    goal: InputElementGoal,
     kwd: Keyword,
 ) -> Result<(Location, Scanner), ParseError> {
     let (tok, tok_loc, after_tok) = scan_token(&scanner, src, goal);
@@ -600,10 +616,10 @@ pub fn scan_for_keyword(
     }
 }
 
-pub fn scan_for_keywords(
+pub(crate) fn scan_for_keywords(
     scanner: Scanner,
     src: &str,
-    goal: ScanGoal,
+    goal: InputElementGoal,
     kwds: &[Keyword],
 ) -> Result<(Keyword, Location, Scanner), ParseError> {
     let (tok, tok_loc, after_tok) = scan_token(&scanner, src, goal);
@@ -614,23 +630,23 @@ pub fn scan_for_keywords(
     }
 }
 
-pub fn scan_for_identifiername(
+pub(crate) fn scan_for_identifiername(
     scanner: Scanner,
     src: &str,
-    goal: ScanGoal,
+    goal: InputElementGoal,
 ) -> Result<(IdentifierData, Location, Scanner), ParseError> {
     let (tok, tok_loc, after_tok) = scan_token(&scanner, src, goal);
     if let Token::Identifier(id) = tok {
         Ok((id, tok_loc, after_tok))
     } else {
-        Err(ParseError::new(PECode::ParseNodeExpected(ParseNodeKind::IdentifierName), tok_loc))
+        Err(ParseError::new(PECode::IdentifierNameExpected, tok_loc))
     }
 }
 
-pub fn scan_for_private_identifier(
+pub(crate) fn scan_for_private_identifier(
     scanner: Scanner,
     src: &str,
-    goal: ScanGoal,
+    goal: InputElementGoal,
 ) -> Result<(IdentifierData, Location, Scanner), ParseError> {
     let (tok, tok_loc, after_tok) = scan_token(&scanner, src, goal);
     if let Token::PrivateIdentifier(id) = tok {
@@ -640,16 +656,16 @@ pub fn scan_for_private_identifier(
     }
 }
 
-pub fn scan_for_eof(scanner: Scanner, src: &str) -> Result<(Location, Scanner), ParseError> {
-    let (tok, tok_loc, after_tok) = scan_token(&scanner, src, ScanGoal::InputElementDiv);
+pub(crate) fn scan_for_eof(scanner: Scanner, src: &str) -> Result<(Location, Scanner), ParseError> {
+    let (tok, tok_loc, after_tok) = scan_token(&scanner, src, InputElementGoal::Div);
     if tok == Token::Eof { Ok((tok_loc, after_tok)) } else { Err(ParseError::new(PECode::EoFExpected, tok_loc)) }
 }
 
 //no_line_terminator(after_cont, parser.source)?;
 // If there is no newline sequence between the scanner's spot and the start of the next token, return Ok
 // else return Err.
-pub fn no_line_terminator(scanner: Scanner, src: &str) -> Result<(), ParseError> {
-    let (_, tok_loc, _) = scan_token(&scanner, src, ScanGoal::InputElementDiv);
+pub(crate) fn no_line_terminator(scanner: Scanner, src: &str) -> Result<(), ParseError> {
+    let (_, tok_loc, _) = scan_token(&scanner, src, InputElementGoal::Div);
     if tok_loc.starting_line == scanner.line { Ok(()) } else { Err(ParseError::new(PECode::ImproperNewline, scanner)) }
 }
 
@@ -667,171 +683,330 @@ pub fn no_line_terminator(scanner: Scanner, src: &str) -> Result<(), ParseError>
 //    implementation-defined, but at least one must be present.
 
 #[derive(Debug, Clone)]
-pub enum ParsedText {
+pub(crate) enum ParsedText {
     Errors(Vec<Object>),
     Empty,
-    AdditiveExpression(Rc<AdditiveExpression>),
-    ArgumentList(Rc<ArgumentList>),
-    Arguments(Rc<Arguments>),
-    ArrayAssignmentPattern(Rc<ArrayAssignmentPattern>),
-    ArrayBindingPattern(Rc<ArrayBindingPattern>),
-    ArrayLiteral(Rc<ArrayLiteral>),
-    ArrowFormalParameters(Rc<ArrowFormalParameters>),
-    ArrowFunction(Rc<ArrowFunction>),
-    ArrowParameters(Rc<ArrowParameters>),
-    AssignmentElement(Rc<AssignmentElement>),
-    AssignmentElementList(Rc<AssignmentElementList>),
-    AssignmentElisionElement(Rc<AssignmentElisionElement>),
-    AssignmentExpression(Rc<AssignmentExpression>),
-    AssignmentPattern(Rc<AssignmentPattern>),
-    AssignmentProperty(Rc<AssignmentProperty>),
-    AssignmentPropertyList(Rc<AssignmentPropertyList>),
-    AssignmentRestElement(Rc<AssignmentRestElement>),
-    AssignmentRestProperty(Rc<AssignmentRestProperty>),
-    AsyncArrowBindingIdentifier(Rc<AsyncArrowBindingIdentifier>),
-    AsyncArrowFunction(Rc<AsyncArrowFunction>),
-    AsyncArrowHead(Rc<AsyncArrowHead>),
-    AsyncConciseBody(Rc<AsyncConciseBody>),
-    AsyncFunctionBody(Rc<AsyncFunctionBody>),
-    AsyncFunctionDeclaration(Rc<AsyncFunctionDeclaration>),
-    AsyncFunctionExpression(Rc<AsyncFunctionExpression>),
-    AsyncGeneratorBody(Rc<AsyncGeneratorBody>),
-    AsyncGeneratorDeclaration(Rc<AsyncGeneratorDeclaration>),
-    AsyncGeneratorExpression(Rc<AsyncGeneratorExpression>),
-    AsyncGeneratorMethod(Rc<AsyncGeneratorMethod>),
-    AsyncMethod(Rc<AsyncMethod>),
-    AwaitExpression(Rc<AwaitExpression>),
-    BindingElement(Rc<BindingElement>),
-    BindingElementList(Rc<BindingElementList>),
-    BindingElisionElement(Rc<BindingElisionElement>),
-    BindingIdentifier(Rc<BindingIdentifier>),
-    BindingList(Rc<BindingList>),
-    BindingPattern(Rc<BindingPattern>),
-    BindingProperty(Rc<BindingProperty>),
-    BindingPropertyList(Rc<BindingPropertyList>),
-    BindingRestElement(Rc<BindingRestElement>),
-    BindingRestProperty(Rc<BindingRestProperty>),
-    BitwiseANDExpression(Rc<BitwiseANDExpression>),
-    BitwiseORExpression(Rc<BitwiseORExpression>),
-    BitwiseXORExpression(Rc<BitwiseXORExpression>),
-    Block(Rc<Block>),
-    BlockStatement(Rc<BlockStatement>),
-    BreakableStatement(Rc<BreakableStatement>),
-    BreakStatement(Rc<BreakStatement>),
-    CallExpression(Rc<CallExpression>),
-    CallMemberExpression(Rc<CallMemberExpression>),
-    CaseBlock(Rc<CaseBlock>),
-    CaseClause(Rc<CaseClause>),
-    CaseClauses(Rc<CaseClauses>),
-    Catch(Rc<Catch>),
-    CatchParameter(Rc<CatchParameter>),
-    ClassBody(Rc<ClassBody>),
-    ClassDeclaration(Rc<ClassDeclaration>),
-    ClassElement(Rc<ClassElement>),
-    ClassElementList(Rc<ClassElementList>),
-    ClassElementName(Rc<ClassElementName>),
-    ClassExpression(Rc<ClassExpression>),
-    ClassHeritage(Rc<ClassHeritage>),
-    ClassStaticBlock(Rc<ClassStaticBlock>),
-    ClassStaticBlockBody(Rc<ClassStaticBlockBody>),
-    ClassStaticBlockStatementList(Rc<ClassStaticBlockStatementList>),
-    ClassTail(Rc<ClassTail>),
-    CoalesceExpression(Rc<CoalesceExpression>),
-    CoalesceExpressionHead(Rc<CoalesceExpressionHead>),
-    ComputedPropertyName(Rc<ComputedPropertyName>),
-    ConciseBody(Rc<ConciseBody>),
-    ConditionalExpression(Rc<ConditionalExpression>),
-    ContinueStatement(Rc<ContinueStatement>),
-    CoverInitializedName(Rc<CoverInitializedName>),
-    CoverParenthesizedExpressionAndArrowParameterList(Rc<CoverParenthesizedExpressionAndArrowParameterList>),
-    DebuggerStatement(Rc<DebuggerStatement>),
-    Declaration(Rc<Declaration>),
-    DefaultClause(Rc<DefaultClause>),
-    DestructuringAssignmentTarget(Rc<DestructuringAssignmentTarget>),
-    DoWhileStatement(Rc<DoWhileStatement>),
-    ElementList(Rc<ElementList>),
-    Elisions(Rc<Elisions>),
-    EmptyStatement(Rc<EmptyStatement>),
-    EqualityExpression(Rc<EqualityExpression>),
-    ExponentiationExpression(Rc<ExponentiationExpression>),
-    Expression(Rc<Expression>),
-    ExpressionBody(Rc<ExpressionBody>),
-    ExpressionStatement(Rc<ExpressionStatement>),
-    FieldDefinition(Rc<FieldDefinition>),
-    Finally(Rc<Finally>),
-    ForBinding(Rc<ForBinding>),
-    ForDeclaration(Rc<ForDeclaration>),
-    ForInOfStatement(Rc<ForInOfStatement>),
-    FormalParameter(Rc<FormalParameter>),
-    FormalParameterList(Rc<FormalParameterList>),
     FormalParameters(Rc<FormalParameters>),
-    ForStatement(Rc<ForStatement>),
     FunctionBody(Rc<FunctionBody>),
-    FunctionDeclaration(Rc<FunctionDeclaration>),
     FunctionExpression(Rc<FunctionExpression>),
-    FunctionRestParameter(Rc<FunctionRestParameter>),
-    FunctionStatementList(Rc<FunctionStatementList>),
     GeneratorBody(Rc<GeneratorBody>),
-    GeneratorDeclaration(Rc<GeneratorDeclaration>),
     GeneratorExpression(Rc<GeneratorExpression>),
-    GeneratorMethod(Rc<GeneratorMethod>),
-    IfStatement(Rc<IfStatement>),
-    Initializer(Rc<Initializer>),
-    IterationStatement(Rc<IterationStatement>),
-    LabelledItem(Rc<LabelledItem>),
-    LabelledStatement(Rc<LabelledStatement>),
-    LeftHandSideExpression(Rc<LeftHandSideExpression>),
-    LexicalBinding(Rc<LexicalBinding>),
-    LexicalDeclaration(Rc<LexicalDeclaration>),
-    Literal(Rc<Literal>),
-    LiteralPropertyName(Rc<LiteralPropertyName>),
-    LogicalANDExpression(Rc<LogicalANDExpression>),
-    LogicalORExpression(Rc<LogicalORExpression>),
-    MemberExpression(Rc<MemberExpression>),
-    MetaProperty(Rc<MetaProperty>),
-    MethodDefinition(Rc<MethodDefinition>),
-    MultiplicativeExpression(Rc<MultiplicativeExpression>),
-    NewExpression(Rc<NewExpression>),
-    ObjectAssignmentPattern(Rc<ObjectAssignmentPattern>),
-    ObjectBindingPattern(Rc<ObjectBindingPattern>),
-    ObjectLiteral(Rc<ObjectLiteral>),
-    OptionalChain(Rc<OptionalChain>),
-    OptionalExpression(Rc<OptionalExpression>),
-    ParenthesizedExpression(Rc<ParenthesizedExpression>),
-    PrimaryExpression(Rc<PrimaryExpression>),
-    PropertyDefinition(Rc<PropertyDefinition>),
-    PropertyDefinitionList(Rc<PropertyDefinitionList>),
-    PropertyName(Rc<PropertyName>),
-    PropertySetParameterList(Rc<PropertySetParameterList>),
-    RelationalExpression(Rc<RelationalExpression>),
-    ReturnStatement(Rc<ReturnStatement>),
     Script(Rc<Script>),
+
+    // The following are all used in testing scenarios, not the actual runtime, so they all get the #[cfg(test)]
+    // treatment
+    #[cfg(test)]
+    AsyncFunctionBody(Rc<AsyncFunctionBody>),
+    #[cfg(test)]
+    AsyncFunctionExpression(Rc<AsyncFunctionExpression>),
+    #[cfg(test)]
+    AsyncGeneratorBody(Rc<AsyncGeneratorBody>),
+    #[cfg(test)]
+    AsyncGeneratorExpression(Rc<AsyncGeneratorExpression>),
+    #[cfg(test)]
+    AdditiveExpression(Rc<AdditiveExpression>),
+    #[cfg(test)]
+    ArgumentList(Rc<ArgumentList>),
+    #[cfg(test)]
+    Arguments(Rc<Arguments>),
+    #[cfg(test)]
+    ArrayAssignmentPattern(Rc<ArrayAssignmentPattern>),
+    #[cfg(test)]
+    ArrayBindingPattern(Rc<ArrayBindingPattern>),
+    #[cfg(test)]
+    ArrayLiteral(Rc<ArrayLiteral>),
+    #[cfg(test)]
+    ArrowFormalParameters(Rc<ArrowFormalParameters>),
+    #[cfg(test)]
+    ArrowFunction(Rc<ArrowFunction>),
+    #[cfg(test)]
+    ArrowParameters(Rc<ArrowParameters>),
+    #[cfg(test)]
+    AssignmentElement(Rc<AssignmentElement>),
+    #[cfg(test)]
+    AssignmentElementList(Rc<AssignmentElementList>),
+    #[cfg(test)]
+    AssignmentElisionElement(Rc<AssignmentElisionElement>),
+    #[cfg(test)]
+    AssignmentExpression(Rc<AssignmentExpression>),
+    #[cfg(test)]
+    AssignmentPattern(Rc<AssignmentPattern>),
+    #[cfg(test)]
+    AssignmentProperty(Rc<AssignmentProperty>),
+    #[cfg(test)]
+    AssignmentPropertyList(Rc<AssignmentPropertyList>),
+    #[cfg(test)]
+    AssignmentRestElement(Rc<AssignmentRestElement>),
+    #[cfg(test)]
+    AssignmentRestProperty(Rc<AssignmentRestProperty>),
+    #[cfg(test)]
+    AsyncArrowBindingIdentifier(Rc<AsyncArrowBindingIdentifier>),
+    //#[cfg(test)]
+    //AsyncArrowFunction(Rc<AsyncArrowFunction>),
+    //#[cfg(test)]
+    //AsyncArrowHead(Rc<AsyncArrowHead>),
+    //#[cfg(test)]
+    //AsyncConciseBody(Rc<AsyncConciseBody>),
+    #[cfg(test)]
+    AsyncFunctionDeclaration(Rc<AsyncFunctionDeclaration>),
+    #[cfg(test)]
+    AsyncGeneratorDeclaration(Rc<AsyncGeneratorDeclaration>),
+    //#[cfg(test)]
+    //AsyncGeneratorMethod(Rc<AsyncGeneratorMethod>),
+    //#[cfg(test)]
+    //AsyncMethod(Rc<AsyncMethod>),
+    //#[cfg(test)]
+    //AwaitExpression(Rc<AwaitExpression>),
+    #[cfg(test)]
+    BindingElement(Rc<BindingElement>),
+    #[cfg(test)]
+    BindingElementList(Rc<BindingElementList>),
+    #[cfg(test)]
+    BindingElisionElement(Rc<BindingElisionElement>),
+    //#[cfg(test)]
+    //BindingIdentifier(Rc<BindingIdentifier>),
+    #[cfg(test)]
+    BindingList(Rc<BindingList>),
+    #[cfg(test)]
+    BindingPattern(Rc<BindingPattern>),
+    #[cfg(test)]
+    BindingProperty(Rc<BindingProperty>),
+    #[cfg(test)]
+    BindingPropertyList(Rc<BindingPropertyList>),
+    #[cfg(test)]
+    BindingRestElement(Rc<BindingRestElement>),
+    //    #[cfg(test)]
+    //    BindingRestProperty(Rc<BindingRestProperty>),
+    #[cfg(test)]
+    BitwiseANDExpression(Rc<BitwiseANDExpression>),
+    #[cfg(test)]
+    BitwiseORExpression(Rc<BitwiseORExpression>),
+    #[cfg(test)]
+    BitwiseXORExpression(Rc<BitwiseXORExpression>),
+    #[cfg(test)]
+    Block(Rc<Block>),
+    #[cfg(test)]
+    BlockStatement(Rc<BlockStatement>),
+    #[cfg(test)]
+    BreakableStatement(Rc<BreakableStatement>),
+    //    #[cfg(test)]
+    //    BreakStatement(Rc<BreakStatement>),
+    #[cfg(test)]
+    CallExpression(Rc<CallExpression>),
+    #[cfg(test)]
+    CallMemberExpression(Rc<CallMemberExpression>),
+    #[cfg(test)]
+    CaseBlock(Rc<CaseBlock>),
+    #[cfg(test)]
+    CaseClause(Rc<CaseClause>),
+    #[cfg(test)]
+    //    CaseClauses(Rc<CaseClauses>),
+    //    #[cfg(test)]
+    Catch(Rc<Catch>),
+    #[cfg(test)]
+    CatchParameter(Rc<CatchParameter>),
+    //    #[cfg(test)]
+    //    ClassBody(Rc<ClassBody>),
+    #[cfg(test)]
+    ClassDeclaration(Rc<ClassDeclaration>),
+    //    #[cfg(test)]
+    //    ClassElement(Rc<ClassElement>),
+    //    #[cfg(test)]
+    //    ClassElementList(Rc<ClassElementList>),
+    #[cfg(test)]
+    ClassElementName(Rc<ClassElementName>),
+    //    #[cfg(test)]
+    //    ClassExpression(Rc<ClassExpression>),
+    //    #[cfg(test)]
+    //    ClassHeritage(Rc<ClassHeritage>),
+    //    #[cfg(test)]
+    //    ClassStaticBlock(Rc<ClassStaticBlock>),
+    #[cfg(test)]
+    ClassStaticBlockBody(Rc<ClassStaticBlockBody>),
+    #[cfg(test)]
+    ClassStaticBlockStatementList(Rc<ClassStaticBlockStatementList>),
+    //    #[cfg(test)]
+    //    ClassTail(Rc<ClassTail>),
+    #[cfg(test)]
+    CoalesceExpression(Rc<CoalesceExpression>),
+    #[cfg(test)]
+    CoalesceExpressionHead(Rc<CoalesceExpressionHead>),
+    #[cfg(test)]
+    ComputedPropertyName(Rc<ComputedPropertyName>),
+    //    #[cfg(test)]
+    //    ConciseBody(Rc<ConciseBody>),
+    #[cfg(test)]
+    ConditionalExpression(Rc<ConditionalExpression>),
+    //    #[cfg(test)]
+    //    ContinueStatement(Rc<ContinueStatement>),
+    //    #[cfg(test)]
+    //    CoverInitializedName(Rc<CoverInitializedName>),
+    //    #[cfg(test)]
+    //    CoverParenthesizedExpressionAndArrowParameterList(Rc<CoverParenthesizedExpressionAndArrowParameterList>),
+    //    #[cfg(test)]
+    //    DebuggerStatement(Rc<DebuggerStatement>),
+    #[cfg(test)]
+    Declaration(Rc<Declaration>),
+    #[cfg(test)]
+    DefaultClause(Rc<DefaultClause>),
+    #[cfg(test)]
+    DestructuringAssignmentTarget(Rc<DestructuringAssignmentTarget>),
+    #[cfg(test)]
+    DoWhileStatement(Rc<DoWhileStatement>),
+    #[cfg(test)]
+    ElementList(Rc<ElementList>),
+    //    #[cfg(test)]
+    //    Elisions(Rc<Elisions>),
+    //    #[cfg(test)]
+    //    EmptyStatement(Rc<EmptyStatement>),
+    #[cfg(test)]
+    EqualityExpression(Rc<EqualityExpression>),
+    #[cfg(test)]
+    ExponentiationExpression(Rc<ExponentiationExpression>),
+    #[cfg(test)]
+    Expression(Rc<Expression>),
+    #[cfg(test)]
+    ExpressionBody(Rc<ExpressionBody>),
+    #[cfg(test)]
+    ExpressionStatement(Rc<ExpressionStatement>),
+    #[cfg(test)]
+    FieldDefinition(Rc<FieldDefinition>),
+    #[cfg(test)]
+    Finally(Rc<Finally>),
+    #[cfg(test)]
+    ForBinding(Rc<ForBinding>),
+    #[cfg(test)]
+    ForDeclaration(Rc<ForDeclaration>),
+    #[cfg(test)]
+    ForInOfStatement(Rc<ForInOfStatement>),
+    #[cfg(test)]
+    FormalParameter(Rc<FormalParameter>),
+    #[cfg(test)]
+    FormalParameterList(Rc<FormalParameterList>),
+    #[cfg(test)]
+    ForStatement(Rc<ForStatement>),
+    #[cfg(test)]
+    FunctionDeclaration(Rc<FunctionDeclaration>),
+    #[cfg(test)]
+    FunctionRestParameter(Rc<FunctionRestParameter>),
+    #[cfg(test)]
+    FunctionStatementList(Rc<FunctionStatementList>),
+    #[cfg(test)]
+    GeneratorDeclaration(Rc<GeneratorDeclaration>),
+    //    #[cfg(test)]
+    //    GeneratorMethod(Rc<GeneratorMethod>),
+    #[cfg(test)]
+    IfStatement(Rc<IfStatement>),
+    #[cfg(test)]
+    Initializer(Rc<Initializer>),
+    #[cfg(test)]
+    IterationStatement(Rc<IterationStatement>),
+    #[cfg(test)]
+    LabelledItem(Rc<LabelledItem>),
+    #[cfg(test)]
+    LabelledStatement(Rc<LabelledStatement>),
+    #[cfg(test)]
+    LeftHandSideExpression(Rc<LeftHandSideExpression>),
+    #[cfg(test)]
+    LexicalBinding(Rc<LexicalBinding>),
+    #[cfg(test)]
+    LexicalDeclaration(Rc<LexicalDeclaration>),
+    //    #[cfg(test)]
+    //    Literal(Rc<Literal>),
+    //    #[cfg(test)]
+    //    LiteralPropertyName(Rc<LiteralPropertyName>),
+    #[cfg(test)]
+    LogicalANDExpression(Rc<LogicalANDExpression>),
+    #[cfg(test)]
+    LogicalORExpression(Rc<LogicalORExpression>),
+    #[cfg(test)]
+    MemberExpression(Rc<MemberExpression>),
+    //    #[cfg(test)]
+    //    MetaProperty(Rc<MetaProperty>),
+    #[cfg(test)]
+    MethodDefinition(Rc<MethodDefinition>),
+    #[cfg(test)]
+    MultiplicativeExpression(Rc<MultiplicativeExpression>),
+    #[cfg(test)]
+    NewExpression(Rc<NewExpression>),
+    #[cfg(test)]
+    ObjectAssignmentPattern(Rc<ObjectAssignmentPattern>),
+    #[cfg(test)]
+    ObjectBindingPattern(Rc<ObjectBindingPattern>),
+    #[cfg(test)]
+    ObjectLiteral(Rc<ObjectLiteral>),
+    #[cfg(test)]
+    OptionalChain(Rc<OptionalChain>),
+    #[cfg(test)]
+    OptionalExpression(Rc<OptionalExpression>),
+    #[cfg(test)]
+    ParenthesizedExpression(Rc<ParenthesizedExpression>),
+    #[cfg(test)]
+    PrimaryExpression(Rc<PrimaryExpression>),
+    #[cfg(test)]
+    PropertyDefinition(Rc<PropertyDefinition>),
+    #[cfg(test)]
+    PropertyDefinitionList(Rc<PropertyDefinitionList>),
+    #[cfg(test)]
+    PropertyName(Rc<PropertyName>),
+    //    #[cfg(test)]
+    //    PropertySetParameterList(Rc<PropertySetParameterList>),
+    #[cfg(test)]
+    RelationalExpression(Rc<RelationalExpression>),
+    #[cfg(test)]
+    ReturnStatement(Rc<ReturnStatement>),
+    #[cfg(test)]
     ScriptBody(Rc<ScriptBody>),
+    #[cfg(test)]
     ShiftExpression(Rc<ShiftExpression>),
+    #[cfg(test)]
     ShortCircuitExpression(Rc<ShortCircuitExpression>),
+    #[cfg(test)]
     SingleNameBinding(Rc<SingleNameBinding>),
+    #[cfg(test)]
     SpreadElement(Rc<SpreadElement>),
+    #[cfg(test)]
     Statement(Rc<Statement>),
+    #[cfg(test)]
     StatementList(Rc<StatementList>),
+    #[cfg(test)]
     StatementListItem(Rc<StatementListItem>),
+    #[cfg(test)]
     SubstitutionTemplate(Rc<SubstitutionTemplate>),
-    SuperCall(Rc<SuperCall>),
-    SuperProperty(Rc<SuperProperty>),
+    //    #[cfg(test)]
+    //    SuperCall(Rc<SuperCall>),
+    //    #[cfg(test)]
+    //    SuperProperty(Rc<SuperProperty>),
+    #[cfg(test)]
     SwitchStatement(Rc<SwitchStatement>),
+    #[cfg(test)]
     TemplateLiteral(Rc<TemplateLiteral>),
+    #[cfg(test)]
     TemplateMiddleList(Rc<TemplateMiddleList>),
+    #[cfg(test)]
     TemplateSpans(Rc<TemplateSpans>),
+    #[cfg(test)]
     ThrowStatement(Rc<ThrowStatement>),
+    #[cfg(test)]
     TryStatement(Rc<TryStatement>),
+    #[cfg(test)]
     UnaryExpression(Rc<UnaryExpression>),
+    #[cfg(test)]
     UniqueFormalParameters(Rc<UniqueFormalParameters>),
+    #[cfg(test)]
     UpdateExpression(Rc<UpdateExpression>),
+    #[cfg(test)]
     VariableDeclaration(Rc<VariableDeclaration>),
+    #[cfg(test)]
     VariableDeclarationList(Rc<VariableDeclarationList>),
+    #[cfg(test)]
     VariableStatement(Rc<VariableStatement>),
+    #[cfg(test)]
     WhileStatement(Rc<WhileStatement>),
-    WithStatement(Rc<WithStatement>),
-    YieldExpression(Rc<YieldExpression>),
+    //    #[cfg(test)]
+    //    WithStatement(Rc<WithStatement>),
+    //    #[cfg(test)]
+    //    YieldExpression(Rc<YieldExpression>),
     // ... more to come
 }
 
@@ -859,11 +1034,11 @@ impl TryFrom<ParsedText> for Result<Rc<FormalParameters>, Vec<Object>> {
     }
 }
 
-pub enum ParsedBody {
-    FunctionBody(Rc<FunctionBody>),
-    GeneratorBody(Rc<GeneratorBody>),
-    AsyncFunctionBody(Rc<AsyncFunctionBody>),
-    AsyncGeneratorBody(Rc<AsyncGeneratorBody>),
+pub(crate) enum ParsedBody {
+    Function(Rc<FunctionBody>),
+    Generator(Rc<GeneratorBody>),
+    AsyncFunction(Rc<AsyncFunctionBody>),
+    AsyncGenerator(Rc<AsyncGeneratorBody>),
 }
 impl TryFrom<ParsedText> for Result<ParsedBody, Vec<Object>> {
     type Error = anyhow::Error;
@@ -871,10 +1046,12 @@ impl TryFrom<ParsedText> for Result<ParsedBody, Vec<Object>> {
     fn try_from(value: ParsedText) -> Result<Self, Self::Error> {
         match value {
             ParsedText::Errors(errs) => Ok(Err(errs)),
-            ParsedText::FunctionBody(node) => Ok(Ok(ParsedBody::FunctionBody(node))),
-            ParsedText::GeneratorBody(node) => Ok(Ok(ParsedBody::GeneratorBody(node))),
-            ParsedText::AsyncFunctionBody(node) => Ok(Ok(ParsedBody::AsyncFunctionBody(node))),
-            ParsedText::AsyncGeneratorBody(node) => Ok(Ok(ParsedBody::AsyncGeneratorBody(node))),
+            ParsedText::FunctionBody(node) => Ok(Ok(ParsedBody::Function(node))),
+            ParsedText::GeneratorBody(node) => Ok(Ok(ParsedBody::Generator(node))),
+            #[cfg(test)]
+            ParsedText::AsyncFunctionBody(node) => Ok(Ok(ParsedBody::AsyncFunction(node))),
+            #[cfg(test)]
+            ParsedText::AsyncGeneratorBody(node) => Ok(Ok(ParsedBody::AsyncGenerator(node))),
             _ => Err(anyhow!("Expected Some kind of function body or Syntax Errors")),
         }
     }
@@ -884,20 +1061,22 @@ impl TryFrom<BodySource> for ParsedBody {
 
     fn try_from(value: BodySource) -> Result<Self, Self::Error> {
         match value {
-            BodySource::Function(function_body) => Ok(Self::FunctionBody(function_body)),
-            BodySource::Generator(generator_body) => Ok(Self::GeneratorBody(generator_body)),
-            BodySource::AsyncFunction(async_function_body) => Ok(Self::AsyncFunctionBody(async_function_body)),
-            BodySource::AsyncGenerator(async_generator_body) => Ok(Self::AsyncGeneratorBody(async_generator_body)),
+            BodySource::Function(function_body) => Ok(Self::Function(function_body)),
+            BodySource::Generator(generator_body) => Ok(Self::Generator(generator_body)),
+            BodySource::AsyncFunction(async_function_body) => Ok(Self::AsyncFunction(async_function_body)),
+            BodySource::AsyncGenerator(async_generator_body) => Ok(Self::AsyncGenerator(async_generator_body)),
             _ => Err(anyhow!("Some kind of normal function body expected")),
         }
     }
 }
 
-pub enum ParsedFunctionExpression {
-    FunctionExpression(Rc<FunctionExpression>),
-    GeneratorExpression(Rc<GeneratorExpression>),
-    AsyncFunctionExpression(Rc<AsyncFunctionExpression>),
-    AsyncGeneratorExpression(Rc<AsyncGeneratorExpression>),
+pub(crate) enum ParsedFunctionExpression {
+    Function(Rc<FunctionExpression>),
+    Generator(Rc<GeneratorExpression>),
+    #[cfg(test)]
+    AsyncFunction(Rc<AsyncFunctionExpression>),
+    #[cfg(test)]
+    AsyncGenerator(Rc<AsyncGeneratorExpression>),
 }
 impl TryFrom<ParsedText> for Result<ParsedFunctionExpression, Vec<Object>> {
     type Error = anyhow::Error;
@@ -905,21 +1084,19 @@ impl TryFrom<ParsedText> for Result<ParsedFunctionExpression, Vec<Object>> {
     fn try_from(value: ParsedText) -> Result<Self, Self::Error> {
         match value {
             ParsedText::Errors(errs) => Ok(Err(errs)),
-            ParsedText::FunctionExpression(node) => Ok(Ok(ParsedFunctionExpression::FunctionExpression(node))),
-            ParsedText::GeneratorExpression(node) => Ok(Ok(ParsedFunctionExpression::GeneratorExpression(node))),
-            ParsedText::AsyncFunctionExpression(node) => {
-                Ok(Ok(ParsedFunctionExpression::AsyncFunctionExpression(node)))
-            }
-            ParsedText::AsyncGeneratorExpression(node) => {
-                Ok(Ok(ParsedFunctionExpression::AsyncGeneratorExpression(node)))
-            }
+            ParsedText::FunctionExpression(node) => Ok(Ok(ParsedFunctionExpression::Function(node))),
+            ParsedText::GeneratorExpression(node) => Ok(Ok(ParsedFunctionExpression::Generator(node))),
+            #[cfg(test)]
+            ParsedText::AsyncFunctionExpression(node) => Ok(Ok(ParsedFunctionExpression::AsyncFunction(node))),
+            #[cfg(test)]
+            ParsedText::AsyncGeneratorExpression(node) => Ok(Ok(ParsedFunctionExpression::AsyncGenerator(node))),
             _ => Err(anyhow!("Expected Some kind of function expression or Syntax Errors")),
         }
     }
 }
 
 impl ParsedText {
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         match self {
             ParsedText::Errors(_) | ParsedText::Empty => None,
@@ -927,11 +1104,15 @@ impl ParsedText {
             ParsedText::FormalParameters(formal_parameters) => formal_parameters.body_containing_location(location),
             ParsedText::FunctionBody(function_body) => function_body.body_containing_location(location),
             ParsedText::GeneratorBody(generator_body) => generator_body.body_containing_location(location),
-            ParsedText::AsyncFunctionBody(async_function_body) => {
-                async_function_body.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::AsyncFunctionBody(_) => {
+                //async_function_body.body_containing_location(location)
+                None
             }
-            ParsedText::AsyncGeneratorBody(async_generator_body) => {
-                async_generator_body.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::AsyncGeneratorBody(_) => {
+                //async_generator_body.body_containing_location(location)
+                None
             }
             ParsedText::FunctionExpression(function_expression) => {
                 function_expression.body_containing_location(location)
@@ -939,296 +1120,500 @@ impl ParsedText {
             ParsedText::GeneratorExpression(generator_expression) => {
                 generator_expression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::AsyncFunctionExpression(async_function_expression) => {
                 async_function_expression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::AsyncGeneratorExpression(async_generator_expression) => {
                 async_generator_expression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::FunctionDeclaration(function_declaration) => {
                 function_declaration.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::AsyncFunctionDeclaration(async_function_declaration) => {
                 async_function_declaration.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::AsyncGeneratorDeclaration(async_generator_declaration) => {
                 async_generator_declaration.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::GeneratorDeclaration(generator_declaration) => {
                 generator_declaration.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::PrimaryExpression(primary_expression) => primary_expression.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::FieldDefinition(field_definition) => field_definition.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::ParenthesizedExpression(parenthesized_expression) => {
                 parenthesized_expression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::ObjectLiteral(object_literal) => object_literal.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::PropertyDefinitionList(property_definition_list) => {
                 property_definition_list.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::PropertyDefinition(property_definition) => {
                 property_definition.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::ArrowFunction(arrow_function) => arrow_function.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::PropertyName(property_name) => property_name.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::ComputedPropertyName(computed_property_name) => {
                 computed_property_name.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::MemberExpression(member_expression) => member_expression.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::NewExpression(new_expression) => new_expression.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::CallExpression(call_expression) => call_expression.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::CallMemberExpression(call_member_expression) => {
                 call_member_expression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::LeftHandSideExpression(left_hand_side_expression) => {
                 left_hand_side_expression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::Arguments(arguments) => arguments.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::ArgumentList(argument_list) => argument_list.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::AdditiveExpression(additive_expression) => {
                 additive_expression.body_containing_location(location)
             }
-            ParsedText::ArrayAssignmentPattern(array_assignment_pattern) => {
-                array_assignment_pattern.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::ArrayAssignmentPattern(_) => {
+                //array_assignment_pattern.body_containing_location(location)
+                None
             }
-            ParsedText::ArrayBindingPattern(array_binding_pattern) => {
-                array_binding_pattern.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::ArrayBindingPattern(_) => {
+                //array_binding_pattern.body_containing_location(location)
+                None
             }
+            #[cfg(test)]
             ParsedText::ArrayLiteral(array_literal) => array_literal.body_containing_location(location),
-            ParsedText::ArrowFormalParameters(arrow_formal_parameters) => {
-                arrow_formal_parameters.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::ArrowFormalParameters(_) => {
+                //arrow_formal_parameters.body_containing_location(location)
+                None
             }
-            ParsedText::ArrowParameters(arrow_parameters) => arrow_parameters.body_containing_location(location),
-            ParsedText::AssignmentElement(assignment_element) => assignment_element.body_containing_location(location),
-            ParsedText::AssignmentElementList(assignment_element_list) => {
-                assignment_element_list.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::ArrowParameters(_) => {
+                //arrow_parameters.body_containing_location(location)
+                None
             }
-            ParsedText::AssignmentElisionElement(assignment_elision_element) => {
-                assignment_elision_element.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::AssignmentElement(_) => {
+                //assignment_element.body_containing_location(location)
+                None
             }
+            #[cfg(test)]
+            ParsedText::AssignmentElementList(_) => {
+                None
+                //assignment_element_list.body_containing_location(location)
+            }
+            #[cfg(test)]
+            ParsedText::AssignmentElisionElement(_) => {
+                None
+                //assignment_elision_element.body_containing_location(location)
+            }
+            #[cfg(test)]
             ParsedText::AssignmentExpression(assignment_expression) => {
                 assignment_expression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::AssignmentPattern(assignment_pattern) => assignment_pattern.body_containing_location(location),
-            ParsedText::AssignmentProperty(assignment_property) => {
-                assignment_property.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::AssignmentProperty(_) => {
+                //assignment_property.body_containing_location(location)
+                None
             }
-            ParsedText::AssignmentPropertyList(assignment_property_list) => {
-                assignment_property_list.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::AssignmentPropertyList(_) => {
+                //assignment_property_list.body_containing_location(location)
+                None
             }
-            ParsedText::AssignmentRestElement(assignment_rest_element) => {
-                assignment_rest_element.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::AssignmentRestElement(_) => {
+                //assignment_rest_element.body_containing_location(location)
+                None
             }
-            ParsedText::AssignmentRestProperty(assignment_rest_property) => {
-                assignment_rest_property.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::AssignmentRestProperty(_) => {
+                //assignment_rest_property.body_containing_location(location)
+                None
             }
-            ParsedText::AsyncArrowBindingIdentifier(async_arrow_binding_identifier) => {
-                async_arrow_binding_identifier.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::AsyncArrowBindingIdentifier(_) => {
+                //async_arrow_binding_identifier.body_containing_location(location)
+                None
             }
-            ParsedText::AsyncArrowFunction(async_arrow_function) => {
-                async_arrow_function.body_containing_location(location)
-            }
-            ParsedText::AsyncArrowHead(async_arrow_head) => async_arrow_head.body_containing_location(location),
-            ParsedText::AsyncConciseBody(async_concise_body) => async_concise_body.body_containing_location(location),
-            ParsedText::AsyncGeneratorMethod(async_generator_method) => {
-                async_generator_method.body_containing_location(location)
-            }
-            ParsedText::AsyncMethod(async_method) => async_method.body_containing_location(location),
-            ParsedText::AwaitExpression(await_expression) => await_expression.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::AsyncArrowFunction(async_arrow_function) => {
+            //    async_arrow_function.body_containing_location(location)
+            //}
+            //#[cfg(test)]
+            //ParsedText::AsyncArrowHead(async_arrow_head) => {
+            //    //async_arrow_head.body_containing_location(location)
+            //    None
+            //}
+            //#[cfg(test)]
+            //ParsedText::AsyncConciseBody(async_concise_body) => {
+            //    //async_concise_body.body_containing_location(location)
+            //    None
+            //}
+            //#[cfg(test)]
+            //ParsedText::AsyncGeneratorMethod(async_generator_method) => {
+            //    async_generator_method.body_containing_location(location)
+            //}
+            //#[cfg(test)]
+            //ParsedText::AsyncMethod(async_method) => async_method.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::AwaitExpression(await_expression) => await_expression.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::BindingElement(binding_element) => binding_element.body_containing_location(location),
-            ParsedText::BindingElementList(binding_element_list) => {
-                binding_element_list.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::BindingElementList(_) => {
+                //binding_element_list.body_containing_location(location)
+                None
             }
-            ParsedText::BindingElisionElement(binding_elision_element) => {
-                binding_elision_element.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::BindingElisionElement(_) => {
+                //binding_elision_element.body_containing_location(location)
+                None
             }
-            ParsedText::BindingIdentifier(binding_identifier) => binding_identifier.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::BindingIdentifier(binding_identifier) => binding_identifier.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::BindingList(binding_list) => binding_list.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::BindingPattern(binding_pattern) => binding_pattern.body_containing_location(location),
-            ParsedText::BindingProperty(binding_property) => binding_property.body_containing_location(location),
-            ParsedText::BindingPropertyList(binding_property_list) => {
-                binding_property_list.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::BindingProperty(_) => {
+                //binding_property.body_containing_location(location)
+                None
             }
-            ParsedText::BindingRestElement(binding_rest_element) => {
-                binding_rest_element.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::BindingPropertyList(_) => {
+                //binding_property_list.body_containing_location(location)
+                None
             }
-            ParsedText::BindingRestProperty(binding_rest_property) => {
-                binding_rest_property.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::BindingRestElement(_) => {
+                //binding_rest_element.body_containing_location(location)
+                None
             }
+            //#[cfg(test)]
+            //ParsedText::BindingRestProperty(binding_rest_property) => {
+            //    //binding_rest_property.body_containing_location(location)
+            //    None
+            //}
+            #[cfg(test)]
             ParsedText::BitwiseANDExpression(bitwise_andexpression) => {
                 bitwise_andexpression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::BitwiseORExpression(bitwise_orexpression) => {
                 bitwise_orexpression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::BitwiseXORExpression(bitwise_xorexpression) => {
                 bitwise_xorexpression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::Block(block) => block.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::BlockStatement(block_statement) => block_statement.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::BreakableStatement(breakable_statement) => {
                 breakable_statement.body_containing_location(location)
             }
-            ParsedText::BreakStatement(break_statement) => break_statement.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::BreakStatement(break_statement) => break_statement.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::CaseBlock(case_block) => case_block.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::CaseClause(case_clause) => case_clause.body_containing_location(location),
-            ParsedText::CaseClauses(case_clauses) => case_clauses.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::CaseClauses(case_clauses) => case_clauses.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::Catch(catch) => catch.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::CatchParameter(catch_parameter) => catch_parameter.body_containing_location(location),
-            ParsedText::ClassBody(class_body) => class_body.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::ClassBody(class_body) => class_body.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::ClassDeclaration(class_declaration) => class_declaration.body_containing_location(location),
-            ParsedText::ClassElement(class_element) => class_element.body_containing_location(location),
-            ParsedText::ClassElementList(class_element_list) => class_element_list.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::ClassElement(class_element) => class_element.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::ClassElementList(class_element_list) => class_element_list.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::ClassElementName(class_element_name) => class_element_name.body_containing_location(location),
-            ParsedText::ClassExpression(class_expression) => class_expression.body_containing_location(location),
-            ParsedText::ClassHeritage(class_heritage) => class_heritage.body_containing_location(location),
-            ParsedText::ClassStaticBlock(class_static_block) => class_static_block.body_containing_location(location),
-            ParsedText::ClassStaticBlockBody(class_static_block_body) => {
-                class_static_block_body.body_containing_location(location)
+            //#[cfg(test)]
+            //ParsedText::ClassExpression(class_expression) => class_expression.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::ClassHeritage(class_heritage) => {
+            //    //class_heritage.body_containing_location(location)
+            //    None
+            //}
+            //#[cfg(test)]
+            //ParsedText::ClassStaticBlock(class_static_block) => class_static_block.body_containing_location(location),
+            #[cfg(test)]
+            ParsedText::ClassStaticBlockBody(_) => {
+                //class_static_block_body.body_containing_location(location)
+                None
             }
-            ParsedText::ClassStaticBlockStatementList(class_static_block_statement_list) => {
-                class_static_block_statement_list.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::ClassStaticBlockStatementList(_) => {
+                //class_static_block_statement_list.body_containing_location(location)
+                None
             }
-            ParsedText::ClassTail(class_tail) => class_tail.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::ClassTail(class_tail) => class_tail.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::CoalesceExpression(coalesce_expression) => {
                 coalesce_expression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::CoalesceExpressionHead(coalesce_expression_head) => {
                 coalesce_expression_head.body_containing_location(location)
             }
-            ParsedText::ConciseBody(concise_body) => concise_body.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::ConciseBody(concise_body) => {
+            //    //concise_body.body_containing_location(location)
+            //    None
+            //}
+            #[cfg(test)]
             ParsedText::ConditionalExpression(conditional_expression) => {
                 conditional_expression.body_containing_location(location)
             }
-            ParsedText::ContinueStatement(continue_statement) => continue_statement.body_containing_location(location),
-            ParsedText::CoverInitializedName(cover_initialized_name) => {
-                cover_initialized_name.body_containing_location(location)
-            }
-            ParsedText::CoverParenthesizedExpressionAndArrowParameterList(
-                cover_parenthesized_expression_and_arrow_parameter_list,
-            ) => cover_parenthesized_expression_and_arrow_parameter_list.body_containing_location(location),
-            ParsedText::DebuggerStatement(debugger_statement) => debugger_statement.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::ContinueStatement(continue_statement) => continue_statement.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::CoverInitializedName(cover_initialized_name) => {
+            //    cover_initialized_name.body_containing_location(location)
+            //}
+            //#[cfg(test)]
+            //ParsedText::CoverParenthesizedExpressionAndArrowParameterList(
+            //    cover_parenthesized_expression_and_arrow_parameter_list,
+            //) => cover_parenthesized_expression_and_arrow_parameter_list.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::DebuggerStatement(debugger_statement) => debugger_statement.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::Declaration(declaration) => declaration.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::DefaultClause(default_clause) => default_clause.body_containing_location(location),
-            ParsedText::DestructuringAssignmentTarget(destructuring_assignment_target) => {
-                destructuring_assignment_target.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::DestructuringAssignmentTarget(_) => {
+                //destructuring_assignment_target.body_containing_location(location)
+                None
             }
+            #[cfg(test)]
             ParsedText::DoWhileStatement(do_while_statement) => do_while_statement.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::ElementList(element_list) => element_list.body_containing_location(location),
-            ParsedText::Elisions(elisions) => elisions.body_containing_location(location),
-            ParsedText::EmptyStatement(empty_statement) => empty_statement.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::Elisions(elisions) => elisions.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::EmptyStatement(empty_statement) => empty_statement.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::EqualityExpression(equality_expression) => {
                 equality_expression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::ExponentiationExpression(exponentiation_expression) => {
                 exponentiation_expression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::Expression(expression) => expression.body_containing_location(location),
-            ParsedText::ExpressionBody(expression_body) => expression_body.body_containing_location(location),
+            #[cfg(test)]
+            ParsedText::ExpressionBody(_) => {
+                //expression_body.body_containing_location(location)
+                None
+            }
+            #[cfg(test)]
             ParsedText::ExpressionStatement(expression_statement) => {
                 expression_statement.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::Finally(finally) => finally.body_containing_location(location),
-            ParsedText::ForBinding(for_binding) => for_binding.body_containing_location(location),
-            ParsedText::ForDeclaration(for_declaration) => for_declaration.body_containing_location(location),
+            #[cfg(test)]
+            ParsedText::ForBinding(_) => {
+                //for_binding.body_containing_location(location)
+                None
+            }
+            #[cfg(test)]
+            ParsedText::ForDeclaration(_) => {
+                //for_declaration.body_containing_location(location)
+                None
+            }
+            #[cfg(test)]
             ParsedText::ForInOfStatement(for_in_of_statement) => for_in_of_statement.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::FormalParameter(formal_parameter) => formal_parameter.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::FormalParameterList(formal_parameter_list) => {
                 formal_parameter_list.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::ForStatement(for_statement) => for_statement.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::FunctionRestParameter(function_rest_parameter) => {
                 function_rest_parameter.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::FunctionStatementList(function_statement_list) => {
                 function_statement_list.body_containing_location(location)
             }
-            ParsedText::GeneratorMethod(generator_method) => generator_method.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::GeneratorMethod(generator_method) => generator_method.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::IfStatement(if_statement) => if_statement.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::Initializer(initializer) => initializer.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::IterationStatement(iteration_statement) => {
                 iteration_statement.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::LabelledItem(labelled_item) => labelled_item.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::LabelledStatement(labelled_statement) => labelled_statement.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::LexicalBinding(lexical_binding) => lexical_binding.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::LexicalDeclaration(lexical_declaration) => {
                 lexical_declaration.body_containing_location(location)
             }
-            ParsedText::Literal(literal) => literal.body_containing_location(location),
-            ParsedText::LiteralPropertyName(literal_property_name) => {
-                literal_property_name.body_containing_location(location)
-            }
+            //#[cfg(test)]
+            //ParsedText::Literal(literal) => literal.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::LiteralPropertyName(literal_property_name) => {
+            //    literal_property_name.body_containing_location(location)
+            //}
+            #[cfg(test)]
             ParsedText::LogicalANDExpression(logical_andexpression) => {
                 logical_andexpression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::LogicalORExpression(logical_orexpression) => {
                 logical_orexpression.body_containing_location(location)
             }
-            ParsedText::MetaProperty(meta_property) => meta_property.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::MetaProperty(meta_property) => meta_property.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::MethodDefinition(method_definition) => method_definition.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::MultiplicativeExpression(multiplicative_expression) => {
                 multiplicative_expression.body_containing_location(location)
             }
-            ParsedText::ObjectAssignmentPattern(object_assignment_pattern) => {
-                object_assignment_pattern.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::ObjectAssignmentPattern(_) => {
+                //object_assignment_pattern.body_containing_location(location)
+                None
             }
-            ParsedText::ObjectBindingPattern(object_binding_pattern) => {
-                object_binding_pattern.body_containing_location(location)
+            #[cfg(test)]
+            ParsedText::ObjectBindingPattern(_) => {
+                //object_binding_pattern.body_containing_location(location)
+                None
             }
+            #[cfg(test)]
             ParsedText::OptionalChain(optional_chain) => optional_chain.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::OptionalExpression(optional_expression) => {
                 optional_expression.body_containing_location(location)
             }
-            ParsedText::PropertySetParameterList(property_set_parameter_list) => {
-                property_set_parameter_list.body_containing_location(location)
-            }
+            //#[cfg(test)]
+            //ParsedText::PropertySetParameterList(property_set_parameter_list) => {
+            //    property_set_parameter_list.body_containing_location(location)
+            //}
+            #[cfg(test)]
             ParsedText::RelationalExpression(relational_expression) => {
                 relational_expression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::ReturnStatement(return_statement) => return_statement.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::ScriptBody(script_body) => script_body.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::ShiftExpression(shift_expression) => shift_expression.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::ShortCircuitExpression(short_circuit_expression) => {
                 short_circuit_expression.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::SingleNameBinding(single_name_binding) => {
                 single_name_binding.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::SpreadElement(spread_element) => spread_element.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::Statement(statement) => statement.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::StatementList(statement_list) => statement_list.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::StatementListItem(statement_list_item) => {
                 statement_list_item.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::SubstitutionTemplate(substitution_template) => {
                 substitution_template.body_containing_location(location)
             }
-            ParsedText::SuperCall(super_call) => super_call.body_containing_location(location),
-            ParsedText::SuperProperty(super_property) => super_property.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::SuperCall(super_call) => super_call.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::SuperProperty(super_property) => super_property.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::SwitchStatement(switch_statement) => switch_statement.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::TemplateLiteral(template_literal) => template_literal.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::TemplateMiddleList(template_middle_list) => {
                 template_middle_list.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::TemplateSpans(template_spans) => template_spans.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::ThrowStatement(throw_statement) => throw_statement.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::TryStatement(try_statement) => try_statement.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::UnaryExpression(unary_expression) => unary_expression.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::UniqueFormalParameters(unique_formal_parameters) => {
                 unique_formal_parameters.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::UpdateExpression(update_expression) => update_expression.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::VariableDeclaration(variable_declaration) => {
                 variable_declaration.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::VariableDeclarationList(variable_declaration_list) => {
                 variable_declaration_list.body_containing_location(location)
             }
+            #[cfg(test)]
             ParsedText::VariableStatement(variable_statement) => variable_statement.body_containing_location(location),
+            #[cfg(test)]
             ParsedText::WhileStatement(while_statement) => while_statement.body_containing_location(location),
-            ParsedText::WithStatement(with_statement) => with_statement.body_containing_location(location),
-            ParsedText::YieldExpression(yield_expression) => yield_expression.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::WithStatement(with_statement) => with_statement.body_containing_location(location),
+            //#[cfg(test)]
+            //ParsedText::YieldExpression(yield_expression) => yield_expression.body_containing_location(location),
         }
     }
 }
@@ -1238,11 +1623,17 @@ enum ParsedItem {
     FormalParameters(Rc<FormalParameters>),
     FunctionBody(Rc<FunctionBody>),
     GeneratorBody(Rc<GeneratorBody>),
-    AsyncFunctionBody(Rc<AsyncFunctionBody>),
-    AsyncGeneratorBody(Rc<AsyncGeneratorBody>),
     FunctionExpression(Rc<FunctionExpression>),
     GeneratorExpression(Rc<GeneratorExpression>),
+
+    // Not currently constructed; relegated to test.
+    #[cfg(test)]
+    AsyncFunctionBody(Rc<AsyncFunctionBody>),
+    #[cfg(test)]
+    AsyncGeneratorBody(Rc<AsyncGeneratorBody>),
+    #[cfg(test)]
     AsyncFunctionExpression(Rc<AsyncFunctionExpression>),
+    #[cfg(test)]
     AsyncGeneratorExpression(Rc<AsyncGeneratorExpression>),
 }
 
@@ -1253,11 +1644,15 @@ impl ParsedItem {
             ParsedItem::FormalParameters(fp) => fp.early_errors(errs, strict, false),
             ParsedItem::FunctionBody(fb) => fb.early_errors(errs, strict),
             ParsedItem::GeneratorBody(gb) => gb.early_errors(errs, strict),
-            ParsedItem::AsyncFunctionBody(body) => body.early_errors(errs, strict),
-            ParsedItem::AsyncGeneratorBody(body) => body.early_errors(errs, strict),
             ParsedItem::FunctionExpression(exp) => exp.early_errors(errs, strict),
             ParsedItem::GeneratorExpression(exp) => exp.early_errors(errs, strict),
+            #[cfg(test)]
+            ParsedItem::AsyncFunctionBody(body) => body.early_errors(errs, strict),
+            #[cfg(test)]
+            ParsedItem::AsyncGeneratorBody(body) => body.early_errors(errs, strict),
+            #[cfg(test)]
             ParsedItem::AsyncFunctionExpression(exp) => exp.early_errors(errs, strict),
+            #[cfg(test)]
             ParsedItem::AsyncGeneratorExpression(exp) => exp.early_errors(errs, strict),
         }
     }
@@ -1270,11 +1665,15 @@ impl From<ParsedItem> for ParsedText {
             ParsedItem::FormalParameters(fp) => ParsedText::FormalParameters(fp),
             ParsedItem::FunctionBody(fb) => ParsedText::FunctionBody(fb),
             ParsedItem::GeneratorBody(gb) => ParsedText::GeneratorBody(gb),
+            #[cfg(test)]
             ParsedItem::AsyncFunctionBody(body) => ParsedText::AsyncFunctionBody(body),
+            #[cfg(test)]
             ParsedItem::AsyncGeneratorBody(body) => ParsedText::AsyncGeneratorBody(body),
             ParsedItem::FunctionExpression(exp) => ParsedText::FunctionExpression(exp),
             ParsedItem::GeneratorExpression(exp) => ParsedText::GeneratorExpression(exp),
+            #[cfg(test)]
             ParsedItem::AsyncFunctionExpression(exp) => ParsedText::AsyncFunctionExpression(exp),
+            #[cfg(test)]
             ParsedItem::AsyncGeneratorExpression(exp) => ParsedText::AsyncGeneratorExpression(exp),
         }
     }
@@ -1311,7 +1710,7 @@ fn direct_parse(parser: &mut Parser, strict: bool, parse_fn: ParseClosure, name:
     }
 }
 
-pub fn parse_text(src: &str, goal_symbol: ParseGoal, strict: bool, direct: bool) -> ParsedText {
+pub(crate) fn parse_text(src: &str, goal_symbol: ParseGoal, strict: bool, direct: bool) -> ParsedText {
     let mut parser = Parser::new(src, direct, goal_symbol);
     let (closure, name): (ParseClosure, &str) = match goal_symbol {
         ParseGoal::Script => (
@@ -1340,7 +1739,7 @@ pub fn parse_text(src: &str, goal_symbol: ParseGoal, strict: bool, direct: bool)
                     Scanner::new(),
                     yield_state == YieldAllowed::Yes,
                     await_state == AwaitAllowed::Yes,
-                    FunctionBodyParent::FunctionBody,
+                    FunctionBodyParent::Function,
                 );
                 Ok((ParsedItem::FunctionBody(body), scanner))
             }),
@@ -1353,6 +1752,7 @@ pub fn parse_text(src: &str, goal_symbol: ParseGoal, strict: bool, direct: bool)
             }),
             "generator body",
         ),
+        #[cfg(test)]
         ParseGoal::AsyncFunctionBody => (
             Box::new(|parser: &mut Parser| {
                 let (body, scanner) = AsyncFunctionBody::parse(parser, Scanner::new());
@@ -1360,6 +1760,7 @@ pub fn parse_text(src: &str, goal_symbol: ParseGoal, strict: bool, direct: bool)
             }),
             "function body",
         ),
+        #[cfg(test)]
         ParseGoal::AsyncGeneratorBody => (
             Box::new(|parser: &mut Parser| {
                 let (body, scanner) = AsyncGeneratorBody::parse(parser, Scanner::new());
@@ -1381,6 +1782,7 @@ pub fn parse_text(src: &str, goal_symbol: ParseGoal, strict: bool, direct: bool)
             }),
             "generator expression",
         ),
+        #[cfg(test)]
         ParseGoal::AsyncFunctionExpression => (
             Box::new(|parser: &mut Parser| {
                 AsyncFunctionExpression::parse(parser, Scanner::new())
@@ -1388,6 +1790,7 @@ pub fn parse_text(src: &str, goal_symbol: ParseGoal, strict: bool, direct: bool)
             }),
             "function expression",
         ),
+        #[cfg(test)]
         ParseGoal::AsyncGeneratorExpression => (
             Box::new(|parser: &mut Parser| {
                 AsyncGeneratorExpression::parse(parser, Scanner::new())
@@ -1399,7 +1802,7 @@ pub fn parse_text(src: &str, goal_symbol: ParseGoal, strict: bool, direct: bool)
     direct_parse(&mut parser, strict, closure, name)
 }
 
-pub fn duplicates(idents: &[JSString]) -> Vec<&JSString> {
+pub(crate) fn duplicates(idents: &[JSString]) -> Vec<&JSString> {
     // Given a vector of strings (probably identifiers), produce a vector of all the duplicates. Each item in the
     // return value is unique (there are no duplicates there!), and ordered by the location of the _second_ occurence
     // within the source array.
@@ -1424,100 +1827,100 @@ pub fn duplicates(idents: &[JSString]) -> Vec<&JSString> {
 }
 
 #[derive(Debug, Clone)]
-pub enum ContainingBody {
+pub(crate) enum ContainingBody {
     FunctionBody(Rc<FunctionBody>),
     ConciseBody(Rc<ConciseBody>),
-    AsyncConciseBody(Rc<AsyncConciseBody>),
+    //AsyncConciseBody(Rc<AsyncConciseBody>), // Add back when Async goes in
 }
 
-pub mod additive_operators;
-pub mod arrow_function_definitions;
-pub mod assignment_operators;
-pub mod async_arrow_function_definitions;
-pub mod async_function_definitions;
-pub mod async_generator_function_definitions;
-pub mod binary_bitwise_operators;
-pub mod binary_logical_operators;
-pub mod bitwise_shift_operators;
-pub mod block;
-pub mod break_statement;
-pub mod class_definitions;
-pub mod comma_operator;
-pub mod conditional_operator;
-pub mod continue_statement;
-pub mod debugger_statement;
-pub mod declarations_and_variables;
-pub mod empty_statement;
-pub mod equality_operators;
-pub mod exponentiation_operator;
-pub mod expression_statement;
-pub mod function_definitions;
-pub mod generator_function_definitions;
-pub mod identifiers;
-pub mod if_statement;
-pub mod iteration_statements;
-pub mod labelled_statements;
-pub mod left_hand_side_expressions;
-pub mod method_definitions;
-pub mod multiplicative_operators;
-pub mod parameter_lists;
-pub mod primary_expressions;
-pub mod relational_operators;
-pub mod return_statement;
-pub mod scripts;
-pub mod statements_and_declarations;
-pub mod switch_statement;
-pub mod throw_statement;
-pub mod try_statement;
-pub mod unary_operators;
-pub mod update_expressions;
-pub mod with_statement;
+pub(crate) mod additive_operators;
+pub(crate) mod arrow_function_definitions;
+pub(crate) mod assignment_operators;
+pub(crate) mod async_arrow_function_definitions;
+pub(crate) mod async_function_definitions;
+pub(crate) mod async_generator_function_definitions;
+pub(crate) mod binary_bitwise_operators;
+pub(crate) mod binary_logical_operators;
+pub(crate) mod bitwise_shift_operators;
+pub(crate) mod block;
+pub(crate) mod break_statement;
+pub(crate) mod class_definitions;
+pub(crate) mod comma_operator;
+pub(crate) mod conditional_operator;
+pub(crate) mod continue_statement;
+pub(crate) mod debugger_statement;
+pub(crate) mod declarations_and_variables;
+pub(crate) mod empty_statement;
+pub(crate) mod equality_operators;
+pub(crate) mod exponentiation_operator;
+pub(crate) mod expression_statement;
+pub(crate) mod function_definitions;
+pub(crate) mod generator_function_definitions;
+pub(crate) mod identifiers;
+pub(crate) mod if_statement;
+pub(crate) mod iteration_statements;
+pub(crate) mod labelled_statements;
+pub(crate) mod left_hand_side_expressions;
+pub(crate) mod method_definitions;
+pub(crate) mod multiplicative_operators;
+pub(crate) mod parameter_lists;
+pub(crate) mod primary_expressions;
+pub(crate) mod relational_operators;
+pub(crate) mod return_statement;
+pub(crate) mod scripts;
+pub(crate) mod statements_and_declarations;
+pub(crate) mod switch_statement;
+pub(crate) mod throw_statement;
+pub(crate) mod try_statement;
+pub(crate) mod unary_operators;
+pub(crate) mod update_expressions;
+pub(crate) mod with_statement;
 
-pub use additive_operators::*;
-pub use arrow_function_definitions::*;
-pub use assignment_operators::*;
-pub use async_arrow_function_definitions::*;
-pub use async_function_definitions::*;
-pub use async_generator_function_definitions::*;
-pub use binary_bitwise_operators::*;
-pub use binary_logical_operators::*;
-pub use bitwise_shift_operators::*;
-pub use block::*;
-pub use break_statement::*;
-pub use class_definitions::*;
-pub use comma_operator::*;
-pub use conditional_operator::*;
-pub use continue_statement::*;
-pub use debugger_statement::*;
-pub use declarations_and_variables::*;
-pub use empty_statement::*;
-pub use equality_operators::*;
-pub use exponentiation_operator::*;
-pub use expression_statement::*;
-pub use function_definitions::*;
-pub use generator_function_definitions::*;
-pub use identifiers::*;
-pub use if_statement::*;
-pub use iteration_statements::*;
-pub use labelled_statements::*;
-pub use left_hand_side_expressions::*;
-pub use method_definitions::*;
-pub use multiplicative_operators::*;
-pub use parameter_lists::*;
-pub use primary_expressions::*;
-pub use relational_operators::*;
-pub use return_statement::*;
-pub use scripts::*;
-pub use statements_and_declarations::*;
-pub use switch_statement::*;
-pub use throw_statement::*;
-pub use try_statement::*;
-pub use unary_operators::*;
-pub use update_expressions::*;
-pub use with_statement::*;
+pub(crate) use additive_operators::*;
+pub(crate) use arrow_function_definitions::*;
+pub(crate) use assignment_operators::*;
+pub(crate) use async_arrow_function_definitions::*;
+pub(crate) use async_function_definitions::*;
+pub(crate) use async_generator_function_definitions::*;
+pub(crate) use binary_bitwise_operators::*;
+pub(crate) use binary_logical_operators::*;
+pub(crate) use bitwise_shift_operators::*;
+pub(crate) use block::*;
+pub(crate) use break_statement::*;
+pub(crate) use class_definitions::*;
+pub(crate) use comma_operator::*;
+pub(crate) use conditional_operator::*;
+pub(crate) use continue_statement::*;
+pub(crate) use debugger_statement::*;
+pub(crate) use declarations_and_variables::*;
+pub(crate) use empty_statement::*;
+pub(crate) use equality_operators::*;
+pub(crate) use exponentiation_operator::*;
+pub(crate) use expression_statement::*;
+pub(crate) use function_definitions::*;
+pub(crate) use generator_function_definitions::*;
+pub(crate) use identifiers::*;
+pub(crate) use if_statement::*;
+pub(crate) use iteration_statements::*;
+pub(crate) use labelled_statements::*;
+pub(crate) use left_hand_side_expressions::*;
+pub(crate) use method_definitions::*;
+pub(crate) use multiplicative_operators::*;
+pub(crate) use parameter_lists::*;
+pub(crate) use primary_expressions::*;
+pub(crate) use relational_operators::*;
+pub(crate) use return_statement::*;
+pub(crate) use scripts::*;
+pub(crate) use statements_and_declarations::*;
+pub(crate) use switch_statement::*;
+pub(crate) use throw_statement::*;
+pub(crate) use try_statement::*;
+pub(crate) use unary_operators::*;
+pub(crate) use update_expressions::*;
+pub(crate) use with_statement::*;
 
 #[cfg(test)]
-pub mod testhelp;
+pub(crate) mod testhelp;
 
 #[cfg(test)]
 mod tests;

--- a/src/parser/multiplicative_operators/tests.rs
+++ b/src/parser/multiplicative_operators/tests.rs
@@ -72,11 +72,6 @@ fn multiplicative_operator_test_concisecheck_3() {
     let (item, _) = MultiplicativeOperator::parse(&mut newparser("%"), Scanner::new()).unwrap();
     concise_error_validate(&*item);
 }
-#[test]
-fn multiplicative_operator_test_contains_01() {
-    let (item, _) = MultiplicativeOperator::parse(&mut newparser("*"), Scanner::new()).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::This), false);
-}
 
 // MULTIPLICATIVE EXPRESSION
 mod multiplicative_expression {
@@ -91,7 +86,6 @@ mod multiplicative_expression {
         pretty_check(&*me, "MultiplicativeExpression: a", &["ExponentiationExpression: a"]);
         concise_check(&*me, "IdentifierName: a", &[]);
         assert_ne!(format!("{me:?}"), "");
-        assert_eq!(me.is_function_definition(), false);
     }
     #[test]
     fn parse_02() {
@@ -109,7 +103,6 @@ mod multiplicative_expression {
             &["IdentifierName: a", "Punctuator: /", "IdentifierName: b"],
         );
         assert_ne!(format!("{me:?}"), "");
-        assert_eq!(me.is_function_definition(), false);
     }
     #[test]
     fn parse_04() {
@@ -245,12 +238,12 @@ mod multiplicative_expression {
         Maker::new(src).multiplicative_expression().assignment_target_type(strict)
     }
 
-    #[test_case("a*b" => false; "expr")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).multiplicative_expression().is_named_function()
-    }
+    //#[test_case("a*b" => false; "expr")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).multiplicative_expression().is_named_function()
+    //}
 
     #[test_case("  a*b" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "expr")]
     #[test_case("  998" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "literal")]

--- a/src/parser/parameter_lists/mod.rs
+++ b/src/parser/parameter_lists/mod.rs
@@ -6,8 +6,8 @@ use std::io::Write;
 // UniqueFormalParameters[Yield, Await] :
 //      FormalParameters[?Yield, ?Await]
 #[derive(Debug)]
-pub struct UniqueFormalParameters {
-    pub formals: Rc<FormalParameters>,
+pub(crate) struct UniqueFormalParameters {
+    pub(crate) formals: Rc<FormalParameters>,
 }
 
 impl fmt::Display for UniqueFormalParameters {
@@ -40,7 +40,12 @@ impl UniqueFormalParameters {
         (Rc::new(UniqueFormalParameters { formals: fp }), after_fp)
     }
 
-    pub fn parse(parser: &mut Parser, scanner: Scanner, yield_flag: bool, await_flag: bool) -> (Rc<Self>, Scanner) {
+    pub(crate) fn parse(
+        parser: &mut Parser,
+        scanner: Scanner,
+        yield_flag: bool,
+        await_flag: bool,
+    ) -> (Rc<Self>, Scanner) {
         let key = YieldAwaitKey { scanner, yield_flag, await_flag };
         match parser.unique_formal_parameters_cache.get(&key) {
             Some(result) => result.clone(),
@@ -52,15 +57,15 @@ impl UniqueFormalParameters {
         }
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         self.formals.location()
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         self.formals.contains(kind)
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -74,7 +79,7 @@ impl UniqueFormalParameters {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -84,7 +89,7 @@ impl UniqueFormalParameters {
         self.formals.contains_arguments()
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         // Static Semantics: Early Errors
         //  UniqueFormalParameters : FormalParameters
         //  * It is a Syntax Error if BoundNames of FormalParameters contains any duplicate elements.
@@ -95,11 +100,11 @@ impl UniqueFormalParameters {
         self.formals.early_errors(errs, strict, true);
     }
 
-    pub fn bound_names(&self) -> Vec<JSString> {
+    pub(crate) fn bound_names(&self) -> Vec<JSString> {
         self.formals.bound_names()
     }
 
-    pub fn is_simple_parameter_list(&self) -> bool {
+    pub(crate) fn is_simple_parameter_list(&self) -> bool {
         // Static Semantics: IsSimpleParameterList
         // The syntax-directed operation IsSimpleParameterList takes no arguments and returns a Boolean.
         //  UniqueFormalParameters : FormalParameters
@@ -107,18 +112,18 @@ impl UniqueFormalParameters {
         self.formals.is_simple_parameter_list()
     }
 
-    pub fn expected_argument_count(&self) -> f64 {
+    pub(crate) fn expected_argument_count(&self) -> f64 {
         self.formals.expected_argument_count()
     }
 
     /// Report whether this portion of a parameter list contains an expression
     ///
     /// See [ContainsExpression](https://tc39.es/ecma262/#sec-static-semantics-containsexpression) in ECMA-262.
-    pub fn contains_expression(&self) -> bool {
+    pub(crate) fn contains_expression(&self) -> bool {
         self.formals.contains_expression()
     }
 
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         if self.location().contains(location) { self.formals.body_containing_location(location) } else { None }
     }
@@ -131,7 +136,7 @@ impl UniqueFormalParameters {
 //      FormalParameterList[?Yield, ?Await] ,
 //      FormalParameterList[?Yield, ?Await] , FunctionRestParameter[?Yield, ?Await]
 #[derive(Debug)]
-pub enum FormalParameters {
+pub(crate) enum FormalParameters {
     Empty(Location),
     Rest(Rc<FunctionRestParameter>),
     List(Rc<FormalParameterList>),
@@ -207,7 +212,7 @@ impl FormalParameters {
             Err(_) => (None, scanner),
             Ok((f, s)) => (Some(f), s),
         };
-        let (pot_comma, pot_loc, after_pot) = scan_token(&after_fpl, parser.source, ScanGoal::InputElementDiv);
+        let (pot_comma, pot_loc, after_pot) = scan_token(&after_fpl, parser.source, InputElementGoal::Div);
         let (has_comma, after_comma) = match pot_comma {
             Token::Punctuator(Punctuator::Comma) => (true, after_pot),
             _ => (false, after_fpl),
@@ -231,7 +236,12 @@ impl FormalParameters {
         }
     }
 
-    pub fn parse(parser: &mut Parser, scanner: Scanner, yield_flag: bool, await_flag: bool) -> (Rc<Self>, Scanner) {
+    pub(crate) fn parse(
+        parser: &mut Parser,
+        scanner: Scanner,
+        yield_flag: bool,
+        await_flag: bool,
+    ) -> (Rc<Self>, Scanner) {
         let key = YieldAwaitKey { scanner, yield_flag, await_flag };
         match parser.formal_parameters_cache.get(&key) {
             Some(result) => result.clone(),
@@ -243,7 +253,7 @@ impl FormalParameters {
         }
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         match self {
             FormalParameters::ListComma(_, location) | FormalParameters::Empty(location) => *location,
             FormalParameters::Rest(rest) => rest.location(),
@@ -252,7 +262,7 @@ impl FormalParameters {
         }
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         match self {
             FormalParameters::Empty(_) => false,
             FormalParameters::Rest(node) => node.contains(kind),
@@ -261,7 +271,7 @@ impl FormalParameters {
         }
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -284,7 +294,7 @@ impl FormalParameters {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -299,7 +309,7 @@ impl FormalParameters {
         }
     }
 
-    pub fn is_simple_parameter_list(&self) -> bool {
+    pub(crate) fn is_simple_parameter_list(&self) -> bool {
         // Static Semantics: IsSimpleParameterList
         match self {
             FormalParameters::Empty(_) => {
@@ -324,7 +334,7 @@ impl FormalParameters {
         }
     }
 
-    pub fn bound_names(&self) -> Vec<JSString> {
+    pub(crate) fn bound_names(&self) -> Vec<JSString> {
         // Static Semantics: BoundNames
         match self {
             FormalParameters::Empty(_) => {
@@ -357,7 +367,7 @@ impl FormalParameters {
         }
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, dups_already_checked: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool, dups_already_checked: bool) {
         // Static Semantics: Early Errors
         //  FormalParameters : FormalParameterList
         //    If BoundNames of FormalParameterList contains any duplicate elements, it is a Syntax Error:
@@ -391,7 +401,7 @@ impl FormalParameters {
     /// undefined as their default value.
     ///
     /// See [ExpectedArgumentCount](https://tc39.es/ecma262/#sec-static-semantics-expectedargumentcount) from ECMA-262.
-    pub fn expected_argument_count(&self) -> f64 {
+    pub(crate) fn expected_argument_count(&self) -> f64 {
         match self {
             FormalParameters::Empty(_) | FormalParameters::Rest(_) => 0.0,
             FormalParameters::List(list)
@@ -403,7 +413,7 @@ impl FormalParameters {
     /// Report whether this portion of a parameter list contains an expression
     ///
     /// See [ContainsExpression](https://tc39.es/ecma262/#sec-static-semantics-containsexpression) in ECMA-262.
-    pub fn contains_expression(&self) -> bool {
+    pub(crate) fn contains_expression(&self) -> bool {
         match self {
             FormalParameters::Empty(..) => false,
             FormalParameters::Rest(rest) => rest.contains_expression(),
@@ -412,7 +422,7 @@ impl FormalParameters {
         }
     }
 
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         if self.location().contains(location) {
             match self {
@@ -432,7 +442,7 @@ impl FormalParameters {
 //      FormalParameter[?Yield, ?Await]
 //      FormalParameterList[?Yield, ?Await] , FormalParameter[?Yield, ?Await]
 #[derive(Debug)]
-pub enum FormalParameterList {
+pub(crate) enum FormalParameterList {
     Item(Rc<FormalParameter>),
     List(Rc<FormalParameterList>, Rc<FormalParameter>),
 }
@@ -480,12 +490,17 @@ impl PrettyPrint for FormalParameterList {
 }
 
 impl FormalParameterList {
-    pub fn parse(parser: &mut Parser, scanner: Scanner, yield_flag: bool, await_flag: bool) -> ParseResult<Self> {
+    pub(crate) fn parse(
+        parser: &mut Parser,
+        scanner: Scanner,
+        yield_flag: bool,
+        await_flag: bool,
+    ) -> ParseResult<Self> {
         let (fp, after_fp) = FormalParameter::parse(parser, scanner, yield_flag, await_flag)?;
         let mut current = Rc::new(FormalParameterList::Item(fp));
         let mut current_scanner = after_fp;
         while let Ok((next, after_next)) =
-            scan_for_punct(current_scanner, parser.source, ScanGoal::InputElementDiv, Punctuator::Comma)
+            scan_for_punct(current_scanner, parser.source, InputElementGoal::Div, Punctuator::Comma)
                 .and_then(|(_, after_comma)| FormalParameter::parse(parser, after_comma, yield_flag, await_flag))
         {
             current = Rc::new(FormalParameterList::List(current, next));
@@ -494,21 +509,21 @@ impl FormalParameterList {
         Ok((current, current_scanner))
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         match self {
             FormalParameterList::Item(item) => item.location(),
             FormalParameterList::List(list, item) => list.location().merge(&item.location()),
         }
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         match self {
             FormalParameterList::Item(node) => node.contains(kind),
             FormalParameterList::List(lst, item) => lst.contains(kind) || item.contains(kind),
         }
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -527,7 +542,7 @@ impl FormalParameterList {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -540,7 +555,7 @@ impl FormalParameterList {
         }
     }
 
-    pub fn is_simple_parameter_list(&self) -> bool {
+    pub(crate) fn is_simple_parameter_list(&self) -> bool {
         // Static Semantics: IsSimpleParameterList
         match self {
             FormalParameterList::Item(formal_parameter) => {
@@ -557,7 +572,7 @@ impl FormalParameterList {
         }
     }
 
-    pub fn bound_names(&self) -> Vec<JSString> {
+    pub(crate) fn bound_names(&self) -> Vec<JSString> {
         // Static Semantics: BoundNames
         match self {
             FormalParameterList::Item(formal_parameter) => {
@@ -578,7 +593,7 @@ impl FormalParameterList {
         }
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
             FormalParameterList::Item(fp) => fp.early_errors(errs, strict),
             FormalParameterList::List(fpl, fp) => {
@@ -627,7 +642,7 @@ impl FormalParameterList {
         }
     }
 
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         if self.location().contains(location) {
             match self {
@@ -645,8 +660,8 @@ impl FormalParameterList {
 // FunctionRestParameter[Yield, Await] :
 //      BindingRestElement[?Yield, ?Await]
 #[derive(Debug)]
-pub struct FunctionRestParameter {
-    pub element: Rc<BindingRestElement>,
+pub(crate) struct FunctionRestParameter {
+    pub(crate) element: Rc<BindingRestElement>,
 }
 
 impl fmt::Display for FunctionRestParameter {
@@ -674,20 +689,25 @@ impl PrettyPrint for FunctionRestParameter {
 }
 
 impl FunctionRestParameter {
-    pub fn parse(parser: &mut Parser, scanner: Scanner, yield_flag: bool, await_flag: bool) -> ParseResult<Self> {
+    pub(crate) fn parse(
+        parser: &mut Parser,
+        scanner: Scanner,
+        yield_flag: bool,
+        await_flag: bool,
+    ) -> ParseResult<Self> {
         let (element, after_bre) = BindingRestElement::parse(parser, scanner, yield_flag, await_flag)?;
         Ok((Rc::new(FunctionRestParameter { element }), after_bre))
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         self.element.location()
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         self.element.contains(kind)
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -701,7 +721,7 @@ impl FunctionRestParameter {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -711,26 +731,26 @@ impl FunctionRestParameter {
         self.element.contains_arguments()
     }
 
-    pub fn bound_names(&self) -> Vec<JSString> {
+    pub(crate) fn bound_names(&self) -> Vec<JSString> {
         // Static Semantics: BoundNames
         // FunctionRestParameter : BindingRestElement
         //  1. Return BoundNames of BindingRestElement.
         self.element.bound_names()
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         self.element.early_errors(errs, strict);
     }
 
     /// Report whether this portion of a parameter list contains an expression
     ///
     /// See [ContainsExpression](https://tc39.es/ecma262/#sec-static-semantics-containsexpression) in ECMA-262.
-    pub fn contains_expression(&self) -> bool {
+    pub(crate) fn contains_expression(&self) -> bool {
         self.element.contains_expression()
     }
 
     #[expect(unused_variables)]
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         todo!()
     }
@@ -739,8 +759,8 @@ impl FunctionRestParameter {
 // FormalParameter[Yield, Await] :
 //      BindingElement[?Yield, ?Await]
 #[derive(Debug)]
-pub struct FormalParameter {
-    pub element: Rc<BindingElement>,
+pub(crate) struct FormalParameter {
+    pub(crate) element: Rc<BindingElement>,
 }
 
 impl fmt::Display for FormalParameter {
@@ -773,7 +793,12 @@ impl FormalParameter {
         Ok((Rc::new(FormalParameter { element }), after_be))
     }
 
-    pub fn parse(parser: &mut Parser, scanner: Scanner, yield_flag: bool, await_flag: bool) -> ParseResult<Self> {
+    pub(crate) fn parse(
+        parser: &mut Parser,
+        scanner: Scanner,
+        yield_flag: bool,
+        await_flag: bool,
+    ) -> ParseResult<Self> {
         let key = YieldAwaitKey { scanner, yield_flag, await_flag };
         match parser.formal_parameter_cache.get(&key) {
             Some(result) => result.clone(),
@@ -785,15 +810,15 @@ impl FormalParameter {
         }
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         self.element.location()
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         self.element.contains(kind)
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -807,7 +832,7 @@ impl FormalParameter {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -817,39 +842,39 @@ impl FormalParameter {
         self.element.contains_arguments()
     }
 
-    pub fn is_simple_parameter_list(&self) -> bool {
+    pub(crate) fn is_simple_parameter_list(&self) -> bool {
         // Static Semantics: IsSimpleParameterList
         // FormalParameter : BindingElement
         //  1. Return IsSimpleParameterList of BindingElement.
         self.element.is_simple_parameter_list()
     }
 
-    pub fn bound_names(&self) -> Vec<JSString> {
+    pub(crate) fn bound_names(&self) -> Vec<JSString> {
         // Static Semantics: BoundNames
         // FormalParameter : BindingElement
         //  1. Return BoundNames of BindingElement.
         self.element.bound_names()
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         self.element.early_errors(errs, strict);
     }
 
     /// Report whether this parameter contains an intializer
     ///
     /// See [HasInitializer](https://tc39.es/ecma262/#sec-static-semantics-hasinitializer) from ECMA-262.
-    pub fn has_initializer(&self) -> bool {
+    pub(crate) fn has_initializer(&self) -> bool {
         self.element.has_initializer()
     }
 
     /// Report whether this portion of a parameter list contains an expression
     ///
     /// See [ContainsExpression](https://tc39.es/ecma262/#sec-static-semantics-containsexpression) in ECMA-262.
-    pub fn contains_expression(&self) -> bool {
+    pub(crate) fn contains_expression(&self) -> bool {
         self.element.contains_expression()
     }
 
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         if self.location().contains(location) { self.element.body_containing_location(location) } else { None }
     }

--- a/src/parser/primary_expressions/tests.rs
+++ b/src/parser/primary_expressions/tests.rs
@@ -46,42 +46,36 @@ fn primary_expression_test_idref() {
     let (boxed_pe, scanner) = check(pe_res);
     chk_scan(&scanner, 4);
     assert!(matches!(*boxed_pe, PrimaryExpression::IdentifierReference { .. }));
-    assert_eq!(boxed_pe.is_function_definition(), false);
 }
 #[test]
 fn primary_expression_test_literal() {
     let (node, scanner) = check(PrimaryExpression::parse(&mut newparser("371"), Scanner::new(), false, false));
     chk_scan(&scanner, 3);
     assert!(matches!(*node, PrimaryExpression::Literal { .. }));
-    assert_eq!(node.is_function_definition(), false);
 }
 #[test]
 fn primary_expression_test_this() {
     let (node, scanner) = check(PrimaryExpression::parse(&mut newparser("this"), Scanner::new(), false, false));
     chk_scan(&scanner, 4);
     assert!(matches!(*node, PrimaryExpression::This { .. }));
-    assert_eq!(node.is_function_definition(), false);
 }
 #[test]
 fn primary_expression_test_arraylit() {
     let (node, scanner) = check(PrimaryExpression::parse(&mut newparser("[]"), Scanner::new(), false, false));
     chk_scan(&scanner, 2);
     assert!(matches!(*node, PrimaryExpression::ArrayLiteral { .. }));
-    assert_eq!(node.is_function_definition(), false);
 }
 #[test]
 fn primary_expression_test_objlit() {
     let (node, scanner) = check(PrimaryExpression::parse(&mut newparser("{}"), Scanner::new(), false, false));
     chk_scan(&scanner, 2);
     assert!(matches!(*node, PrimaryExpression::ObjectLiteral { .. }));
-    assert_eq!(node.is_function_definition(), false);
 }
 #[test]
 fn primary_expression_test_group() {
     let (node, scanner) = check(PrimaryExpression::parse(&mut newparser("(a)"), Scanner::new(), false, false));
     chk_scan(&scanner, 3);
     assert!(matches!(*node, PrimaryExpression::Parenthesized { .. }));
-    assert_eq!(node.is_function_definition(), false);
 }
 #[test]
 fn primary_expression_test_func() {
@@ -89,7 +83,6 @@ fn primary_expression_test_func() {
         check(PrimaryExpression::parse(&mut newparser("function a(){}"), Scanner::new(), false, false));
     chk_scan(&scanner, 14);
     assert!(matches!(*node, PrimaryExpression::Function { .. }));
-    assert_eq!(node.is_function_definition(), true);
     pretty_check(&*node, "PrimaryExpression: function a ( ) { }", &["FunctionExpression: function a ( ) { }"]);
     concise_check(
         &*node,
@@ -103,7 +96,6 @@ fn primary_expression_test_generator() {
         check(PrimaryExpression::parse(&mut newparser("function *a(b){c;}"), Scanner::new(), false, false));
     chk_scan(&scanner, 18);
     assert!(matches!(*node, PrimaryExpression::Generator { .. }));
-    assert_eq!(node.is_function_definition(), true);
     pretty_check(
         &*node,
         "PrimaryExpression: function * a ( b ) { c ; }",
@@ -131,7 +123,6 @@ fn primary_expression_test_async_generator() {
         check(PrimaryExpression::parse(&mut newparser("async function *a(b){c;}"), Scanner::new(), false, false));
     chk_scan(&scanner, 24);
     assert!(matches!(*node, PrimaryExpression::AsyncGenerator { .. }));
-    assert_eq!(node.is_function_definition(), true);
     pretty_check(
         &*node,
         "PrimaryExpression: async function * a ( b ) { c ; }",
@@ -160,7 +151,6 @@ fn primary_expression_test_async_function() {
         check(PrimaryExpression::parse(&mut newparser("async function a(b){c;}"), Scanner::new(), false, false));
     chk_scan(&scanner, 23);
     assert!(matches!(*node, PrimaryExpression::AsyncFunction { .. }));
-    assert_eq!(node.is_function_definition(), true);
     pretty_check(
         &*node,
         "PrimaryExpression: async function a ( b ) { c ; }",
@@ -187,14 +177,12 @@ fn primary_expression_test_regexp() {
     let (node, scanner) = check(PrimaryExpression::parse(&mut newparser("/rust/"), Scanner::new(), false, false));
     chk_scan(&scanner, 6);
     assert!(matches!(*node, PrimaryExpression::RegularExpression { .. }));
-    assert_eq!(node.is_function_definition(), false);
 }
 #[test]
 fn primary_expression_test_class_expression() {
     let (node, scanner) = check(PrimaryExpression::parse(&mut newparser("class{}"), Scanner::new(), false, false));
     chk_scan(&scanner, 7);
     assert!(matches!(*node, PrimaryExpression::Class { .. }));
-    assert_eq!(node.is_function_definition(), true);
     pretty_check(&*node, "PrimaryExpression: class { }", &["ClassExpression: class { }"]);
     concise_check(&*node, "ClassExpression: class { }", &["Keyword: class", "ClassTail: { }"]);
 }
@@ -581,22 +569,22 @@ mod primary_expression {
         Maker::new(src).primary_expression().assignment_target_type(strict)
     }
 
-    #[test_case("this" => false; "this")]
-    #[test_case("a" => true; "identifier ref")]
-    #[test_case("1" => false; "literal")]
-    #[test_case("[1]" => false; "array literal")]
-    #[test_case("{a:1}" => false; "object literal")]
-    #[test_case("function (){}" => false; "function expression")]
-    #[test_case("class {}" => false; "class expression")]
-    #[test_case("function *(){}" => false; "generator expression")]
-    #[test_case("async function (){}" => false; "async fn")]
-    #[test_case("async function *(){}" => false; "async gen")]
-    #[test_case("/a/" => false; "regex")]
-    #[test_case("``" => false; "template")]
-    #[test_case("(a)" => false; "parenthesized")]
-    fn is_identifier_ref(src: &str) -> bool {
-        Maker::new(src).primary_expression().is_identifier_ref()
-    }
+    //#[test_case("this" => false; "this")]
+    //#[test_case("a" => true; "identifier ref")]
+    //#[test_case("1" => false; "literal")]
+    //#[test_case("[1]" => false; "array literal")]
+    //#[test_case("{a:1}" => false; "object literal")]
+    //#[test_case("function (){}" => false; "function expression")]
+    //#[test_case("class {}" => false; "class expression")]
+    //#[test_case("function *(){}" => false; "generator expression")]
+    //#[test_case("async function (){}" => false; "async fn")]
+    //#[test_case("async function *(){}" => false; "async gen")]
+    //#[test_case("/a/" => false; "regex")]
+    //#[test_case("``" => false; "template")]
+    //#[test_case("(a)" => false; "parenthesized")]
+    //fn is_identifier_ref(src: &str) -> bool {
+    //    Maker::new(src).primary_expression().is_identifier_ref()
+    //}
 
     #[test_case("this" => None; "this")]
     #[test_case("a" => ssome("a"); "identifier ref")]
@@ -615,28 +603,28 @@ mod primary_expression {
         Maker::new(src).primary_expression().identifier_ref().map(|id| id.to_string())
     }
 
-    #[test_case("this" => false; "this")]
-    #[test_case("a" => false; "identifier ref")]
-    #[test_case("1" => false; "literal")]
-    #[test_case("[1]" => false; "array literal")]
-    #[test_case("{a:1}" => false; "object literal")]
-    #[test_case("function (){}" => false; "function expression")]
-    #[test_case("class {}" => false; "class expression")]
-    #[test_case("function *(){}" => false; "generator expression")]
-    #[test_case("async function (){}" => false; "async fn")]
-    #[test_case("async function *(){}" => false; "async gen")]
-    #[test_case("/a/" => false; "regex")]
-    #[test_case("``" => false; "template")]
-    #[test_case("(a)" => false; "parenthesized")]
-    #[test_case("function bob(){}" => true; "named function expression")]
-    #[test_case("class bob {}" => true; "named class expression")]
-    #[test_case("function *bob(){}" => true; "named generator expression")]
-    #[test_case("async function bob(){}" => true; "named async fn")]
-    #[test_case("async function *bob(){}" => true; "named async gen")]
-    #[test_case("(class bob {})" => true; "named parenthesized")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).primary_expression().is_named_function()
-    }
+    //#[test_case("this" => false; "this")]
+    //#[test_case("a" => false; "identifier ref")]
+    //#[test_case("1" => false; "literal")]
+    //#[test_case("[1]" => false; "array literal")]
+    //#[test_case("{a:1}" => false; "object literal")]
+    //#[test_case("function (){}" => false; "function expression")]
+    //#[test_case("class {}" => false; "class expression")]
+    //#[test_case("function *(){}" => false; "generator expression")]
+    //#[test_case("async function (){}" => false; "async fn")]
+    //#[test_case("async function *(){}" => false; "async gen")]
+    //#[test_case("/a/" => false; "regex")]
+    //#[test_case("``" => false; "template")]
+    //#[test_case("(a)" => false; "parenthesized")]
+    //#[test_case("function bob(){}" => true; "named function expression")]
+    //#[test_case("class bob {}" => true; "named class expression")]
+    //#[test_case("function *bob(){}" => true; "named generator expression")]
+    //#[test_case("async function bob(){}" => true; "named async fn")]
+    //#[test_case("async function *bob(){}" => true; "named async gen")]
+    //#[test_case("(class bob {})" => true; "named parenthesized")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).primary_expression().is_named_function()
+    //}
 
     #[test_case("   this" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 4 } }; "this")]
     #[test_case("   a" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 1 } }; "identifier ref")]
@@ -668,7 +656,7 @@ fn literal_test_null() {
     chk_scan(&scanner, 4);
     assert!(matches!(
         *lit,
-        Literal::NullLiteral {
+        Literal::Null {
             location: Location { starting_line: 1, starting_column: 1, span: Span { starting_index: 0, length: 4 } }
         }
     ));
@@ -681,7 +669,7 @@ fn literal_test_boolean_01() {
     chk_scan(&scanner, 4);
     assert!(matches!(
         *lit,
-        Literal::BooleanLiteral {
+        Literal::Boolean {
             val: true,
             location: Location { starting_line: 1, starting_column: 1, span: Span { starting_index: 0, length: 4 } }
         }
@@ -695,7 +683,7 @@ fn literal_test_boolean_02() {
     chk_scan(&scanner, 5);
     assert!(matches!(
         *lit,
-        Literal::BooleanLiteral {
+        Literal::Boolean {
             val: false,
             location: Location { starting_line: 1, starting_column: 1, span: Span { starting_index: 0, length: 5 } }
         }
@@ -709,7 +697,7 @@ fn literal_test_leading_dot() {
     chk_scan(&scanner, 3);
     assert_eq!(
         *lit,
-        Literal::NumericLiteral {
+        Literal::Numeric {
             val: Numeric::Number(0.25),
             location: Location { starting_line: 1, starting_column: 1, span: Span { starting_index: 0, length: 3 } }
         }
@@ -723,7 +711,7 @@ fn literal_test_bigint() {
     chk_scan(&scanner, 5);
     assert!(matches!(
         *lit,
-        Literal::NumericLiteral {
+        Literal::Numeric {
             val: Numeric::BigInt(_),
             location: Location { starting_line: 1, starting_column: 1, span: Span { starting_index: 0, length: 5 } }
         }
@@ -738,7 +726,7 @@ fn literal_test_string() {
     chk_scan(&scanner, 8);
     assert!(matches!(
         *lit,
-        Literal::StringLiteral {
+        Literal::String {
             val: _,
             location: Location { starting_line: 1, starting_column: 1, span: Span { starting_index: 0, length: 8 } }
         }
@@ -752,7 +740,7 @@ fn literal_test_debugmark() {
     chk_scan(&scanner, 3);
     assert!(matches!(
         *lit,
-        Literal::DebugLiteral {
+        Literal::Debug {
             val: DebugKind::Char('H'),
             location: Location { starting_line: 1, starting_column: 1, span: Span { starting_index: 0, length: 3 } }
         }
@@ -904,11 +892,6 @@ fn elision_test_conciseerrors_1() {
     let (item, _) = Elisions::parse(&mut newparser(",,,"), Scanner::new()).unwrap();
     concise_error_validate(&*item);
 }
-#[test]
-fn elision_test_contains_01() {
-    let (item, _) = Elisions::parse(&mut newparser(",,,"), Scanner::new()).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::This), false);
-}
 mod elision {
     use super::*;
     use test_case::test_case;
@@ -1053,7 +1036,7 @@ fn element_list_test_06() {
 fn element_list_test_07() {
     let (el, scanner) = check(ElementList::parse(&mut newparser("a,b"), Scanner::new(), false, false));
     chk_scan(&scanner, 3);
-    assert!(matches!(&*el, ElementList::ElementListAssignmentExpression { elision: None, .. }));
+    assert!(matches!(&*el, ElementList::ListAssignmentExpression { elision: None, .. }));
     pretty_check(&*el, "ElementList: a , b", &["ElementList: a", "AssignmentExpression: b"]);
     concise_check(&*el, "ElementList: a , b", &["IdentifierName: a", "Punctuator: ,", "IdentifierName: b"]);
 }
@@ -1061,7 +1044,7 @@ fn element_list_test_07() {
 fn element_list_test_08() {
     let (el, scanner) = check(ElementList::parse(&mut newparser("a,,b"), Scanner::new(), false, false));
     chk_scan(&scanner, 4);
-    assert!(matches!(&*el, ElementList::ElementListAssignmentExpression{elision: Some(be), ..} if be.count == 1));
+    assert!(matches!(&*el, ElementList::ListAssignmentExpression{elision: Some(be), ..} if be.count == 1));
     pretty_check(&*el, "ElementList: a , , b", &["ElementList: a", "Elisions: ,", "AssignmentExpression: b"]);
     concise_check(
         &*el,
@@ -1073,7 +1056,7 @@ fn element_list_test_08() {
 fn element_list_test_09() {
     let (el, scanner) = check(ElementList::parse(&mut newparser("a,...b"), Scanner::new(), false, false));
     chk_scan(&scanner, 6);
-    assert!(matches!(&*el, ElementList::ElementListSpreadElement { elision: None, .. }));
+    assert!(matches!(&*el, ElementList::ListSpreadElement { elision: None, .. }));
     pretty_check(&*el, "ElementList: a , ... b", &["ElementList: a", "SpreadElement: ... b"]);
     concise_check(&*el, "ElementList: a , ... b", &["IdentifierName: a", "Punctuator: ,", "SpreadElement: ... b"]);
 }
@@ -1081,7 +1064,7 @@ fn element_list_test_09() {
 fn element_list_test_10() {
     let (el, scanner) = check(ElementList::parse(&mut newparser("a,,...b"), Scanner::new(), false, false));
     chk_scan(&scanner, 7);
-    assert!(matches!(&*el, ElementList::ElementListSpreadElement{elision: Some(be), ..} if be.count == 1));
+    assert!(matches!(&*el, ElementList::ListSpreadElement{elision: Some(be), ..} if be.count == 1));
     pretty_check(&*el, "ElementList: a , , ... b", &["ElementList: a", "Elisions: ,", "SpreadElement: ... b"]);
     concise_check(
         &*el,
@@ -1735,11 +1718,11 @@ mod initializer {
         Maker::new(src).initializer().location()
     }
 
-    #[test_case("=a" => false; "not anon func")]
-    #[test_case("=function (){}" => true; "anon func")]
-    fn is_anonymous_function_definition(src: &str) -> bool {
-        Maker::new(src).initializer().is_anonymous_function_definition()
-    }
+    //#[test_case("=a" => false; "not anon func")]
+    //#[test_case("=function (){}" => true; "anon func")]
+    //fn is_anonymous_function_definition(src: &str) -> bool {
+    //    Maker::new(src).initializer().is_anonymous_function_definition()
+    //}
 
     #[test_case("=a" => None; "not function")]
     #[test_case("=function a(){}" => None; "named function")]
@@ -1807,12 +1790,6 @@ mod cover_initialized_name {
             .0
             .early_errors(&mut errs, strict);
         errs.iter().map(|err| unwind_syntax_error_object(&err.clone())).collect()
-    }
-
-    #[test]
-    fn prop_name() {
-        let (item, _) = CoverInitializedName::parse(&mut newparser("a=b"), Scanner::new(), true, true).unwrap();
-        assert_eq!(item.prop_name(), JSString::from("a"));
     }
 
     #[test_case("   n=a" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 3 } }; "typical")]
@@ -1903,11 +1880,6 @@ mod computed_property_name {
     #[test_case("   [3]" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 3 } }; "typical")]
     fn location(src: &str) -> Location {
         Maker::new(src).computed_property_name().location()
-    }
-
-    #[test_case("[computed]" => true; "typical")]
-    fn is_computed_property_key(src: &str) -> bool {
-        Maker::new(src).computed_property_name().is_computed_property_key()
     }
 }
 
@@ -2008,11 +1980,6 @@ fn literal_property_name_test_conciseerrors_3() {
     let (item, _) = LiteralPropertyName::parse(&mut newparser("'a'"), Scanner::new()).unwrap();
     concise_error_validate(&*item);
 }
-#[test]
-fn literal_property_name_test_contains_01() {
-    let (item, _) = LiteralPropertyName::parse(&mut newparser("'a'"), Scanner::new()).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::This), false);
-}
 mod literal_property_name {
     use super::*;
     use test_case::test_case;
@@ -2031,11 +1998,6 @@ mod literal_property_name {
     #[test_case("   3" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 1 } }; "numeric")]
     fn location(src: &str) -> Location {
         Maker::new(src).literal_property_name().location()
-    }
-
-    #[test_case("ident" => false; "typical")]
-    fn is_computed_property_key(src: &str) -> bool {
-        Maker::new(src).literal_property_name().is_computed_property_key()
     }
 }
 
@@ -2396,15 +2358,15 @@ mod property_definition {
         errs.iter().map(|err| unwind_syntax_error_object(&err.clone())).collect()
     }
 
-    #[test_case("a" => Some(JSString::from("a")); "identifier")]
-    #[test_case("a=b" => Some(JSString::from("a")); "cover init")]
-    #[test_case("a:3" => Some(JSString::from("a")); "property name")]
-    #[test_case("a(){}" => Some(JSString::from("a")); "method def")]
-    #[test_case("...3" => None; "spread element")]
-    fn prop_name(src: &str) -> Option<JSString> {
-        let (item, _) = PropertyDefinition::parse(&mut newparser(src), Scanner::new(), true, true).unwrap();
-        item.prop_name()
-    }
+    //#[test_case("a" => Some(JSString::from("a")); "identifier")]
+    //#[test_case("a=b" => Some(JSString::from("a")); "cover init")]
+    //#[test_case("a:3" => Some(JSString::from("a")); "property name")]
+    //#[test_case("a(){}" => Some(JSString::from("a")); "method def")]
+    //#[test_case("...3" => None; "spread element")]
+    //fn prop_name(src: &str) -> Option<JSString> {
+    //    let (item, _) = PropertyDefinition::parse(&mut newparser(src), Scanner::new(), true, true).unwrap();
+    //    item.prop_name()
+    //}
 
     #[test_case("__proto__" => 0; "identifier")]
     #[test_case("__proto__=b" => 0; "cover init")]
@@ -2761,7 +2723,6 @@ fn parenthesized_expression_test_01() {
     pretty_check(&*pe, "ParenthesizedExpression: ( a )", &["Expression: a"]);
     concise_check(&*pe, "ParenthesizedExpression: ( a )", &["Punctuator: (", "IdentifierName: a", "Punctuator: )"]);
     assert_ne!(format!("{pe:?}"), "");
-    assert_eq!(pe.is_function_definition(), false);
 }
 #[test]
 fn parenthesized_expression_test_02() {
@@ -2846,11 +2807,11 @@ mod parenthesized_expression {
         Maker::new(src).parenthesized_expression().assignment_target_type(strict)
     }
 
-    #[test_case("(function a(){})" => true; "named")]
-    #[test_case("(function (){})" => false; "unnamed")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).parenthesized_expression().is_named_function()
-    }
+    //#[test_case("(function a(){})" => true; "named")]
+    //#[test_case("(function (){})" => false; "unnamed")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).parenthesized_expression().is_named_function()
+    //}
 
     #[test_case("   (a)" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 3 } }; "typical")]
     fn location(src: &str) -> Location {
@@ -3424,7 +3385,6 @@ mod template_literal {
 // COVER PARENTHESIZED EXPRESSION AND ARROW PARAMETER LIST
 mod cover_parenthesized_expression_and_arrow_parameter_list {
     use super::*;
-    use test_case::test_case;
 
     #[test]
     fn test_01() {
@@ -3435,7 +3395,7 @@ mod cover_parenthesized_expression_and_arrow_parameter_list {
             false,
         ));
         chk_scan(&scanner, 2);
-        assert!(matches!(&*node, CoverParenthesizedExpressionAndArrowParameterList::Empty { .. }));
+        assert!(matches!(&*node, CoverParenthesizedExpressionAndArrowParameterList::Empty));
         pretty_check(&*node, "CoverParenthesizedExpressionAndArrowParameterList: ( )", &[]);
         concise_check(
             &*node,
@@ -3837,157 +3797,6 @@ mod cover_parenthesized_expression_and_arrow_parameter_list {
             check(CoverParenthesizedExpressionAndArrowParameterList::parse(&mut parser, Scanner::new(), false, false));
         assert!(scanner == scanner2);
         assert!(Rc::ptr_eq(&node, &node2));
-    }
-
-    #[test]
-    fn test_contains_01() {
-        let (item, _) = CoverParenthesizedExpressionAndArrowParameterList::parse(
-            &mut newparser("(this)"),
-            Scanner::new(),
-            false,
-            false,
-        )
-        .unwrap();
-        assert_eq!(item.contains(ParseNodeKind::This), true);
-    }
-    #[test]
-    fn test_contains_02() {
-        let (item, _) = CoverParenthesizedExpressionAndArrowParameterList::parse(
-            &mut newparser("(a)"),
-            Scanner::new(),
-            false,
-            false,
-        )
-        .unwrap();
-        assert_eq!(item.contains(ParseNodeKind::This), false);
-    }
-    #[test]
-    fn test_contains_03() {
-        let (item, _) = CoverParenthesizedExpressionAndArrowParameterList::parse(
-            &mut newparser("(this,)"),
-            Scanner::new(),
-            false,
-            false,
-        )
-        .unwrap();
-        assert_eq!(item.contains(ParseNodeKind::This), true);
-    }
-    #[test]
-    fn test_contains_04() {
-        let (item, _) = CoverParenthesizedExpressionAndArrowParameterList::parse(
-            &mut newparser("(a,)"),
-            Scanner::new(),
-            false,
-            false,
-        )
-        .unwrap();
-        assert_eq!(item.contains(ParseNodeKind::This), false);
-    }
-    #[test]
-    fn test_contains_05() {
-        let (item, _) = CoverParenthesizedExpressionAndArrowParameterList::parse(
-            &mut newparser("()"),
-            Scanner::new(),
-            false,
-            false,
-        )
-        .unwrap();
-        assert_eq!(item.contains(ParseNodeKind::This), false);
-    }
-    #[test]
-    fn test_contains_06() {
-        let (item, _) = CoverParenthesizedExpressionAndArrowParameterList::parse(
-            &mut newparser("(...blue)"),
-            Scanner::new(),
-            false,
-            false,
-        )
-        .unwrap();
-        assert_eq!(item.contains(ParseNodeKind::This), false);
-    }
-    #[test]
-    fn test_contains_07() {
-        let (item, _) = CoverParenthesizedExpressionAndArrowParameterList::parse(
-            &mut newparser("(...[a,b,c])"),
-            Scanner::new(),
-            false,
-            false,
-        )
-        .unwrap();
-        assert_eq!(item.contains(ParseNodeKind::This), false);
-    }
-    #[test]
-    fn test_contains_08() {
-        let (item, _) = CoverParenthesizedExpressionAndArrowParameterList::parse(
-            &mut newparser("(this, ...thing)"),
-            Scanner::new(),
-            false,
-            false,
-        )
-        .unwrap();
-        assert_eq!(item.contains(ParseNodeKind::This), true);
-    }
-    #[test]
-    fn test_contains_09() {
-        let (item, _) = CoverParenthesizedExpressionAndArrowParameterList::parse(
-            &mut newparser("(a, ...thing)"),
-            Scanner::new(),
-            false,
-            false,
-        )
-        .unwrap();
-        assert_eq!(item.contains(ParseNodeKind::This), false);
-    }
-    #[test]
-    fn test_contains_10() {
-        let (item, _) = CoverParenthesizedExpressionAndArrowParameterList::parse(
-            &mut newparser("(this, ...[a])"),
-            Scanner::new(),
-            false,
-            false,
-        )
-        .unwrap();
-        assert_eq!(item.contains(ParseNodeKind::This), true);
-    }
-    #[test]
-    fn test_contains_11() {
-        let (item, _) = CoverParenthesizedExpressionAndArrowParameterList::parse(
-            &mut newparser("(b, ...[a])"),
-            Scanner::new(),
-            false,
-            false,
-        )
-        .unwrap();
-        assert_eq!(item.contains(ParseNodeKind::This), false);
-    }
-    #[test_case("(package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "Expression")]
-    #[test_case("(package,)", true => sset(&[PACKAGE_NOT_ALLOWED]); "Expression+Comma")]
-    #[test_case("()", true => sset(&[]); "Empty")]
-    #[test_case("(...package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "rest id")]
-    #[test_case("(...{package=a})", true => sset(&[PACKAGE_NOT_ALLOWED]); "rest pattern")]
-    #[test_case("(package, ...a)", true => sset(&[PACKAGE_NOT_ALLOWED]); "exp rest id; exp bad")]
-    #[test_case("(a, ...package)", true => sset(&[PACKAGE_NOT_ALLOWED]); "exp rest id; id bad")]
-    #[test_case("(package, ...{a=b})", true => sset(&[PACKAGE_NOT_ALLOWED]); "exp rest pat; exp bad")]
-    #[test_case("(a, ...{package=b})", true => sset(&[PACKAGE_NOT_ALLOWED]); "exp rest pat; pat bad")]
-    fn early_errors(src: &str, strict: bool) -> AHashSet<String> {
-        setup_test_agent();
-        let mut errs = vec![];
-        CoverParenthesizedExpressionAndArrowParameterList::parse(&mut newparser(src), Scanner::new(), false, true)
-            .unwrap()
-            .0
-            .early_errors(&mut errs, strict);
-        errs.iter().map(|err| unwind_syntax_error_object(&err.clone())).collect()
-    }
-
-    #[test_case("   (a)" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 3 } }; "parenthesized")]
-    #[test_case("   (a,)" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 4 } }; "Expression+Comma")]
-    #[test_case("   ()" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 2 } }; "Empty")]
-    #[test_case("   (...a)" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 6 } }; "rest id")]
-    #[test_case("   (...{z=a})" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 10 } }; "rest pattern")]
-    #[test_case("   (z, ...a)" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 9 } }; "exp rest id; exp")]
-    #[test_case("   (z, ...{a=b})" => Location { starting_line: 1, starting_column: 4, span: Span { starting_index: 3, length: 13 } }; "exp rest pat; exp")]
-    fn location(src: &str) -> Location {
-        Maker::new(src).cover_parenthesized_expression_and_arrow_parameter_list().location()
     }
 }
 

--- a/src/parser/relational_operators/tests.rs
+++ b/src/parser/relational_operators/tests.rs
@@ -18,7 +18,6 @@ mod relational_expression {
         pretty_check(&*se, "RelationalExpression: a", &["ShiftExpression: a"]);
         concise_check(&*se, "IdentifierName: a", &[]);
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_02() {
@@ -33,7 +32,6 @@ mod relational_expression {
             &["IdentifierName: a", "Punctuator: <", "IdentifierName: b"],
         );
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_03() {
@@ -48,7 +46,6 @@ mod relational_expression {
             &["IdentifierName: a", "Punctuator: >", "IdentifierName: b"],
         );
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_04() {
@@ -63,7 +60,6 @@ mod relational_expression {
             &["IdentifierName: a", "Punctuator: <=", "IdentifierName: b"],
         );
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_05() {
@@ -78,7 +74,6 @@ mod relational_expression {
             &["IdentifierName: a", "Punctuator: >=", "IdentifierName: b"],
         );
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_06() {
@@ -93,7 +88,6 @@ mod relational_expression {
             &["IdentifierName: a", "Keyword: instanceof", "IdentifierName: b"],
         );
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_07() {
@@ -104,7 +98,6 @@ mod relational_expression {
         pretty_check(&*se, "RelationalExpression: a in b", &["RelationalExpression: a", "ShiftExpression: b"]);
         concise_check(&*se, "RelationalExpression: a in b", &["IdentifierName: a", "Keyword: in", "IdentifierName: b"]);
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_08() {
@@ -115,7 +108,6 @@ mod relational_expression {
         pretty_check(&*se, "RelationalExpression: a", &["ShiftExpression: a"]);
         concise_check(&*se, "IdentifierName: a", &[]);
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_09() {
@@ -126,7 +118,6 @@ mod relational_expression {
         pretty_check(&*se, "RelationalExpression: a", &["ShiftExpression: a"]);
         concise_check(&*se, "IdentifierName: a", &[]);
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_10() {
@@ -150,7 +141,6 @@ mod relational_expression {
             &["PrivateIdentifier: #a", "Keyword: in", "IdentifierName: b"],
         );
         assert_ne!(format!("{se:?}"), "");
-        assert_eq!(se.is_function_definition(), false);
     }
     #[test]
     fn parse_12() {
@@ -502,18 +492,18 @@ mod relational_expression {
         Maker::new(src).relational_expression().assignment_target_type(strict)
     }
 
-    #[test_case("a<b" => false; "lt")]
-    #[test_case("a<=b" => false; "le")]
-    #[test_case("a>b" => false; "gt")]
-    #[test_case("a>=b" => false; "ge")]
-    #[test_case("a in b" => false; "a in b")]
-    #[test_case("a instanceof b" => false; "instanceof")]
-    #[test_case("#a in b" => false; "privateid")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).relational_expression().is_named_function()
-    }
+    //#[test_case("a<b" => false; "lt")]
+    //#[test_case("a<=b" => false; "le")]
+    //#[test_case("a>b" => false; "gt")]
+    //#[test_case("a>=b" => false; "ge")]
+    //#[test_case("a in b" => false; "a in b")]
+    //#[test_case("a instanceof b" => false; "instanceof")]
+    //#[test_case("#a in b" => false; "privateid")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).relational_expression().is_named_function()
+    //}
 
     #[test_case("  a<b" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "lt")]
     #[test_case("  a<=b" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 4 }}; "le")]

--- a/src/parser/return_statement/mod.rs
+++ b/src/parser/return_statement/mod.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 //      return ;
 //      return [no LineTerminator here] Expression[+In, ?Yield, ?Await] ;
 #[derive(Debug)]
-pub enum ReturnStatement {
+pub(crate) enum ReturnStatement {
     Bare { location: Location },
     Expression { exp: Rc<Expression>, location: Location },
 }
@@ -49,34 +49,38 @@ impl PrettyPrint for ReturnStatement {
 }
 
 impl ReturnStatement {
-    pub fn parse(parser: &mut Parser, scanner: Scanner, yield_flag: bool, await_flag: bool) -> ParseResult<Self> {
-        let (ret_loc, after_ret) =
-            scan_for_keyword(scanner, parser.source, ScanGoal::InputElementRegExp, Keyword::Return)?;
-        scan_for_auto_semi(after_ret, parser.source, ScanGoal::InputElementRegExp)
+    pub(crate) fn parse(
+        parser: &mut Parser,
+        scanner: Scanner,
+        yield_flag: bool,
+        await_flag: bool,
+    ) -> ParseResult<Self> {
+        let (ret_loc, after_ret) = scan_for_keyword(scanner, parser.source, InputElementGoal::RegExp, Keyword::Return)?;
+        scan_for_auto_semi(after_ret, parser.source, InputElementGoal::RegExp)
             .map(|(semi_loc, after_semi)| {
                 (Rc::new(ReturnStatement::Bare { location: ret_loc.merge(&semi_loc) }), after_semi)
             })
             .otherwise(|| {
                 let (exp, after_exp) = Expression::parse(parser, after_ret, true, yield_flag, await_flag)?;
-                let (semi_loc, after_semi) = scan_for_auto_semi(after_exp, parser.source, ScanGoal::InputElementDiv)?;
+                let (semi_loc, after_semi) = scan_for_auto_semi(after_exp, parser.source, InputElementGoal::Div)?;
                 Ok((Rc::new(ReturnStatement::Expression { exp, location: ret_loc.merge(&semi_loc) }), after_semi))
             })
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         match self {
             ReturnStatement::Bare { location } | ReturnStatement::Expression { location, .. } => *location,
         }
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         match self {
             ReturnStatement::Bare { .. } => false,
             ReturnStatement::Expression { exp, .. } => exp.contains(kind),
         }
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -93,7 +97,7 @@ impl ReturnStatement {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -106,14 +110,14 @@ impl ReturnStatement {
         }
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         match self {
             ReturnStatement::Bare { .. } => {}
             ReturnStatement::Expression { exp, .. } => exp.early_errors(errs, strict),
         }
     }
 
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         if self.location().contains(location) {
             match self {
@@ -125,7 +129,7 @@ impl ReturnStatement {
         }
     }
 
-    pub fn has_call_in_tail_position(&self, location: &Location) -> bool {
+    pub(crate) fn has_call_in_tail_position(&self, location: &Location) -> bool {
         // Static Semantics: HasCallInTailPosition
         // The syntax-directed operation HasCallInTailPosition takes argument call (a CallExpression Parse Node, a
         // MemberExpression Parse Node, or an OptionalChain Parse Node) and returns a Boolean.

--- a/src/parser/scripts/tests.rs
+++ b/src/parser/scripts/tests.rs
@@ -11,10 +11,10 @@ mod var_scope_decl {
     use super::*;
     use test_case::test_case;
 
-    #[test_case(HoistableDeclPart::FunctionDeclaration(Maker::new("function a(){}").function_declaration()) => "function a ( ) { }"; "function decl")]
-    #[test_case(HoistableDeclPart::GeneratorDeclaration(Maker::new("function *a(){}").generator_declaration()) => "function * a ( ) { }"; "generator decl")]
-    #[test_case(HoistableDeclPart::AsyncFunctionDeclaration(Maker::new("async function a(){}").async_function_declaration()) => "async function a ( ) { }"; "async function decl")]
-    #[test_case(HoistableDeclPart::AsyncGeneratorDeclaration(Maker::new("async function *a(){}").async_generator_declaration()) => "async function * a ( ) { }"; "async generator decl")]
+    #[test_case(HoistableDeclPart::Function(Maker::new("function a(){}").function_declaration()) => "function a ( ) { }"; "function decl")]
+    #[test_case(HoistableDeclPart::Generator(Maker::new("function *a(){}").generator_declaration()) => "function * a ( ) { }"; "generator decl")]
+    #[test_case(HoistableDeclPart::AsyncFunction(Maker::new("async function a(){}").async_function_declaration()) => "async function a ( ) { }"; "async function decl")]
+    #[test_case(HoistableDeclPart::AsyncGenerator(Maker::new("async function *a(){}").async_generator_declaration()) => "async function * a ( ) { }"; "async generator decl")]
     fn from_hoistable(part: HoistableDeclPart) -> String {
         VarScopeDecl::from(part).to_string()
     }

--- a/src/parser/statements_and_declarations/tests.rs
+++ b/src/parser/statements_and_declarations/tests.rs
@@ -605,25 +605,25 @@ mod hoistable_decl_part {
     use super::*;
     use test_case::test_case;
 
-    #[test_case(&HoistableDeclPart::FunctionDeclaration(Maker::new("function a(){}").function_declaration()) => with |s| assert_ne!(s, ""); "Function Decl")]
-    #[test_case(&HoistableDeclPart::GeneratorDeclaration(Maker::new("function *a(){}").generator_declaration()) => with |s| assert_ne!(s, ""); "Generator Decl")]
-    #[test_case(&HoistableDeclPart::AsyncFunctionDeclaration(Maker::new("async function a(){}").async_function_declaration()) => with |s| assert_ne!(s, ""); "Async Function Decl")]
-    #[test_case(&HoistableDeclPart::AsyncGeneratorDeclaration(Maker::new("async function *a(){}").async_generator_declaration()) => with |s| assert_ne!(s, ""); "Async Generator Decl")]
+    #[test_case(&HoistableDeclPart::Function(Maker::new("function a(){}").function_declaration()) => with |s| assert_ne!(s, ""); "Function Decl")]
+    #[test_case(&HoistableDeclPart::Generator(Maker::new("function *a(){}").generator_declaration()) => with |s| assert_ne!(s, ""); "Generator Decl")]
+    #[test_case(&HoistableDeclPart::AsyncFunction(Maker::new("async function a(){}").async_function_declaration()) => with |s| assert_ne!(s, ""); "Async Function Decl")]
+    #[test_case(&HoistableDeclPart::AsyncGenerator(Maker::new("async function *a(){}").async_generator_declaration()) => with |s| assert_ne!(s, ""); "Async Generator Decl")]
     fn debug(part: &HoistableDeclPart) -> String {
         format!("{part:?}")
     }
 
     #[test]
     fn clone() {
-        let hdp = HoistableDeclPart::FunctionDeclaration(Maker::new("function a(){'hdp';}").function_declaration());
+        let hdp = HoistableDeclPart::Function(Maker::new("function a(){'hdp';}").function_declaration());
         let my_copy = hdp.clone();
         assert_eq!(hdp.to_string(), my_copy.to_string());
     }
 
-    #[test_case(&HoistableDeclPart::FunctionDeclaration(Maker::new("function banana(){}").function_declaration()) => "function banana ( ) { }"; "Function Decl")]
-    #[test_case(&HoistableDeclPart::GeneratorDeclaration(Maker::new("function *a(){'apple';}").generator_declaration()) => "function * a ( ) { 'apple' ; }"; "Generator Decl")]
-    #[test_case(&HoistableDeclPart::AsyncFunctionDeclaration(Maker::new("async function a(strawberry){}").async_function_declaration()) => "async function a ( strawberry ) { }"; "Async Function Decl")]
-    #[test_case(&HoistableDeclPart::AsyncGeneratorDeclaration(Maker::new("async function *a(){plum();}").async_generator_declaration()) => "async function * a ( ) { plum ( ) ; }"; "Async Generator Decl")]
+    #[test_case(&HoistableDeclPart::Function(Maker::new("function banana(){}").function_declaration()) => "function banana ( ) { }"; "Function Decl")]
+    #[test_case(&HoistableDeclPart::Generator(Maker::new("function *a(){'apple';}").generator_declaration()) => "function * a ( ) { 'apple' ; }"; "Generator Decl")]
+    #[test_case(&HoistableDeclPart::AsyncFunction(Maker::new("async function a(strawberry){}").async_function_declaration()) => "async function a ( strawberry ) { }"; "Async Function Decl")]
+    #[test_case(&HoistableDeclPart::AsyncGenerator(Maker::new("async function *a(){plum();}").async_generator_declaration()) => "async function * a ( ) { plum ( ) ; }"; "Async Generator Decl")]
     fn display(part: &HoistableDeclPart) -> String {
         part.to_string()
     }
@@ -633,35 +633,35 @@ mod decl_part {
     use super::*;
     use test_case::test_case;
 
-    #[test_case(&DeclPart::FunctionDeclaration(Maker::new("function banana(){}").function_declaration()) => with |s| assert_ne!(s, ""); "function decl")]
+    #[test_case(&DeclPart::Function(Maker::new("function banana(){}").function_declaration()) => with |s| assert_ne!(s, ""); "function decl")]
     fn debug(part: &DeclPart) -> String {
         format!("{part:?}")
     }
 
-    #[test_case(HoistableDeclPart::FunctionDeclaration(Maker::new("function banana(){}").function_declaration()) => "function banana ( ) { }"; "Function Decl")]
-    #[test_case(HoistableDeclPart::GeneratorDeclaration(Maker::new("function *a(){'apple';}").generator_declaration()) => "function * a ( ) { 'apple' ; }"; "Generator Decl")]
-    #[test_case(HoistableDeclPart::AsyncFunctionDeclaration(Maker::new("async function a(strawberry){}").async_function_declaration()) => "async function a ( strawberry ) { }"; "Async Function Decl")]
-    #[test_case(HoistableDeclPart::AsyncGeneratorDeclaration(Maker::new("async function *a(){plum();}").async_generator_declaration()) => "async function * a ( ) { plum ( ) ; }"; "Async Generator Decl")]
+    #[test_case(HoistableDeclPart::Function(Maker::new("function banana(){}").function_declaration()) => "function banana ( ) { }"; "Function Decl")]
+    #[test_case(HoistableDeclPart::Generator(Maker::new("function *a(){'apple';}").generator_declaration()) => "function * a ( ) { 'apple' ; }"; "Generator Decl")]
+    #[test_case(HoistableDeclPart::AsyncFunction(Maker::new("async function a(strawberry){}").async_function_declaration()) => "async function a ( strawberry ) { }"; "Async Function Decl")]
+    #[test_case(HoistableDeclPart::AsyncGenerator(Maker::new("async function *a(){plum();}").async_generator_declaration()) => "async function * a ( ) { plum ( ) ; }"; "Async Generator Decl")]
     fn from_hoistable(part: HoistableDeclPart) -> String {
         DeclPart::from(part).to_string()
     }
 
-    #[test_case(&DeclPart::FunctionDeclaration(Maker::new("function banana(){}").function_declaration()) => "function banana ( ) { }"; "Function Decl")]
-    #[test_case(&DeclPart::GeneratorDeclaration(Maker::new("function *a(){'apple';}").generator_declaration()) => "function * a ( ) { 'apple' ; }"; "Generator Decl")]
-    #[test_case(&DeclPart::AsyncFunctionDeclaration(Maker::new("async function a(strawberry){}").async_function_declaration()) => "async function a ( strawberry ) { }"; "Async Function Decl")]
-    #[test_case(&DeclPart::AsyncGeneratorDeclaration(Maker::new("async function *a(){plum();}").async_generator_declaration()) => "async function * a ( ) { plum ( ) ; }"; "Async Generator Decl")]
-    #[test_case(&DeclPart::ClassDeclaration(Maker::new("class rust {}").class_declaration()) => "class rust { }"; "class def")]
-    #[test_case(&DeclPart::LexicalDeclaration(Maker::new("const PI = 4.0;").lexical_declaration()) => "const PI = 4 ;"; "lexical decl")]
+    #[test_case(&DeclPart::Function(Maker::new("function banana(){}").function_declaration()) => "function banana ( ) { }"; "Function Decl")]
+    #[test_case(&DeclPart::Generator(Maker::new("function *a(){'apple';}").generator_declaration()) => "function * a ( ) { 'apple' ; }"; "Generator Decl")]
+    #[test_case(&DeclPart::AsyncFunction(Maker::new("async function a(strawberry){}").async_function_declaration()) => "async function a ( strawberry ) { }"; "Async Function Decl")]
+    #[test_case(&DeclPart::AsyncGenerator(Maker::new("async function *a(){plum();}").async_generator_declaration()) => "async function * a ( ) { plum ( ) ; }"; "Async Generator Decl")]
+    #[test_case(&DeclPart::Class(Maker::new("class rust {}").class_declaration()) => "class rust { }"; "class def")]
+    #[test_case(&DeclPart::Lexical(Maker::new("const PI = 4.0;").lexical_declaration()) => "const PI = 4 ;"; "lexical decl")]
     fn display(part: &DeclPart) -> String {
         part.to_string()
     }
 
-    #[test_case(&DeclPart::FunctionDeclaration(Maker::new("function banana(){}").function_declaration()) => "function banana ( ) { }"; "Function Decl")]
-    #[test_case(&DeclPart::GeneratorDeclaration(Maker::new("function *a(){'apple';}").generator_declaration()) => "function * a ( ) { 'apple' ; }"; "Generator Decl")]
-    #[test_case(&DeclPart::AsyncFunctionDeclaration(Maker::new("async function a(strawberry){}").async_function_declaration()) => "async function a ( strawberry ) { }"; "Async Function Decl")]
-    #[test_case(&DeclPart::AsyncGeneratorDeclaration(Maker::new("async function *a(){plum();}").async_generator_declaration()) => "async function * a ( ) { plum ( ) ; }"; "Async Generator Decl")]
-    #[test_case(&DeclPart::ClassDeclaration(Maker::new("class rust {}").class_declaration()) => "class rust { }"; "class def")]
-    #[test_case(&DeclPart::LexicalDeclaration(Maker::new("const PI = 4.0;").lexical_declaration()) => "const PI = 4 ;"; "lexical decl")]
+    #[test_case(&DeclPart::Function(Maker::new("function banana(){}").function_declaration()) => "function banana ( ) { }"; "Function Decl")]
+    #[test_case(&DeclPart::Generator(Maker::new("function *a(){'apple';}").generator_declaration()) => "function * a ( ) { 'apple' ; }"; "Generator Decl")]
+    #[test_case(&DeclPart::AsyncFunction(Maker::new("async function a(strawberry){}").async_function_declaration()) => "async function a ( strawberry ) { }"; "Async Function Decl")]
+    #[test_case(&DeclPart::AsyncGenerator(Maker::new("async function *a(){plum();}").async_generator_declaration()) => "async function * a ( ) { plum ( ) ; }"; "Async Generator Decl")]
+    #[test_case(&DeclPart::Class(Maker::new("class rust {}").class_declaration()) => "class rust { }"; "class def")]
+    #[test_case(&DeclPart::Lexical(Maker::new("const PI = 4.0;").lexical_declaration()) => "const PI = 4 ;"; "lexical decl")]
     fn string_from(part: &DeclPart) -> String {
         String::from(part)
     }
@@ -671,24 +671,24 @@ mod decl_part {
         DeclPart::from(part).to_string()
     }
 
-    #[test_case(&DeclPart::FunctionDeclaration(Maker::new("function banana(){}").function_declaration()) => false; "Function Decl")]
-    #[test_case(&DeclPart::GeneratorDeclaration(Maker::new("function *a(){'apple';}").generator_declaration()) => false; "Generator Decl")]
-    #[test_case(&DeclPart::AsyncFunctionDeclaration(Maker::new("async function a(strawberry){}").async_function_declaration()) => false; "Async Function Decl")]
-    #[test_case(&DeclPart::AsyncGeneratorDeclaration(Maker::new("async function *a(){plum();}").async_generator_declaration()) => false; "Async Generator Decl")]
-    #[test_case(&DeclPart::ClassDeclaration(Maker::new("class rust {}").class_declaration()) => false; "class def")]
-    #[test_case(&DeclPart::LexicalDeclaration(Maker::new("const PI = 4.0;").lexical_declaration()) => true; "const lexical decl")]
-    #[test_case(&DeclPart::LexicalDeclaration(Maker::new("let age = 49.0;").lexical_declaration()) => false; "mutable lexical decl")]
+    #[test_case(&DeclPart::Function(Maker::new("function banana(){}").function_declaration()) => false; "Function Decl")]
+    #[test_case(&DeclPart::Generator(Maker::new("function *a(){'apple';}").generator_declaration()) => false; "Generator Decl")]
+    #[test_case(&DeclPart::AsyncFunction(Maker::new("async function a(strawberry){}").async_function_declaration()) => false; "Async Function Decl")]
+    #[test_case(&DeclPart::AsyncGenerator(Maker::new("async function *a(){plum();}").async_generator_declaration()) => false; "Async Generator Decl")]
+    #[test_case(&DeclPart::Class(Maker::new("class rust {}").class_declaration()) => false; "class def")]
+    #[test_case(&DeclPart::Lexical(Maker::new("const PI = 4.0;").lexical_declaration()) => true; "const lexical decl")]
+    #[test_case(&DeclPart::Lexical(Maker::new("let age = 49.0;").lexical_declaration()) => false; "mutable lexical decl")]
     fn is_constant_declaration(part: &DeclPart) -> bool {
         part.is_constant_declaration()
     }
 
-    #[test_case(&DeclPart::FunctionDeclaration(Maker::new("function banana(){}").function_declaration()) => svec(&["banana"]); "Function Decl")]
-    #[test_case(&DeclPart::GeneratorDeclaration(Maker::new("function *a(){'apple';}").generator_declaration()) => svec(&["a"]); "Generator Decl")]
-    #[test_case(&DeclPart::AsyncFunctionDeclaration(Maker::new("async function a(strawberry){}").async_function_declaration()) => svec(&["a"]); "Async Function Decl")]
-    #[test_case(&DeclPart::AsyncGeneratorDeclaration(Maker::new("async function *a(){plum();}").async_generator_declaration()) => svec(&["a"]); "Async Generator Decl")]
-    #[test_case(&DeclPart::ClassDeclaration(Maker::new("class rust {}").class_declaration()) => svec(&["rust"]); "class def")]
-    #[test_case(&DeclPart::LexicalDeclaration(Maker::new("const PI = 4.0;").lexical_declaration()) => svec(&["PI"]); "const lexical decl")]
-    #[test_case(&DeclPart::LexicalDeclaration(Maker::new("let age = 49.0, b, c, elephant;").lexical_declaration()) => svec(&["age", "b", "c", "elephant"]); "many lexical decl")]
+    #[test_case(&DeclPart::Function(Maker::new("function banana(){}").function_declaration()) => svec(&["banana"]); "Function Decl")]
+    #[test_case(&DeclPart::Generator(Maker::new("function *a(){'apple';}").generator_declaration()) => svec(&["a"]); "Generator Decl")]
+    #[test_case(&DeclPart::AsyncFunction(Maker::new("async function a(strawberry){}").async_function_declaration()) => svec(&["a"]); "Async Function Decl")]
+    #[test_case(&DeclPart::AsyncGenerator(Maker::new("async function *a(){plum();}").async_generator_declaration()) => svec(&["a"]); "Async Generator Decl")]
+    #[test_case(&DeclPart::Class(Maker::new("class rust {}").class_declaration()) => svec(&["rust"]); "class def")]
+    #[test_case(&DeclPart::Lexical(Maker::new("const PI = 4.0;").lexical_declaration()) => svec(&["PI"]); "const lexical decl")]
+    #[test_case(&DeclPart::Lexical(Maker::new("let age = 49.0, b, c, elephant;").lexical_declaration()) => svec(&["age", "b", "c", "elephant"]); "many lexical decl")]
     fn bound_names(part: &DeclPart) -> Vec<String> {
         part.bound_names().iter().map(String::from).collect()
     }
@@ -1001,17 +1001,6 @@ fn hoistable_declaration_test_bound_names() {
     hoistable_bn_check("function *a(){}");
     hoistable_bn_check("async function a(){}");
     hoistable_bn_check("async function *a(){}");
-}
-fn hoistable_contains_check(src: &str) {
-    let (item, _) = HoistableDeclaration::parse(&mut newparser(src), Scanner::new(), true, true, true).unwrap();
-    assert_eq!(item.contains(ParseNodeKind::Literal), false);
-}
-#[test]
-fn hoistable_declaration_test_contains() {
-    hoistable_contains_check("function a(b=0){0;}");
-    hoistable_contains_check("function *a(b=0){0;}");
-    hoistable_contains_check("async function a(b=0){0;}");
-    hoistable_contains_check("async function *a(b=0){0;}");
 }
 #[test_case("function a(b){b.#valid;}" => true; "function valid")]
 #[test_case("function *a(b){b.#valid;}" => true; "generator valid")]

--- a/src/parser/testhelp.rs
+++ b/src/parser/testhelp.rs
@@ -2,11 +2,11 @@ use super::*;
 use ahash::AHashSet;
 use std::fmt;
 
-pub fn check<T>(res: ParseResult<T>) -> (Rc<T>, Scanner) {
+pub(crate) fn check<T>(res: ParseResult<T>) -> (Rc<T>, Scanner) {
     assert!(res.is_ok());
     res.unwrap()
 }
-pub fn check_err<T>(res: ParseResult<T>, msg: &str, line: u32, column: u32)
+pub(crate) fn check_err<T>(res: ParseResult<T>, msg: &str, line: u32, column: u32)
 where
     T: fmt::Debug,
 {
@@ -15,20 +15,20 @@ where
     assert_eq!(err.location.starting_column, column);
     assert_eq!(format!("{err}"), String::from(msg));
 }
-pub fn expected_scan(count: u32) -> Scanner {
+pub(crate) fn expected_scan(count: u32) -> Scanner {
     // Expected Scanner for tests. (The real world will be more varied.)
     Scanner { line: 1, column: count + 1, start_idx: count as usize }
 }
-pub fn sv(strings: &[&str]) -> Vec<String> {
+pub(crate) fn sv(strings: &[&str]) -> Vec<String> {
     strings.iter().map(|s| String::from(*s)).collect()
 }
-pub fn chk_scan(scanner: &Scanner, count: u32) {
+pub(crate) fn chk_scan(scanner: &Scanner, count: u32) {
     assert_eq!(*scanner, expected_scan(count));
 }
-pub fn newparser(text: &str) -> Parser<'_> {
+pub(crate) fn newparser(text: &str) -> Parser<'_> {
     Parser::new(text, false, ParseGoal::Script)
 }
-pub fn check_parse_error<T, U>(result: ParseResult<T>, msg: U, token_len: usize)
+pub(crate) fn check_parse_error<T, U>(result: ParseResult<T>, msg: U, token_len: usize)
 where
     T: fmt::Debug,
     U: Into<String>,
@@ -40,14 +40,15 @@ where
     );
     assert_eq!(format!("{pe}"), msg.into());
 }
-pub fn sset(items: &[&str]) -> AHashSet<String> {
+pub(crate) fn sset(items: &[&str]) -> AHashSet<String> {
     items.iter().map(|&x| String::from(x)).collect()
 }
 
-pub fn svec(items: &[&str]) -> Vec<String> {
+pub(crate) fn svec(items: &[&str]) -> Vec<String> {
     items.iter().map(|&s| String::from(s)).collect::<Vec<_>>()
 }
-pub fn ssome(item: &str) -> Option<String> {
+#[expect(clippy::unnecessary_wraps)]
+pub(crate) fn ssome(item: &str) -> Option<String> {
     Some(String::from(item))
 }
 
@@ -84,7 +85,7 @@ pub fn ssome(item: &str) -> Option<String> {
 /// In           | `true`
 /// Default      | `true`
 #[expect(clippy::struct_excessive_bools)]
-pub struct Maker<'a> {
+pub(crate) struct Maker<'a> {
     source: &'a str,
     yield_flag: bool,
     await_flag: bool,
@@ -104,14 +105,14 @@ impl Default for Maker<'_> {
             tagged_flag: false,
             in_flag: true,
             default_flag: true,
-            parent: FunctionBodyParent::FunctionBody,
+            parent: FunctionBodyParent::Function,
         }
     }
 }
 
 impl<'a> Maker<'a> {
     /// Construct a new Maker object with the given source.
-    pub fn new(src: &'a str) -> Self {
+    pub(crate) fn new(src: &'a str) -> Self {
         Maker { source: src, ..Default::default() }
     }
     /// Set the `yield_flag` in the maker object.
@@ -119,7 +120,7 @@ impl<'a> Maker<'a> {
     /// `true` means that yield expressions are allowed; `false` means that the `yield` keyword can be used as an
     /// identifier.
     #[must_use]
-    pub fn yield_ok(self, yield_flag: bool) -> Self {
+    pub(crate) fn yield_ok(self, yield_flag: bool) -> Self {
         Self { yield_flag, ..self }
     }
     /// Set the `await_flag` in the maker object.
@@ -127,52 +128,58 @@ impl<'a> Maker<'a> {
     /// `true` means that await expressions are allowed; `false` means that the `await` keyword can be used as an
     /// identifier.
     #[must_use]
-    pub fn await_ok(self, await_flag: bool) -> Self {
+    pub(crate) fn await_ok(self, await_flag: bool) -> Self {
         Self { await_flag, ..self }
     }
-    /// Set the `in_flag` in the maker object.
-    ///
-    /// `true` means that the `in` keyword may be used in a [`RelationalExpression`]; `false` means that it may not.
-    /// (This is the case in some `for` statements.)
-    #[must_use]
-    pub fn in_ok(self, in_flag: bool) -> Self {
-        Self { in_flag, ..self }
-    }
-    /// Set the `return_flag` in the maker object.
-    ///
-    /// `true` means that `return` statements are currently allowed (generally within function bodies); `false` means
-    /// they are not.
-    #[must_use]
-    pub fn return_ok(self, return_flag: bool) -> Self {
-        Self { return_flag, ..self }
-    }
+
+    // /// Set the `in_flag` in the maker object.
+    // ///
+    // /// `true` means that the `in` keyword may be used in a [`RelationalExpression`]; `false` means that it may not.
+    // /// (This is the case in some `for` statements.)
+    // #[must_use]
+    // pub(crate) fn in_ok(self, in_flag: bool) -> Self {
+    //     Self { in_flag, ..self }
+    // }
+
+    // /// Set the `return_flag` in the maker object.
+    // ///
+    // /// `true` means that `return` statements are currently allowed (generally within function bodies); `false` means
+    // /// they are not.
+    // #[must_use]
+    // pub(crate) fn return_ok(self, return_flag: bool) -> Self {
+    //     Self { return_flag, ..self }
+    // }
+
     /// Set the `tagged` flag in the maker object.
     ///
     /// `true` means that a template literal is being treated as a [tagged template][1]; `false` means that is is not.
     ///
     /// [1]: https://tc39.es/ecma262/#sec-tagged-templates
     #[must_use]
-    pub fn tagged_ok(self, tagged_flag: bool) -> Self {
+    pub(crate) fn tagged_ok(self, tagged_flag: bool) -> Self {
         Self { tagged_flag, ..self }
     }
-    /// Set the `default_flag` in the maker object.
-    ///
-    /// `true` means that nameless functions are allowed.
-    #[must_use]
-    pub fn default_ok(self, default_flag: bool) -> Self {
-        Self { default_flag, ..self }
-    }
-    #[must_use]
-    pub fn parent(self, parent: FunctionBodyParent) -> Self {
-        Self { parent, ..self }
-    }
+
+    // /// Set the `default_flag` in the maker object.
+    // ///
+    // /// `true` means that nameless functions are allowed.
+    // #[must_use]
+    // pub(crate) fn default_ok(self, default_flag: bool) -> Self {
+    //     Self { default_flag, ..self }
+    // }
+
+    // #[must_use]
+    // pub(crate) fn parent(self, parent: FunctionBodyParent) -> Self {
+    //     Self { parent, ..self }
+    // }
+
     /// Use the configs in the [`Maker`] object to make a [`AdditiveExpression`] parse node.
-    pub fn additive_expression(self) -> Rc<AdditiveExpression> {
+    pub(crate) fn additive_expression(self) -> Rc<AdditiveExpression> {
         AdditiveExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn additive_expression_ast(self) -> (Rc<AdditiveExpression>, SourceTree) {
+    pub(crate) fn additive_expression_ast(self) -> (Rc<AdditiveExpression>, SourceTree) {
         let source = self.source.to_string();
         let node =
             AdditiveExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -180,11 +187,11 @@ impl<'a> Maker<'a> {
                 .0;
         (node.clone(), SourceTree { text: source, ast: ParsedText::AdditiveExpression(node) })
     }
-    /// Use the configs in the [`Maker`] object to make a [`ArgumentList`] parse node.
-    pub fn argument_list(self) -> Rc<ArgumentList> {
-        ArgumentList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
-    }
-    pub fn argument_list_ast(self) -> (Rc<ArgumentList>, SourceTree) {
+    // /// Use the configs in the [`Maker`] object to make a [`ArgumentList`] parse node.
+    // pub(crate) fn argument_list(self) -> Rc<ArgumentList> {
+    //     ArgumentList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
+    // }
+    pub(crate) fn argument_list_ast(self) -> (Rc<ArgumentList>, SourceTree) {
         let source = self.source.to_string();
         let node = ArgumentList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -192,22 +199,22 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ArgumentList(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`Arguments`] parse node.
-    pub fn arguments(self) -> Rc<Arguments> {
+    pub(crate) fn arguments(self) -> Rc<Arguments> {
         Arguments::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn arguments_ast(self) -> (Rc<Arguments>, SourceTree) {
+    pub(crate) fn arguments_ast(self) -> (Rc<Arguments>, SourceTree) {
         let source = self.source.to_string();
         let node =
             Arguments::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0;
         (node.clone(), SourceTree { text: source, ast: ParsedText::Arguments(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ArrowFormalParameters`] parse node.
-    pub fn arrow_formal_parameters(self) -> Rc<ArrowFormalParameters> {
+    pub(crate) fn arrow_formal_parameters(self) -> Rc<ArrowFormalParameters> {
         ArrowFormalParameters::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn arrow_formal_parameters_ast(self) -> (Rc<ArrowFormalParameters>, SourceTree) {
+    pub(crate) fn arrow_formal_parameters_ast(self) -> (Rc<ArrowFormalParameters>, SourceTree) {
         let source = self.source.to_string();
         let node =
             ArrowFormalParameters::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -216,12 +223,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ArrowFormalParameters(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ArrayAssignmentPattern`] parse node.
-    pub fn array_assignment_pattern(self) -> Rc<ArrayAssignmentPattern> {
+    pub(crate) fn array_assignment_pattern(self) -> Rc<ArrayAssignmentPattern> {
         ArrayAssignmentPattern::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn array_assignment_pattern_ast(self) -> (Rc<ArrayAssignmentPattern>, SourceTree) {
+    pub(crate) fn array_assignment_pattern_ast(self) -> (Rc<ArrayAssignmentPattern>, SourceTree) {
         let source = self.source.to_string();
         let node = ArrayAssignmentPattern::parse(
             &mut newparser(self.source),
@@ -234,12 +241,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ArrayAssignmentPattern(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ArrayBindingPattern`] parse node.
-    pub fn array_binding_pattern(self) -> Rc<ArrayBindingPattern> {
+    pub(crate) fn array_binding_pattern(self) -> Rc<ArrayBindingPattern> {
         ArrayBindingPattern::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn array_binding_pattern_ast(self) -> (Rc<ArrayBindingPattern>, SourceTree) {
+    pub(crate) fn array_binding_pattern_ast(self) -> (Rc<ArrayBindingPattern>, SourceTree) {
         let source = self.source.to_string();
         let node =
             ArrayBindingPattern::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -248,10 +255,10 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ArrayBindingPattern(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ArrayLiteral`] parse node.
-    pub fn array_literal(self) -> Rc<ArrayLiteral> {
+    pub(crate) fn array_literal(self) -> Rc<ArrayLiteral> {
         ArrayLiteral::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn array_literal_ast(self) -> (Rc<ArrayLiteral>, SourceTree) {
+    pub(crate) fn array_literal_ast(self) -> (Rc<ArrayLiteral>, SourceTree) {
         let source = self.source.to_string();
         let node = ArrayLiteral::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -259,7 +266,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ArrayLiteral(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ArrowFunction`] parse node.
-    pub fn arrow_function(self) -> Rc<ArrowFunction> {
+    pub(crate) fn arrow_function(self) -> Rc<ArrowFunction> {
         ArrowFunction::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -270,7 +277,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn arrow_function_ast(self) -> (Rc<ArrowFunction>, SourceTree) {
+    pub(crate) fn arrow_function_ast(self) -> (Rc<ArrowFunction>, SourceTree) {
         let source = self.source.to_string();
         let node = ArrowFunction::parse(
             &mut newparser(self.source),
@@ -284,10 +291,10 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ArrowFunction(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ArrowParameters`] parse node.
-    pub fn arrow_parameters(self) -> Rc<ArrowParameters> {
+    pub(crate) fn arrow_parameters(self) -> Rc<ArrowParameters> {
         ArrowParameters::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn arrow_parameters_ast(self) -> (Rc<ArrowParameters>, SourceTree) {
+    pub(crate) fn arrow_parameters_ast(self) -> (Rc<ArrowParameters>, SourceTree) {
         let source = self.source.to_string();
         let node =
             ArrowParameters::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -295,13 +302,13 @@ impl<'a> Maker<'a> {
                 .0;
         (node.clone(), SourceTree { text: source, ast: ParsedText::ArrowParameters(node) })
     }
-    /// Use the configs in the [`Maker`] object to make a [`AssignmentElement`] parse node.
-    pub fn assignment_element(self) -> Rc<AssignmentElement> {
-        AssignmentElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-            .unwrap()
-            .0
-    }
-    pub fn assignment_element_ast(self) -> (Rc<AssignmentElement>, SourceTree) {
+    // /// Use the configs in the [`Maker`] object to make a [`AssignmentElement`] parse node.
+    // pub(crate) fn assignment_element(self) -> Rc<AssignmentElement> {
+    //     AssignmentElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //         .unwrap()
+    //         .0
+    // }
+    pub(crate) fn assignment_element_ast(self) -> (Rc<AssignmentElement>, SourceTree) {
         let source = self.source.to_string();
         let node =
             AssignmentElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -309,13 +316,13 @@ impl<'a> Maker<'a> {
                 .0;
         (node.clone(), SourceTree { text: source, ast: ParsedText::AssignmentElement(node) })
     }
-    /// Use the configs in the [`Maker`] object to make a [`AssignmentElementList`] parse node.
-    pub fn assignment_element_list(self) -> Rc<AssignmentElementList> {
-        AssignmentElementList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-            .unwrap()
-            .0
-    }
-    pub fn assignment_element_list_ast(self) -> (Rc<AssignmentElementList>, SourceTree) {
+    // /// Use the configs in the [`Maker`] object to make a [`AssignmentElementList`] parse node.
+    // pub(crate) fn assignment_element_list(self) -> Rc<AssignmentElementList> {
+    //     AssignmentElementList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //         .unwrap()
+    //         .0
+    // }
+    pub(crate) fn assignment_element_list_ast(self) -> (Rc<AssignmentElementList>, SourceTree) {
         let source = self.source.to_string();
         let node =
             AssignmentElementList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -323,13 +330,13 @@ impl<'a> Maker<'a> {
                 .0;
         (node.clone(), SourceTree { text: source, ast: ParsedText::AssignmentElementList(node) })
     }
-    /// Use the configs in the [`Maker`] object to make a [`AssignmentElisionElement`] parse node.
-    pub fn assignment_elision_element(self) -> Rc<AssignmentElisionElement> {
-        AssignmentElisionElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-            .unwrap()
-            .0
-    }
-    pub fn assignment_elision_element_ast(self) -> (Rc<AssignmentElisionElement>, SourceTree) {
+    // /// Use the configs in the [`Maker`] object to make a [`AssignmentElisionElement`] parse node.
+    // pub(crate) fn assignment_elision_element(self) -> Rc<AssignmentElisionElement> {
+    //     AssignmentElisionElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //         .unwrap()
+    //         .0
+    // }
+    pub(crate) fn assignment_elision_element_ast(self) -> (Rc<AssignmentElisionElement>, SourceTree) {
         let source = self.source.to_string();
         let node = AssignmentElisionElement::parse(
             &mut newparser(self.source),
@@ -342,7 +349,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::AssignmentElisionElement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`AssignmentExpression`] parse node.
-    pub fn assignment_expression(self) -> Rc<AssignmentExpression> {
+    pub(crate) fn assignment_expression(self) -> Rc<AssignmentExpression> {
         AssignmentExpression::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -353,7 +360,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn assignment_expression_ast(self) -> (Rc<AssignmentExpression>, SourceTree) {
+    pub(crate) fn assignment_expression_ast(self) -> (Rc<AssignmentExpression>, SourceTree) {
         let source = self.source.to_string();
         let node = AssignmentExpression::parse(
             &mut newparser(self.source),
@@ -367,12 +374,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::AssignmentExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`AssignmentPattern`] parse node.
-    pub fn assignment_pattern(self) -> Rc<AssignmentPattern> {
+    pub(crate) fn assignment_pattern(self) -> Rc<AssignmentPattern> {
         AssignmentPattern::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn assignment_pattern_ast(self) -> (Rc<AssignmentPattern>, SourceTree) {
+    pub(crate) fn assignment_pattern_ast(self) -> (Rc<AssignmentPattern>, SourceTree) {
         let source = self.source.to_string();
         let node =
             AssignmentPattern::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -380,13 +387,13 @@ impl<'a> Maker<'a> {
                 .0;
         (node.clone(), SourceTree { text: source, ast: ParsedText::AssignmentPattern(node) })
     }
-    /// Use the configs in the [`Maker`] object to make a [`AssignmentProperty`] parse node.
-    pub fn assignment_property(self) -> Rc<AssignmentProperty> {
-        AssignmentProperty::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-            .unwrap()
-            .0
-    }
-    pub fn assignment_property_ast(self) -> (Rc<AssignmentProperty>, SourceTree) {
+    // /// Use the configs in the [`Maker`] object to make a [`AssignmentProperty`] parse node.
+    // pub(crate) fn assignment_property(self) -> Rc<AssignmentProperty> {
+    //     AssignmentProperty::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //         .unwrap()
+    //         .0
+    // }
+    pub(crate) fn assignment_property_ast(self) -> (Rc<AssignmentProperty>, SourceTree) {
         let source = self.source.to_string();
         let node =
             AssignmentProperty::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -394,13 +401,13 @@ impl<'a> Maker<'a> {
                 .0;
         (node.clone(), SourceTree { text: source, ast: ParsedText::AssignmentProperty(node) })
     }
-    /// Use the configs in the [`Maker`] object to make a [`AssignmentPropertyList`] parse node.
-    pub fn assignment_property_list(self) -> Rc<AssignmentPropertyList> {
-        AssignmentPropertyList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-            .unwrap()
-            .0
-    }
-    pub fn assignment_property_list_ast(self) -> (Rc<AssignmentPropertyList>, SourceTree) {
+    // /// Use the configs in the [`Maker`] object to make a [`AssignmentPropertyList`] parse node.
+    // pub(crate) fn assignment_property_list(self) -> Rc<AssignmentPropertyList> {
+    //     AssignmentPropertyList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //         .unwrap()
+    //         .0
+    // }
+    pub(crate) fn assignment_property_list_ast(self) -> (Rc<AssignmentPropertyList>, SourceTree) {
         let source = self.source.to_string();
         let node = AssignmentPropertyList::parse(
             &mut newparser(self.source),
@@ -412,13 +419,13 @@ impl<'a> Maker<'a> {
         .0;
         (node.clone(), SourceTree { text: source, ast: ParsedText::AssignmentPropertyList(node) })
     }
-    /// Use the configs in the [`Maker`] object to make a [`AssignmentRestElement`] parse node.
-    pub fn assignment_rest_element(self) -> Rc<AssignmentRestElement> {
-        AssignmentRestElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-            .unwrap()
-            .0
-    }
-    pub fn assignment_rest_element_ast(self) -> (Rc<AssignmentRestElement>, SourceTree) {
+    // /// Use the configs in the [`Maker`] object to make a [`AssignmentRestElement`] parse node.
+    // pub(crate) fn assignment_rest_element(self) -> Rc<AssignmentRestElement> {
+    //     AssignmentRestElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //         .unwrap()
+    //         .0
+    // }
+    pub(crate) fn assignment_rest_element_ast(self) -> (Rc<AssignmentRestElement>, SourceTree) {
         let source = self.source.to_string();
         let node =
             AssignmentRestElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -426,13 +433,13 @@ impl<'a> Maker<'a> {
                 .0;
         (node.clone(), SourceTree { text: source, ast: ParsedText::AssignmentRestElement(node) })
     }
-    /// Use the configs in the [`Maker`] object to make a [`AssignmentRestProperty`] parse node.
-    pub fn assignment_rest_property(self) -> Rc<AssignmentRestProperty> {
-        AssignmentRestProperty::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-            .unwrap()
-            .0
-    }
-    pub fn assignment_rest_property_ast(self) -> (Rc<AssignmentRestProperty>, SourceTree) {
+    // /// Use the configs in the [`Maker`] object to make a [`AssignmentRestProperty`] parse node.
+    // pub(crate) fn assignment_rest_property(self) -> Rc<AssignmentRestProperty> {
+    //     AssignmentRestProperty::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //         .unwrap()
+    //         .0
+    // }
+    pub(crate) fn assignment_rest_property_ast(self) -> (Rc<AssignmentRestProperty>, SourceTree) {
         let source = self.source.to_string();
         let node = AssignmentRestProperty::parse(
             &mut newparser(self.source),
@@ -445,17 +452,17 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::AssignmentRestProperty(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`AsyncArrowBindingIdentifier`] parse node.
-    pub fn async_arrow_binding_identifier(self) -> Rc<AsyncArrowBindingIdentifier> {
+    pub(crate) fn async_arrow_binding_identifier(self) -> Rc<AsyncArrowBindingIdentifier> {
         AsyncArrowBindingIdentifier::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag).unwrap().0
     }
-    pub fn async_arrow_binding_identifier_ast(self) -> (Rc<AsyncArrowBindingIdentifier>, SourceTree) {
+    pub(crate) fn async_arrow_binding_identifier_ast(self) -> (Rc<AsyncArrowBindingIdentifier>, SourceTree) {
         let source = self.source.to_string();
         let node =
             AsyncArrowBindingIdentifier::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag).unwrap().0;
         (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncArrowBindingIdentifier(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`AsyncArrowFunction`] parse node.
-    pub fn async_arrow_function(self) -> Rc<AsyncArrowFunction> {
+    pub(crate) fn async_arrow_function(self) -> Rc<AsyncArrowFunction> {
         AsyncArrowFunction::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -466,48 +473,48 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn async_arrow_function_ast(self) -> (Rc<AsyncArrowFunction>, SourceTree) {
-        let source = self.source.to_string();
-        let node = AsyncArrowFunction::parse(
-            &mut newparser(self.source),
-            Scanner::new(),
-            self.in_flag,
-            self.yield_flag,
-            self.await_flag,
-        )
-        .unwrap()
-        .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncArrowFunction(node) })
-    }
+    //pub(crate) fn async_arrow_function_ast(self) -> (Rc<AsyncArrowFunction>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = AsyncArrowFunction::parse(
+    //        &mut newparser(self.source),
+    //        Scanner::new(),
+    //        self.in_flag,
+    //        self.yield_flag,
+    //        self.await_flag,
+    //    )
+    //    .unwrap()
+    //    .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncArrowFunction(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`AsyncArrowHead`] parse node.
-    pub fn async_arrow_head(self) -> Rc<AsyncArrowHead> {
+    pub(crate) fn async_arrow_head(self) -> Rc<AsyncArrowHead> {
         AsyncArrowHead::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
-    pub fn async_arrow_head_ast(self) -> (Rc<AsyncArrowHead>, SourceTree) {
-        let source = self.source.to_string();
-        let node = AsyncArrowHead::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncArrowHead(node) })
-    }
+    //pub(crate) fn async_arrow_head_ast(self) -> (Rc<AsyncArrowHead>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = AsyncArrowHead::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncArrowHead(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`AsyncConciseBody`] parse node.
-    pub fn async_concise_body(self) -> Rc<AsyncConciseBody> {
+    pub(crate) fn async_concise_body(self) -> Rc<AsyncConciseBody> {
         AsyncConciseBody::parse(&mut newparser(self.source), Scanner::new(), self.in_flag).unwrap().0
     }
-    pub fn async_concise_body_ast(self) -> (Rc<AsyncConciseBody>, SourceTree) {
-        let source = self.source.to_string();
-        let node = AsyncConciseBody::parse(&mut newparser(self.source), Scanner::new(), self.in_flag).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncConciseBody(node) })
-    }
+    //pub(crate) fn async_concise_body_ast(self) -> (Rc<AsyncConciseBody>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = AsyncConciseBody::parse(&mut newparser(self.source), Scanner::new(), self.in_flag).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncConciseBody(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`AsyncFunctionBody`] parse node.
-    pub fn async_function_body(self) -> Rc<AsyncFunctionBody> {
+    pub(crate) fn async_function_body(self) -> Rc<AsyncFunctionBody> {
         AsyncFunctionBody::parse(&mut newparser(self.source), Scanner::new()).0
     }
-    pub fn async_function_body_ast(self) -> (Rc<AsyncFunctionBody>, SourceTree) {
-        let source = self.source.to_string();
-        let node = AsyncFunctionBody::parse(&mut newparser(self.source), Scanner::new()).0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncFunctionBody(node) })
-    }
+    //pub(crate) fn async_function_body_ast(self) -> (Rc<AsyncFunctionBody>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = AsyncFunctionBody::parse(&mut newparser(self.source), Scanner::new()).0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncFunctionBody(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`AsyncFunctionDeclaration`] parse node.
-    pub fn async_function_declaration(self) -> Rc<AsyncFunctionDeclaration> {
+    pub(crate) fn async_function_declaration(self) -> Rc<AsyncFunctionDeclaration> {
         AsyncFunctionDeclaration::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -518,7 +525,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn async_function_declaration_ast(self) -> (Rc<AsyncFunctionDeclaration>, SourceTree) {
+    pub(crate) fn async_function_declaration_ast(self) -> (Rc<AsyncFunctionDeclaration>, SourceTree) {
         let source = self.source.to_string();
         let node = AsyncFunctionDeclaration::parse(
             &mut newparser(self.source),
@@ -532,25 +539,25 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::AsyncFunctionDeclaration(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`AsyncFunctionExpression`] parse node.
-    pub fn async_function_expression(self) -> Rc<AsyncFunctionExpression> {
+    pub(crate) fn async_function_expression(self) -> Rc<AsyncFunctionExpression> {
         AsyncFunctionExpression::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
-    pub fn async_function_expression_ast(self) -> (Rc<AsyncFunctionExpression>, SourceTree) {
-        let source = self.source.to_string();
-        let node = AsyncFunctionExpression::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncFunctionExpression(node) })
-    }
+    //pub(crate) fn async_function_expression_ast(self) -> (Rc<AsyncFunctionExpression>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = AsyncFunctionExpression::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncFunctionExpression(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`AsyncGeneratorBody`] parse node.
-    pub fn async_generator_body(self) -> Rc<AsyncGeneratorBody> {
+    pub(crate) fn async_generator_body(self) -> Rc<AsyncGeneratorBody> {
         AsyncGeneratorBody::parse(&mut newparser(self.source), Scanner::new()).0
     }
-    pub fn async_generator_body_ast(self) -> (Rc<AsyncGeneratorBody>, SourceTree) {
-        let source = self.source.to_string();
-        let node = AsyncGeneratorBody::parse(&mut newparser(self.source), Scanner::new()).0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncGeneratorBody(node) })
-    }
+    //pub(crate) fn async_generator_body_ast(self) -> (Rc<AsyncGeneratorBody>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = AsyncGeneratorBody::parse(&mut newparser(self.source), Scanner::new()).0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncGeneratorBody(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`AsyncGeneratorDeclaration`] parse node.
-    pub fn async_generator_declaration(self) -> Rc<AsyncGeneratorDeclaration> {
+    pub(crate) fn async_generator_declaration(self) -> Rc<AsyncGeneratorDeclaration> {
         AsyncGeneratorDeclaration::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -561,7 +568,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn async_generator_declaration_ast(self) -> (Rc<AsyncGeneratorDeclaration>, SourceTree) {
+    pub(crate) fn async_generator_declaration_ast(self) -> (Rc<AsyncGeneratorDeclaration>, SourceTree) {
         let source = self.source;
         let node = AsyncGeneratorDeclaration::parse(
             &mut newparser(self.source),
@@ -575,53 +582,53 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::AsyncGeneratorDeclaration(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`AsyncGeneratorExpression`] parse node.
-    pub fn async_generator_expression(self) -> Rc<AsyncGeneratorExpression> {
+    pub(crate) fn async_generator_expression(self) -> Rc<AsyncGeneratorExpression> {
         AsyncGeneratorExpression::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
-    pub fn async_generator_expression_ast(self) -> (Rc<AsyncGeneratorExpression>, SourceTree) {
-        let source = self.source.to_string();
-        let node = AsyncGeneratorExpression::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncGeneratorExpression(node) })
-    }
+    //pub(crate) fn async_generator_expression_ast(self) -> (Rc<AsyncGeneratorExpression>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = AsyncGeneratorExpression::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncGeneratorExpression(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`AsyncGeneratorMethod`] parse node.
-    pub fn async_generator_method(self) -> Rc<AsyncGeneratorMethod> {
+    pub(crate) fn async_generator_method(self) -> Rc<AsyncGeneratorMethod> {
         AsyncGeneratorMethod::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn async_generator_method_ast(self) -> (Rc<AsyncGeneratorMethod>, SourceTree) {
-        let source = self.source.to_string();
-        let node =
-            AsyncGeneratorMethod::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-                .unwrap()
-                .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncGeneratorMethod(node) })
-    }
+    //pub(crate) fn async_generator_method_ast(self) -> (Rc<AsyncGeneratorMethod>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node =
+    //        AsyncGeneratorMethod::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //            .unwrap()
+    //            .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncGeneratorMethod(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`AsyncMethod`] parse node.
-    pub fn async_method(self) -> Rc<AsyncMethod> {
+    pub(crate) fn async_method(self) -> Rc<AsyncMethod> {
         AsyncMethod::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn async_method_ast(self) -> (Rc<AsyncMethod>, SourceTree) {
-        let source = self.source.to_string();
-        let node = AsyncMethod::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-            .unwrap()
-            .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncMethod(node) })
-    }
+    //pub(crate) fn async_method_ast(self) -> (Rc<AsyncMethod>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = AsyncMethod::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //        .unwrap()
+    //        .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::AsyncMethod(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`AwaitExpression`] parse node.
-    pub fn await_expression(self) -> Rc<AwaitExpression> {
+    pub(crate) fn await_expression(self) -> Rc<AwaitExpression> {
         AwaitExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag).unwrap().0
     }
-    pub fn await_expression_ast(self) -> (Rc<AwaitExpression>, SourceTree) {
-        let source = self.source.to_string();
-        let node = AwaitExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::AwaitExpression(node) })
-    }
+    //pub(crate) fn await_expression_ast(self) -> (Rc<AwaitExpression>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = AwaitExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::AwaitExpression(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`BindingElement`] parse node.
-    pub fn binding_element(self) -> Rc<BindingElement> {
+    pub(crate) fn binding_element(self) -> Rc<BindingElement> {
         BindingElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn binding_element_ast(self) -> (Rc<BindingElement>, SourceTree) {
+    pub(crate) fn binding_element_ast(self) -> (Rc<BindingElement>, SourceTree) {
         let source = self.source.to_string();
         let node = BindingElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -629,12 +636,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::BindingElement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`BindingElementList`] parse node.
-    pub fn binding_element_list(self) -> Rc<BindingElementList> {
+    pub(crate) fn binding_element_list(self) -> Rc<BindingElementList> {
         BindingElementList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn binding_element_list_ast(self) -> (Rc<BindingElementList>, SourceTree) {
+    pub(crate) fn binding_element_list_ast(self) -> (Rc<BindingElementList>, SourceTree) {
         let source = self.source.to_string();
         let node =
             BindingElementList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -643,12 +650,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::BindingElementList(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`BindingElisionElement`] parse node.
-    pub fn binding_elision_element(self) -> Rc<BindingElisionElement> {
+    pub(crate) fn binding_elision_element(self) -> Rc<BindingElisionElement> {
         BindingElisionElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn binding_elision_element_ast(self) -> (Rc<BindingElisionElement>, SourceTree) {
+    pub(crate) fn binding_elision_element_ast(self) -> (Rc<BindingElisionElement>, SourceTree) {
         let source = self.source.to_string();
         let node =
             BindingElisionElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -657,26 +664,26 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::BindingElisionElement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`BindingIdentifier`] parse node.
-    pub fn binding_identifier(self) -> Rc<BindingIdentifier> {
+    pub(crate) fn binding_identifier(self) -> Rc<BindingIdentifier> {
         BindingIdentifier::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn binding_identifier_ast(self) -> (Rc<BindingIdentifier>, SourceTree) {
-        let source = self.source.to_string();
-        let node =
-            BindingIdentifier::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-                .unwrap()
-                .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::BindingIdentifier(node) })
-    }
+    //pub(crate) fn binding_identifier_ast(self) -> (Rc<BindingIdentifier>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node =
+    //        BindingIdentifier::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //            .unwrap()
+    //            .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::BindingIdentifier(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`BindingList`] parse node.
-    pub fn binding_list(self) -> Rc<BindingList> {
+    pub(crate) fn binding_list(self) -> Rc<BindingList> {
         BindingList::parse(&mut newparser(self.source), Scanner::new(), self.in_flag, self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn binding_list_ast(self) -> (Rc<BindingList>, SourceTree) {
+    pub(crate) fn binding_list_ast(self) -> (Rc<BindingList>, SourceTree) {
         let source = self.source.to_string();
         let node = BindingList::parse(
             &mut newparser(self.source),
@@ -690,10 +697,10 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::BindingList(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`BindingPattern`] parse node.
-    pub fn binding_pattern(self) -> Rc<BindingPattern> {
+    pub(crate) fn binding_pattern(self) -> Rc<BindingPattern> {
         BindingPattern::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn binding_pattern_ast(self) -> (Rc<BindingPattern>, SourceTree) {
+    pub(crate) fn binding_pattern_ast(self) -> (Rc<BindingPattern>, SourceTree) {
         let source = self.source.to_string();
         let node = BindingPattern::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -701,10 +708,10 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::BindingPattern(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`BindingProperty`] parse node.
-    pub fn binding_property(self) -> Rc<BindingProperty> {
+    pub(crate) fn binding_property(self) -> Rc<BindingProperty> {
         BindingProperty::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn binding_property_ast(self) -> (Rc<BindingProperty>, SourceTree) {
+    pub(crate) fn binding_property_ast(self) -> (Rc<BindingProperty>, SourceTree) {
         let source = self.source.to_string();
         let node =
             BindingProperty::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -713,12 +720,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::BindingProperty(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`BindingPropertyList`] parse node.
-    pub fn binding_property_list(self) -> Rc<BindingPropertyList> {
+    pub(crate) fn binding_property_list(self) -> Rc<BindingPropertyList> {
         BindingPropertyList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn binding_property_list_ast(self) -> (Rc<BindingPropertyList>, SourceTree) {
+    pub(crate) fn binding_property_list_ast(self) -> (Rc<BindingPropertyList>, SourceTree) {
         let source = self.source.to_string();
         let node =
             BindingPropertyList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -727,12 +734,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::BindingPropertyList(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`BindingRestElement`] parse node.
-    pub fn binding_rest_element(self) -> Rc<BindingRestElement> {
+    pub(crate) fn binding_rest_element(self) -> Rc<BindingRestElement> {
         BindingRestElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn binding_rest_element_ast(self) -> (Rc<BindingRestElement>, SourceTree) {
+    pub(crate) fn binding_rest_element_ast(self) -> (Rc<BindingRestElement>, SourceTree) {
         let source = self.source.to_string();
         let node =
             BindingRestElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -741,21 +748,21 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::BindingRestElement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`BindingRestProperty`] parse node.
-    pub fn binding_rest_property(self) -> Rc<BindingRestProperty> {
+    pub(crate) fn binding_rest_property(self) -> Rc<BindingRestProperty> {
         BindingRestProperty::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn binding_rest_property_ast(self) -> (Rc<BindingRestProperty>, SourceTree) {
-        let source = self.source.to_string();
-        let node =
-            BindingRestProperty::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-                .unwrap()
-                .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::BindingRestProperty(node) })
-    }
+    //pub(crate) fn binding_rest_property_ast(self) -> (Rc<BindingRestProperty>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node =
+    //        BindingRestProperty::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //            .unwrap()
+    //            .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::BindingRestProperty(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`BitwiseANDExpression`] parse node.
-    pub fn bitwise_and_expression(self) -> Rc<BitwiseANDExpression> {
+    pub(crate) fn bitwise_and_expression(self) -> Rc<BitwiseANDExpression> {
         BitwiseANDExpression::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -766,7 +773,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn bitwise_and_expression_ast(self) -> (Rc<BitwiseANDExpression>, SourceTree) {
+    pub(crate) fn bitwise_and_expression_ast(self) -> (Rc<BitwiseANDExpression>, SourceTree) {
         let source = self.source.to_string();
         let node = BitwiseANDExpression::parse(
             &mut newparser(self.source),
@@ -780,7 +787,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::BitwiseANDExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`BitwiseXORExpression`] parse node.
-    pub fn bitwise_xor_expression(self) -> Rc<BitwiseXORExpression> {
+    pub(crate) fn bitwise_xor_expression(self) -> Rc<BitwiseXORExpression> {
         BitwiseXORExpression::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -791,7 +798,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn bitwise_xor_expression_ast(self) -> (Rc<BitwiseXORExpression>, SourceTree) {
+    pub(crate) fn bitwise_xor_expression_ast(self) -> (Rc<BitwiseXORExpression>, SourceTree) {
         let source = self.source.to_string();
         let node = BitwiseXORExpression::parse(
             &mut newparser(self.source),
@@ -805,7 +812,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::BitwiseXORExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`BitwiseORExpression`] parse node.
-    pub fn bitwise_or_expression(self) -> Rc<BitwiseORExpression> {
+    pub(crate) fn bitwise_or_expression(self) -> Rc<BitwiseORExpression> {
         BitwiseORExpression::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -816,7 +823,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn bitwise_or_expression_ast(self) -> (Rc<BitwiseORExpression>, SourceTree) {
+    pub(crate) fn bitwise_or_expression_ast(self) -> (Rc<BitwiseORExpression>, SourceTree) {
         let source = self.source.to_string();
         let node = BitwiseORExpression::parse(
             &mut newparser(self.source),
@@ -830,12 +837,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::BitwiseORExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`Block`] parse node.
-    pub fn block(self) -> Rc<Block> {
+    pub(crate) fn block(self) -> Rc<Block> {
         Block::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag, self.return_flag)
             .unwrap()
             .0
     }
-    pub fn block_ast(self) -> (Rc<Block>, SourceTree) {
+    pub(crate) fn block_ast(self) -> (Rc<Block>, SourceTree) {
         let source = self.source.to_string();
         let node = Block::parse(
             &mut newparser(self.source),
@@ -849,7 +856,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::Block(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`BlockStatement`] parse node.
-    pub fn block_statement(self) -> Rc<BlockStatement> {
+    pub(crate) fn block_statement(self) -> Rc<BlockStatement> {
         BlockStatement::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -860,7 +867,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn block_statement_ast(self) -> (Rc<BlockStatement>, SourceTree) {
+    pub(crate) fn block_statement_ast(self) -> (Rc<BlockStatement>, SourceTree) {
         let source = self.source.to_string();
         let node = BlockStatement::parse(
             &mut newparser(self.source),
@@ -874,18 +881,18 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::BlockStatement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`BreakStatement`] parse node.
-    pub fn break_statement(self) -> Rc<BreakStatement> {
+    pub(crate) fn break_statement(self) -> Rc<BreakStatement> {
         BreakStatement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn break_statement_ast(self) -> (Rc<BreakStatement>, SourceTree) {
-        let source = self.source.to_string();
-        let node = BreakStatement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-            .unwrap()
-            .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::BreakStatement(node) })
-    }
+    //pub(crate) fn break_statement_ast(self) -> (Rc<BreakStatement>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = BreakStatement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //        .unwrap()
+    //        .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::BreakStatement(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`BreakableStatement`] parse node.
-    pub fn breakable_statement(self) -> Rc<BreakableStatement> {
+    pub(crate) fn breakable_statement(self) -> Rc<BreakableStatement> {
         BreakableStatement::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -896,7 +903,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn breakable_statement_ast(self) -> (Rc<BreakableStatement>, SourceTree) {
+    pub(crate) fn breakable_statement_ast(self) -> (Rc<BreakableStatement>, SourceTree) {
         let source = self.source.to_string();
         let node = BreakableStatement::parse(
             &mut newparser(self.source),
@@ -910,10 +917,10 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::BreakableStatement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`CallExpression`] parse node.
-    pub fn call_expression(self) -> Rc<CallExpression> {
+    pub(crate) fn call_expression(self) -> Rc<CallExpression> {
         CallExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn call_expression_ast(self) -> (Rc<CallExpression>, SourceTree) {
+    pub(crate) fn call_expression_ast(self) -> (Rc<CallExpression>, SourceTree) {
         let source = self.source.to_string();
         let node = CallExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -921,12 +928,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::CallExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`CallMemberExpression`] parse node.
-    pub fn call_member_expression(self) -> Rc<CallMemberExpression> {
+    pub(crate) fn call_member_expression(self) -> Rc<CallMemberExpression> {
         CallMemberExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn call_member_expression_ast(self) -> (Rc<CallMemberExpression>, SourceTree) {
+    pub(crate) fn call_member_expression_ast(self) -> (Rc<CallMemberExpression>, SourceTree) {
         let source = self.source.to_string();
         let node =
             CallMemberExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -935,7 +942,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::CallMemberExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`CaseBlock`] parse node.
-    pub fn case_block(self) -> Rc<CaseBlock> {
+    pub(crate) fn case_block(self) -> Rc<CaseBlock> {
         CaseBlock::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -946,7 +953,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn case_block_ast(self) -> (Rc<CaseBlock>, SourceTree) {
+    pub(crate) fn case_block_ast(self) -> (Rc<CaseBlock>, SourceTree) {
         let source = self.source.to_string();
         let node = CaseBlock::parse(
             &mut newparser(self.source),
@@ -960,7 +967,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::CaseBlock(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`CaseClause`] parse node.
-    pub fn case_clause(self) -> Rc<CaseClause> {
+    pub(crate) fn case_clause(self) -> Rc<CaseClause> {
         CaseClause::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -971,7 +978,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn case_clause_ast(self) -> (Rc<CaseClause>, SourceTree) {
+    pub(crate) fn case_clause_ast(self) -> (Rc<CaseClause>, SourceTree) {
         let source = self.source.to_string();
         let node = CaseClause::parse(
             &mut newparser(self.source),
@@ -985,7 +992,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::CaseClause(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`CaseClauses`] parse node.
-    pub fn case_clauses(self) -> Rc<CaseClauses> {
+    pub(crate) fn case_clauses(self) -> Rc<CaseClauses> {
         CaseClauses::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -996,26 +1003,26 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn case_clauses_ast(self) -> (Rc<CaseClauses>, SourceTree) {
-        let source = self.source.to_string();
-        let node = CaseClauses::parse(
-            &mut newparser(self.source),
-            Scanner::new(),
-            self.yield_flag,
-            self.await_flag,
-            self.return_flag,
-        )
-        .unwrap()
-        .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::CaseClauses(node) })
-    }
+    //pub(crate) fn case_clauses_ast(self) -> (Rc<CaseClauses>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = CaseClauses::parse(
+    //        &mut newparser(self.source),
+    //        Scanner::new(),
+    //        self.yield_flag,
+    //        self.await_flag,
+    //        self.return_flag,
+    //    )
+    //    .unwrap()
+    //    .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::CaseClauses(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`Catch`] parse node.
-    pub fn catch(self) -> Rc<Catch> {
+    pub(crate) fn catch(self) -> Rc<Catch> {
         Catch::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag, self.return_flag)
             .unwrap()
             .0
     }
-    pub fn catch_ast(self) -> (Rc<Catch>, SourceTree) {
+    pub(crate) fn catch_ast(self) -> (Rc<Catch>, SourceTree) {
         let source = self.source.to_string();
         let node = Catch::parse(
             &mut newparser(self.source),
@@ -1029,10 +1036,10 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::Catch(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`CatchParameter`] parse node.
-    pub fn catch_parameter(self) -> Rc<CatchParameter> {
+    pub(crate) fn catch_parameter(self) -> Rc<CatchParameter> {
         CatchParameter::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn catch_parameter_ast(self) -> (Rc<CatchParameter>, SourceTree) {
+    pub(crate) fn catch_parameter_ast(self) -> (Rc<CatchParameter>, SourceTree) {
         let source = self.source.to_string();
         let node = CatchParameter::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -1040,17 +1047,17 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::CatchParameter(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ClassBody`] parse node.
-    pub fn class_body(self) -> Rc<ClassBody> {
+    pub(crate) fn class_body(self) -> Rc<ClassBody> {
         ClassBody::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn class_body_ast(self) -> (Rc<ClassBody>, SourceTree) {
-        let source = self.source.to_string();
-        let node =
-            ClassBody::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::ClassBody(node) })
-    }
+    //pub(crate) fn class_body_ast(self) -> (Rc<ClassBody>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node =
+    //        ClassBody::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::ClassBody(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`ClassDeclaration`] parse node.
-    pub fn class_declaration(self) -> Rc<ClassDeclaration> {
+    pub(crate) fn class_declaration(self) -> Rc<ClassDeclaration> {
         ClassDeclaration::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1061,7 +1068,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn class_declaration_ast(self) -> (Rc<ClassDeclaration>, SourceTree) {
+    pub(crate) fn class_declaration_ast(self) -> (Rc<ClassDeclaration>, SourceTree) {
         let source = self.source.to_string();
         let node = ClassDeclaration::parse(
             &mut newparser(self.source),
@@ -1075,37 +1082,37 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ClassDeclaration(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ClassElement`] parse node.
-    pub fn class_element(self) -> Rc<ClassElement> {
+    pub(crate) fn class_element(self) -> Rc<ClassElement> {
         ClassElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn class_element_ast(self) -> (Rc<ClassElement>, SourceTree) {
-        let source = self.source.to_string();
-        let node = ClassElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-            .unwrap()
-            .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::ClassElement(node) })
-    }
+    //pub(crate) fn class_element_ast(self) -> (Rc<ClassElement>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = ClassElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //        .unwrap()
+    //        .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::ClassElement(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`ClassElementList`] parse node.
-    pub fn class_element_list(self) -> Rc<ClassElementList> {
+    pub(crate) fn class_element_list(self) -> Rc<ClassElementList> {
         ClassElementList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn class_element_list_ast(self) -> (Rc<ClassElementList>, SourceTree) {
-        let source = self.source.to_string();
-        let node =
-            ClassElementList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-                .unwrap()
-                .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::ClassElementList(node) })
-    }
+    //pub(crate) fn class_element_list_ast(self) -> (Rc<ClassElementList>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node =
+    //        ClassElementList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //            .unwrap()
+    //            .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::ClassElementList(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`ClassElementName`] parse node.
-    pub fn class_element_name(self) -> Rc<ClassElementName> {
+    pub(crate) fn class_element_name(self) -> Rc<ClassElementName> {
         ClassElementName::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn class_element_name_ast(self) -> (Rc<ClassElementName>, SourceTree) {
+    pub(crate) fn class_element_name_ast(self) -> (Rc<ClassElementName>, SourceTree) {
         let source = self.source.to_string();
         let node =
             ClassElementName::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -1114,67 +1121,67 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ClassElementName(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ClassExpression`] parse node.
-    pub fn class_expression(self) -> Rc<ClassExpression> {
+    pub(crate) fn class_expression(self) -> Rc<ClassExpression> {
         ClassExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn class_expression_ast(self) -> (Rc<ClassExpression>, SourceTree) {
-        let source = self.source.to_string();
-        let node =
-            ClassExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-                .unwrap()
-                .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::ClassExpression(node) })
-    }
+    //pub(crate) fn class_expression_ast(self) -> (Rc<ClassExpression>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node =
+    //        ClassExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //            .unwrap()
+    //            .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::ClassExpression(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`ClassHeritage`] parse node.
-    pub fn class_heritage(self) -> Rc<ClassHeritage> {
+    pub(crate) fn class_heritage(self) -> Rc<ClassHeritage> {
         ClassHeritage::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn class_heritage_ast(self) -> (Rc<ClassHeritage>, SourceTree) {
-        let source = self.source.to_string();
-        let node = ClassHeritage::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-            .unwrap()
-            .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::ClassHeritage(node) })
-    }
+    //pub(crate) fn class_heritage_ast(self) -> (Rc<ClassHeritage>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = ClassHeritage::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //        .unwrap()
+    //        .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::ClassHeritage(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`ClassStaticBlock`] parse node.
-    pub fn class_static_block(self) -> Rc<ClassStaticBlock> {
+    pub(crate) fn class_static_block(self) -> Rc<ClassStaticBlock> {
         ClassStaticBlock::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
-    pub fn class_static_block_ast(self) -> (Rc<ClassStaticBlock>, SourceTree) {
-        let source = self.source.to_string();
-        let node = ClassStaticBlock::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::ClassStaticBlock(node) })
-    }
+    //pub(crate) fn class_static_block_ast(self) -> (Rc<ClassStaticBlock>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = ClassStaticBlock::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::ClassStaticBlock(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`ClassStaticBlockBody`] parse node.
-    pub fn class_static_block_body(self) -> Rc<ClassStaticBlockBody> {
+    pub(crate) fn class_static_block_body(self) -> Rc<ClassStaticBlockBody> {
         ClassStaticBlockBody::parse(&mut newparser(self.source), Scanner::new()).0
     }
-    pub fn class_static_block_body_ast(self) -> (Rc<ClassStaticBlockBody>, SourceTree) {
+    pub(crate) fn class_static_block_body_ast(self) -> (Rc<ClassStaticBlockBody>, SourceTree) {
         let source = self.source.to_string();
         let node = ClassStaticBlockBody::parse(&mut newparser(self.source), Scanner::new()).0;
         (node.clone(), SourceTree { text: source, ast: ParsedText::ClassStaticBlockBody(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ClassStaticBlockStatementList`] parse node.
-    pub fn class_static_block_statement_list(self) -> Rc<ClassStaticBlockStatementList> {
+    pub(crate) fn class_static_block_statement_list(self) -> Rc<ClassStaticBlockStatementList> {
         ClassStaticBlockStatementList::parse(&mut newparser(self.source), Scanner::new()).0
     }
-    pub fn class_static_block_statement_list_ast(self) -> (Rc<ClassStaticBlockStatementList>, SourceTree) {
+    pub(crate) fn class_static_block_statement_list_ast(self) -> (Rc<ClassStaticBlockStatementList>, SourceTree) {
         let source = self.source.to_string();
         let node = ClassStaticBlockStatementList::parse(&mut newparser(self.source), Scanner::new()).0;
         (node.clone(), SourceTree { text: source, ast: ParsedText::ClassStaticBlockStatementList(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ClassTail`] parse node.
-    pub fn class_tail(self) -> Rc<ClassTail> {
+    pub(crate) fn class_tail(self) -> Rc<ClassTail> {
         ClassTail::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn class_tail_ast(self) -> (Rc<ClassTail>, SourceTree) {
-        let source = self.source.to_string();
-        let node =
-            ClassTail::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::ClassTail(node) })
-    }
+    //pub(crate) fn class_tail_ast(self) -> (Rc<ClassTail>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node =
+    //        ClassTail::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::ClassTail(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`CoalesceExpression`] parse node.
-    pub fn coalesce_expression(self) -> Rc<CoalesceExpression> {
+    pub(crate) fn coalesce_expression(self) -> Rc<CoalesceExpression> {
         CoalesceExpression::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1185,7 +1192,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn coalesce_expression_ast(self) -> (Rc<CoalesceExpression>, SourceTree) {
+    pub(crate) fn coalesce_expression_ast(self) -> (Rc<CoalesceExpression>, SourceTree) {
         let source = self.source.to_string();
         let node = CoalesceExpression::parse(
             &mut newparser(self.source),
@@ -1203,7 +1210,7 @@ impl<'a> Maker<'a> {
     /// Note that unlike the other `Maker` creation helpers, the source string provided for a `CoalesceExpressionHead`
     /// creator must actually be the source for a complete `CoalesceExpression`. The parsing for the two structures is
     /// tightly joined.
-    pub fn coalesce_expression_head(self) -> Rc<CoalesceExpressionHead> {
+    pub(crate) fn coalesce_expression_head(self) -> Rc<CoalesceExpressionHead> {
         CoalesceExpression::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1216,7 +1223,7 @@ impl<'a> Maker<'a> {
         .head
         .clone()
     }
-    pub fn coalesce_expression_head_ast(self) -> (Rc<CoalesceExpressionHead>, SourceTree) {
+    pub(crate) fn coalesce_expression_head_ast(self) -> (Rc<CoalesceExpressionHead>, SourceTree) {
         let source = self.source.to_string();
         let node = CoalesceExpression::parse(
             &mut newparser(self.source),
@@ -1232,12 +1239,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::CoalesceExpressionHead(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ComputedPropertyName`] parse node.
-    pub fn computed_property_name(self) -> Rc<ComputedPropertyName> {
+    pub(crate) fn computed_property_name(self) -> Rc<ComputedPropertyName> {
         ComputedPropertyName::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn computed_property_name_ast(self) -> (Rc<ComputedPropertyName>, SourceTree) {
+    pub(crate) fn computed_property_name_ast(self) -> (Rc<ComputedPropertyName>, SourceTree) {
         let source = self.source.to_string();
         let node =
             ComputedPropertyName::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -1246,16 +1253,16 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ComputedPropertyName(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ConciseBody`] parse node.
-    pub fn concise_body(self) -> Rc<ConciseBody> {
+    pub(crate) fn concise_body(self) -> Rc<ConciseBody> {
         ConciseBody::parse(&mut newparser(self.source), Scanner::new(), self.in_flag).unwrap().0
     }
-    pub fn concise_body_ast(self) -> (Rc<ConciseBody>, SourceTree) {
-        let source = self.source.to_string();
-        let node = ConciseBody::parse(&mut newparser(self.source), Scanner::new(), self.in_flag).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::ConciseBody(node) })
-    }
+    //pub(crate) fn concise_body_ast(self) -> (Rc<ConciseBody>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = ConciseBody::parse(&mut newparser(self.source), Scanner::new(), self.in_flag).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::ConciseBody(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`ConditionalExpression`] parse node.
-    pub fn conditional_expression(self) -> Rc<ConditionalExpression> {
+    pub(crate) fn conditional_expression(self) -> Rc<ConditionalExpression> {
         ConditionalExpression::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1266,7 +1273,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn conditional_expression_ast(self) -> (Rc<ConditionalExpression>, SourceTree) {
+    pub(crate) fn conditional_expression_ast(self) -> (Rc<ConditionalExpression>, SourceTree) {
         let source = self.source.to_string();
         let node = ConditionalExpression::parse(
             &mut newparser(self.source),
@@ -1280,77 +1287,77 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ConditionalExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ContinueStatement`] parse node.
-    pub fn continue_statement(self) -> Rc<ContinueStatement> {
+    pub(crate) fn continue_statement(self) -> Rc<ContinueStatement> {
         ContinueStatement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn continue_statement_ast(self) -> (Rc<ContinueStatement>, SourceTree) {
-        let source = self.source.to_string();
-        let node =
-            ContinueStatement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-                .unwrap()
-                .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::ContinueStatement(node) })
-    }
+    //pub(crate) fn continue_statement_ast(self) -> (Rc<ContinueStatement>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node =
+    //        ContinueStatement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //            .unwrap()
+    //            .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::ContinueStatement(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`CoverInitializedName`] parse node.
-    pub fn cover_initialized_name(self) -> Rc<CoverInitializedName> {
+    pub(crate) fn cover_initialized_name(self) -> Rc<CoverInitializedName> {
         CoverInitializedName::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn cover_initialized_name_ast(self) -> (Rc<CoverInitializedName>, SourceTree) {
-        let source = self.source.to_string();
-        let node =
-            CoverInitializedName::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-                .unwrap()
-                .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::CoverInitializedName(node) })
-    }
+    //pub(crate) fn cover_initialized_name_ast(self) -> (Rc<CoverInitializedName>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node =
+    //        CoverInitializedName::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //            .unwrap()
+    //            .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::CoverInitializedName(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`CoverParenthesizedExpressionAndArrowParameterList`] parse node.
-    pub fn cover_parenthesized_expression_and_arrow_parameter_list(
-        self,
-    ) -> Rc<CoverParenthesizedExpressionAndArrowParameterList> {
-        CoverParenthesizedExpressionAndArrowParameterList::parse(
-            &mut newparser(self.source),
-            Scanner::new(),
-            self.yield_flag,
-            self.await_flag,
-        )
-        .unwrap()
-        .0
-    }
-    pub fn cover_parenthesized_expression_and_arrow_parameter_list_ast(
-        self,
-    ) -> (Rc<CoverParenthesizedExpressionAndArrowParameterList>, SourceTree) {
-        let source = self.source.to_string();
-        let node = CoverParenthesizedExpressionAndArrowParameterList::parse(
-            &mut newparser(self.source),
-            Scanner::new(),
-            self.yield_flag,
-            self.await_flag,
-        )
-        .unwrap()
-        .0;
-        (
-            node.clone(),
-            SourceTree { text: source, ast: ParsedText::CoverParenthesizedExpressionAndArrowParameterList(node) },
-        )
-    }
+    //pub(crate) fn cover_parenthesized_expression_and_arrow_parameter_list(
+    //    self,
+    //) -> Rc<CoverParenthesizedExpressionAndArrowParameterList> {
+    //    CoverParenthesizedExpressionAndArrowParameterList::parse(
+    //        &mut newparser(self.source),
+    //        Scanner::new(),
+    //        self.yield_flag,
+    //        self.await_flag,
+    //    )
+    //    .unwrap()
+    //    .0
+    //}
+    //pub(crate) fn cover_parenthesized_expression_and_arrow_parameter_list_ast(
+    //    self,
+    //) -> (Rc<CoverParenthesizedExpressionAndArrowParameterList>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = CoverParenthesizedExpressionAndArrowParameterList::parse(
+    //        &mut newparser(self.source),
+    //        Scanner::new(),
+    //        self.yield_flag,
+    //        self.await_flag,
+    //    )
+    //    .unwrap()
+    //    .0;
+    //    (
+    //        node.clone(),
+    //        SourceTree { text: source, ast: ParsedText::CoverParenthesizedExpressionAndArrowParameterList(node) },
+    //    )
+    //}
     /// Use the configs in the [`Maker`] object to make a [`DebuggerStatement`] parse node.
-    pub fn debugger_statement(self) -> Rc<DebuggerStatement> {
+    pub(crate) fn debugger_statement(self) -> Rc<DebuggerStatement> {
         DebuggerStatement::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
-    pub fn debugger_statement_ast(self) -> (Rc<DebuggerStatement>, SourceTree) {
-        let source = self.source.to_string();
-        let node = DebuggerStatement::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::DebuggerStatement(node) })
-    }
+    //pub(crate) fn debugger_statement_ast(self) -> (Rc<DebuggerStatement>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = DebuggerStatement::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::DebuggerStatement(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`Declaration`] parse node.
-    pub fn declaration(self) -> Rc<Declaration> {
+    pub(crate) fn declaration(self) -> Rc<Declaration> {
         Declaration::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn declaration_ast(self) -> (Rc<Declaration>, SourceTree) {
+    pub(crate) fn declaration_ast(self) -> (Rc<Declaration>, SourceTree) {
         let source = self.source.to_string();
         let node = Declaration::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -1358,7 +1365,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::Declaration(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`DefaultClause`] parse node.
-    pub fn default_clause(self) -> Rc<DefaultClause> {
+    pub(crate) fn default_clause(self) -> Rc<DefaultClause> {
         DefaultClause::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1369,7 +1376,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn default_clause_ast(self) -> (Rc<DefaultClause>, SourceTree) {
+    pub(crate) fn default_clause_ast(self) -> (Rc<DefaultClause>, SourceTree) {
         let source = self.source.to_string();
         let node = DefaultClause::parse(
             &mut newparser(self.source),
@@ -1383,7 +1390,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::DefaultClause(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`DestructuringAssignmentTarget`] parse node.
-    pub fn destructuring_assignment_target(self) -> Rc<DestructuringAssignmentTarget> {
+    pub(crate) fn destructuring_assignment_target(self) -> Rc<DestructuringAssignmentTarget> {
         DestructuringAssignmentTarget::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1393,7 +1400,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn destructuring_assignment_target_ast(self) -> (Rc<DestructuringAssignmentTarget>, SourceTree) {
+    pub(crate) fn destructuring_assignment_target_ast(self) -> (Rc<DestructuringAssignmentTarget>, SourceTree) {
         let source = self.source.to_string();
         let node = DestructuringAssignmentTarget::parse(
             &mut newparser(self.source),
@@ -1406,7 +1413,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::DestructuringAssignmentTarget(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`DoWhileStatement`] parse node.
-    pub fn do_while_statement(self) -> Rc<DoWhileStatement> {
+    pub(crate) fn do_while_statement(self) -> Rc<DoWhileStatement> {
         DoWhileStatement::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1417,7 +1424,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn do_while_statement_ast(self) -> (Rc<DoWhileStatement>, SourceTree) {
+    pub(crate) fn do_while_statement_ast(self) -> (Rc<DoWhileStatement>, SourceTree) {
         let source = self.source.to_string();
         let node = DoWhileStatement::parse(
             &mut newparser(self.source),
@@ -1431,19 +1438,19 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::DoWhileStatement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`Elisions`] parse node.
-    pub fn elision(self) -> Rc<Elisions> {
+    pub(crate) fn elision(self) -> Rc<Elisions> {
         Elisions::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
-    pub fn elision_ast(self) -> (Rc<Elisions>, SourceTree) {
-        let source = self.source.to_string();
-        let node = Elisions::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::Elisions(node) })
-    }
+    //pub(crate) fn elision_ast(self) -> (Rc<Elisions>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = Elisions::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::Elisions(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`ElementList`] parse node.
-    pub fn element_list(self) -> Rc<ElementList> {
+    pub(crate) fn element_list(self) -> Rc<ElementList> {
         ElementList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn element_list_ast(self) -> (Rc<ElementList>, SourceTree) {
+    pub(crate) fn element_list_ast(self) -> (Rc<ElementList>, SourceTree) {
         let source = self.source.to_string();
         let node = ElementList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -1451,16 +1458,16 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ElementList(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`EmptyStatement`] parse node.
-    pub fn empty_statement(self) -> Rc<EmptyStatement> {
+    pub(crate) fn empty_statement(self) -> Rc<EmptyStatement> {
         EmptyStatement::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
-    pub fn empty_statement_ast(self) -> (Rc<EmptyStatement>, SourceTree) {
-        let source = self.source.to_string();
-        let node = EmptyStatement::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::EmptyStatement(node) })
-    }
+    //pub(crate) fn empty_statement_ast(self) -> (Rc<EmptyStatement>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = EmptyStatement::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::EmptyStatement(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`EqualityExpression`] parse node.
-    pub fn equality_expression(self) -> Rc<EqualityExpression> {
+    pub(crate) fn equality_expression(self) -> Rc<EqualityExpression> {
         EqualityExpression::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1471,7 +1478,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn equality_expression_ast(self) -> (Rc<EqualityExpression>, SourceTree) {
+    pub(crate) fn equality_expression_ast(self) -> (Rc<EqualityExpression>, SourceTree) {
         let source = self.source.to_string();
         let node = EqualityExpression::parse(
             &mut newparser(self.source),
@@ -1485,12 +1492,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::EqualityExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`Expression`] parse node.
-    pub fn expression(self) -> Rc<Expression> {
+    pub(crate) fn expression(self) -> Rc<Expression> {
         Expression::parse(&mut newparser(self.source), Scanner::new(), self.in_flag, self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn expression_ast(self) -> (Rc<Expression>, SourceTree) {
+    pub(crate) fn expression_ast(self) -> (Rc<Expression>, SourceTree) {
         let source = self.source.to_string();
         let node = Expression::parse(
             &mut newparser(self.source),
@@ -1504,10 +1511,10 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::Expression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ExpressionBody`] parse node.
-    pub fn expression_body(self) -> Rc<ExpressionBody> {
+    pub(crate) fn expression_body(self) -> Rc<ExpressionBody> {
         ExpressionBody::parse(&mut newparser(self.source), Scanner::new(), self.in_flag, self.await_flag).unwrap().0
     }
-    pub fn expression_body_ast(self) -> (Rc<ExpressionBody>, SourceTree) {
+    pub(crate) fn expression_body_ast(self) -> (Rc<ExpressionBody>, SourceTree) {
         let source = self.source.to_string();
         let node = ExpressionBody::parse(&mut newparser(self.source), Scanner::new(), self.in_flag, self.yield_flag)
             .unwrap()
@@ -1515,12 +1522,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ExpressionBody(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ExpressionStatement`] parse node.
-    pub fn expression_statement(self) -> Rc<ExpressionStatement> {
+    pub(crate) fn expression_statement(self) -> Rc<ExpressionStatement> {
         ExpressionStatement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn expression_statement_ast(self) -> (Rc<ExpressionStatement>, SourceTree) {
+    pub(crate) fn expression_statement_ast(self) -> (Rc<ExpressionStatement>, SourceTree) {
         let source = self.source.to_string();
         let node =
             ExpressionStatement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -1529,12 +1536,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ExpressionStatement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ExponentiationExpression`] parse node.
-    pub fn exponentiation_expression(self) -> Rc<ExponentiationExpression> {
+    pub(crate) fn exponentiation_expression(self) -> Rc<ExponentiationExpression> {
         ExponentiationExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn exponentiation_expression_ast(self) -> (Rc<ExponentiationExpression>, SourceTree) {
+    pub(crate) fn exponentiation_expression_ast(self) -> (Rc<ExponentiationExpression>, SourceTree) {
         let source = self.source.to_string();
         let node = ExponentiationExpression::parse(
             &mut newparser(self.source),
@@ -1547,10 +1554,10 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ExponentiationExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`FieldDefinition`] parse node.
-    pub fn field_definition(self) -> Rc<FieldDefinition> {
+    pub(crate) fn field_definition(self) -> Rc<FieldDefinition> {
         FieldDefinition::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn field_definition_ast(self) -> (Rc<FieldDefinition>, SourceTree) {
+    pub(crate) fn field_definition_ast(self) -> (Rc<FieldDefinition>, SourceTree) {
         let source = self.source;
         let node =
             FieldDefinition::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -1559,12 +1566,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::FieldDefinition(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`Finally`] parse node.
-    pub fn finally(self) -> Rc<Finally> {
+    pub(crate) fn finally(self) -> Rc<Finally> {
         Finally::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag, self.return_flag)
             .unwrap()
             .0
     }
-    pub fn finally_ast(self) -> (Rc<Finally>, SourceTree) {
+    pub(crate) fn finally_ast(self) -> (Rc<Finally>, SourceTree) {
         let source = self.source.to_string();
         let node = Finally::parse(
             &mut newparser(self.source),
@@ -1578,20 +1585,20 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::Finally(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ForBinding`] parse node.
-    pub fn for_binding(self) -> Rc<ForBinding> {
+    pub(crate) fn for_binding(self) -> Rc<ForBinding> {
         ForBinding::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn for_binding_ast(self) -> (Rc<ForBinding>, SourceTree) {
+    pub(crate) fn for_binding_ast(self) -> (Rc<ForBinding>, SourceTree) {
         let source = self.source.to_string();
         let node =
             ForBinding::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0;
         (node.clone(), SourceTree { text: source, ast: ParsedText::ForBinding(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ForDeclaration`] parse node.
-    pub fn for_declaration(self) -> Rc<ForDeclaration> {
+    pub(crate) fn for_declaration(self) -> Rc<ForDeclaration> {
         ForDeclaration::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn for_declaration_ast(self) -> (Rc<ForDeclaration>, SourceTree) {
+    pub(crate) fn for_declaration_ast(self) -> (Rc<ForDeclaration>, SourceTree) {
         let source = self.source.to_string();
         let node = ForDeclaration::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -1599,10 +1606,10 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ForDeclaration(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`FormalParameter`] parse node.
-    pub fn formal_parameter(self) -> Rc<FormalParameter> {
+    pub(crate) fn formal_parameter(self) -> Rc<FormalParameter> {
         FormalParameter::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn formal_parameter_ast(self) -> (Rc<FormalParameter>, SourceTree) {
+    pub(crate) fn formal_parameter_ast(self) -> (Rc<FormalParameter>, SourceTree) {
         let source = self.source.to_string();
         let node =
             FormalParameter::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -1611,12 +1618,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::FormalParameter(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`FormalParameterList`] parse node.
-    pub fn formal_parameter_list(self) -> Rc<FormalParameterList> {
+    pub(crate) fn formal_parameter_list(self) -> Rc<FormalParameterList> {
         FormalParameterList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn formal_parameter_list_ast(self) -> (Rc<FormalParameterList>, SourceTree) {
+    pub(crate) fn formal_parameter_list_ast(self) -> (Rc<FormalParameterList>, SourceTree) {
         let source = self.source.to_string();
         let node =
             FormalParameterList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -1625,17 +1632,17 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::FormalParameterList(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`FormalParameters`] parse node.
-    pub fn formal_parameters(self) -> Rc<FormalParameters> {
+    pub(crate) fn formal_parameters(self) -> Rc<FormalParameters> {
         FormalParameters::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).0
     }
-    pub fn formal_parameters_ast(self) -> (Rc<FormalParameters>, SourceTree) {
+    pub(crate) fn formal_parameters_ast(self) -> (Rc<FormalParameters>, SourceTree) {
         let source = self.source.to_string();
         let node =
             FormalParameters::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).0;
         (node.clone(), SourceTree { text: source, ast: ParsedText::FormalParameters(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ForInOfStatement`] parse node.
-    pub fn for_in_of_statement(self) -> Rc<ForInOfStatement> {
+    pub(crate) fn for_in_of_statement(self) -> Rc<ForInOfStatement> {
         ForInOfStatement::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1646,7 +1653,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn for_in_of_statement_ast(self) -> (Rc<ForInOfStatement>, SourceTree) {
+    pub(crate) fn for_in_of_statement_ast(self) -> (Rc<ForInOfStatement>, SourceTree) {
         let source = self.source.to_string();
         let node = ForInOfStatement::parse(
             &mut newparser(self.source),
@@ -1660,7 +1667,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ForInOfStatement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ForStatement`] parse node.
-    pub fn for_statement(self) -> Rc<ForStatement> {
+    pub(crate) fn for_statement(self) -> Rc<ForStatement> {
         ForStatement::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1671,7 +1678,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn for_statement_ast(self) -> (Rc<ForStatement>, SourceTree) {
+    pub(crate) fn for_statement_ast(self) -> (Rc<ForStatement>, SourceTree) {
         let source = self.source.to_string();
         let node = ForStatement::parse(
             &mut newparser(self.source),
@@ -1685,24 +1692,24 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ForStatement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`FunctionBody`] parse node.
-    pub fn function_body(self) -> Rc<FunctionBody> {
+    pub(crate) fn function_body(self) -> Rc<FunctionBody> {
         FunctionBody::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag, self.parent)
             .0
     }
-    pub fn function_body_ast(self) -> (Rc<FunctionBody>, SourceTree) {
-        let source = self.source.to_string();
-        let node = FunctionBody::parse(
-            &mut newparser(self.source),
-            Scanner::new(),
-            self.yield_flag,
-            self.await_flag,
-            self.parent,
-        )
-        .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::FunctionBody(node) })
-    }
+    //pub(crate) fn function_body_ast(self) -> (Rc<FunctionBody>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = FunctionBody::parse(
+    //        &mut newparser(self.source),
+    //        Scanner::new(),
+    //        self.yield_flag,
+    //        self.await_flag,
+    //        self.parent,
+    //    )
+    //    .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::FunctionBody(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`FunctionDeclaration`] parse node.
-    pub fn function_declaration(self) -> Rc<FunctionDeclaration> {
+    pub(crate) fn function_declaration(self) -> Rc<FunctionDeclaration> {
         FunctionDeclaration::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1713,7 +1720,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn function_declaration_ast(self) -> (Rc<FunctionDeclaration>, SourceTree) {
+    pub(crate) fn function_declaration_ast(self) -> (Rc<FunctionDeclaration>, SourceTree) {
         let source = self.source;
         let node = FunctionDeclaration::parse(
             &mut newparser(source),
@@ -1727,21 +1734,21 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::FunctionDeclaration(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`FunctionExpression`] parse node.
-    pub fn function_expression(self) -> Rc<FunctionExpression> {
+    pub(crate) fn function_expression(self) -> Rc<FunctionExpression> {
         FunctionExpression::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
-    pub fn function_expression_ast(self) -> (Rc<FunctionExpression>, SourceTree) {
+    pub(crate) fn function_expression_ast(self) -> (Rc<FunctionExpression>, SourceTree) {
         let source = self.source;
         let node = FunctionExpression::parse(&mut newparser(source), Scanner::new()).unwrap().0;
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::FunctionExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`FunctionRestParameter`] parse node.
-    pub fn function_rest_parameter(self) -> Rc<FunctionRestParameter> {
+    pub(crate) fn function_rest_parameter(self) -> Rc<FunctionRestParameter> {
         FunctionRestParameter::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn function_rest_parameter_ast(self) -> (Rc<FunctionRestParameter>, SourceTree) {
+    pub(crate) fn function_rest_parameter_ast(self) -> (Rc<FunctionRestParameter>, SourceTree) {
         let source = self.source;
         let node =
             FunctionRestParameter::parse(&mut newparser(source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -1750,26 +1757,26 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::FunctionRestParameter(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`FunctionStatementList`] parse node.
-    pub fn function_statement_list(self) -> Rc<FunctionStatementList> {
+    pub(crate) fn function_statement_list(self) -> Rc<FunctionStatementList> {
         FunctionStatementList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).0
     }
-    pub fn function_statement_list_ast(self) -> (Rc<FunctionStatementList>, SourceTree) {
+    pub(crate) fn function_statement_list_ast(self) -> (Rc<FunctionStatementList>, SourceTree) {
         let source = self.source;
         let node =
             FunctionStatementList::parse(&mut newparser(source), Scanner::new(), self.yield_flag, self.await_flag).0;
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::FunctionStatementList(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`GeneratorBody`] parse node.
-    pub fn generator_body(self) -> Rc<GeneratorBody> {
+    pub(crate) fn generator_body(self) -> Rc<GeneratorBody> {
         GeneratorBody::parse(&mut newparser(self.source), Scanner::new()).0
     }
-    pub fn generator_body_ast(self) -> (Rc<GeneratorBody>, SourceTree) {
-        let source = self.source;
-        let node = GeneratorBody::parse(&mut newparser(source), Scanner::new()).0;
-        (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::GeneratorBody(node) })
-    }
+    //pub(crate) fn generator_body_ast(self) -> (Rc<GeneratorBody>, SourceTree) {
+    //    let source = self.source;
+    //    let node = GeneratorBody::parse(&mut newparser(source), Scanner::new()).0;
+    //    (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::GeneratorBody(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`GeneratorDeclaration`] parse node.
-    pub fn generator_declaration(self) -> Rc<GeneratorDeclaration> {
+    pub(crate) fn generator_declaration(self) -> Rc<GeneratorDeclaration> {
         GeneratorDeclaration::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1780,7 +1787,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn generator_declaration_ast(self) -> (Rc<GeneratorDeclaration>, SourceTree) {
+    pub(crate) fn generator_declaration_ast(self) -> (Rc<GeneratorDeclaration>, SourceTree) {
         let source = self.source;
         let node = GeneratorDeclaration::parse(
             &mut newparser(self.source),
@@ -1794,26 +1801,26 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::GeneratorDeclaration(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`GeneratorExpression`] parse node.
-    pub fn generator_expression(self) -> Rc<GeneratorExpression> {
+    pub(crate) fn generator_expression(self) -> Rc<GeneratorExpression> {
         GeneratorExpression::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
-    pub fn generator_expression_ast(self) -> (Rc<GeneratorExpression>, SourceTree) {
-        let node = GeneratorExpression::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
-        (node.clone(), SourceTree { text: self.source.to_string(), ast: ParsedText::GeneratorExpression(node) })
-    }
+    //pub(crate) fn generator_expression_ast(self) -> (Rc<GeneratorExpression>, SourceTree) {
+    //    let node = GeneratorExpression::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
+    //    (node.clone(), SourceTree { text: self.source.to_string(), ast: ParsedText::GeneratorExpression(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`GeneratorMethod`] parse node.
-    pub fn generator_method(self) -> Rc<GeneratorMethod> {
+    pub(crate) fn generator_method(self) -> Rc<GeneratorMethod> {
         GeneratorMethod::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn generator_method_ast(self) -> (Rc<GeneratorMethod>, SourceTree) {
-        let node =
-            GeneratorMethod::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-                .unwrap()
-                .0;
-        (node.clone(), SourceTree { text: self.source.to_string(), ast: ParsedText::GeneratorMethod(node) })
-    }
+    //pub(crate) fn generator_method_ast(self) -> (Rc<GeneratorMethod>, SourceTree) {
+    //    let node =
+    //        GeneratorMethod::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //            .unwrap()
+    //            .0;
+    //    (node.clone(), SourceTree { text: self.source.to_string(), ast: ParsedText::GeneratorMethod(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`HoistableDeclaration`] parse node.
-    pub fn hoistable_declaration(self) -> Rc<HoistableDeclaration> {
+    pub(crate) fn hoistable_declaration(self) -> Rc<HoistableDeclaration> {
         HoistableDeclaration::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1825,17 +1832,17 @@ impl<'a> Maker<'a> {
         .0
     }
     /// Use the configs in the [`Maker`] object to make a [`Identifier`] parse node.
-    pub fn identifier(self) -> Rc<Identifier> {
+    pub(crate) fn identifier(self) -> Rc<Identifier> {
         Identifier::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
     /// Use the configs in the [`Maker`] object to make a [`IdentifierReference`] parse node.
-    pub fn identifier_reference(self) -> Rc<IdentifierReference> {
+    pub(crate) fn identifier_reference(self) -> Rc<IdentifierReference> {
         IdentifierReference::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
     /// Use the configs in the [`Maker`] object to make a [`IfStatement`] parse node.
-    pub fn if_statement(self) -> Rc<IfStatement> {
+    pub(crate) fn if_statement(self) -> Rc<IfStatement> {
         IfStatement::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1846,7 +1853,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn if_statement_ast(self) -> (Rc<IfStatement>, SourceTree) {
+    pub(crate) fn if_statement_ast(self) -> (Rc<IfStatement>, SourceTree) {
         let node = IfStatement::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1859,16 +1866,16 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: self.source.to_string(), ast: ParsedText::IfStatement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ImportCall`] parse node.
-    pub fn import_call(self) -> Rc<ImportCall> {
+    pub(crate) fn import_call(self) -> Rc<ImportCall> {
         ImportCall::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
     /// Use the configs in the [`Maker`] object to make a [`Initializer`] parse node.
-    pub fn initializer(self) -> Rc<Initializer> {
+    pub(crate) fn initializer(self) -> Rc<Initializer> {
         Initializer::parse(&mut newparser(self.source), Scanner::new(), self.in_flag, self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn initializer_ast(self) -> (Rc<Initializer>, SourceTree) {
+    pub(crate) fn initializer_ast(self) -> (Rc<Initializer>, SourceTree) {
         let node = Initializer::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1881,7 +1888,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: self.source.to_string(), ast: ParsedText::Initializer(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`IterationStatement`] parse node.
-    pub fn iteration_statement(self) -> Rc<IterationStatement> {
+    pub(crate) fn iteration_statement(self) -> Rc<IterationStatement> {
         IterationStatement::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1892,7 +1899,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn iteration_statement_ast(self) -> (Rc<IterationStatement>, SourceTree) {
+    pub(crate) fn iteration_statement_ast(self) -> (Rc<IterationStatement>, SourceTree) {
         let source = self.source.to_string();
         let node = IterationStatement::parse(
             &mut newparser(self.source),
@@ -1906,11 +1913,11 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::IterationStatement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`LabelIdentifier`] parse node.
-    pub fn label_identifier(self) -> Rc<LabelIdentifier> {
+    pub(crate) fn label_identifier(self) -> Rc<LabelIdentifier> {
         LabelIdentifier::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
     /// Use the configs in the [`Maker`] object to make a [`LabelledItem`] parse node.
-    pub fn labelled_item(self) -> Rc<LabelledItem> {
+    pub(crate) fn labelled_item(self) -> Rc<LabelledItem> {
         LabelledItem::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1921,7 +1928,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn labelled_item_ast(self) -> (Rc<LabelledItem>, SourceTree) {
+    pub(crate) fn labelled_item_ast(self) -> (Rc<LabelledItem>, SourceTree) {
         let source = self.source.to_string();
         let node = LabelledItem::parse(
             &mut newparser(self.source),
@@ -1935,7 +1942,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::LabelledItem(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`LabelledStatement`] parse node.
-    pub fn labelled_statement(self) -> Rc<LabelledStatement> {
+    pub(crate) fn labelled_statement(self) -> Rc<LabelledStatement> {
         LabelledStatement::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1946,7 +1953,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn labelled_statement_ast(self) -> (Rc<LabelledStatement>, SourceTree) {
+    pub(crate) fn labelled_statement_ast(self) -> (Rc<LabelledStatement>, SourceTree) {
         let source = self.source.to_string();
         let node = LabelledStatement::parse(
             &mut newparser(self.source),
@@ -1960,12 +1967,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::LabelledStatement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`LeftHandSideExpression`] parse node.
-    pub fn left_hand_side_expression(self) -> Rc<LeftHandSideExpression> {
+    pub(crate) fn left_hand_side_expression(self) -> Rc<LeftHandSideExpression> {
         LeftHandSideExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn left_hand_side_expression_ast(self) -> (Rc<LeftHandSideExpression>, SourceTree) {
+    pub(crate) fn left_hand_side_expression_ast(self) -> (Rc<LeftHandSideExpression>, SourceTree) {
         let source = self.source.to_string();
         let node = LeftHandSideExpression::parse(
             &mut newparser(self.source),
@@ -1978,7 +1985,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::LeftHandSideExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`LexicalBinding`] parse node.
-    pub fn lexical_binding(self) -> Rc<LexicalBinding> {
+    pub(crate) fn lexical_binding(self) -> Rc<LexicalBinding> {
         LexicalBinding::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -1989,7 +1996,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn lexical_binding_ast(self) -> (Rc<LexicalBinding>, SourceTree) {
+    pub(crate) fn lexical_binding_ast(self) -> (Rc<LexicalBinding>, SourceTree) {
         let node = LexicalBinding::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2002,7 +2009,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: self.source.to_string(), ast: ParsedText::LexicalBinding(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`LexicalDeclaration`] parse node.
-    pub fn lexical_declaration(self) -> Rc<LexicalDeclaration> {
+    pub(crate) fn lexical_declaration(self) -> Rc<LexicalDeclaration> {
         LexicalDeclaration::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2013,7 +2020,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn lexical_declaration_ast(self) -> (Rc<LexicalDeclaration>, SourceTree) {
+    pub(crate) fn lexical_declaration_ast(self) -> (Rc<LexicalDeclaration>, SourceTree) {
         let node = LexicalDeclaration::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2026,24 +2033,24 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: self.source.to_string(), ast: ParsedText::LexicalDeclaration(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`Literal`] parse node.
-    pub fn literal(self) -> Rc<Literal> {
+    pub(crate) fn literal(self) -> Rc<Literal> {
         Literal::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
-    pub fn literal_ast(self) -> (Rc<Literal>, SourceTree) {
-        let node = Literal::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
-        (node.clone(), SourceTree { text: self.source.to_string(), ast: ParsedText::Literal(node) })
-    }
+    //pub(crate) fn literal_ast(self) -> (Rc<Literal>, SourceTree) {
+    //    let node = Literal::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
+    //    (node.clone(), SourceTree { text: self.source.to_string(), ast: ParsedText::Literal(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`LiteralPropertyName`] parse node.
-    pub fn literal_property_name(self) -> Rc<LiteralPropertyName> {
+    pub(crate) fn literal_property_name(self) -> Rc<LiteralPropertyName> {
         LiteralPropertyName::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
-    pub fn literal_property_name_ast(self) -> (Rc<LiteralPropertyName>, SourceTree) {
-        let source = self.source.to_string();
-        let node = LiteralPropertyName::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::LiteralPropertyName(node) })
-    }
+    //pub(crate) fn literal_property_name_ast(self) -> (Rc<LiteralPropertyName>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = LiteralPropertyName::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::LiteralPropertyName(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`LogicalANDExpression`] parse node.
-    pub fn logical_and_expression(self) -> Rc<LogicalANDExpression> {
+    pub(crate) fn logical_and_expression(self) -> Rc<LogicalANDExpression> {
         LogicalANDExpression::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2054,7 +2061,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn logical_and_expression_ast(self) -> (Rc<LogicalANDExpression>, SourceTree) {
+    pub(crate) fn logical_and_expression_ast(self) -> (Rc<LogicalANDExpression>, SourceTree) {
         let source = self.source.to_string();
         let node = LogicalANDExpression::parse(
             &mut newparser(self.source),
@@ -2068,7 +2075,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::LogicalANDExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`LogicalORExpression`] parse node.
-    pub fn logical_or_expression(self) -> Rc<LogicalORExpression> {
+    pub(crate) fn logical_or_expression(self) -> Rc<LogicalORExpression> {
         LogicalORExpression::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2079,7 +2086,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn logical_or_expression_ast(self) -> (Rc<LogicalORExpression>, SourceTree) {
+    pub(crate) fn logical_or_expression_ast(self) -> (Rc<LogicalORExpression>, SourceTree) {
         let source = self.source.to_string();
         let node = LogicalORExpression::parse(
             &mut newparser(self.source),
@@ -2093,12 +2100,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::LogicalORExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`MemberExpression`] parse node.
-    pub fn member_expression(self) -> Rc<MemberExpression> {
+    pub(crate) fn member_expression(self) -> Rc<MemberExpression> {
         MemberExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn member_expression_ast(self) -> (Rc<MemberExpression>, SourceTree) {
+    pub(crate) fn member_expression_ast(self) -> (Rc<MemberExpression>, SourceTree) {
         let source = self.source;
         let node = MemberExpression::parse(&mut newparser(source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -2106,21 +2113,21 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::MemberExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`MetaProperty`] parse node.
-    pub fn meta_property(self) -> Rc<MetaProperty> {
+    pub(crate) fn meta_property(self) -> Rc<MetaProperty> {
         MetaProperty::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
-    pub fn meta_property_ast(self) -> (Rc<MetaProperty>, SourceTree) {
-        let source = self.source.to_string();
-        let node = MetaProperty::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::MetaProperty(node) })
-    }
+    //pub(crate) fn meta_property_ast(self) -> (Rc<MetaProperty>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = MetaProperty::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::MetaProperty(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`MethodDefinition`] parse node.
-    pub fn method_definition(self) -> Rc<MethodDefinition> {
+    pub(crate) fn method_definition(self) -> Rc<MethodDefinition> {
         MethodDefinition::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn method_definition_ast(self) -> (Rc<MethodDefinition>, SourceTree) {
+    pub(crate) fn method_definition_ast(self) -> (Rc<MethodDefinition>, SourceTree) {
         let source = self.source.to_string();
         let node =
             MethodDefinition::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -2129,12 +2136,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::MethodDefinition(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`MultiplicativeExpression`] parse node.
-    pub fn multiplicative_expression(self) -> Rc<MultiplicativeExpression> {
+    pub(crate) fn multiplicative_expression(self) -> Rc<MultiplicativeExpression> {
         MultiplicativeExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn multiplicative_expression_ast(self) -> (Rc<MultiplicativeExpression>, SourceTree) {
+    pub(crate) fn multiplicative_expression_ast(self) -> (Rc<MultiplicativeExpression>, SourceTree) {
         let source = self.source.to_string();
         let node = MultiplicativeExpression::parse(
             &mut newparser(self.source),
@@ -2147,22 +2154,22 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::MultiplicativeExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`NewExpression`] parse node.
-    pub fn new_expression(self) -> Rc<NewExpression> {
+    pub(crate) fn new_expression(self) -> Rc<NewExpression> {
         NewExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn new_expression_ast(self) -> (Rc<NewExpression>, SourceTree) {
+    pub(crate) fn new_expression_ast(self) -> (Rc<NewExpression>, SourceTree) {
         let source = self.source;
         let node =
             NewExpression::parse(&mut newparser(source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0;
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::NewExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ObjectAssignmentPattern`] parse node.
-    pub fn object_assignment_pattern(self) -> Rc<ObjectAssignmentPattern> {
+    pub(crate) fn object_assignment_pattern(self) -> Rc<ObjectAssignmentPattern> {
         ObjectAssignmentPattern::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn object_assignment_pattern_ast(self) -> (Rc<ObjectAssignmentPattern>, SourceTree) {
+    pub(crate) fn object_assignment_pattern_ast(self) -> (Rc<ObjectAssignmentPattern>, SourceTree) {
         let source = self.source.to_string();
         let node = ObjectAssignmentPattern::parse(
             &mut newparser(self.source),
@@ -2175,12 +2182,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ObjectAssignmentPattern(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ObjectBindingPattern`] parse node.
-    pub fn object_binding_pattern(self) -> Rc<ObjectBindingPattern> {
+    pub(crate) fn object_binding_pattern(self) -> Rc<ObjectBindingPattern> {
         ObjectBindingPattern::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn object_binding_pattern_ast(self) -> (Rc<ObjectBindingPattern>, SourceTree) {
+    pub(crate) fn object_binding_pattern_ast(self) -> (Rc<ObjectBindingPattern>, SourceTree) {
         let source = self.source.to_string();
         let node =
             ObjectBindingPattern::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -2189,20 +2196,20 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ObjectBindingPattern(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ObjectLiteral`] parse node.
-    pub fn object_literal(self) -> Rc<ObjectLiteral> {
+    pub(crate) fn object_literal(self) -> Rc<ObjectLiteral> {
         ObjectLiteral::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn object_literal_ast(self) -> (Rc<ObjectLiteral>, SourceTree) {
+    pub(crate) fn object_literal_ast(self) -> (Rc<ObjectLiteral>, SourceTree) {
         let source = self.source;
         let node =
             ObjectLiteral::parse(&mut newparser(source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0;
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::ObjectLiteral(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`OptionalChain`] parse node.
-    pub fn optional_chain(self) -> Rc<OptionalChain> {
+    pub(crate) fn optional_chain(self) -> Rc<OptionalChain> {
         OptionalChain::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn optional_chain_ast(self) -> (Rc<OptionalChain>, SourceTree) {
+    pub(crate) fn optional_chain_ast(self) -> (Rc<OptionalChain>, SourceTree) {
         let source = self.source.to_string();
         let node = OptionalChain::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -2210,12 +2217,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::OptionalChain(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`OptionalExpression`] parse node.
-    pub fn optional_expression(self) -> Rc<OptionalExpression> {
+    pub(crate) fn optional_expression(self) -> Rc<OptionalExpression> {
         OptionalExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn optional_expression_ast(self) -> (Rc<OptionalExpression>, SourceTree) {
+    pub(crate) fn optional_expression_ast(self) -> (Rc<OptionalExpression>, SourceTree) {
         let source = self.source.to_string();
         let node =
             OptionalExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -2224,12 +2231,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::OptionalExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ParenthesizedExpression`] parse node.
-    pub fn parenthesized_expression(self) -> Rc<ParenthesizedExpression> {
+    pub(crate) fn parenthesized_expression(self) -> Rc<ParenthesizedExpression> {
         ParenthesizedExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn parenthesized_expression_ast(self) -> (Rc<ParenthesizedExpression>, SourceTree) {
+    pub(crate) fn parenthesized_expression_ast(self) -> (Rc<ParenthesizedExpression>, SourceTree) {
         let source = self.source;
         let node =
             ParenthesizedExpression::parse(&mut newparser(source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -2238,12 +2245,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::ParenthesizedExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`PrimaryExpression`] parse node.
-    pub fn primary_expression(self) -> Rc<PrimaryExpression> {
+    pub(crate) fn primary_expression(self) -> Rc<PrimaryExpression> {
         PrimaryExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn primary_expression_ast(self) -> (Rc<PrimaryExpression>, SourceTree) {
+    pub(crate) fn primary_expression_ast(self) -> (Rc<PrimaryExpression>, SourceTree) {
         let source = self.source;
         let node = PrimaryExpression::parse(&mut newparser(source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -2251,12 +2258,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::PrimaryExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`PropertyDefinition`] parse node.
-    pub fn property_definition(self) -> Rc<PropertyDefinition> {
+    pub(crate) fn property_definition(self) -> Rc<PropertyDefinition> {
         PropertyDefinition::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn property_definition_ast(self) -> (Rc<PropertyDefinition>, SourceTree) {
+    pub(crate) fn property_definition_ast(self) -> (Rc<PropertyDefinition>, SourceTree) {
         let source = self.source;
         let node = PropertyDefinition::parse(&mut newparser(source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -2264,12 +2271,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::PropertyDefinition(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`PropertyDefinitionList`] parse node.
-    pub fn property_definition_list(self) -> Rc<PropertyDefinitionList> {
+    pub(crate) fn property_definition_list(self) -> Rc<PropertyDefinitionList> {
         PropertyDefinitionList::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn property_definition_list_ast(self) -> (Rc<PropertyDefinitionList>, SourceTree) {
+    pub(crate) fn property_definition_list_ast(self) -> (Rc<PropertyDefinitionList>, SourceTree) {
         let source = self.source;
         let node =
             PropertyDefinitionList::parse(&mut newparser(source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -2278,26 +2285,26 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::PropertyDefinitionList(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`PropertyName`] parse node.
-    pub fn property_name(self) -> Rc<PropertyName> {
+    pub(crate) fn property_name(self) -> Rc<PropertyName> {
         PropertyName::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn property_name_ast(self) -> (Rc<PropertyName>, SourceTree) {
+    pub(crate) fn property_name_ast(self) -> (Rc<PropertyName>, SourceTree) {
         let source = self.source;
         let node =
             PropertyName::parse(&mut newparser(source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0;
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::PropertyName(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`PropertySetParameterList`] parse node.
-    pub fn property_set_parameter_list(self) -> Rc<PropertySetParameterList> {
+    pub(crate) fn property_set_parameter_list(self) -> Rc<PropertySetParameterList> {
         PropertySetParameterList::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
-    pub fn property_set_parameter_list_ast(self) -> (Rc<PropertySetParameterList>, SourceTree) {
-        let source = self.source.to_string();
-        let node = PropertySetParameterList::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::PropertySetParameterList(node) })
-    }
+    //pub(crate) fn property_set_parameter_list_ast(self) -> (Rc<PropertySetParameterList>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = PropertySetParameterList::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::PropertySetParameterList(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`RelationalExpression`] parse node.
-    pub fn relational_expression(self) -> Rc<RelationalExpression> {
+    pub(crate) fn relational_expression(self) -> Rc<RelationalExpression> {
         RelationalExpression::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2308,7 +2315,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn relational_expression_ast(self) -> (Rc<RelationalExpression>, SourceTree) {
+    pub(crate) fn relational_expression_ast(self) -> (Rc<RelationalExpression>, SourceTree) {
         let source = self.source.to_string();
         let node = RelationalExpression::parse(
             &mut newparser(self.source),
@@ -2322,10 +2329,10 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::RelationalExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ReturnStatement`] parse node.
-    pub fn return_statement(self) -> Rc<ReturnStatement> {
+    pub(crate) fn return_statement(self) -> Rc<ReturnStatement> {
         ReturnStatement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn return_statement_ast(self) -> (Rc<ReturnStatement>, SourceTree) {
+    pub(crate) fn return_statement_ast(self) -> (Rc<ReturnStatement>, SourceTree) {
         let source = self.source.to_string();
         let node =
             ReturnStatement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -2334,29 +2341,29 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ReturnStatement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ScriptBody`] parse node.
-    pub fn script_body(self) -> Rc<ScriptBody> {
+    pub(crate) fn script_body(self) -> Rc<ScriptBody> {
         ScriptBody::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
-    pub fn script_body_ast(self) -> (Rc<ScriptBody>, SourceTree) {
+    pub(crate) fn script_body_ast(self) -> (Rc<ScriptBody>, SourceTree) {
         let source = self.source.to_string();
         let node = ScriptBody::parse(&mut newparser(self.source), Scanner::new()).unwrap().0;
         (node.clone(), SourceTree { text: source, ast: ParsedText::ScriptBody(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`Script`] parse node.
-    pub fn script(self) -> Rc<Script> {
+    pub(crate) fn script(self) -> Rc<Script> {
         Script::parse(&mut newparser(self.source), Scanner::new()).unwrap().0
     }
-    pub fn script_ast(self) -> (Rc<Script>, SourceTree) {
+    pub(crate) fn script_ast(self) -> (Rc<Script>, SourceTree) {
         let src = self.source;
         let node = Script::parse(&mut newparser(src), Scanner::new()).unwrap().0;
         (node.clone(), SourceTree { ast: ParsedText::Script(node), text: String::from(src) })
     }
 
     /// Use the configs in the [`Maker`] object to make a [`ShiftExpression`] parse node.
-    pub fn shift_expression(self) -> Rc<ShiftExpression> {
+    pub(crate) fn shift_expression(self) -> Rc<ShiftExpression> {
         ShiftExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn shift_expression_ast(self) -> (Rc<ShiftExpression>, SourceTree) {
+    pub(crate) fn shift_expression_ast(self) -> (Rc<ShiftExpression>, SourceTree) {
         let source = self.source.to_string();
         let node =
             ShiftExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -2365,7 +2372,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ShiftExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ShortCircuitExpression`] parse node.
-    pub fn short_circuit_expression(self) -> Rc<ShortCircuitExpression> {
+    pub(crate) fn short_circuit_expression(self) -> Rc<ShortCircuitExpression> {
         ShortCircuitExpression::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2376,7 +2383,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn short_circuit_expression_ast(self) -> (Rc<ShortCircuitExpression>, SourceTree) {
+    pub(crate) fn short_circuit_expression_ast(self) -> (Rc<ShortCircuitExpression>, SourceTree) {
         let source = self.source.to_string();
         let node = ShortCircuitExpression::parse(
             &mut newparser(self.source),
@@ -2390,12 +2397,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ShortCircuitExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`SingleNameBinding`] parse node.
-    pub fn single_name_binding(self) -> Rc<SingleNameBinding> {
+    pub(crate) fn single_name_binding(self) -> Rc<SingleNameBinding> {
         SingleNameBinding::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn single_name_binding_ast(self) -> (Rc<SingleNameBinding>, SourceTree) {
+    pub(crate) fn single_name_binding_ast(self) -> (Rc<SingleNameBinding>, SourceTree) {
         let source = self.source.to_string();
         let node =
             SingleNameBinding::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -2404,10 +2411,10 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::SingleNameBinding(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`SpreadElement`] parse node.
-    pub fn spread_element(self) -> Rc<SpreadElement> {
+    pub(crate) fn spread_element(self) -> Rc<SpreadElement> {
         SpreadElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn spread_element_ast(self) -> (Rc<SpreadElement>, SourceTree) {
+    pub(crate) fn spread_element_ast(self) -> (Rc<SpreadElement>, SourceTree) {
         let source = self.source.to_string();
         let node = SpreadElement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -2415,7 +2422,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::SpreadElement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`Statement`] parse node.
-    pub fn statement(self) -> Rc<Statement> {
+    pub(crate) fn statement(self) -> Rc<Statement> {
         Statement::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2426,7 +2433,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn statement_ast(self) -> (Rc<Statement>, SourceTree) {
+    pub(crate) fn statement_ast(self) -> (Rc<Statement>, SourceTree) {
         let source = self.source.to_string();
         let node = Statement::parse(
             &mut newparser(self.source),
@@ -2440,7 +2447,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::Statement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`StatementList`] parse node.
-    pub fn statement_list(self) -> Rc<StatementList> {
+    pub(crate) fn statement_list(self) -> Rc<StatementList> {
         StatementList::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2451,7 +2458,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn statement_list_ast(self) -> (Rc<StatementList>, SourceTree) {
+    pub(crate) fn statement_list_ast(self) -> (Rc<StatementList>, SourceTree) {
         let source = self.source.to_string();
         let node = StatementList::parse(
             &mut newparser(self.source),
@@ -2465,7 +2472,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::StatementList(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`StatementListItem`] parse node.
-    pub fn statement_list_item(self) -> Rc<StatementListItem> {
+    pub(crate) fn statement_list_item(self) -> Rc<StatementListItem> {
         StatementListItem::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2476,7 +2483,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn statement_list_item_ast(self) -> (Rc<StatementListItem>, SourceTree) {
+    pub(crate) fn statement_list_item_ast(self) -> (Rc<StatementListItem>, SourceTree) {
         let source = self.source.to_string();
         let node = StatementListItem::parse(
             &mut newparser(self.source),
@@ -2490,7 +2497,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::StatementListItem(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`SubstitutionTemplate`] parse node.
-    pub fn substitution_template(self) -> Rc<SubstitutionTemplate> {
+    pub(crate) fn substitution_template(self) -> Rc<SubstitutionTemplate> {
         SubstitutionTemplate::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2501,7 +2508,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn substitution_template_ast(self) -> (Rc<SubstitutionTemplate>, SourceTree) {
+    pub(crate) fn substitution_template_ast(self) -> (Rc<SubstitutionTemplate>, SourceTree) {
         let source = self.source.to_string();
         let node = SubstitutionTemplate::parse(
             &mut newparser(self.source),
@@ -2515,28 +2522,28 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::SubstitutionTemplate(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`SuperCall`] parse node.
-    pub fn super_call(self) -> Rc<SuperCall> {
+    pub(crate) fn super_call(self) -> Rc<SuperCall> {
         SuperCall::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn super_call_ast(self) -> (Rc<SuperCall>, SourceTree) {
-        let source = self.source.to_string();
-        let node =
-            SuperCall::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::SuperCall(node) })
-    }
+    //pub(crate) fn super_call_ast(self) -> (Rc<SuperCall>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node =
+    //        SuperCall::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::SuperCall(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`SuperProperty`] parse node.
-    pub fn super_property(self) -> Rc<SuperProperty> {
+    pub(crate) fn super_property(self) -> Rc<SuperProperty> {
         SuperProperty::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn super_property_ast(self) -> (Rc<SuperProperty>, SourceTree) {
-        let source = self.source.to_string();
-        let node = SuperProperty::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
-            .unwrap()
-            .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::SuperProperty(node) })
-    }
+    //pub(crate) fn super_property_ast(self) -> (Rc<SuperProperty>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = SuperProperty::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
+    //        .unwrap()
+    //        .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::SuperProperty(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`SwitchStatement`] parse node.
-    pub fn switch_statement(self) -> Rc<SwitchStatement> {
+    pub(crate) fn switch_statement(self) -> Rc<SwitchStatement> {
         SwitchStatement::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2547,7 +2554,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn switch_statement_ast(self) -> (Rc<SwitchStatement>, SourceTree) {
+    pub(crate) fn switch_statement_ast(self) -> (Rc<SwitchStatement>, SourceTree) {
         let source = self.source.to_string();
         let node = SwitchStatement::parse(
             &mut newparser(self.source),
@@ -2561,7 +2568,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::SwitchStatement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`TemplateLiteral`] parse node.
-    pub fn template_literal(self) -> Rc<TemplateLiteral> {
+    pub(crate) fn template_literal(self) -> Rc<TemplateLiteral> {
         TemplateLiteral::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2572,7 +2579,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn template_literal_ast(self) -> (Rc<TemplateLiteral>, SourceTree) {
+    pub(crate) fn template_literal_ast(self) -> (Rc<TemplateLiteral>, SourceTree) {
         let source = self.source.to_string();
         let node = TemplateLiteral::parse(
             &mut newparser(self.source),
@@ -2586,18 +2593,18 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::TemplateLiteral(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`TemplateMiddleList`] parse node.
-    pub fn template_middle_list(self) -> Rc<TemplateMiddleList> {
-        TemplateMiddleList::parse(
-            &mut newparser(self.source),
-            Scanner::new(),
-            self.yield_flag,
-            self.await_flag,
-            self.tagged_flag,
-        )
-        .unwrap()
-        .0
-    }
-    pub fn template_middle_list_ast(self) -> (Rc<TemplateMiddleList>, SourceTree) {
+    // pub(crate) fn template_middle_list(self) -> Rc<TemplateMiddleList> {
+    //     TemplateMiddleList::parse(
+    //         &mut newparser(self.source),
+    //         Scanner::new(),
+    //         self.yield_flag,
+    //         self.await_flag,
+    //         self.tagged_flag,
+    //     )
+    //     .unwrap()
+    //     .0
+    // }
+    pub(crate) fn template_middle_list_ast(self) -> (Rc<TemplateMiddleList>, SourceTree) {
         let source = self.source.to_string();
         let node = TemplateMiddleList::parse(
             &mut newparser(self.source),
@@ -2611,7 +2618,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::TemplateMiddleList(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`TemplateSpans`] parse node.
-    pub fn template_spans(self) -> Rc<TemplateSpans> {
+    pub(crate) fn template_spans(self) -> Rc<TemplateSpans> {
         TemplateSpans::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2622,7 +2629,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn template_spans_ast(self) -> (Rc<TemplateSpans>, SourceTree) {
+    pub(crate) fn template_spans_ast(self) -> (Rc<TemplateSpans>, SourceTree) {
         let source = self.source.to_string();
         let node = TemplateSpans::parse(
             &mut newparser(self.source),
@@ -2636,10 +2643,10 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::TemplateSpans(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`ThrowStatement`] parse node.
-    pub fn throw_statement(self) -> Rc<ThrowStatement> {
+    pub(crate) fn throw_statement(self) -> Rc<ThrowStatement> {
         ThrowStatement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn throw_statement_ast(self) -> (Rc<ThrowStatement>, SourceTree) {
+    pub(crate) fn throw_statement_ast(self) -> (Rc<ThrowStatement>, SourceTree) {
         let source = self.source.to_string();
         let node = ThrowStatement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -2647,7 +2654,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::ThrowStatement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`TryStatement`] parse node.
-    pub fn try_statement(self) -> Rc<TryStatement> {
+    pub(crate) fn try_statement(self) -> Rc<TryStatement> {
         TryStatement::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2658,7 +2665,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn try_statement_ast(self) -> (Rc<TryStatement>, SourceTree) {
+    pub(crate) fn try_statement_ast(self) -> (Rc<TryStatement>, SourceTree) {
         let source = self.source.to_string();
         let node = TryStatement::parse(
             &mut newparser(self.source),
@@ -2672,10 +2679,10 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::TryStatement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`UniqueFormalParameters`] parse node.
-    pub fn unique_formal_parameters(self) -> Rc<UniqueFormalParameters> {
+    pub(crate) fn unique_formal_parameters(self) -> Rc<UniqueFormalParameters> {
         UniqueFormalParameters::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).0
     }
-    pub fn unique_formal_parameters_ast(self) -> (Rc<UniqueFormalParameters>, SourceTree) {
+    pub(crate) fn unique_formal_parameters_ast(self) -> (Rc<UniqueFormalParameters>, SourceTree) {
         let source = self.source.to_string();
         let node = UniqueFormalParameters::parse(
             &mut newparser(self.source),
@@ -2687,12 +2694,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::UniqueFormalParameters(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`UpdateExpression`] parse node.
-    pub fn update_expression(self) -> Rc<UpdateExpression> {
+    pub(crate) fn update_expression(self) -> Rc<UpdateExpression> {
         UpdateExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn update_expression_ast(self) -> (Rc<UpdateExpression>, SourceTree) {
+    pub(crate) fn update_expression_ast(self) -> (Rc<UpdateExpression>, SourceTree) {
         let source = self.source;
         let node = UpdateExpression::parse(&mut newparser(source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
@@ -2700,17 +2707,17 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::UpdateExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`UnaryExpression`] parse node.
-    pub fn unary_expression(self) -> Rc<UnaryExpression> {
+    pub(crate) fn unary_expression(self) -> Rc<UnaryExpression> {
         UnaryExpression::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0
     }
-    pub fn unary_expression_ast(self) -> (Rc<UnaryExpression>, SourceTree) {
+    pub(crate) fn unary_expression_ast(self) -> (Rc<UnaryExpression>, SourceTree) {
         let source = self.source;
         let node =
             UnaryExpression::parse(&mut newparser(source), Scanner::new(), self.yield_flag, self.await_flag).unwrap().0;
         (node.clone(), SourceTree { text: source.to_string(), ast: ParsedText::UnaryExpression(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`VariableDeclaration`] parse node.
-    pub fn variable_declaration(self) -> Rc<VariableDeclaration> {
+    pub(crate) fn variable_declaration(self) -> Rc<VariableDeclaration> {
         VariableDeclaration::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2721,7 +2728,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn variable_declaration_ast(self) -> (Rc<VariableDeclaration>, SourceTree) {
+    pub(crate) fn variable_declaration_ast(self) -> (Rc<VariableDeclaration>, SourceTree) {
         let source = self.source.to_string();
         let node = VariableDeclaration::parse(
             &mut newparser(self.source),
@@ -2735,7 +2742,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::VariableDeclaration(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`VariableDeclarationList`] parse node.
-    pub fn variable_declaration_list(self) -> Rc<VariableDeclarationList> {
+    pub(crate) fn variable_declaration_list(self) -> Rc<VariableDeclarationList> {
         VariableDeclarationList::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2746,7 +2753,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn variable_declaration_list_ast(self) -> (Rc<VariableDeclarationList>, SourceTree) {
+    pub(crate) fn variable_declaration_list_ast(self) -> (Rc<VariableDeclarationList>, SourceTree) {
         let source = self.source.to_string();
         let node = VariableDeclarationList::parse(
             &mut newparser(self.source),
@@ -2760,12 +2767,12 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::VariableDeclarationList(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`VariableStatement`] parse node.
-    pub fn variable_statement(self) -> Rc<VariableStatement> {
+    pub(crate) fn variable_statement(self) -> Rc<VariableStatement> {
         VariableStatement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
             .unwrap()
             .0
     }
-    pub fn variable_statement_ast(self) -> (Rc<VariableStatement>, SourceTree) {
+    pub(crate) fn variable_statement_ast(self) -> (Rc<VariableStatement>, SourceTree) {
         let source = self.source.to_string();
         let node =
             VariableStatement::parse(&mut newparser(self.source), Scanner::new(), self.yield_flag, self.await_flag)
@@ -2774,7 +2781,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::VariableStatement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`WhileStatement`] parse node.
-    pub fn while_statement(self) -> Rc<WhileStatement> {
+    pub(crate) fn while_statement(self) -> Rc<WhileStatement> {
         WhileStatement::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2785,7 +2792,7 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn while_statement_ast(self) -> (Rc<WhileStatement>, SourceTree) {
+    pub(crate) fn while_statement_ast(self) -> (Rc<WhileStatement>, SourceTree) {
         let source = self.source.to_string();
         let node = WhileStatement::parse(
             &mut newparser(self.source),
@@ -2799,7 +2806,7 @@ impl<'a> Maker<'a> {
         (node.clone(), SourceTree { text: source, ast: ParsedText::WhileStatement(node) })
     }
     /// Use the configs in the [`Maker`] object to make a [`WithStatement`] parse node.
-    pub fn with_statement(self) -> Rc<WithStatement> {
+    pub(crate) fn with_statement(self) -> Rc<WithStatement> {
         WithStatement::parse(
             &mut newparser(self.source),
             Scanner::new(),
@@ -2810,63 +2817,63 @@ impl<'a> Maker<'a> {
         .unwrap()
         .0
     }
-    pub fn with_statement_ast(self) -> (Rc<WithStatement>, SourceTree) {
-        let source = self.source.to_string();
-        let node = WithStatement::parse(
-            &mut newparser(self.source),
-            Scanner::new(),
-            self.yield_flag,
-            self.await_flag,
-            self.return_flag,
-        )
-        .unwrap()
-        .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::WithStatement(node) })
-    }
+    //pub(crate) fn with_statement_ast(self) -> (Rc<WithStatement>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = WithStatement::parse(
+    //        &mut newparser(self.source),
+    //        Scanner::new(),
+    //        self.yield_flag,
+    //        self.await_flag,
+    //        self.return_flag,
+    //    )
+    //    .unwrap()
+    //    .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::WithStatement(node) })
+    //}
     /// Use the configs in the [`Maker`] object to make a [`YieldExpression`] parse node.
-    pub fn yield_expression(self) -> Rc<YieldExpression> {
+    pub(crate) fn yield_expression(self) -> Rc<YieldExpression> {
         YieldExpression::parse(&mut newparser(self.source), Scanner::new(), self.in_flag, self.await_flag).unwrap().0
     }
-    pub fn yield_expression_ast(self) -> (Rc<YieldExpression>, SourceTree) {
-        let source = self.source.to_string();
-        let node = YieldExpression::parse(&mut newparser(self.source), Scanner::new(), self.in_flag, self.await_flag)
-            .unwrap()
-            .0;
-        (node.clone(), SourceTree { text: source, ast: ParsedText::YieldExpression(node) })
-    }
+    //pub(crate) fn yield_expression_ast(self) -> (Rc<YieldExpression>, SourceTree) {
+    //    let source = self.source.to_string();
+    //    let node = YieldExpression::parse(&mut newparser(self.source), Scanner::new(), self.in_flag, self.await_flag)
+    //        .unwrap()
+    //        .0;
+    //    (node.clone(), SourceTree { text: source, ast: ParsedText::YieldExpression(node) })
+    //}
 }
 
-pub const PACKAGE_NOT_ALLOWED: &str = "‘package’ not allowed as an identifier in strict mode";
-pub const INTERFACE_NOT_ALLOWED: &str = "‘interface’ not allowed as an identifier in strict mode";
-pub const IMPLEMENTS_NOT_ALLOWED: &str = "‘implements’ not allowed as an identifier in strict mode";
-pub const CONTINUE_ITER: &str = "Continue statements must lie within iteration statements.";
-pub const DUPLICATE_LEXICAL: &str = "Duplicate lexically declared names";
-pub const LEX_DUPED_BY_VAR: &str = "Name defined both lexically and var-style";
-pub const WITH_NOT_ALLOWED: &str = "'with' statements not allowed in strict mode";
-pub const PRIVATE_NOT_ALLOWED: &str = "‘private’ not allowed as an identifier in strict mode";
-pub const UNDEFINED_BREAK: &str = "undefined break target detected";
-pub const DUPLICATE_LABELS: &str = "duplicate labels detected";
-pub const UNEXPECTED_ARGS: &str = "‘arguments’ not expected here";
-pub const UNEXPECTED_SUPER: &str = "Calls to ‘super’ not allowed here";
-pub const UNEXPECTED_SUPER2: &str = "‘super’ not allowed here";
-pub const UNDEF_CONT_TGT: &str = "undefined continue target detected";
-pub const A_ALREADY_DEFN: &str = "‘a’ already defined";
-pub const PRIVATE_CONSTRUCTOR: &str = "#constructor is an invalid private id";
-pub const BAD_SUPER: &str = "super only allowed for constructors";
-pub const CONSTRUCTOR_FIELD: &str = "constructors may not be defined as class fields";
-pub const STATIC_PROTO: &str = "prototypes cannot be static";
-pub const SPECIAL_CONSTRUCTOR: &str = "special methods not allowed for constructors";
-pub const DUPLICATE_CONSTRUCTOR: &str = "Classes may have only one constructor";
-pub const PRIVATE_A_ALREADY_DEFN: &str = "‘#a’ already defined";
-pub const PREV_STATIC_GETTER: &str = "‘#a’ was previously defined as a static getter method.";
-pub const PREV_GETTER: &str = "‘#a’ was previously defined as a getter method.";
-pub const PREV_STATIC_SETTER: &str = "‘#a’ was previously defined as a static setter method.";
-pub const PREV_SETTER: &str = "‘#a’ was previously defined as a setter method.";
-pub const PARENTLESS_SUPER: &str = "Cannot use super in a constructor with no parent class";
-pub const BAD_USE_STRICT: &str = "Illegal 'use strict' directive in function with non-simple parameter list";
-pub const UNEXPECTED_AWAIT: &str = "Await expressions can't be parameter initializers in async functions";
-pub const ILLEGAL_ASYNC_AWAIT: &str = "Illegal await-expression in formal parameters of async function";
-pub const YIELD_IN_GENPARAM: &str = "Yield expressions can't be parameter initializers in generators";
-pub const AWAIT_IN_CLASS_STATIC: &str = "Cannot use await in class static initialization block";
-pub const BAD_EVAL: &str = "identifier not allowed in strict mode: eval";
-pub const BAD_ARGUMENTS: &str = "identifier not allowed in strict mode: arguments";
+pub(crate) const PACKAGE_NOT_ALLOWED: &str = "‘package’ not allowed as an identifier in strict mode";
+pub(crate) const INTERFACE_NOT_ALLOWED: &str = "‘interface’ not allowed as an identifier in strict mode";
+pub(crate) const IMPLEMENTS_NOT_ALLOWED: &str = "‘implements’ not allowed as an identifier in strict mode";
+pub(crate) const CONTINUE_ITER: &str = "Continue statements must lie within iteration statements.";
+pub(crate) const DUPLICATE_LEXICAL: &str = "Duplicate lexically declared names";
+pub(crate) const LEX_DUPED_BY_VAR: &str = "Name defined both lexically and var-style";
+pub(crate) const WITH_NOT_ALLOWED: &str = "'with' statements not allowed in strict mode";
+pub(crate) const PRIVATE_NOT_ALLOWED: &str = "‘private’ not allowed as an identifier in strict mode";
+pub(crate) const UNDEFINED_BREAK: &str = "undefined break target detected";
+pub(crate) const DUPLICATE_LABELS: &str = "duplicate labels detected";
+pub(crate) const UNEXPECTED_ARGS: &str = "‘arguments’ not expected here";
+pub(crate) const UNEXPECTED_SUPER: &str = "Calls to ‘super’ not allowed here";
+pub(crate) const UNEXPECTED_SUPER2: &str = "‘super’ not allowed here";
+pub(crate) const UNDEF_CONT_TGT: &str = "undefined continue target detected";
+pub(crate) const A_ALREADY_DEFN: &str = "‘a’ already defined";
+pub(crate) const PRIVATE_CONSTRUCTOR: &str = "#constructor is an invalid private id";
+pub(crate) const BAD_SUPER: &str = "super only allowed for constructors";
+pub(crate) const CONSTRUCTOR_FIELD: &str = "constructors may not be defined as class fields";
+pub(crate) const STATIC_PROTO: &str = "prototypes cannot be static";
+pub(crate) const SPECIAL_CONSTRUCTOR: &str = "special methods not allowed for constructors";
+pub(crate) const DUPLICATE_CONSTRUCTOR: &str = "Classes may have only one constructor";
+pub(crate) const PRIVATE_A_ALREADY_DEFN: &str = "‘#a’ already defined";
+pub(crate) const PREV_STATIC_GETTER: &str = "‘#a’ was previously defined as a static getter method.";
+pub(crate) const PREV_GETTER: &str = "‘#a’ was previously defined as a getter method.";
+pub(crate) const PREV_STATIC_SETTER: &str = "‘#a’ was previously defined as a static setter method.";
+pub(crate) const PREV_SETTER: &str = "‘#a’ was previously defined as a setter method.";
+pub(crate) const PARENTLESS_SUPER: &str = "Cannot use super in a constructor with no parent class";
+pub(crate) const BAD_USE_STRICT: &str = "Illegal 'use strict' directive in function with non-simple parameter list";
+pub(crate) const UNEXPECTED_AWAIT: &str = "Await expressions can't be parameter initializers in async functions";
+pub(crate) const ILLEGAL_ASYNC_AWAIT: &str = "Illegal await-expression in formal parameters of async function";
+pub(crate) const YIELD_IN_GENPARAM: &str = "Yield expressions can't be parameter initializers in generators";
+pub(crate) const AWAIT_IN_CLASS_STATIC: &str = "Cannot use await in class static initialization block";
+pub(crate) const BAD_EVAL: &str = "identifier not allowed in strict mode: eval";
+pub(crate) const BAD_ARGUMENTS: &str = "identifier not allowed in strict mode: arguments";

--- a/src/parser/throw_statement/mod.rs
+++ b/src/parser/throw_statement/mod.rs
@@ -6,8 +6,8 @@ use std::io::Write;
 // ThrowStatement[Yield, Await] :
 //      throw [no LineTerminator here] Expression[+In, ?Yield, ?Await] ;
 #[derive(Debug)]
-pub struct ThrowStatement {
-    pub exp: Rc<Expression>,
+pub(crate) struct ThrowStatement {
+    pub(crate) exp: Rc<Expression>,
     location: Location,
 }
 
@@ -40,24 +40,29 @@ impl PrettyPrint for ThrowStatement {
 }
 
 impl ThrowStatement {
-    pub fn parse(parser: &mut Parser, scanner: Scanner, yield_flag: bool, await_flag: bool) -> ParseResult<Self> {
+    pub(crate) fn parse(
+        parser: &mut Parser,
+        scanner: Scanner,
+        yield_flag: bool,
+        await_flag: bool,
+    ) -> ParseResult<Self> {
         let (throw_loc, after_throw) =
-            scan_for_keyword(scanner, parser.source, ScanGoal::InputElementRegExp, Keyword::Throw)?;
+            scan_for_keyword(scanner, parser.source, InputElementGoal::RegExp, Keyword::Throw)?;
         no_line_terminator(after_throw, parser.source)?;
         let (exp, after_exp) = Expression::parse(parser, after_throw, true, yield_flag, await_flag)?;
-        let (semi_loc, after_semi) = scan_for_auto_semi(after_exp, parser.source, ScanGoal::InputElementRegExp)?;
+        let (semi_loc, after_semi) = scan_for_auto_semi(after_exp, parser.source, InputElementGoal::RegExp)?;
         Ok((Rc::new(ThrowStatement { exp, location: throw_loc.merge(&semi_loc) }), after_semi))
     }
 
-    pub fn location(&self) -> Location {
+    pub(crate) fn location(&self) -> Location {
         self.location
     }
 
-    pub fn contains(&self, kind: ParseNodeKind) -> bool {
+    pub(crate) fn contains(&self, kind: ParseNodeKind) -> bool {
         self.exp.contains(kind)
     }
 
-    pub fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
+    pub(crate) fn all_private_identifiers_valid(&self, names: &[JSString]) -> bool {
         // Static Semantics: AllPrivateIdentifiersValid
         // With parameter names.
         //  1. For each child node child of this Parse Node, do
@@ -71,7 +76,7 @@ impl ThrowStatement {
     /// [`IdentifierReference`] with string value `"arguments"`.
     ///
     /// See [ContainsArguments](https://tc39.es/ecma262/#sec-static-semantics-containsarguments) from ECMA-262.
-    pub fn contains_arguments(&self) -> bool {
+    pub(crate) fn contains_arguments(&self) -> bool {
         // Static Semantics: ContainsArguments
         // The syntax-directed operation ContainsArguments takes no arguments and returns a Boolean.
         //  1. For each child node child of this Parse Node, do
@@ -81,12 +86,12 @@ impl ThrowStatement {
         self.exp.contains_arguments()
     }
 
-    pub fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
+    pub(crate) fn early_errors(&self, errs: &mut Vec<Object>, strict: bool) {
         self.exp.early_errors(errs, strict);
     }
 
     #[expect(unused_variables)]
-    pub fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
+    pub(crate) fn body_containing_location(&self, location: &Location) -> Option<ContainingBody> {
         // Finds the FunctionBody, ConciseBody, or AsyncConciseBody that contains location most closely.
         todo!()
     }

--- a/src/parser/unary_operators/tests.rs
+++ b/src/parser/unary_operators/tests.rs
@@ -17,7 +17,6 @@ mod unary_expression {
         assert!(matches!(*ue, UnaryExpression::UpdateExpression(_)));
         pretty_check(&*ue, "UnaryExpression: 900", &["UpdateExpression: 900"]);
         concise_check(&*ue, "Numeric: 900", &[]);
-        assert!(!ue.is_function_definition());
         assert_ne!(format!("{ue:?}"), "");
     }
     #[test]
@@ -27,7 +26,6 @@ mod unary_expression {
         assert!(matches!(*ue, UnaryExpression::Delete { .. }));
         pretty_check(&*ue, "UnaryExpression: delete bob", &["UnaryExpression: bob"]);
         concise_check(&*ue, "UnaryExpression: delete bob", &["Keyword: delete", "IdentifierName: bob"]);
-        assert!(!ue.is_function_definition());
         assert_ne!(format!("{ue:?}"), "");
     }
     #[test]
@@ -37,7 +35,6 @@ mod unary_expression {
         assert!(matches!(*ue, UnaryExpression::Void { .. }));
         pretty_check(&*ue, "UnaryExpression: void bob", &["UnaryExpression: bob"]);
         concise_check(&*ue, "UnaryExpression: void bob", &["Keyword: void", "IdentifierName: bob"]);
-        assert!(!ue.is_function_definition());
         assert_ne!(format!("{ue:?}"), "");
     }
     #[test]
@@ -47,7 +44,6 @@ mod unary_expression {
         assert!(matches!(*ue, UnaryExpression::Typeof { .. }));
         pretty_check(&*ue, "UnaryExpression: typeof bob", &["UnaryExpression: bob"]);
         concise_check(&*ue, "UnaryExpression: typeof bob", &["Keyword: typeof", "IdentifierName: bob"]);
-        assert!(!ue.is_function_definition());
         assert_ne!(format!("{ue:?}"), "");
     }
     #[test]
@@ -57,7 +53,6 @@ mod unary_expression {
         assert!(matches!(*ue, UnaryExpression::NoOp { .. }));
         pretty_check(&*ue, "UnaryExpression: + bob", &["UnaryExpression: bob"]);
         concise_check(&*ue, "UnaryExpression: + bob", &["Punctuator: +", "IdentifierName: bob"]);
-        assert!(!ue.is_function_definition());
         assert_ne!(format!("{ue:?}"), "");
     }
     #[test]
@@ -67,7 +62,6 @@ mod unary_expression {
         assert!(matches!(*ue, UnaryExpression::Negate { .. }));
         pretty_check(&*ue, "UnaryExpression: - bob", &["UnaryExpression: bob"]);
         concise_check(&*ue, "UnaryExpression: - bob", &["Punctuator: -", "IdentifierName: bob"]);
-        assert!(!ue.is_function_definition());
         assert_ne!(format!("{ue:?}"), "");
     }
     #[test]
@@ -77,7 +71,6 @@ mod unary_expression {
         assert!(matches!(*ue, UnaryExpression::Complement { .. }));
         pretty_check(&*ue, "UnaryExpression: ~ bob", &["UnaryExpression: bob"]);
         concise_check(&*ue, "UnaryExpression: ~ bob", &["Punctuator: ~", "IdentifierName: bob"]);
-        assert!(!ue.is_function_definition());
         assert_ne!(format!("{ue:?}"), "");
     }
     #[test]
@@ -87,7 +80,6 @@ mod unary_expression {
         assert!(matches!(*ue, UnaryExpression::Not { .. }));
         pretty_check(&*ue, "UnaryExpression: ! bob", &["UnaryExpression: bob"]);
         concise_check(&*ue, "UnaryExpression: ! bob", &["Punctuator: !", "IdentifierName: bob"]);
-        assert!(!ue.is_function_definition());
         assert_ne!(format!("{ue:?}"), "");
     }
     #[test]
@@ -97,7 +89,6 @@ mod unary_expression {
         assert!(matches!(*ue, UnaryExpression::Await(_)));
         pretty_check(&*ue, "UnaryExpression: await bob", &["AwaitExpression: await bob"]);
         concise_check(&*ue, "AwaitExpression: await bob", &["Keyword: await", "IdentifierName: bob"]);
-        assert!(!ue.is_function_definition());
         assert_ne!(format!("{ue:?}"), "");
     }
     #[test]
@@ -459,12 +450,12 @@ mod unary_expression {
         Maker::new(src).unary_expression().assignment_target_type(strict)
     }
 
-    #[test_case("-a" => false; "expr")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).unary_expression().is_named_function()
-    }
+    //#[test_case("-a" => false; "expr")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).unary_expression().is_named_function()
+    //}
 
     #[test_case("  delete a" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 8 }}; "delete")]
     #[test_case("  void a" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 6 }}; "void")]

--- a/src/parser/update_expressions/tests.rs
+++ b/src/parser/update_expressions/tests.rs
@@ -18,7 +18,6 @@ mod update_expression {
         assert_ne!(format!("{ue:?}"), "");
         pretty_check(&*ue, "UpdateExpression: 78", &["LeftHandSideExpression: 78"]);
         concise_check(&*ue, "Numeric: 78", &[]);
-        assert!(!ue.is_function_definition());
     }
     #[test]
     fn lhs_2() {
@@ -32,7 +31,6 @@ mod update_expression {
             "ParenthesizedExpression: ( x => x * 2 )",
             &["Punctuator: (", "ArrowFunction: x => x * 2", "Punctuator: )"],
         );
-        assert!(ue.is_function_definition());
     }
     #[test]
     fn lhs_3() {
@@ -42,7 +40,6 @@ mod update_expression {
         assert_ne!(format!("{ue:?}"), "");
         pretty_check(&*ue, "UpdateExpression: x", &["LeftHandSideExpression: x"]);
         concise_check(&*ue, "IdentifierName: x", &[]);
-        assert!(!ue.is_function_definition());
     }
     #[test]
     fn preinc() {
@@ -52,7 +49,6 @@ mod update_expression {
         assert_ne!(format!("{ue:?}"), "");
         pretty_check(&*ue, "UpdateExpression: ++ a", &["UnaryExpression: a"]);
         concise_check(&*ue, "UpdateExpression: ++ a", &["Punctuator: ++", "IdentifierName: a"]);
-        assert!(!ue.is_function_definition());
     }
     #[test]
     fn predec() {
@@ -62,7 +58,6 @@ mod update_expression {
         assert_ne!(format!("{ue:?}"), "");
         pretty_check(&*ue, "UpdateExpression: -- a", &["UnaryExpression: a"]);
         concise_check(&*ue, "UpdateExpression: -- a", &["Punctuator: --", "IdentifierName: a"]);
-        assert!(!ue.is_function_definition());
     }
     #[test]
     fn postinc() {
@@ -72,7 +67,6 @@ mod update_expression {
         assert_ne!(format!("{ue:?}"), "");
         pretty_check(&*ue, "UpdateExpression: a ++", &["LeftHandSideExpression: a"]);
         concise_check(&*ue, "UpdateExpression: a ++", &["IdentifierName: a", "Punctuator: ++"]);
-        assert!(!ue.is_function_definition());
     }
     #[test]
     fn postdec() {
@@ -82,7 +76,6 @@ mod update_expression {
         assert_ne!(format!("{ue:?}"), "");
         pretty_check(&*ue, "UpdateExpression: a --", &["LeftHandSideExpression: a"]);
         concise_check(&*ue, "UpdateExpression: a --", &["IdentifierName: a", "Punctuator: --"]);
-        assert!(!ue.is_function_definition());
     }
     #[test]
     fn newline() {
@@ -291,12 +284,12 @@ mod update_expression {
         Maker::new(src).update_expression().assignment_target_type(strict)
     }
 
-    #[test_case("--a" => false; "expr")]
-    #[test_case("function bob(){}" => true; "function fallthru")]
-    #[test_case("1" => false; "literal fallthru")]
-    fn is_named_function(src: &str) -> bool {
-        Maker::new(src).update_expression().is_named_function()
-    }
+    //#[test_case("--a" => false; "expr")]
+    //#[test_case("function bob(){}" => true; "function fallthru")]
+    //#[test_case("1" => false; "literal fallthru")]
+    //fn is_named_function(src: &str) -> bool {
+    //    Maker::new(src).update_expression().is_named_function()
+    //}
 
     #[test_case("  a++" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "postinc")]
     #[test_case("  a--" => Location{ starting_line: 1, starting_column: 3, span: Span{ starting_index: 2, length: 3 }}; "postdec")]

--- a/src/prettyprint/mod.rs
+++ b/src/prettyprint/mod.rs
@@ -3,13 +3,13 @@ use std::io::Result as IoResult;
 use std::io::Write;
 
 #[derive(Copy, Clone)]
-pub enum Spot {
+pub(crate) enum Spot {
     Initial,
     NotFinal,
     Final,
 }
 
-pub fn prettypad(pad: &str, state: Spot) -> (String, String) {
+pub(crate) fn prettypad(pad: &str, state: Spot) -> (String, String) {
     let mut first = String::from(pad);
     let mut successive = String::from(pad);
     match state {
@@ -27,7 +27,7 @@ pub fn prettypad(pad: &str, state: Spot) -> (String, String) {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub enum TokenType {
+pub(crate) enum TokenType {
     Keyword,
     Punctuator,
     IdentifierName,
@@ -59,7 +59,7 @@ impl fmt::Display for TokenType {
     }
 }
 
-pub fn pprint_token<T, U>(writer: &mut T, tokstr: U, kind: TokenType, pad: &str, state: Spot) -> IoResult<()>
+pub(crate) fn pprint_token<T, U>(writer: &mut T, tokstr: U, kind: TokenType, pad: &str, state: Spot) -> IoResult<()>
 where
     T: Write,
     U: fmt::Display,
@@ -68,7 +68,8 @@ where
     writeln!(writer, "{first}{kind}: {tokstr}")
 }
 
-pub trait PrettyPrint {
+pub(crate) trait PrettyPrint {
+    #[cfg(test)]
     fn pprint<T>(&self, writer: &mut T) -> IoResult<()>
     where
         T: Write,
@@ -91,7 +92,7 @@ pub trait PrettyPrint {
 }
 
 #[cfg(test)]
-pub mod pp_testhelp;
+pub(crate) mod pp_testhelp;
 
 #[cfg(test)]
-pub mod tests;
+pub(crate) mod tests;

--- a/src/prettyprint/pp_testhelp.rs
+++ b/src/prettyprint/pp_testhelp.rs
@@ -20,14 +20,14 @@ fn split_message(msg: &str) -> Vec<String> {
     lines
 }
 
-pub fn pretty_data(item: &impl PrettyPrint) -> Vec<String> {
+pub(crate) fn pretty_data(item: &impl PrettyPrint) -> Vec<String> {
     let mut msg = Vec::new();
     item.pprint(&mut msg).unwrap();
     let whole_message = str::from_utf8(&msg).unwrap();
     split_message(whole_message)
 }
 
-pub fn concise_data(item: &impl PrettyPrint) -> Vec<String> {
+pub(crate) fn concise_data(item: &impl PrettyPrint) -> Vec<String> {
     let mut msg = Vec::new();
     item.pprint_concise(&mut msg).unwrap();
     let whole_message = str::from_utf8(&msg).unwrap();
@@ -58,7 +58,7 @@ fn check_message(msg: &str, selfstring: &str, childstrings: &[&str]) {
     assert!(expected_iter.next().is_none());
 }
 
-pub fn pretty_check<T>(item: &T, selfstring: &str, childstrings: &[&str])
+pub(crate) fn pretty_check<T>(item: &T, selfstring: &str, childstrings: &[&str])
 where
     T: PrettyPrint,
 {
@@ -68,7 +68,7 @@ where
     pp_testhelp::check_message(whole_message, selfstring, childstrings);
 }
 
-pub fn concise_check<T>(item: &T, selfstring: &str, childstrings: &[&str])
+pub(crate) fn concise_check<T>(item: &T, selfstring: &str, childstrings: &[&str])
 where
     T: PrettyPrint,
 {
@@ -78,13 +78,13 @@ where
     pp_testhelp::check_message(whole_message, selfstring, childstrings);
 }
 
-pub fn pretty_error_validate<T>(item: &T)
+pub(crate) fn pretty_error_validate<T>(item: &T)
 where
     T: PrettyPrint,
 {
     printer_validate(|w| item.pprint(w));
 }
-pub fn concise_error_validate<T>(item: &T)
+pub(crate) fn concise_error_validate<T>(item: &T)
 where
     T: PrettyPrint,
 {

--- a/src/realm/mod.rs
+++ b/src/realm/mod.rs
@@ -6,16 +6,16 @@ use std::fmt;
 use std::rc::Rc;
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-pub enum IntrinsicId {
+pub(crate) enum IntrinsicId {
     // If you add something here, _please_ update the ALL_INTRINSIC_IDS list in the unit tests!
     // And to the "which" function, below.
     Array,
     ArrayPrototype,
     ArrayPrototypeValues,
     ArrayIteratorPrototype,
-    AsyncFunctionPrototype,
-    AsyncGeneratorFunctionPrototype,
-    AsyncGeneratorFunctionPrototypePrototype,
+    //AsyncFunctionPrototype,
+    //AsyncGeneratorFunctionPrototype,
+    //AsyncGeneratorFunctionPrototypePrototype,
     BigInt,
     BigIntPrototype,
     Boolean,
@@ -74,100 +74,100 @@ pub enum IntrinsicId {
     URIErrorPrototype,
 }
 
-pub struct Intrinsics {
-    pub aggregate_error: Object,          // aka "AggregateError", The AggregateError constructor
-    pub array: Object,                    // aka "Array", The Array constructor
-    pub array_prototype: Object,          // %Array.prototype%
-    pub array_prototype_values: Object,   // %Array.prototype.values%
-    pub array_buffer: Object,             // ArrayBuffer	The ArrayBuffer constructor (25.1.3)
-    pub array_iterator_prototype: Object, // The prototype of Array iterator objects (23.1.5)
-    pub async_from_sync_iterator_prototype: Object, // The prototype of async-from-sync iterator objects (27.1.4)
-    pub async_function: Object,           // The constructor of async function objects (27.7.1)
-    pub async_function_prototype: Object,
-    pub async_generator_function: Object, // The constructor of async iterator objects (27.4.1)
-    pub async_generator_function_prototype: Object,
-    pub async_generator_function_prototype_prototype: Object,
-    pub async_iterator_prototype: Object, // An object that all standard built-in async iterator objects indirectly inherit from
-    pub atomics: Object,                  // Atomics	The Atomics object (25.4)
-    pub big_int: Object,                  // BigInt	The BigInt constructor (21.2.1)
-    pub big_int_prototype: Object,        //
-    pub big_int64_array: Object,          // BigInt64Array	The BigInt64Array constructor (23.2)
-    pub big_uint64_array: Object,         // BigUint64Array	The BigUint64Array constructor (23.2)
-    pub boolean: Object,                  // Boolean	The Boolean constructor (20.3.1)
-    pub boolean_prototype: Object,        // The Boolean object prototoype
-    pub data_view: Object,                // DataView	The DataView constructor (25.3.2)
-    pub date: Object,                     // Date	The Date constructor (21.4.2)
-    pub date_prototype: Object,           // Date.prototype
-    pub decode_uri: Object,               // decodeURI	The decodeURI function (19.2.6.2)
-    pub decode_uri_component: Object,     // decodeURIComponent	The decodeURIComponent function (19.2.6.3)
-    pub encode_uri: Object,               // encodeURI	The encodeURI function (19.2.6.4)
-    pub encode_uri_component: Object,     // encodeURIComponent	The encodeURIComponent function (19.2.6.5)
-    pub error: Object,                    // Error	The Error constructor (20.5.1)
-    pub error_prototype: Object,          //
-    pub eval: Object,                     // eval	The eval function (19.2.1)
-    pub eval_error: Object,               // EvalError	The EvalError constructor (20.5.5.1)
-    pub eval_error_prototype: Object,     //
-    pub finalization_registry: Object,    // FinalizationRegistry	The FinalizationRegistry constructor (26.2.1)
-    pub float32_array: Object,            // Float32Array	The Float32Array constructor (23.2)
-    pub float64_array: Object,            // Float64Array	The Float64Array constructor (23.2)
-    pub for_in_iterator_prototype: Object, // The prototype of For-In iterator objects (14.7.5.10)
-    pub function: Object,                 // Function	The Function constructor (20.2.1)
-    pub function_prototype: Object,       //
-    pub generator_function: Object,       // The constructor of generator objects (27.3.1)
-    pub generator_function_prototype: Object, //
-    pub generator_function_prototype_prototype: Object, //
-    pub generator_function_prototype_prototype_next: Object, //
-    pub int8_array: Object,               // Int8Array	The Int8Array constructor (23.2)
-    pub int16_array: Object,              // Int16Array	The Int16Array constructor (23.2)
-    pub int32_array: Object,              // Int32Array	The Int32Array constructor (23.2)
-    pub is_finite: Object,                // isFinite	The isFinite function (19.2.2)
-    pub is_nan: Object,                   // isNaN	The isNaN function (19.2.3)
-    pub iterator_prototype: Object, // An object that all standard built-in iterator objects indirectly inherit from
-    pub json: Object,               // JSON	The JSON object (25.5)
-    pub map: Object,                // Map	The Map constructor (24.1.1)
-    pub map_prototype: Object,      // Map's prototype object
-    pub map_iterator_prototype: Object, // The prototype of Map iterator objects (24.1.5)
-    pub math: Object,               // Math	The Math object (21.3)
-    pub number: Object,             // Number	The Number constructor (21.1.1)
-    pub number_prototype: Object,   //
-    pub object: Object,             // Object	The Object constructor (20.1.1)
-    pub object_prototype: Object,   // The Object prototype object
-    pub object_prototype_to_string: Object, // The initial value of %ObjectPrototype%.toString
-    pub parse_float: Object,        // parseFloat	The parseFloat function (19.2.4)
-    pub parse_int: Object,          // parseInt	The parseInt function (19.2.5)
-    pub promise: Object,            // Promise	The Promise constructor (27.2.3)
-    pub proxy: Object,              // Proxy	The Proxy constructor (28.2.1)
-    pub range_error: Object,        // RangeError	The RangeError constructor (20.5.5.2)
-    pub range_error_prototype: Object, //
-    pub reference_error: Object,    // ReferenceError	The ReferenceError constructor (20.5.5.3)
-    pub reference_error_prototype: Object, //
-    pub reflect: Object,            // Reflect	The Reflect object (28.1)
-    pub reg_exp: Object,            // RegExp	The RegExp constructor (22.2.3)
-    pub reg_exp_prototype: Object,
-    pub reg_exp_string_iterator_prototype: Object, // The prototype of RegExp String Iterator objects (22.2.7)
-    pub set: Object,                               // Set	The Set constructor (24.2.1)
-    pub set_iterator_prototype: Object,            // The prototype of Set iterator objects (24.2.5)
-    pub shared_array_buffer: Object,               // SharedArrayBuffer	The SharedArrayBuffer constructor (25.2.2)
-    pub string: Object,                            // String	The String constructor (22.1.1)
-    pub string_prototype: Object,                  // Initial value of %String.prototype%.
-    pub string_iterator_prototype: Object,         // The prototype of String iterator objects (22.1.5)
-    pub symbol: Object,                            // Symbol	The Symbol constructor (20.4.1)
-    pub symbol_prototype: Object,                  //
-    pub syntax_error: Object,                      // SyntaxError	The SyntaxError constructor (20.5.5.4)
-    pub syntax_error_prototype: Object,            //
-    pub throw_type_error: Object, // A function object that unconditionally throws a new instance of %TypeError%
-    pub typed_array: Object,      // The super class of all typed Array constructors (23.2.1)
-    pub type_error: Object,       // TypeError	The TypeError constructor (20.5.5.5)
-    pub type_error_prototype: Object, //
-    pub uint8_array: Object,      // Uint8Array	The Uint8Array constructor (23.2)
-    pub uint8_clampedarray: Object, // Uint8ClampedArray	The Uint8ClampedArray constructor (23.2)
-    pub uint16_array: Object,     // Uint16Array	The Uint16Array constructor (23.2)
-    pub uint32_array: Object,     // Uint32Array	The Uint32Array constructor (23.2)
-    pub uri_error: Object,        // URIError	The URIError constructor (20.5.5.6)
-    pub uri_error_prototype: Object, //
-    pub weak_map: Object,         // WeakMap	The WeakMap constructor (24.3.1)
-    pub weak_ref: Object,         // WeakRef	The WeakRef constructor (26.1.1)
-    pub weak_set: Object,         // WeakSet	The WeakSet constructor (24.4.1)
+pub(crate) struct Intrinsics {
+    //pub(crate) aggregate_error: Object, // aka "AggregateError", The AggregateError constructor
+    pub(crate) array: Object,                  // aka "Array", The Array constructor
+    pub(crate) array_prototype: Object,        // %Array.prototype%
+    pub(crate) array_prototype_values: Object, // %Array.prototype.values%
+    //pub(crate) array_buffer: Object,    // ArrayBuffer	The ArrayBuffer constructor (25.1.3)
+    pub(crate) array_iterator_prototype: Object, // The prototype of Array iterator objects (23.1.5)
+    //pub(crate) async_from_sync_iterator_prototype: Object, // The prototype of async-from-sync iterator objects (27.1.4)
+    //pub(crate) async_function: Object,  // The constructor of async function objects (27.7.1)
+    //pub(crate) async_function_prototype: Object,
+    //pub(crate) async_generator_function: Object, // The constructor of async iterator objects (27.4.1)
+    //pub(crate) async_generator_function_prototype: Object,
+    //pub(crate) async_generator_function_prototype_prototype: Object,
+    //pub(crate) async_iterator_prototype: Object, // An object that all standard built-in async iterator objects indirectly inherit from
+    //pub(crate) atomics: Object,                  // Atomics	The Atomics object (25.4)
+    pub(crate) big_int: Object,           // BigInt	The BigInt constructor (21.2.1)
+    pub(crate) big_int_prototype: Object, //
+    //pub(crate) big_int64_array: Object,          // BigInt64Array	The BigInt64Array constructor (23.2)
+    //pub(crate) big_uint64_array: Object,         // BigUint64Array	The BigUint64Array constructor (23.2)
+    pub(crate) boolean: Object,           // Boolean	The Boolean constructor (20.3.1)
+    pub(crate) boolean_prototype: Object, // The Boolean object prototoype
+    //pub(crate) data_view: Object,                // DataView	The DataView constructor (25.3.2)
+    pub(crate) date: Object,                 // Date	The Date constructor (21.4.2)
+    pub(crate) date_prototype: Object,       // Date.prototype
+    pub(crate) decode_uri: Object,           // decodeURI	The decodeURI function (19.2.6.2)
+    pub(crate) decode_uri_component: Object, // decodeURIComponent	The decodeURIComponent function (19.2.6.3)
+    pub(crate) encode_uri: Object,           // encodeURI	The encodeURI function (19.2.6.4)
+    pub(crate) encode_uri_component: Object, // encodeURIComponent	The encodeURIComponent function (19.2.6.5)
+    pub(crate) error: Object,                // Error	The Error constructor (20.5.1)
+    pub(crate) error_prototype: Object,      //
+    pub(crate) eval: Object,                 // eval	The eval function (19.2.1)
+    pub(crate) eval_error: Object,           // EvalError	The EvalError constructor (20.5.5.1)
+    pub(crate) eval_error_prototype: Object, //
+    //pub(crate) finalization_registry: Object,    // FinalizationRegistry	The FinalizationRegistry constructor (26.2.1)
+    //pub(crate) float32_array: Object,            // Float32Array	The Float32Array constructor (23.2)
+    //pub(crate) float64_array: Object,            // Float64Array	The Float64Array constructor (23.2)
+    pub(crate) for_in_iterator_prototype: Object, // The prototype of For-In iterator objects (14.7.5.10)
+    pub(crate) function: Object,                  // Function	The Function constructor (20.2.1)
+    pub(crate) function_prototype: Object,        //
+    pub(crate) generator_function: Object,        // The constructor of generator objects (27.3.1)
+    pub(crate) generator_function_prototype: Object, //
+    pub(crate) generator_function_prototype_prototype: Object, //
+    pub(crate) generator_function_prototype_prototype_next: Object, //
+    //pub(crate) int8_array: Object,               // Int8Array	The Int8Array constructor (23.2)
+    //pub(crate) int16_array: Object,              // Int16Array	The Int16Array constructor (23.2)
+    //pub(crate) int32_array: Object,              // Int32Array	The Int32Array constructor (23.2)
+    pub(crate) is_finite: Object,          // isFinite	The isFinite function (19.2.2)
+    pub(crate) is_nan: Object,             // isNaN	The isNaN function (19.2.3)
+    pub(crate) iterator_prototype: Object, // An object that all standard built-in iterator objects indirectly inherit from
+    //pub(crate) json: Object,               // JSON	The JSON object (25.5)
+    pub(crate) map: Object,                        // Map	The Map constructor (24.1.1)
+    pub(crate) map_prototype: Object,              // Map's prototype object
+    pub(crate) map_iterator_prototype: Object,     // The prototype of Map iterator objects (24.1.5)
+    pub(crate) math: Object,                       // Math	The Math object (21.3)
+    pub(crate) number: Object,                     // Number	The Number constructor (21.1.1)
+    pub(crate) number_prototype: Object,           //
+    pub(crate) object: Object,                     // Object	The Object constructor (20.1.1)
+    pub(crate) object_prototype: Object,           // The Object prototype object
+    pub(crate) object_prototype_to_string: Object, // The initial value of %ObjectPrototype%.toString
+    pub(crate) parse_float: Object,                // parseFloat	The parseFloat function (19.2.4)
+    pub(crate) parse_int: Object,                  // parseInt	The parseInt function (19.2.5)
+    //pub(crate) promise: Object,            // Promise	The Promise constructor (27.2.3)
+    pub(crate) proxy: Object,                     // Proxy	The Proxy constructor (28.2.1)
+    pub(crate) range_error: Object,               // RangeError	The RangeError constructor (20.5.5.2)
+    pub(crate) range_error_prototype: Object,     //
+    pub(crate) reference_error: Object,           // ReferenceError	The ReferenceError constructor (20.5.5.3)
+    pub(crate) reference_error_prototype: Object, //
+    pub(crate) reflect: Object,                   // Reflect	The Reflect object (28.1)
+    pub(crate) reg_exp: Object,                   // RegExp	The RegExp constructor (22.2.3)
+    pub(crate) reg_exp_prototype: Object,
+    //pub(crate) reg_exp_string_iterator_prototype: Object, // The prototype of RegExp String Iterator objects (22.2.7)
+    //pub(crate) set: Object,                               // Set	The Set constructor (24.2.1)
+    //pub(crate) set_iterator_prototype: Object,            // The prototype of Set iterator objects (24.2.5)
+    //pub(crate) shared_array_buffer: Object, // SharedArrayBuffer	The SharedArrayBuffer constructor (25.2.2)
+    pub(crate) string: Object,                    // String	The String constructor (22.1.1)
+    pub(crate) string_prototype: Object,          // Initial value of %String.prototype%.
+    pub(crate) string_iterator_prototype: Object, // The prototype of String iterator objects (22.1.5)
+    pub(crate) symbol: Object,                    // Symbol	The Symbol constructor (20.4.1)
+    pub(crate) symbol_prototype: Object,          //
+    pub(crate) syntax_error: Object,              // SyntaxError	The SyntaxError constructor (20.5.5.4)
+    pub(crate) syntax_error_prototype: Object,    //
+    pub(crate) throw_type_error: Object, // A function object that unconditionally throws a new instance of %TypeError%
+    //pub(crate) typed_array: Object,      // The super class of all typed Array constructors (23.2.1)
+    pub(crate) type_error: Object, // TypeError	The TypeError constructor (20.5.5.5)
+    pub(crate) type_error_prototype: Object, //
+    //pub(crate) uint8_array: Object,      // Uint8Array	The Uint8Array constructor (23.2)
+    //pub(crate) uint8_clampedarray: Object, // Uint8ClampedArray	The Uint8ClampedArray constructor (23.2)
+    //pub(crate) uint16_array: Object,     // Uint16Array	The Uint16Array constructor (23.2)
+    //pub(crate) uint32_array: Object,     // Uint32Array	The Uint32Array constructor (23.2)
+    pub(crate) uri_error: Object, // URIError	The URIError constructor (20.5.5.6)
+    pub(crate) uri_error_prototype: Object, //
+                                  //pub(crate) weak_map: Object,         // WeakMap	The WeakMap constructor (24.3.1)
+                                  //pub(crate) weak_ref: Object,         // WeakRef	The WeakRef constructor (26.1.1)
+                                  //pub(crate) weak_set: Object,         // WeakSet	The WeakSet constructor (24.4.1)
 }
 
 impl Intrinsics {
@@ -180,27 +180,27 @@ impl Intrinsics {
         // less overhead.)
         let dead = DeadObject::object();
         Intrinsics {
-            aggregate_error: dead.clone(),
+            //aggregate_error: dead.clone(),
             array: dead.clone(),
             array_prototype: dead.clone(),
             array_prototype_values: dead.clone(),
-            array_buffer: dead.clone(),
+            //array_buffer: dead.clone(),
             array_iterator_prototype: dead.clone(),
-            async_from_sync_iterator_prototype: dead.clone(),
-            async_function: dead.clone(),
-            async_function_prototype: dead.clone(),
-            async_generator_function: dead.clone(),
-            async_generator_function_prototype: dead.clone(),
-            async_generator_function_prototype_prototype: dead.clone(),
-            async_iterator_prototype: dead.clone(),
-            atomics: dead.clone(),
+            //async_from_sync_iterator_prototype: dead.clone(),
+            //async_function: dead.clone(),
+            //async_function_prototype: dead.clone(),
+            //async_generator_function: dead.clone(),
+            //async_generator_function_prototype: dead.clone(),
+            //async_generator_function_prototype_prototype: dead.clone(),
+            //async_iterator_prototype: dead.clone(),
+            //atomics: dead.clone(),
             big_int: dead.clone(),
             big_int_prototype: dead.clone(),
-            big_int64_array: dead.clone(),
-            big_uint64_array: dead.clone(),
+            //big_int64_array: dead.clone(),
+            //big_uint64_array: dead.clone(),
             boolean: dead.clone(),
             boolean_prototype: dead.clone(),
-            data_view: dead.clone(),
+            //data_view: dead.clone(),
             date: dead.clone(),
             date_prototype: dead.clone(),
             decode_uri: dead.clone(),
@@ -212,9 +212,9 @@ impl Intrinsics {
             eval: dead.clone(),
             eval_error: dead.clone(),
             eval_error_prototype: dead.clone(),
-            finalization_registry: dead.clone(),
-            float32_array: dead.clone(),
-            float64_array: dead.clone(),
+            //finalization_registry: dead.clone(),
+            //float32_array: dead.clone(),
+            //float64_array: dead.clone(),
             for_in_iterator_prototype: dead.clone(),
             function: dead.clone(),
             function_prototype: dead.clone(),
@@ -222,13 +222,13 @@ impl Intrinsics {
             generator_function_prototype: dead.clone(),
             generator_function_prototype_prototype: dead.clone(),
             generator_function_prototype_prototype_next: dead.clone(),
-            int8_array: dead.clone(),
-            int16_array: dead.clone(),
-            int32_array: dead.clone(),
+            //int8_array: dead.clone(),
+            //int16_array: dead.clone(),
+            //int32_array: dead.clone(),
             is_finite: dead.clone(),
             is_nan: dead.clone(),
             iterator_prototype: dead.clone(),
-            json: dead.clone(),
+            //json: dead.clone(),
             map: dead.clone(),
             map_prototype: dead.clone(),
             map_iterator_prototype: dead.clone(),
@@ -240,7 +240,7 @@ impl Intrinsics {
             object_prototype_to_string: dead.clone(),
             parse_float: dead.clone(),
             parse_int: dead.clone(),
-            promise: dead.clone(),
+            //promise: dead.clone(),
             proxy: dead.clone(),
             range_error: dead.clone(),
             range_error_prototype: dead.clone(),
@@ -249,10 +249,10 @@ impl Intrinsics {
             reflect: dead.clone(),
             reg_exp: dead.clone(),
             reg_exp_prototype: dead.clone(),
-            reg_exp_string_iterator_prototype: dead.clone(),
-            set: dead.clone(),
-            set_iterator_prototype: dead.clone(),
-            shared_array_buffer: dead.clone(),
+            //reg_exp_string_iterator_prototype: dead.clone(),
+            //set: dead.clone(),
+            //set_iterator_prototype: dead.clone(),
+            //shared_array_buffer: dead.clone(),
             string: dead.clone(),
             string_prototype: dead.clone(),
             string_iterator_prototype: dead.clone(),
@@ -261,29 +261,29 @@ impl Intrinsics {
             syntax_error: dead.clone(),
             syntax_error_prototype: dead.clone(),
             throw_type_error: dead.clone(),
-            typed_array: dead.clone(),
+            //typed_array: dead.clone(),
             type_error: dead.clone(),
             type_error_prototype: dead.clone(),
-            uint8_array: dead.clone(),
-            uint8_clampedarray: dead.clone(),
-            uint16_array: dead.clone(),
-            uint32_array: dead.clone(),
+            //uint8_array: dead.clone(),
+            //uint8_clampedarray: dead.clone(),
+            //uint16_array: dead.clone(),
+            //uint32_array: dead.clone(),
             uri_error: dead.clone(),
             uri_error_prototype: dead.clone(),
-            weak_map: dead.clone(),
-            weak_ref: dead.clone(),
-            weak_set: dead,
+            //weak_map: dead.clone(),
+            //weak_ref: dead.clone(),
+            //weak_set: dead,
         }
     }
-    pub fn get(&self, id: IntrinsicId) -> Object {
+    pub(crate) fn get(&self, id: IntrinsicId) -> Object {
         match id {
             IntrinsicId::Array => &self.array,
             IntrinsicId::ArrayPrototype => &self.array_prototype,
             IntrinsicId::ArrayPrototypeValues => &self.array_prototype_values,
             IntrinsicId::ArrayIteratorPrototype => &self.array_iterator_prototype,
-            IntrinsicId::AsyncFunctionPrototype => &self.async_function_prototype,
-            IntrinsicId::AsyncGeneratorFunctionPrototype => &self.async_generator_function_prototype,
-            IntrinsicId::AsyncGeneratorFunctionPrototypePrototype => &self.async_generator_function_prototype_prototype,
+            //IntrinsicId::AsyncFunctionPrototype => &self.async_function_prototype,
+            //IntrinsicId::AsyncGeneratorFunctionPrototype => &self.async_generator_function_prototype,
+            //IntrinsicId::AsyncGeneratorFunctionPrototypePrototype => &self.async_generator_function_prototype_prototype,
             IntrinsicId::BigInt => &self.big_int,
             IntrinsicId::BigIntPrototype => &self.big_int_prototype,
             IntrinsicId::Boolean => &self.boolean,
@@ -343,7 +343,7 @@ impl Intrinsics {
         }
         .clone()
     }
-    pub fn which(&self, intrinsic: &Object) -> Option<IntrinsicId> {
+    pub(crate) fn which(&self, intrinsic: &Object) -> Option<IntrinsicId> {
         match intrinsic {
             o if o == &self.array => Some(IntrinsicId::Array),
             o if o == &self.array_prototype => Some(IntrinsicId::ArrayPrototype),
@@ -418,9 +418,9 @@ impl fmt::Debug for Intrinsics {
     }
 }
 
-pub type RealmId = u64;
+pub(crate) type RealmId = u64;
 
-pub struct Realm {
+pub(crate) struct Realm {
     // NOTE NOTE NOTE NOTE: Realm is a circular structure. The function objects in the Intrinsics field each have their
     // own Realm pointer, which points back to this structure. They _should_ be weak pointers, because of that, except
     // that anything can duplicate an intrinsic, and doing so should mean that the pointer is no longer weak.
@@ -430,9 +430,9 @@ pub struct Realm {
     //
     // Until I figure out a solution for that, once a realm is created, it can never be dropped. (Currently, aside from
     // testing, only one realm is ever made, so it's not a huge issue.)
-    pub intrinsics: Intrinsics,
-    pub global_object: Option<Object>,
-    pub global_env: Option<Rc<GlobalEnvironmentRecord>>,
+    pub(crate) intrinsics: Intrinsics,
+    pub(crate) global_object: Option<Object>,
+    pub(crate) global_env: Option<Rc<GlobalEnvironmentRecord>>,
     // TemplateMap: later, when needed
     id: RealmId,
 }
@@ -448,7 +448,8 @@ impl fmt::Debug for Realm {
 }
 
 impl Realm {
-    pub fn id(&self) -> RealmId {
+    #[cfg(test)]
+    pub(crate) fn id(&self) -> RealmId {
         self.id
     }
 }
@@ -463,7 +464,7 @@ impl Realm {
 //  4. Set realmRec.[[GlobalEnv]] to undefined.
 //  5. Set realmRec.[[TemplateMap]] to a new empty List.
 //  6. Return realmRec.
-pub fn create_realm(id: RealmId) -> Rc<RefCell<Realm>> {
+pub(crate) fn create_realm(id: RealmId) -> Rc<RefCell<Realm>> {
     let r = Rc::new(RefCell::new(Realm { intrinsics: Intrinsics::new(), global_object: None, global_env: None, id }));
     create_intrinsics(&r);
     r
@@ -487,7 +488,7 @@ pub fn create_realm(id: RealmId) -> Rc<RefCell<Realm>> {
 //     not yet been created.
 //  4. Perform AddRestrictedFunctionProperties(intrinsics.[[%Function.prototype%]], realmRec).
 //  5. Return intrinsics.
-pub fn create_intrinsics(realm_rec: &Rc<RefCell<Realm>>) {
+pub(crate) fn create_intrinsics(realm_rec: &Rc<RefCell<Realm>>) {
     // ToDo: All of step 3.
 
     // %Object.prototype%
@@ -578,7 +579,7 @@ pub fn create_intrinsics(realm_rec: &Rc<RefCell<Realm>>) {
 //    [[Enumerable]]: false, [[Configurable]]: true }).
 // 4. Return ! DefinePropertyOrThrow(F, "arguments", PropertyDescriptor { [[Get]]: thrower, [[Set]]: thrower,
 //    [[Enumerable]]: false, [[Configurable]]: true }).
-pub fn add_restricted_function_properties(f: &Object, realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn add_restricted_function_properties(f: &Object, realm: &Rc<RefCell<Realm>>) {
     let thrower = ECMAScriptValue::Object(realm.borrow().intrinsics.get(IntrinsicId::ThrowTypeError));
     define_property_or_throw(
         f,
@@ -612,7 +613,7 @@ pub fn add_restricted_function_properties(f: &Object, realm: &Rc<RefCell<Realm>>
 //
 // The "name" property of a %ThrowTypeError% function has the attributes { [[Writable]]: false, [[Enumerable]]: false,
 // [[Configurable]]: false }.
-pub fn throw_type_error(
+pub(crate) fn throw_type_error(
     _this_value: &ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -649,7 +650,8 @@ fn create_throw_type_error_builtin(realm: Rc<RefCell<Realm>>) -> Object {
     fcn
 }
 
-pub fn do_nothing(
+#[expect(clippy::unnecessary_wraps)]
+pub(crate) fn do_nothing(
     _this_value: &ECMAScriptValue,
     _new_target: Option<&Object>,
     _arguments: &[ECMAScriptValue],
@@ -841,13 +843,13 @@ fn parse_int(
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum EvalCallStatus {
+pub(crate) enum EvalCallStatus {
     DirectWithStrictCaller,
     DirectWithNonStrictCaller,
     NotDirect,
 }
 
-pub fn perform_eval(x: ECMAScriptValue, call_state: EvalCallStatus) -> Completion<ECMAScriptValue> {
+pub(crate) fn perform_eval(x: ECMAScriptValue, call_state: EvalCallStatus) -> Completion<ECMAScriptValue> {
     match x {
         ECMAScriptValue::String(x) => {
             let eval_realm = current_realm_record().unwrap();

--- a/src/realm/tests.rs
+++ b/src/realm/tests.rs
@@ -8,9 +8,9 @@ const ALL_INTRINSIC_IDS: &[IntrinsicId] = &[
     IntrinsicId::ArrayPrototype,
     IntrinsicId::ArrayPrototypeValues,
     IntrinsicId::ArrayIteratorPrototype,
-    IntrinsicId::AsyncFunctionPrototype,
-    IntrinsicId::AsyncGeneratorFunctionPrototype,
-    IntrinsicId::AsyncGeneratorFunctionPrototypePrototype,
+    //IntrinsicId::AsyncFunctionPrototype,
+    //IntrinsicId::AsyncGeneratorFunctionPrototype,
+    //IntrinsicId::AsyncGeneratorFunctionPrototypePrototype,
     IntrinsicId::BigInt,
     IntrinsicId::BigIntPrototype,
     IntrinsicId::Boolean,
@@ -119,15 +119,6 @@ mod intrinsics {
         assert_eq!(intrinsics.get(IntrinsicId::ArrayPrototype), intrinsics.array_prototype);
         assert_eq!(intrinsics.get(IntrinsicId::ArrayPrototypeValues), intrinsics.array_prototype_values);
         assert_eq!(intrinsics.get(IntrinsicId::ArrayIteratorPrototype), intrinsics.array_iterator_prototype);
-        assert_eq!(intrinsics.get(IntrinsicId::AsyncFunctionPrototype), intrinsics.async_function_prototype);
-        assert_eq!(
-            intrinsics.get(IntrinsicId::AsyncGeneratorFunctionPrototype),
-            intrinsics.async_generator_function_prototype
-        );
-        assert_eq!(
-            intrinsics.get(IntrinsicId::AsyncGeneratorFunctionPrototypePrototype),
-            intrinsics.async_generator_function_prototype_prototype
-        );
         assert_eq!(intrinsics.get(IntrinsicId::Boolean), intrinsics.boolean);
         assert_eq!(intrinsics.get(IntrinsicId::BooleanPrototype), intrinsics.boolean_prototype);
         assert_eq!(intrinsics.get(IntrinsicId::DecodeURI), intrinsics.decode_uri);

--- a/src/reflect.rs
+++ b/src/reflect.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub fn provision_reflect_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_reflect_intrinsic(realm: &Rc<RefCell<Realm>>) {
     // The Reflect object:
     //
     //  * is %Reflect%.

--- a/src/regexp.rs
+++ b/src/regexp.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub fn provision_regexp_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_regexp_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -90,7 +90,7 @@ pub fn provision_regexp_intrinsic(realm: &Rc<RefCell<Realm>>) {
 
 #[derive(Debug)]
 #[allow(clippy::struct_excessive_bools)]
-pub struct RegExpData {
+pub(crate) struct RegExpData {
     original_source: JSString,
     original_flags: JSString,
     ignore_case: bool,
@@ -102,7 +102,7 @@ pub struct RegExpData {
 }
 
 #[derive(Debug)]
-pub struct RegExpObject {
+pub(crate) struct RegExpObject {
     common: RefCell<CommonObjectData>,
     regexp_data: RefCell<RegExpData>,
 }
@@ -123,6 +123,7 @@ impl ObjectInterface for RegExpObject {
     fn to_regexp_object(&self) -> Option<&RegExpObject> {
         Some(self)
     }
+    #[cfg(test)]
     fn is_regexp_object(&self) -> bool {
         true
     }
@@ -236,10 +237,14 @@ impl ObjectInterface for RegExpObject {
     fn own_property_keys(&self) -> Completion<Vec<PropertyKey>> {
         Ok(ordinary_own_property_keys(self))
     }
+
+    fn kind(&self) -> ObjectTag {
+        ObjectTag::RegExp
+    }
 }
 
 impl RegExpObject {
-    pub fn new(prototype: Option<Object>) -> Self {
+    pub(crate) fn new(prototype: Option<Object>) -> Self {
         Self {
             common: RefCell::new(CommonObjectData::new(prototype, true, REGEXP_OBJECT_SLOTS)),
             regexp_data: RefCell::new(RegExpData {
@@ -254,12 +259,12 @@ impl RegExpObject {
             }),
         }
     }
-    pub fn object(prototype: Option<Object>) -> Object {
+    pub(crate) fn object(prototype: Option<Object>) -> Object {
         Object { o: Rc::new(Self::new(prototype)) }
     }
 }
 
-pub fn reg_exp_create(p: ECMAScriptValue, f: Option<JSString>) -> Completion<Object> {
+pub(crate) fn reg_exp_create(p: ECMAScriptValue, f: Option<JSString>) -> Completion<Object> {
     // RegExpCreate ( P, F )
     // The abstract operation RegExpCreate takes arguments P (an ECMAScript language value) and F (a String or
     // undefined) and returns either a normal completion containing an Object or a throw completion. It performs the

--- a/src/scanner/ranges.rs
+++ b/src/scanner/ranges.rs
@@ -1,10 +1,10 @@
 #[derive(Debug, Copy, Clone)]
-pub struct CharRange {
-    pub first: char,
-    pub last: char,
+pub(crate) struct CharRange {
+    pub(crate) first: char,
+    pub(crate) last: char,
 }
 
-pub const ID_START: &[CharRange] = &[
+pub(crate) const ID_START: &[CharRange] = &[
     CharRange { first: 'A', last: 'Z' },                 // A .. Z
     CharRange { first: 'a', last: 'z' },                 // a .. z
     CharRange { first: '\u{aa}', last: '\u{aa}' },       // ª .. ª
@@ -616,7 +616,7 @@ pub const ID_START: &[CharRange] = &[
     CharRange { first: '\u{2f800}', last: '\u{2fa1d}' }, // 丽 .. 𪘀
 ];
 
-pub const ID_CONTINUE: &[CharRange] = &[
+pub(crate) const ID_CONTINUE: &[CharRange] = &[
     CharRange { first: '0', last: '9' },                 // 0 .. 9
     CharRange { first: 'A', last: 'Z' },                 // A .. Z
     CharRange { first: '_', last: '_' },                 // _ .. _

--- a/src/scanner/tests.rs
+++ b/src/scanner/tests.rs
@@ -527,7 +527,7 @@ fn hex_integer_literal_05() {
 }
 #[test]
 fn scan_numeric() {
-    let result = scan_token(&Scanner::new(), ".25", ScanGoal::InputElementRegExp);
+    let result = scan_token(&Scanner::new(), ".25", InputElementGoal::RegExp);
     assert_eq!(
         result,
         (
@@ -539,7 +539,7 @@ fn scan_numeric() {
 }
 #[test]
 fn scan_token_id_01() {
-    let result = scan_token(&Scanner::new(), "\\u004Abc\\u004a\\u{1235}", ScanGoal::InputElementRegExp);
+    let result = scan_token(&Scanner::new(), "\\u004Abc\\u004a\\u{1235}", InputElementGoal::RegExp);
     assert_eq!(
         result,
         (
@@ -550,7 +550,7 @@ fn scan_token_id_01() {
     );
 }
 fn keyword_test_helper(inp: &str, expected: Option<Keyword>) {
-    let result = scan_token(&Scanner::new(), inp, ScanGoal::InputElementRegExp);
+    let result = scan_token(&Scanner::new(), inp, InputElementGoal::RegExp);
     assert_eq!(
         result,
         (
@@ -645,7 +645,7 @@ fn scan_token_keywords() {
 }
 #[test]
 fn optional_chaining_test_01() {
-    let result = scan_token(&Scanner::new(), "?.", ScanGoal::InputElementRegExp);
+    let result = scan_token(&Scanner::new(), "?.", InputElementGoal::RegExp);
     assert_eq!(
         result,
         (
@@ -657,7 +657,7 @@ fn optional_chaining_test_01() {
 }
 #[test]
 fn optional_chaining_test_02() {
-    let result = scan_token(&Scanner::new(), "?.P", ScanGoal::InputElementRegExp);
+    let result = scan_token(&Scanner::new(), "?.P", InputElementGoal::RegExp);
     assert_eq!(
         result,
         (
@@ -669,7 +669,7 @@ fn optional_chaining_test_02() {
 }
 #[test]
 fn optional_chaining_test_03() {
-    let result = scan_token(&Scanner::new(), "?.999", ScanGoal::InputElementRegExp);
+    let result = scan_token(&Scanner::new(), "?.999", InputElementGoal::RegExp);
     assert_eq!(
         result,
         (
@@ -681,7 +681,7 @@ fn optional_chaining_test_03() {
 }
 #[test]
 fn optional_chaining_test_04() {
-    let result = scan_token(&Scanner::new(), "?mulberry", ScanGoal::InputElementRegExp);
+    let result = scan_token(&Scanner::new(), "?mulberry", InputElementGoal::RegExp);
     assert_eq!(
         result,
         (
@@ -695,7 +695,7 @@ mod punctuator {
     use super::*;
 
     fn punct_check(inp: &str, tok: Token) {
-        let result = scan_token(&Scanner::new(), inp, ScanGoal::InputElementRegExp);
+        let result = scan_token(&Scanner::new(), inp, InputElementGoal::RegExp);
         assert_eq!(
             result,
             (
@@ -763,7 +763,7 @@ mod punctuator {
     }
 
     fn punct_chk2(inp: &str, tok: Token, consumed: u32) {
-        let result = scan_token(&Scanner::new(), inp, ScanGoal::InputElementRegExp);
+        let result = scan_token(&Scanner::new(), inp, InputElementGoal::RegExp);
         assert_eq!(
             result,
             (
@@ -784,7 +784,7 @@ mod punctuator {
     }
     #[test]
     fn nomatch() {
-        let result = scan_token(&Scanner::new(), "@", ScanGoal::InputElementRegExp);
+        let result = scan_token(&Scanner::new(), "@", InputElementGoal::RegExp);
         let (token, location, scanner) = result;
         assert!(matches!(token, Token::Error(_)));
         assert_eq!(
@@ -1144,47 +1144,47 @@ fn template_test() {
 #[test]
 fn div_punctuator_test() {
     assert_eq!(
-        div_punctuator(&Scanner::new(), "/", ScanGoal::InputElementDiv),
+        div_punctuator(&Scanner::new(), "/", InputElementGoal::Div),
         Some((Token::Punctuator(Punctuator::Slash), Scanner { line: 1, column: 2, start_idx: 1 }))
     );
-    assert_eq!(div_punctuator(&Scanner::new(), "/", ScanGoal::InputElementRegExp), None);
-    assert_eq!(div_punctuator(&Scanner::new(), "/", ScanGoal::InputElementRegExpOrTemplateTail), None);
+    assert_eq!(div_punctuator(&Scanner::new(), "/", InputElementGoal::RegExp), None);
+    assert_eq!(div_punctuator(&Scanner::new(), "/", InputElementGoal::RegExpOrTemplateTail), None);
     assert_eq!(
-        div_punctuator(&Scanner::new(), "/", ScanGoal::InputElementTemplateTail),
+        div_punctuator(&Scanner::new(), "/", InputElementGoal::TemplateTail),
         Some((Token::Punctuator(Punctuator::Slash), Scanner { line: 1, column: 2, start_idx: 1 }))
     );
     assert_eq!(
-        div_punctuator(&Scanner::new(), "/=", ScanGoal::InputElementDiv),
+        div_punctuator(&Scanner::new(), "/=", InputElementGoal::Div),
         Some((Token::Punctuator(Punctuator::SlashEq), Scanner { line: 1, column: 3, start_idx: 2 }))
     );
-    assert_eq!(div_punctuator(&Scanner::new(), "/=", ScanGoal::InputElementRegExp), None);
-    assert_eq!(div_punctuator(&Scanner::new(), "/=", ScanGoal::InputElementRegExpOrTemplateTail), None);
+    assert_eq!(div_punctuator(&Scanner::new(), "/=", InputElementGoal::RegExp), None);
+    assert_eq!(div_punctuator(&Scanner::new(), "/=", InputElementGoal::RegExpOrTemplateTail), None);
     assert_eq!(
-        div_punctuator(&Scanner::new(), "/=", ScanGoal::InputElementTemplateTail),
+        div_punctuator(&Scanner::new(), "/=", InputElementGoal::TemplateTail),
         Some((Token::Punctuator(Punctuator::SlashEq), Scanner { line: 1, column: 3, start_idx: 2 }))
     );
-    assert_eq!(div_punctuator(&Scanner::new(), "Q", ScanGoal::InputElementDiv), None);
-    assert_eq!(div_punctuator(&Scanner::new(), "Q", ScanGoal::InputElementRegExp), None);
-    assert_eq!(div_punctuator(&Scanner::new(), "Q", ScanGoal::InputElementRegExpOrTemplateTail), None);
-    assert_eq!(div_punctuator(&Scanner::new(), "Q", ScanGoal::InputElementTemplateTail), None);
+    assert_eq!(div_punctuator(&Scanner::new(), "Q", InputElementGoal::Div), None);
+    assert_eq!(div_punctuator(&Scanner::new(), "Q", InputElementGoal::RegExp), None);
+    assert_eq!(div_punctuator(&Scanner::new(), "Q", InputElementGoal::RegExpOrTemplateTail), None);
+    assert_eq!(div_punctuator(&Scanner::new(), "Q", InputElementGoal::TemplateTail), None);
 }
 
 #[test]
 fn right_brace_punctuator_test() {
     assert_eq!(
-        right_brace_punctuator(&Scanner::new(), "}", ScanGoal::InputElementDiv),
+        right_brace_punctuator(&Scanner::new(), "}", InputElementGoal::Div),
         Some((Token::Punctuator(Punctuator::RightBrace), Scanner { line: 1, column: 2, start_idx: 1 }))
     );
     assert_eq!(
-        right_brace_punctuator(&Scanner::new(), "}", ScanGoal::InputElementRegExp),
+        right_brace_punctuator(&Scanner::new(), "}", InputElementGoal::RegExp),
         Some((Token::Punctuator(Punctuator::RightBrace), Scanner { line: 1, column: 2, start_idx: 1 }))
     );
-    assert_eq!(right_brace_punctuator(&Scanner::new(), "}", ScanGoal::InputElementTemplateTail), None);
-    assert_eq!(right_brace_punctuator(&Scanner::new(), "}", ScanGoal::InputElementRegExpOrTemplateTail), None);
-    assert_eq!(right_brace_punctuator(&Scanner::new(), "Q", ScanGoal::InputElementDiv), None);
-    assert_eq!(right_brace_punctuator(&Scanner::new(), "Q", ScanGoal::InputElementRegExp), None);
-    assert_eq!(right_brace_punctuator(&Scanner::new(), "Q", ScanGoal::InputElementRegExpOrTemplateTail), None);
-    assert_eq!(right_brace_punctuator(&Scanner::new(), "Q", ScanGoal::InputElementTemplateTail), None);
+    assert_eq!(right_brace_punctuator(&Scanner::new(), "}", InputElementGoal::TemplateTail), None);
+    assert_eq!(right_brace_punctuator(&Scanner::new(), "}", InputElementGoal::RegExpOrTemplateTail), None);
+    assert_eq!(right_brace_punctuator(&Scanner::new(), "Q", InputElementGoal::Div), None);
+    assert_eq!(right_brace_punctuator(&Scanner::new(), "Q", InputElementGoal::RegExp), None);
+    assert_eq!(right_brace_punctuator(&Scanner::new(), "Q", InputElementGoal::RegExpOrTemplateTail), None);
+    assert_eq!(right_brace_punctuator(&Scanner::new(), "Q", InputElementGoal::TemplateTail), None);
 }
 
 #[test]
@@ -1230,16 +1230,16 @@ fn common_token_test_nstemp() {
 
 #[test]
 fn regular_expression_literal_test_01() {
-    assert_eq!(regular_expression_literal(&Scanner::new(), "", ScanGoal::InputElementRegExp), None);
-    assert_eq!(regular_expression_literal(&Scanner::new(), "", ScanGoal::InputElementRegExpOrTemplateTail), None);
-    assert_eq!(regular_expression_literal(&Scanner::new(), "", ScanGoal::InputElementDiv), None);
-    assert_eq!(regular_expression_literal(&Scanner::new(), "", ScanGoal::InputElementTemplateTail), None);
-    assert_eq!(regular_expression_literal(&Scanner::new(), "/abcd/", ScanGoal::InputElementDiv), None);
-    assert_eq!(regular_expression_literal(&Scanner::new(), "/abcd/", ScanGoal::InputElementTemplateTail), None);
+    assert_eq!(regular_expression_literal(&Scanner::new(), "", InputElementGoal::RegExp), None);
+    assert_eq!(regular_expression_literal(&Scanner::new(), "", InputElementGoal::RegExpOrTemplateTail), None);
+    assert_eq!(regular_expression_literal(&Scanner::new(), "", InputElementGoal::Div), None);
+    assert_eq!(regular_expression_literal(&Scanner::new(), "", InputElementGoal::TemplateTail), None);
+    assert_eq!(regular_expression_literal(&Scanner::new(), "/abcd/", InputElementGoal::Div), None);
+    assert_eq!(regular_expression_literal(&Scanner::new(), "/abcd/", InputElementGoal::TemplateTail), None);
 }
 #[test]
 fn regular_expression_literal_test_02() {
-    let result = regular_expression_literal(&Scanner::new(), "/abcd/", ScanGoal::InputElementRegExp);
+    let result = regular_expression_literal(&Scanner::new(), "/abcd/", InputElementGoal::RegExp);
     assert_eq!(
         result,
         Some((
@@ -1250,7 +1250,7 @@ fn regular_expression_literal_test_02() {
 }
 #[test]
 fn regular_expression_literal_test_03() {
-    let result = regular_expression_literal(&Scanner::new(), "/abcd/", ScanGoal::InputElementRegExpOrTemplateTail);
+    let result = regular_expression_literal(&Scanner::new(), "/abcd/", InputElementGoal::RegExpOrTemplateTail);
     assert_eq!(
         result,
         Some((
@@ -1261,7 +1261,7 @@ fn regular_expression_literal_test_03() {
 }
 #[test]
 fn regular_expression_literal_test_04() {
-    let result = regular_expression_literal(&Scanner::new(), "/\\//", ScanGoal::InputElementRegExpOrTemplateTail);
+    let result = regular_expression_literal(&Scanner::new(), "/\\//", InputElementGoal::RegExpOrTemplateTail);
     assert_eq!(
         result,
         Some((
@@ -1273,18 +1273,18 @@ fn regular_expression_literal_test_04() {
 
 #[test]
 fn template_literal_test_01() {
-    assert_eq!(template_substitution_tail(&Scanner::new(), "", ScanGoal::InputElementRegExp), None);
-    assert_eq!(template_substitution_tail(&Scanner::new(), "", ScanGoal::InputElementRegExpOrTemplateTail), None);
-    assert_eq!(template_substitution_tail(&Scanner::new(), "", ScanGoal::InputElementDiv), None);
-    assert_eq!(template_substitution_tail(&Scanner::new(), "", ScanGoal::InputElementTemplateTail), None);
-    assert_eq!(template_substitution_tail(&Scanner::new(), "} middle {", ScanGoal::InputElementDiv), None);
-    assert_eq!(template_substitution_tail(&Scanner::new(), "} middle {", ScanGoal::InputElementRegExp), None);
+    assert_eq!(template_substitution_tail(&Scanner::new(), "", InputElementGoal::RegExp), None);
+    assert_eq!(template_substitution_tail(&Scanner::new(), "", InputElementGoal::RegExpOrTemplateTail), None);
+    assert_eq!(template_substitution_tail(&Scanner::new(), "", InputElementGoal::Div), None);
+    assert_eq!(template_substitution_tail(&Scanner::new(), "", InputElementGoal::TemplateTail), None);
+    assert_eq!(template_substitution_tail(&Scanner::new(), "} middle {", InputElementGoal::Div), None);
+    assert_eq!(template_substitution_tail(&Scanner::new(), "} middle {", InputElementGoal::RegExp), None);
 }
 
 #[test]
 fn scan_token_test_01() {
     assert_eq!(
-        scan_token(&Scanner::new(), "", ScanGoal::InputElementRegExp),
+        scan_token(&Scanner::new(), "", InputElementGoal::RegExp),
         (
             Token::Eof,
             Location { starting_line: 1, starting_column: 1, span: Span { starting_index: 0, length: 0 } },
@@ -1292,7 +1292,7 @@ fn scan_token_test_01() {
         )
     );
     assert_eq!(
-        scan_token(&Scanner::new(), "  /* nothing to see here */   ", ScanGoal::InputElementRegExp),
+        scan_token(&Scanner::new(), "  /* nothing to see here */   ", InputElementGoal::RegExp),
         (
             Token::Eof,
             Location { starting_line: 1, starting_column: 31, span: Span { starting_index: 30, length: 0 } },
@@ -1300,7 +1300,7 @@ fn scan_token_test_01() {
         )
     );
     assert_eq!(
-        scan_token(&Scanner::new(), "/=", ScanGoal::InputElementDiv),
+        scan_token(&Scanner::new(), "/=", InputElementGoal::Div),
         (
             Token::Punctuator(Punctuator::SlashEq),
             Location { starting_line: 1, starting_column: 1, span: Span { starting_index: 0, length: 2 } },
@@ -1308,7 +1308,7 @@ fn scan_token_test_01() {
         )
     );
     assert_eq!(
-        scan_token(&Scanner::new(), "}", ScanGoal::InputElementRegExp),
+        scan_token(&Scanner::new(), "}", InputElementGoal::RegExp),
         (
             Token::Punctuator(Punctuator::RightBrace),
             Location { starting_line: 1, starting_column: 1, span: Span { starting_index: 0, length: 1 } },
@@ -1318,7 +1318,7 @@ fn scan_token_test_01() {
 }
 #[test]
 fn scan_token_panic_01() {
-    let (token, location, scanner) = scan_token(&Scanner::new(), "@", ScanGoal::InputElementRegExp);
+    let (token, location, scanner) = scan_token(&Scanner::new(), "@", InputElementGoal::RegExp);
     assert!(matches!(token, Token::Error(_)));
     assert_eq!(scanner, Scanner { line: 1, column: 1, start_idx: 0 });
     assert_eq!(
@@ -1354,7 +1354,7 @@ fn thd_count_ne() {
 
 #[test]
 fn template_test_01() {
-    let r = scan_token(&Scanner::new(), "``", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "``", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 3, start_idx: 2 });
     assert_eq!(
@@ -1368,7 +1368,7 @@ fn template_test_01() {
 }
 #[test]
 fn template_test_02() {
-    let r = scan_token(&Scanner::new(), "`a`", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "`a`", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 4, start_idx: 3 });
     assert_eq!(
@@ -1382,7 +1382,7 @@ fn template_test_02() {
 }
 #[test]
 fn template_test_03() {
-    let r = scan_token(&Scanner::new(), "`aa`", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "`aa`", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 5, start_idx: 4 });
     assert_eq!(
@@ -1399,7 +1399,7 @@ fn template_test_04() {
     let r = scan_token(
         &Scanner::new(),
         "`=\\0\\b\\t\\n\\v\\f\\r\\\"\\'\\\\\\x66\\u2288\\u{1f48b}\\\u{1f498}`",
-        ScanGoal::InputElementRegExp,
+        InputElementGoal::RegExp,
     );
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 45, start_idx: 47 });
@@ -1417,7 +1417,7 @@ fn template_test_04() {
 }
 #[test]
 fn template_test_05() {
-    let r = scan_token(&Scanner::new(), "`\\ubob`", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "`\\ubob`", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 8, start_idx: 7 });
     assert_eq!(token, Token::NoSubstitutionTemplate(TemplateData { tv: None, trv: JSString::from("\\ubob") }));
@@ -1428,7 +1428,7 @@ fn template_test_05() {
 }
 #[test]
 fn template_test_06() {
-    let r = scan_token(&Scanner::new(), "`\\u{}`", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "`\\u{}`", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 7, start_idx: 6 });
     assert_eq!(token, Token::NoSubstitutionTemplate(TemplateData { tv: None, trv: JSString::from("\\u{}") }));
@@ -1442,7 +1442,7 @@ fn template_test_07() {
     let r = scan_token(
         &Scanner::new(),
         "`\\u{9999999999999999999999999999999999999999999999999999999999}`",
-        ScanGoal::InputElementRegExp,
+        InputElementGoal::RegExp,
     );
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 65, start_idx: 64 });
@@ -1460,7 +1460,7 @@ fn template_test_07() {
 }
 #[test]
 fn template_test_08() {
-    let r = scan_token(&Scanner::new(), "`\\u{9999:`", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "`\\u{9999:`", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 11, start_idx: 10 });
     assert_eq!(token, Token::NoSubstitutionTemplate(TemplateData { tv: None, trv: JSString::from("\\u{9999:") }));
@@ -1471,7 +1471,7 @@ fn template_test_08() {
 }
 #[test]
 fn template_test_09() {
-    let r = scan_token(&Scanner::new(), "`\\", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "`\\", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 1, start_idx: 0 });
     assert!(matches!(token, Token::Error(_)));
@@ -1482,7 +1482,7 @@ fn template_test_09() {
 }
 #[test]
 fn template_test_10() {
-    let r = scan_token(&Scanner::new(), "`\\03`", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "`\\03`", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 6, start_idx: 5 });
     assert_eq!(token, Token::NoSubstitutionTemplate(TemplateData { tv: None, trv: JSString::from("\\03") }));
@@ -1493,7 +1493,7 @@ fn template_test_10() {
 }
 #[test]
 fn template_test_11() {
-    let r = scan_token(&Scanner::new(), "`\\03 and escapes later? \\u{1f48b}?`", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "`\\03 and escapes later? \\u{1f48b}?`", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 36, start_idx: 35 });
     assert_eq!(
@@ -1513,7 +1513,7 @@ fn template_test_12() {
     let r = scan_token(
         &Scanner::new(),
         "`one\\\ntwo\\\u{2028}three\\\u{2029}four\\\r\nfive\\\rsix`",
-        ScanGoal::InputElementRegExp,
+        InputElementGoal::RegExp,
     );
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 6, column: 5, start_idx: 39 });
@@ -1531,7 +1531,7 @@ fn template_test_12() {
 }
 #[test]
 fn template_test_13() {
-    let r = scan_token(&Scanner::new(), "`This ${thing} is great`", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "`This ${thing} is great`", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 9, start_idx: 8 });
     assert_eq!(
@@ -1546,7 +1546,7 @@ fn template_test_13() {
 
 #[test]
 fn template_test_14() {
-    let r = scan_token(&Scanner::new(), "}${", ScanGoal::InputElementTemplateTail);
+    let r = scan_token(&Scanner::new(), "}${", InputElementGoal::TemplateTail);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 4, start_idx: 3 });
     assert_eq!(token, Token::TemplateMiddle(TemplateData { tv: Some(JSString::from("")), trv: JSString::from("") }));
@@ -1557,7 +1557,7 @@ fn template_test_14() {
 }
 #[test]
 fn template_test_15() {
-    let r = scan_token(&Scanner::new(), "}`", ScanGoal::InputElementTemplateTail);
+    let r = scan_token(&Scanner::new(), "}`", InputElementGoal::TemplateTail);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 3, start_idx: 2 });
     assert_eq!(token, Token::TemplateTail(TemplateData { tv: Some(JSString::from("")), trv: JSString::from("") }));
@@ -1589,7 +1589,7 @@ fn charval_ne() {
 
 #[test]
 fn regex_test_01() {
-    let r = scan_token(&Scanner::new(), "/a/", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "/a/", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 4, start_idx: 3 });
     assert_eq!(
@@ -1604,7 +1604,7 @@ fn regex_test_01() {
 
 #[test]
 fn regex_test_02() {
-    let r = scan_token(&Scanner::new(), "/blue/green", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "/blue/green", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 12, start_idx: 11 });
     assert_eq!(
@@ -1619,7 +1619,7 @@ fn regex_test_02() {
 #[test]
 fn regex_test_03() {
     let scanner = Scanner { line: 1, column: 5, start_idx: 4 };
-    let r = scan_token(&scanner, "####/blue/green", ScanGoal::InputElementRegExp);
+    let r = scan_token(&scanner, "####/blue/green", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 16, start_idx: 15 });
     assert_eq!(
@@ -1633,7 +1633,7 @@ fn regex_test_03() {
 }
 #[test]
 fn scan_token_binary_digits_01() {
-    let r = scan_token(&Scanner::new(), "0b01__01", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "0b01__01", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 1, start_idx: 0 });
     assert_eq!(token, Token::Error(String::from("Unrecognized Token")));
@@ -1644,7 +1644,7 @@ fn scan_token_binary_digits_01() {
 }
 #[test]
 fn scan_token_binary_digits_02() {
-    let r = scan_token(&Scanner::new(), "0bx", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "0bx", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 1, start_idx: 0 });
     assert_eq!(token, Token::Error(String::from("Unrecognized Token")));
@@ -1655,7 +1655,7 @@ fn scan_token_binary_digits_02() {
 }
 #[test]
 fn scan_token_octal_digits_01() {
-    let r = scan_token(&Scanner::new(), "0o01__01", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "0o01__01", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 1, start_idx: 0 });
     assert_eq!(token, Token::Error(String::from("Unrecognized Token")));
@@ -1666,7 +1666,7 @@ fn scan_token_octal_digits_01() {
 }
 #[test]
 fn scan_token_octal_digits_02() {
-    let r = scan_token(&Scanner::new(), "0ox", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "0ox", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 1, start_idx: 0 });
     assert_eq!(token, Token::Error(String::from("Unrecognized Token")));
@@ -1677,7 +1677,7 @@ fn scan_token_octal_digits_02() {
 }
 #[test]
 fn scan_token_hex_digits_01() {
-    let r = scan_token(&Scanner::new(), "0x01__01", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "0x01__01", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 1, start_idx: 0 });
     assert_eq!(token, Token::Error(String::from("Unrecognized Token")));
@@ -1688,7 +1688,7 @@ fn scan_token_hex_digits_01() {
 }
 #[test]
 fn scan_token_hex_digits_02() {
-    let r = scan_token(&Scanner::new(), "0xx", ScanGoal::InputElementRegExp);
+    let r = scan_token(&Scanner::new(), "0xx", InputElementGoal::RegExp);
     let (token, location, scanner) = r;
     assert_eq!(scanner, Scanner { line: 1, column: 1, start_idx: 0 });
     assert_eq!(token, Token::Error(String::from("Unrecognized Token")));
@@ -1699,7 +1699,7 @@ fn scan_token_hex_digits_02() {
 }
 #[test]
 fn scan_token_err() {
-    let (token, location, scanner) = scan_token(&Scanner::new(), "/*", ScanGoal::InputElementRegExp);
+    let (token, location, scanner) = scan_token(&Scanner::new(), "/*", InputElementGoal::RegExp);
     assert_eq!(scanner, Scanner { line: 1, column: 1, start_idx: 0 });
     assert_eq!(token, Token::Error(String::from("Unterminated /*-style comment. Started on line 1, column 1.")));
     assert_eq!(
@@ -2120,11 +2120,11 @@ mod regular_expression_data {
 
 #[test]
 fn scan_goal_debug() {
-    assert_ne!(format!("{:?}", ScanGoal::InputElementRegExp), "");
+    assert_ne!(format!("{:?}", InputElementGoal::RegExp), "");
 }
 #[test]
 fn scan_goal_clone() {
-    let sg1 = ScanGoal::InputElementRegExp;
+    let sg1 = InputElementGoal::RegExp;
     let sg2 = sg1.clone();
 
     assert_eq!(sg1, sg2);
@@ -2132,7 +2132,7 @@ fn scan_goal_clone() {
 
 #[test]
 fn private_identifier_01() {
-    let (tok, location, scan) = scan_token(&Scanner::new(), "#bobo", ScanGoal::InputElementRegExp);
+    let (tok, location, scan) = scan_token(&Scanner::new(), "#bobo", InputElementGoal::RegExp);
     assert_eq!(scan, Scanner { line: 1, column: 6, start_idx: 5 });
     assert!(matches!(tok, Token::PrivateIdentifier(_)));
     if let Token::PrivateIdentifier(data) = tok {
@@ -2146,7 +2146,7 @@ fn private_identifier_01() {
 }
 #[test]
 fn private_identifier_02() {
-    let (tok, location, scan) = scan_token(&Scanner::new(), "#100", ScanGoal::InputElementRegExp);
+    let (tok, location, scan) = scan_token(&Scanner::new(), "#100", InputElementGoal::RegExp);
     assert_eq!(scan, Scanner { line: 1, column: 1, start_idx: 0 });
     println!("{tok:?}");
     assert!(matches!(tok, Token::Error(_)));
@@ -2160,7 +2160,7 @@ fn private_identifier_02() {
 }
 #[test]
 fn private_identifier_03() {
-    let (tok, location, scan) = scan_token(&Scanner::new(), "#ident\\u{20}aa", ScanGoal::InputElementRegExp);
+    let (tok, location, scan) = scan_token(&Scanner::new(), "#ident\\u{20}aa", InputElementGoal::RegExp);
     assert_eq!(scan, Scanner { line: 1, column: 7, start_idx: 6 });
     assert!(matches!(tok, Token::Error(_)));
     if let Token::Error(msg) = tok {

--- a/src/string_object/mod.rs
+++ b/src/string_object/mod.rs
@@ -25,7 +25,7 @@ use std::cell::RefCell;
 // internal slot.
 
 #[derive(Debug)]
-pub struct StringObject {
+pub(crate) struct StringObject {
     common: RefCell<CommonObjectData>,
     string_data: JSString,
 }
@@ -188,7 +188,7 @@ impl ObjectInterface for StringObject {
     }
 }
 
-pub fn string_create(value: JSString, prototype: Option<Object>) -> Object {
+pub(crate) fn string_create(value: JSString, prototype: Option<Object>) -> Object {
     StringObject::object(value, prototype)
 }
 impl From<JSString> for Object {
@@ -204,11 +204,11 @@ impl From<&str> for Object {
 }
 
 impl StringObject {
-    pub fn new(value: JSString, prototype: Option<Object>) -> Self {
+    pub(crate) fn new(value: JSString, prototype: Option<Object>) -> Self {
         Self { common: RefCell::new(CommonObjectData::new(prototype, true, STRING_OBJECT_SLOTS)), string_data: value }
     }
 
-    pub fn object(value: JSString, prototype: Option<Object>) -> Object {
+    pub(crate) fn object(value: JSString, prototype: Option<Object>) -> Object {
         // StringCreate ( value, prototype )
         //
         // The abstract operation StringCreate takes arguments value (a String) and prototype and returns a
@@ -237,7 +237,7 @@ impl StringObject {
         s
     }
 
-    pub fn string_get_own_property(&self, key: &PropertyKey) -> Option<PropertyDescriptor> {
+    pub(crate) fn string_get_own_property(&self, key: &PropertyKey) -> Option<PropertyDescriptor> {
         // StringGetOwnProperty ( S, P )
         //
         // The abstract operation StringGetOwnProperty takes arguments S (an Object that has a [[StringData]]
@@ -278,7 +278,7 @@ impl StringObject {
     }
 }
 
-pub fn provision_string_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_string_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -685,14 +685,15 @@ fn string_prototype_pad_start(
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]
-pub enum PadPlacement {
+pub(crate) enum PadPlacement {
     Start,
+    #[expect(dead_code)]
     End,
 }
 
 impl JSString {
     #[must_use]
-    pub fn string_pad(&self, max_length: usize, fill_string: &JSString, placement: PadPlacement) -> JSString {
+    pub(crate) fn string_pad(&self, max_length: usize, fill_string: &JSString, placement: PadPlacement) -> JSString {
         // StringPad ( S, maxLength, fillString, placement )
         // The abstract operation StringPad takes arguments S (a String), maxLength (a non-negative integer), fillString
         // (a String), and placement (start or end) and returns a String. It performs the following steps when called:
@@ -730,7 +731,7 @@ impl JSString {
     }
 }
 
-pub fn to_zero_padded_decimal_string(n: usize, min_length: usize) -> JSString {
+pub(crate) fn to_zero_padded_decimal_string(n: usize, min_length: usize) -> JSString {
     // ToZeroPaddedDecimalString ( n, minLength )
     // The abstract operation ToZeroPaddedDecimalString takes arguments n (a non-negative integer) and minLength (a
     // non-negative integer) and returns a String. It performs the following steps when called:
@@ -1228,13 +1229,13 @@ fn string_prototype_trim(
 }
 
 #[derive(Copy, Clone, PartialEq)]
-pub enum TrimHint {
+pub(crate) enum TrimHint {
     Start,
     End,
     Both,
 }
 
-pub fn trim_string(string: ECMAScriptValue, hint: TrimHint) -> Completion<JSString> {
+pub(crate) fn trim_string(string: ECMAScriptValue, hint: TrimHint) -> Completion<JSString> {
     // TrimString ( string, where )
     // The abstract operation TrimString takes arguments string (an ECMAScript language value) and where
     // (start, end, or start+end) and returns either a normal completion containing a String or a throw
@@ -1365,7 +1366,7 @@ fn string_prototype_iterator(
     )))
 }
 
-pub fn provision_string_iterator_prototype(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_string_iterator_prototype(realm: &Rc<RefCell<Realm>>) {
     // The %StringIteratorPrototype% object:
     //
     //  * has properties that are inherited by all String Iterator Objects.

--- a/src/symbol_object/mod.rs
+++ b/src/symbol_object/mod.rs
@@ -13,12 +13,12 @@ use std::rc::Rc;
 // a [[SymbolData]] internal slot. The [[SymbolData]] internal slot is the Symbol value represented by this Symbol
 // object.
 
-pub trait SymbolObjectInterface: ObjectInterface {
+pub(crate) trait SymbolObjectInterface: ObjectInterface {
     fn symbol_data(&self) -> &Symbol;
 }
 
 #[derive(Debug)]
-pub struct SymbolObject {
+pub(crate) struct SymbolObject {
     common: RefCell<CommonObjectData>,
     symbol_data: Symbol,
 }
@@ -45,6 +45,7 @@ impl ObjectInterface for SymbolObject {
     fn to_symbol_obj(&self) -> Option<&dyn SymbolObjectInterface> {
         Some(self)
     }
+    #[cfg(test)]
     fn is_symbol_object(&self) -> bool {
         true
     }
@@ -161,10 +162,10 @@ impl SymbolObjectInterface for SymbolObject {
 }
 
 impl SymbolObject {
-    pub fn new(prototype: Option<Object>, sym: Symbol) -> Self {
+    pub(crate) fn new(prototype: Option<Object>, sym: Symbol) -> Self {
         Self { common: RefCell::new(CommonObjectData::new(prototype, true, SYMBOL_OBJECT_SLOTS)), symbol_data: sym }
     }
-    pub fn object(prototype: Option<Object>, sym: Symbol) -> Object {
+    pub(crate) fn object(prototype: Option<Object>, sym: Symbol) -> Object {
         Object { o: Rc::new(Self::new(prototype, sym)) }
     }
 }
@@ -176,7 +177,7 @@ impl From<Symbol> for Object {
     }
 }
 
-pub fn provision_symbol_intrinsic(realm: &Rc<RefCell<Realm>>) {
+pub(crate) fn provision_symbol_intrinsic(realm: &Rc<RefCell<Realm>>) {
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let function_prototype = realm.borrow().intrinsics.function_prototype.clone();
 
@@ -404,7 +405,7 @@ fn symbol_constructor_function(
     }
 }
 
-pub fn global_symbol(key: JSString) -> Symbol {
+pub(crate) fn global_symbol(key: JSString) -> Symbol {
     let gsm = global_symbol_registry();
     let mut registry = gsm.borrow_mut();
     let maybe_sym = registry.symbol_by_key(&key);
@@ -528,27 +529,29 @@ fn symbol_description(
 }
 
 #[derive(Debug, Default)]
-pub struct SymbolRegistry {
+pub(crate) struct SymbolRegistry {
     symbols: BiMap<Symbol, JSString>,
 }
 
 impl SymbolRegistry {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
-    pub fn symbol_by_key(&self, key: &JSString) -> Option<Symbol> {
+    pub(crate) fn symbol_by_key(&self, key: &JSString) -> Option<Symbol> {
         self.symbols.get_by_right(key).cloned()
     }
-    pub fn key_by_symbol(&self, sym: &Symbol) -> Option<JSString> {
+    pub(crate) fn key_by_symbol(&self, sym: &Symbol) -> Option<JSString> {
         self.symbols.get_by_left(sym).cloned()
     }
-    pub fn add(&mut self, key: JSString, sym: Symbol) {
+    pub(crate) fn add(&mut self, key: JSString, sym: Symbol) {
         self.symbols.insert_no_overwrite(sym, key).unwrap();
     }
-    pub fn len(&self) -> usize {
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
         self.symbols.len()
     }
-    pub fn is_empty(&self) -> bool {
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
         self.symbols.is_empty()
     }
 }

--- a/src/tests/integration.rs
+++ b/src/tests/integration.rs
@@ -1092,7 +1092,7 @@ fn argument_list(src: &str) -> Result<ECMAScriptValue, String> {
 // 2025/07/31 - destructuring broken in catch parameters
 #[test_case("try{throw[10];}catch([z]){z;}" => vok(10); "catch parameter destructuring")]
 #[test_case("try{throw 10;}catch([z]){}" => serr("Thrown: TypeError: object is not iterable"); "catch parameter bad destructuring")]
-pub fn code(src: &str) -> Result<ECMAScriptValue, String> {
+pub(crate) fn code(src: &str) -> Result<ECMAScriptValue, String> {
     setup_test_agent();
     process_ecmascript(src).map_err(|e| e.to_string())
 }

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -12,7 +12,7 @@ use std::sync::LazyLock;
 use uid::Id as IdT;
 
 #[derive(Clone, Debug)]
-pub enum PrimitiveValue {
+pub(crate) enum PrimitiveValue {
     Undefined,
     Null,
     Boolean(bool),
@@ -58,7 +58,7 @@ impl PartialEq for PrimitiveValue {
 impl Eq for PrimitiveValue {}
 
 #[derive(Clone, Debug)]
-pub enum ECMAScriptValue {
+pub(crate) enum ECMAScriptValue {
     Undefined,
     Null,
     Boolean(bool),
@@ -126,33 +126,33 @@ impl fmt::Display for ECMAScriptValue {
 }
 
 impl ECMAScriptValue {
-    pub fn is_object(&self) -> bool {
+    pub(crate) fn is_object(&self) -> bool {
         matches!(self, ECMAScriptValue::Object(_))
     }
-    pub fn is_undefined(&self) -> bool {
+    pub(crate) fn is_undefined(&self) -> bool {
         matches!(self, ECMAScriptValue::Undefined)
     }
-    pub fn is_null(&self) -> bool {
+    pub(crate) fn is_null(&self) -> bool {
         matches!(self, ECMAScriptValue::Null)
     }
-    pub fn is_boolean(&self) -> bool {
-        matches!(self, ECMAScriptValue::Boolean(_))
-    }
-    pub fn is_string(&self) -> bool {
+    //pub(crate) fn is_boolean(&self) -> bool {
+    //    matches!(self, ECMAScriptValue::Boolean(_))
+    //}
+    pub(crate) fn is_string(&self) -> bool {
         matches!(self, ECMAScriptValue::String(_))
     }
-    pub fn is_number(&self) -> bool {
-        matches!(self, ECMAScriptValue::Number(_))
-    }
-    pub fn is_bigint(&self) -> bool {
+    //pub(crate) fn is_number(&self) -> bool {
+    //    matches!(self, ECMAScriptValue::Number(_))
+    //}
+    pub(crate) fn is_bigint(&self) -> bool {
         matches!(self, ECMAScriptValue::BigInt(_))
     }
-    pub fn is_symbol(&self) -> bool {
-        matches!(self, ECMAScriptValue::Symbol(_))
-    }
-    pub fn is_numeric(&self) -> bool {
-        self.is_number() || self.is_bigint()
-    }
+    //pub(crate) fn is_symbol(&self) -> bool {
+    //    matches!(self, ECMAScriptValue::Symbol(_))
+    //}
+    //pub(crate) fn is_numeric(&self) -> bool {
+    //    self.is_number() || self.is_bigint()
+    //}
 
     // IsArray ( argument )
     //
@@ -165,14 +165,14 @@ impl ECMAScriptValue {
     //      b. Let target be argument.[[ProxyTarget]].
     //      c. Return ? IsArray(target).
     //  4. Return false.
-    pub fn is_array(&self) -> Completion<bool> {
+    pub(crate) fn is_array(&self) -> Completion<bool> {
         match self {
             ECMAScriptValue::Object(obj) => obj.is_array(),
             _ => Ok(false),
         }
     }
 
-    pub fn concise(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    pub(crate) fn concise(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ECMAScriptValue::Undefined => write!(f, "undefined"),
             ECMAScriptValue::Null => write!(f, "null"),
@@ -185,28 +185,28 @@ impl ECMAScriptValue {
         }
     }
 
-    pub fn to_obj_or_undefined(from: Option<Object>) -> Self {
+    pub(crate) fn to_obj_or_undefined(from: Option<Object>) -> Self {
         match from {
             Some(obj) => Self::Object(obj),
             _ => Self::Undefined,
         }
     }
 
-    pub fn to_obj_or_null(from: Option<Object>) -> Self {
+    pub(crate) fn to_obj_or_null(from: Option<Object>) -> Self {
         match from {
             Some(obj) => Self::Object(obj),
             _ => Self::Null,
         }
     }
 
-    pub fn to_date_object(&self) -> Option<&DateObject> {
+    pub(crate) fn to_date_object(&self) -> Option<&DateObject> {
         match self {
             ECMAScriptValue::Object(o) => o.o.to_date_obj(),
             _ => None,
         }
     }
 
-    pub fn to_map_object(&self) -> Option<&MapObject> {
+    pub(crate) fn to_map_object(&self) -> Option<&MapObject> {
         match self {
             ECMAScriptValue::Object(o) => o.o.to_map_obj(),
             _ => None,
@@ -405,13 +405,13 @@ impl Default for ECMAScriptValue {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum PropertyKey {
+pub(crate) enum PropertyKey {
     String(JSString),
     Symbol(Symbol),
 }
 
 impl PropertyKey {
-    pub fn is_array_index(&self) -> bool {
+    pub(crate) fn is_array_index(&self) -> bool {
         // A String property name P is an array index if and only if ToString(ToUint32(P)) equals P and ToUint32(P) is not the same value as 𝔽(2**32 - 1).
         match self {
             PropertyKey::Symbol(_) => false,
@@ -547,7 +547,7 @@ impl TryFrom<ECMAScriptValue> for Option<Object> {
 }
 
 #[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Copy, Clone)]
-pub struct ArrayIndex(u32);
+pub(crate) struct ArrayIndex(u32);
 
 impl TryFrom<u32> for ArrayIndex {
     type Error = &'static str;
@@ -583,13 +583,13 @@ impl TryFrom<&PropertyKey> for ArrayIndex {
 }
 
 #[derive(Debug, Clone)]
-pub struct SymbolInternals {
-    pub id: usize,
-    pub description: Option<JSString>,
+pub(crate) struct SymbolInternals {
+    pub(crate) id: usize,
+    pub(crate) description: Option<JSString>,
 }
 
 #[derive(Debug, Clone)]
-pub struct Symbol(pub Rc<SymbolInternals>);
+pub(crate) struct Symbol(pub(crate) Rc<SymbolInternals>);
 
 impl PartialEq for Symbol {
     fn eq(&self, other: &Symbol) -> bool {
@@ -604,13 +604,13 @@ impl Hash for Symbol {
 }
 
 impl Symbol {
-    pub fn new(description: Option<JSString>) -> Self {
+    pub(crate) fn new(description: Option<JSString>) -> Self {
         Self(Rc::new(SymbolInternals { id: next_symbol_id(), description }))
     }
-    pub fn description(&self) -> Option<JSString> {
+    pub(crate) fn description(&self) -> Option<JSString> {
         self.0.description.clone()
     }
-    pub fn descriptive_string(&self) -> JSString {
+    pub(crate) fn descriptive_string(&self) -> JSString {
         let desc = self.description().unwrap_or_else(|| JSString::from(""));
         JSString::from("Symbol(").concat(desc).concat(")")
     }
@@ -623,7 +623,7 @@ impl fmt::Display for Symbol {
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]
-pub enum ValueKind {
+pub(crate) enum ValueKind {
     Undefined,
     Null,
     Boolean,
@@ -646,8 +646,8 @@ struct PN(());
 type PNId = IdT<PN>;
 
 #[derive(Debug, Clone, Eq)]
-pub struct PrivateName {
-    pub description: JSString,
+pub(crate) struct PrivateName {
+    pub(crate) description: JSString,
     id: PNId,
 }
 impl fmt::Display for PrivateName {
@@ -669,7 +669,7 @@ impl Hash for PrivateName {
 }
 
 impl PrivateName {
-    pub fn new(description: impl Into<JSString>) -> Self {
+    pub(crate) fn new(description: impl Into<JSString>) -> Self {
         PrivateName { description: description.into(), id: PNId::new() }
     }
 }
@@ -703,7 +703,7 @@ impl PrivateName {
 // | [[Set]]    | accessor         | Function or Undefined         | The setter for a private accessor.          |
 // +------------+------------------+-------------------------------+---------------------------------------------+
 #[derive(Debug, Clone, PartialEq)]
-pub enum PrivateElementKind {
+pub(crate) enum PrivateElementKind {
     Field { value: RefCell<ECMAScriptValue> },
     Method { value: ECMAScriptValue },
     Accessor { get: Option<Object>, set: Option<Object> },
@@ -736,9 +736,9 @@ impl fmt::Display for PrivateElementKind {
     }
 }
 #[derive(Debug, Clone, PartialEq)]
-pub struct PrivateElement {
-    pub key: PrivateName,
-    pub kind: PrivateElementKind,
+pub(crate) struct PrivateElement {
+    pub(crate) key: PrivateName,
+    pub(crate) kind: PrivateElementKind,
 }
 impl fmt::Display for PrivateElement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -747,7 +747,7 @@ impl fmt::Display for PrivateElement {
 }
 impl PrivateElement {}
 
-pub fn number_to_string<T>(writer: &mut T, value: f64) -> io::Result<()>
+pub(crate) fn number_to_string<T>(writer: &mut T, value: f64) -> io::Result<()>
 where
     T: io::Write,
 {
@@ -836,11 +836,11 @@ where
 //          ii. If Type(result) is not Object, return result.
 //  6. Throw a TypeError exception.
 #[derive(Copy, Clone)]
-pub enum ConversionHint {
+pub(crate) enum ConversionHint {
     String,
     Number,
 }
-pub fn ordinary_to_primitive(obj: &Object, hint: ConversionHint) -> Completion<PrimitiveValue> {
+pub(crate) fn ordinary_to_primitive(obj: &Object, hint: ConversionHint) -> Completion<PrimitiveValue> {
     let method_names = match hint {
         ConversionHint::String => {
             vec![PropertyKey::from("toString"), PropertyKey::from("valueOf")]
@@ -888,7 +888,7 @@ pub fn ordinary_to_primitive(obj: &Object, hint: ConversionHint) -> Completion<P
 //          specification only Date objects (see 21.4.4.45) and Symbol objects (see 20.4.3.5) over-ride the default
 //          ToPrimitive behaviour. Date objects treat no hint as if the hint were string.
 impl Object {
-    pub fn to_primitive(&self, preferred_type: Option<ConversionHint>) -> Completion<PrimitiveValue> {
+    pub(crate) fn to_primitive(&self, preferred_type: Option<ConversionHint>) -> Completion<PrimitiveValue> {
         let exotic_to_prim = self.get_method(&PropertyKey::from(wks(WksId::ToPrimitive)))?;
         if !exotic_to_prim.is_undefined() {
             let hint = ECMAScriptValue::from(match preferred_type {
@@ -905,12 +905,8 @@ impl Object {
     }
 }
 
-pub fn to_primitive(input: &ECMAScriptValue, preferred_type: Option<ConversionHint>) -> Completion<PrimitiveValue> {
-    input.to_primitive(preferred_type)
-}
-
 impl ECMAScriptValue {
-    pub fn to_primitive(&self, preferred_type: Option<ConversionHint>) -> Completion<PrimitiveValue> {
+    pub(crate) fn to_primitive(&self, preferred_type: Option<ConversionHint>) -> Completion<PrimitiveValue> {
         if let ECMAScriptValue::Object(obj) = self {
             obj.to_primitive(preferred_type)
         } else {
@@ -950,11 +946,11 @@ impl From<ECMAScriptValue> for bool {
         }
     }
 }
-pub fn to_boolean(val: impl Into<ECMAScriptValue>) -> bool {
+pub(crate) fn to_boolean(val: impl Into<ECMAScriptValue>) -> bool {
     bool::from(val.into())
 }
 impl ECMAScriptValue {
-    pub fn to_boolean(self) -> bool {
+    pub(crate) fn into_boolean(self) -> bool {
         bool::from(self)
     }
 }
@@ -968,12 +964,12 @@ impl ECMAScriptValue {
 //      2. If Type(primValue) is BigInt, return primValue.
 //      3. Return ? ToNumber(primValue).
 #[derive(Debug, PartialEq)]
-pub enum Numeric {
+pub(crate) enum Numeric {
     Number(f64),
     BigInt(Rc<BigInt>),
 }
 impl ECMAScriptValue {
-    pub fn to_numeric(&self) -> Completion<Numeric> {
+    pub(crate) fn to_numeric(&self) -> Completion<Numeric> {
         let prim_value = self.to_primitive(Some(ConversionHint::Number))?;
         match prim_value {
             PrimitiveValue::BigInt(bi) => Ok(Numeric::BigInt(bi)),
@@ -1010,7 +1006,7 @@ impl ECMAScriptValue {
 // |               |     2. Return ? ToNumber(primValue).                              |
 // +---------------+-------------------------------------------------------------------+
 impl PrimitiveValue {
-    pub fn to_number(&self) -> Completion<f64> {
+    pub(crate) fn to_number(&self) -> Completion<f64> {
         match self {
             PrimitiveValue::Undefined => Ok(f64::NAN),
             PrimitiveValue::Null => Ok(0_f64),
@@ -1023,7 +1019,7 @@ impl PrimitiveValue {
     }
 }
 impl ECMAScriptValue {
-    pub fn to_number(&self) -> Completion<f64> {
+    pub(crate) fn to_number(&self) -> Completion<f64> {
         if let Ok(val) = PrimitiveValue::try_from(self.clone()) {
             val.to_number()
         } else {
@@ -1033,7 +1029,7 @@ impl ECMAScriptValue {
 }
 
 impl JSString {
-    pub fn to_number(&self) -> f64 {
+    pub(crate) fn to_number(&self) -> f64 {
         static STR_WHITE_SPACE: &str = r"(?:[\t\v\f \u{a0}\u{feff}\n\r\u{2028}\u{2029}]+)";
         static DECIMAL_DIGITS: &str = "(?:[0-9]+)";
         static EXPONENT_PART: &str = "(?:[eE][-+]?[0-9]+)";
@@ -1098,11 +1094,11 @@ impl JSString {
 // 𝔽(ToIntegerOrInfinity(x)) never returns -0𝔽 for any value of x. The truncation of the fractional part is performed
 // after converting x to a mathematical value.
 impl ECMAScriptValue {
-    pub fn to_integer_or_infinity(&self) -> Completion<f64> {
+    pub(crate) fn to_integer_or_infinity(&self) -> Completion<f64> {
         Ok(to_integer_or_infinity(self.to_number()?))
     }
 }
-pub fn to_integer_or_infinity(number: f64) -> f64 {
+pub(crate) fn to_integer_or_infinity(number: f64) -> f64 {
     if number.is_nan() || number == 0.0 {
         0.0
     } else if number.is_infinite() {
@@ -1116,7 +1112,7 @@ pub fn to_integer_or_infinity(number: f64) -> f64 {
 #[expect(clippy::cast_possible_truncation)]
 #[expect(clippy::cast_precision_loss)]
 #[expect(clippy::cast_sign_loss)]
-pub fn to_usize(arg: f64) -> anyhow::Result<usize> {
+pub(crate) fn to_usize(arg: f64) -> anyhow::Result<usize> {
     if arg.is_finite() && arg >= 0.0 && arg <= usize::MAX as f64 && arg.fract() == 0.0 {
         Ok(arg as usize)
     } else {
@@ -1126,7 +1122,7 @@ pub fn to_usize(arg: f64) -> anyhow::Result<usize> {
 
 #[expect(clippy::cast_possible_truncation)]
 #[expect(clippy::cast_precision_loss)]
-pub fn to_isize(arg: f64) -> anyhow::Result<isize> {
+pub(crate) fn to_isize(arg: f64) -> anyhow::Result<isize> {
     if arg.is_finite() && arg >= isize::MIN as f64 && arg <= isize::MAX as f64 && arg.fract() == 0.0 {
         Ok(arg as isize)
     } else {
@@ -1135,7 +1131,7 @@ pub fn to_isize(arg: f64) -> anyhow::Result<isize> {
 }
 
 #[expect(clippy::cast_precision_loss)]
-pub fn to_f64(arg: usize) -> anyhow::Result<f64> {
+pub(crate) fn to_f64(arg: usize) -> anyhow::Result<f64> {
     if arg <= 1 << 53 {
         Ok(arg as f64)
     } else {
@@ -1169,32 +1165,32 @@ fn to_core_int_f64(modulo: f64, number: f64) -> f64 {
         i.rem_euclid(modulo)
     }
 }
-impl ECMAScriptValue {
-    fn to_core_int(&self, modulo: f64) -> Completion<f64> {
-        Ok(to_core_int_f64(modulo, self.to_number()?))
-    }
-}
-impl JSString {
-    pub fn to_core_int(&self, modulo: f64) -> f64 {
-        let number = self.to_number();
-        to_core_int_f64(modulo, number)
-    }
-}
+//impl ECMAScriptValue {
+//    fn to_core_int(&self, modulo: f64) -> Completion<f64> {
+//        Ok(to_core_int_f64(modulo, self.to_number()?))
+//    }
+//}
+//impl JSString {
+//    pub(crate) fn to_core_int(&self, modulo: f64) -> f64 {
+//        let number = self.to_number();
+//        to_core_int_f64(modulo, number)
+//    }
+//}
 fn to_core_signed_f64(modulo: f64, number: f64) -> f64 {
     let intval = to_core_int_f64(modulo, number);
     if intval >= modulo / 2.0 { intval - modulo } else { intval }
 }
-impl ECMAScriptValue {
-    fn to_core_signed(&self, modulo: f64) -> Completion<f64> {
-        Ok(to_core_signed_f64(modulo, self.to_number()?))
-    }
-}
+//impl ECMAScriptValue {
+//    fn to_core_signed(&self, modulo: f64) -> Completion<f64> {
+//        Ok(to_core_signed_f64(modulo, self.to_number()?))
+//    }
+//}
 #[expect(clippy::cast_possible_truncation)]
-pub fn to_int32_f64(number: f64) -> i32 {
+pub(crate) fn to_int32_f64(number: f64) -> i32 {
     to_core_signed_f64(4_294_967_296.0, number) as i32
 }
 impl ECMAScriptValue {
-    pub fn to_int32(&self) -> Completion<i32> {
+    pub(crate) fn to_int32(&self) -> Completion<i32> {
         Ok(to_int32_f64(self.to_number()?))
     }
 }
@@ -1219,17 +1215,17 @@ impl ECMAScriptValue {
 //      |   property that +∞𝔽 and -∞𝔽 are mapped to +0𝔽.)
 //      | * ToUint32 maps -0𝔽 to +0𝔽.
 #[expect(clippy::cast_possible_truncation)]
-pub fn to_uint32_f64(number: f64) -> u32 {
+pub(crate) fn to_uint32_f64(number: f64) -> u32 {
     let i = to_core_int_f64(4_294_967_296.0, number) as i64; // will always be >= 0
     i.try_into().expect("Math results in in-bounds calculation")
 }
 impl ECMAScriptValue {
-    pub fn to_uint32(&self) -> Completion<u32> {
+    pub(crate) fn to_uint32(&self) -> Completion<u32> {
         Ok(to_uint32_f64(self.to_number()?))
     }
 }
 impl JSString {
-    pub fn to_uint32(&self) -> u32 {
+    pub(crate) fn to_uint32(&self) -> u32 {
         to_uint32_f64(self.to_number())
     }
 }
@@ -1244,15 +1240,15 @@ impl JSString {
 //  3. Let int be the mathematical value whose sign is the sign of number and whose magnitude is floor(abs(ℝ(number))).
 //  4. Let int16bit be int modulo 2**16.
 //  5. If int16bit ≥ 2**15, return 𝔽(int16bit - 2**16); otherwise return 𝔽(int16bit).
-#[expect(clippy::cast_possible_truncation)]
-pub fn to_int16_f64(number: f64) -> i16 {
-    to_core_signed_f64(65536.0, number) as i16
-}
-impl ECMAScriptValue {
-    pub fn to_int16(&self) -> Completion<i16> {
-        Ok(to_int16_f64(self.to_number()?))
-    }
-}
+//#[expect(clippy::cast_possible_truncation)]
+//pub(crate) fn to_int16_f64(number: f64) -> i16 {
+//    to_core_signed_f64(65536.0, number) as i16
+//}
+//impl ECMAScriptValue {
+//    pub(crate) fn to_int16(&self) -> Completion<i16> {
+//        Ok(to_int16_f64(self.to_number()?))
+//    }
+//}
 
 // ToUint16 ( argument )
 //
@@ -1270,12 +1266,12 @@ impl ECMAScriptValue {
 //      | * The substitution of 2**16 for 2**32 in step 4 is the only difference between ToUint32 and ToUint16.
 //      | * ToUint16 maps -0𝔽 to +0𝔽.
 #[expect(clippy::cast_possible_truncation)]
-pub fn to_uint16_f64(number: f64) -> u16 {
+pub(crate) fn to_uint16_f64(number: f64) -> u16 {
     let i = to_core_int_f64(65536.0, number) as i64; // will always be 0..65536
     i.try_into().expect("Math results in in-bounds calculation")
 }
 impl ECMAScriptValue {
-    pub fn to_uint16(&self) -> Completion<u16> {
+    pub(crate) fn to_uint16(&self) -> Completion<u16> {
         Ok(to_uint16_f64(self.to_number()?))
     }
 }
@@ -1290,12 +1286,12 @@ impl ECMAScriptValue {
 //  3. Let int be the mathematical value whose sign is the sign of number and whose magnitude is floor(abs(ℝ(number))).
 //  4. Let int8bit be int modulo 2**8.
 //  5. If int8bit ≥ 2**7, return 𝔽(int8bit - 2**8); otherwise return 𝔽(int8bit).
-impl ECMAScriptValue {
-    #[expect(clippy::cast_possible_truncation)]
-    pub fn to_int8(&self) -> Completion<i8> {
-        Ok(self.to_core_signed(256.0)? as i8)
-    }
-}
+//impl ECMAScriptValue {
+//    #[expect(clippy::cast_possible_truncation)]
+//    pub(crate) fn to_int8(&self) -> Completion<i8> {
+//        Ok(self.to_core_signed(256.0)? as i8)
+//    }
+//}
 
 // ToUint8 ( argument )
 //
@@ -1307,13 +1303,13 @@ impl ECMAScriptValue {
 //  3. Let int be the mathematical value whose sign is the sign of number and whose magnitude is floor(abs(ℝ(number))).
 //  4. Let int8bit be int modulo 2**8.
 //  5. Return 𝔽(int8bit).
-impl ECMAScriptValue {
-    #[expect(clippy::cast_possible_truncation)]
-    pub fn to_uint8(&self) -> Completion<u8> {
-        let i = self.to_core_int(256.0)? as i64; // will always be 0..256
-        Ok(i.try_into().expect("Math results in in-bounds calculation"))
-    }
-}
+//impl ECMAScriptValue {
+//    #[expect(clippy::cast_possible_truncation)]
+//    pub(crate) fn to_uint8(&self) -> Completion<u8> {
+//        let i = self.to_core_int(256.0)? as i64; // will always be 0..256
+//        Ok(i.try_into().expect("Math results in in-bounds calculation"))
+//    }
+//}
 
 // ToString ( argument )
 //
@@ -1344,20 +1340,20 @@ impl ECMAScriptValue {
 // |               |      2. Return ? ToString(primValue).                     |
 // +---------------+-----------------------------------------------------------+
 impl Object {
-    pub fn to_string(&self) -> Completion<JSString> {
+    pub(crate) fn to_string(&self) -> Completion<JSString> {
         let prim_value = self.to_primitive(Some(ConversionHint::String))?;
-        prim_value.to_string()
+        prim_value.into_string()
     }
 }
 impl PrimitiveValue {
-    pub fn to_string(self) -> Completion<JSString> {
+    pub(crate) fn into_string(self) -> Completion<JSString> {
         JSString::try_from(self).map_err(|e| create_type_error(e.to_string()))
     }
 }
-pub fn to_string(val: ECMAScriptValue) -> Completion<JSString> {
+pub(crate) fn to_string(val: ECMAScriptValue) -> Completion<JSString> {
     if val.is_object() {
         let prim_value = val.to_primitive(Some(ConversionHint::String))?;
-        prim_value.to_string()
+        prim_value.into_string()
     } else {
         JSString::try_from(val).map_err(|e| create_type_error(e.to_string()))
     }
@@ -1407,7 +1403,7 @@ impl TryFrom<ECMAScriptValue> for JSString {
     }
 }
 
-pub fn bigint_to_string_radix(bi: &Rc<BigInt>, radix: u32) -> JSString {
+pub(crate) fn bigint_to_string_radix(bi: &Rc<BigInt>, radix: u32) -> JSString {
     bi.to_str_radix(radix).into()
 }
 
@@ -1429,7 +1425,7 @@ pub fn bigint_to_string_radix(bi: &Rc<BigInt>, radix: u32) -> JSString {
 // | BigInt        | Return a new BigInt object whose [[BigIntData]] internal slot is set to argument.   |
 // | Object        | Return argument.                                                                    |
 // +---------------+-------------------------------------------------------------------------------------+
-pub fn to_object(val: ECMAScriptValue) -> Completion<Object> {
+pub(crate) fn to_object(val: ECMAScriptValue) -> Completion<Object> {
     match val {
         ECMAScriptValue::Null | ECMAScriptValue::Undefined => {
             Err(create_type_error("Undefined and null cannot be converted to objects"))
@@ -1444,7 +1440,7 @@ pub fn to_object(val: ECMAScriptValue) -> Completion<Object> {
 }
 
 impl ECMAScriptValue {
-    pub fn object_ref(&self) -> Option<&Object> {
+    pub(crate) fn object_ref(&self) -> Option<&Object> {
         match self {
             ECMAScriptValue::Object(o) => Some(o),
             _ => None,
@@ -1461,15 +1457,12 @@ impl ECMAScriptValue {
 //  2. If Type(key) is Symbol, then
 //      a. Return key.
 //  3. Return ! ToString(key).
-pub fn to_property_key(argument: &ECMAScriptValue) -> Completion<PropertyKey> {
-    argument.to_property_key()
-}
 impl ECMAScriptValue {
-    pub fn to_property_key(&self) -> Completion<PropertyKey> {
+    pub(crate) fn to_property_key(&self) -> Completion<PropertyKey> {
         let key = self.to_primitive(Some(ConversionHint::String))?;
         match key {
             PrimitiveValue::Symbol(sym) => Ok(PropertyKey::from(sym)),
-            _ => Ok(PropertyKey::from(key.to_string().unwrap())),
+            _ => Ok(PropertyKey::from(key.into_string().unwrap())),
         }
     }
 }
@@ -1483,12 +1476,12 @@ impl ECMAScriptValue {
 //  2. If len ≤ 0, return +0𝔽.
 //  3. Return 𝔽(min(len, 2**53 - 1)).
 impl ECMAScriptValue {
-    pub fn to_length(&self) -> Completion<f64> {
+    pub(crate) fn to_length(&self) -> Completion<f64> {
         let len = self.to_integer_or_infinity()?;
         Ok(len.clamp(0.0, 9_007_199_254_740_991.0))
     }
 }
-pub fn to_length(argument: impl Into<ECMAScriptValue>) -> Completion<f64> {
+pub(crate) fn to_length(argument: impl Into<ECMAScriptValue>) -> Completion<f64> {
     argument.into().to_length()
 }
 
@@ -1505,7 +1498,7 @@ pub fn to_length(argument: impl Into<ECMAScriptValue>) -> Completion<f64> {
 //
 // A canonical numeric string is any String value for which the CanonicalNumericIndexString abstract operation does not
 // return undefined.
-pub fn canonical_numeric_index_string(argument: &JSString) -> Option<f64> {
+pub(crate) fn canonical_numeric_index_string(argument: &JSString) -> Option<f64> {
     if *argument == "-0" {
         Some(-0.0)
     } else {
@@ -1528,7 +1521,7 @@ pub fn canonical_numeric_index_string(argument: &JSString) -> Option<f64> {
 //      c. If ! SameValue(𝔽(integer), clamped) is false, throw a RangeError exception.
 //      d. Assert: 0 ≤ integer ≤ 2**53 - 1.
 //      e. Return integer.
-pub fn to_index(value: impl Into<ECMAScriptValue>) -> Completion<f64> {
+pub(crate) fn to_index(value: impl Into<ECMAScriptValue>) -> Completion<f64> {
     let value = value.into();
     if value == ECMAScriptValue::Undefined {
         Ok(0.0)
@@ -1543,10 +1536,10 @@ pub fn to_index(value: impl Into<ECMAScriptValue>) -> Completion<f64> {
     }
 }
 
-pub fn number_same_value(x: f64, y: f64) -> bool {
+pub(crate) fn number_same_value(x: f64, y: f64) -> bool {
     (x.is_nan() && y.is_nan()) || (x == y && x.signum() == y.signum())
 }
-pub fn number_same_value_zero(x: f64, y: f64) -> bool {
+pub(crate) fn number_same_value_zero(x: f64, y: f64) -> bool {
     (x.is_nan() && y.is_nan()) || (x == y)
 }
 
@@ -1558,11 +1551,11 @@ pub fn number_same_value_zero(x: f64, y: f64) -> bool {
 //  1. If Type(argument) is not Object, return false.
 //  2. If argument has a [[Call]] internal method, return true.
 //  3. Return false.
-pub fn is_callable(value: &ECMAScriptValue) -> bool {
+pub(crate) fn is_callable(value: &ECMAScriptValue) -> bool {
     value.is_callable()
 }
 impl ECMAScriptValue {
-    pub fn is_callable(&self) -> bool {
+    pub(crate) fn is_callable(&self) -> bool {
         to_callable(self).is_some()
     }
 }
@@ -1575,12 +1568,12 @@ impl ECMAScriptValue {
 //  1. If Type(argument) is not Object, return false.
 //  2. If argument has a [[Construct]] internal method, return true.
 //  3. Return false.
-pub fn is_constructor(value: &ECMAScriptValue) -> bool {
+pub(crate) fn is_constructor(value: &ECMAScriptValue) -> bool {
     value.is_constructor()
 }
 
 impl ECMAScriptValue {
-    pub fn as_constructor(&self) -> Option<&Object> {
+    pub(crate) fn as_constructor(&self) -> Option<&Object> {
         if let Self::Object(o) = self
             && o.is_constructor()
         {
@@ -1589,12 +1582,12 @@ impl ECMAScriptValue {
         None
     }
 
-    pub fn is_constructor(&self) -> bool {
+    pub(crate) fn is_constructor(&self) -> bool {
         if let Self::Object(o) = self { o.is_constructor() } else { false }
     }
 
     #[inline]
-    pub fn same_value_non_numeric(&self, other: &ECMAScriptValue) -> bool {
+    pub(crate) fn same_value_non_numeric(&self, other: &ECMAScriptValue) -> bool {
         match (self, other) {
             (ECMAScriptValue::Undefined, ECMAScriptValue::Undefined)
             | (ECMAScriptValue::Null, ECMAScriptValue::Null) => true,
@@ -1606,7 +1599,7 @@ impl ECMAScriptValue {
         }
     }
 
-    pub fn same_value_zero(&self, other: &ECMAScriptValue) -> bool {
+    pub(crate) fn same_value_zero(&self, other: &ECMAScriptValue) -> bool {
         match (self, other) {
             (ECMAScriptValue::Number(a), ECMAScriptValue::Number(b)) => number_same_value_zero(*a, *b),
             (ECMAScriptValue::BigInt(a), ECMAScriptValue::BigInt(b)) => a == b,
@@ -1620,7 +1613,7 @@ impl ECMAScriptValue {
         }
     }
 
-    pub fn same_value(&self, other: &ECMAScriptValue) -> bool {
+    pub(crate) fn same_value(&self, other: &ECMAScriptValue) -> bool {
         match (self, other) {
             (ECMAScriptValue::Number(a), ECMAScriptValue::Number(b)) => number_same_value(*a, *b),
             (ECMAScriptValue::BigInt(a), ECMAScriptValue::BigInt(b)) => a == b,
@@ -1634,7 +1627,7 @@ impl ECMAScriptValue {
         }
     }
 
-    pub fn is_strictly_equal(&self, other: &ECMAScriptValue) -> bool {
+    pub(crate) fn is_strictly_equal(&self, other: &ECMAScriptValue) -> bool {
         match (self, other) {
             (&ECMAScriptValue::Number(x), &ECMAScriptValue::Number(y)) => x == y,
             (ECMAScriptValue::BigInt(x), ECMAScriptValue::BigInt(y)) => x == y,
@@ -1648,7 +1641,7 @@ impl ECMAScriptValue {
         }
     }
 
-    pub fn kind(&self) -> ValueKind {
+    pub(crate) fn kind(&self) -> ValueKind {
         match self {
             ECMAScriptValue::Undefined => ValueKind::Undefined,
             ECMAScriptValue::Null => ValueKind::Null,
@@ -1664,7 +1657,7 @@ impl ECMAScriptValue {
 
 impl PrimitiveValue {
     #[inline]
-    pub fn same_value_non_numeric(&self, other: &Self) -> bool {
+    pub(crate) fn same_value_non_numeric(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Undefined, Self::Undefined) | (Self::Null, Self::Null) => true,
             (Self::String(a), Self::String(b)) => a == b,
@@ -1673,7 +1666,7 @@ impl PrimitiveValue {
             _ => panic!("Invalid input args"),
         }
     }
-    pub fn same_value(&self, other: &Self) -> bool {
+    pub(crate) fn same_value(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Number(a), Self::Number(b)) => number_same_value(*a, *b),
             (Self::BigInt(a), Self::BigInt(b)) => a == b,
@@ -1687,7 +1680,7 @@ impl PrimitiveValue {
     }
 }
 
-pub fn is_loosely_equal(x: &ECMAScriptValue, y: &ECMAScriptValue) -> Completion<bool> {
+pub(crate) fn is_loosely_equal(x: &ECMAScriptValue, y: &ECMAScriptValue) -> Completion<bool> {
     match (x, y) {
         (ECMAScriptValue::Number(_), ECMAScriptValue::Number(_))
         | (ECMAScriptValue::BigInt(_), ECMAScriptValue::BigInt(_))
@@ -1753,7 +1746,7 @@ pub fn is_loosely_equal(x: &ECMAScriptValue, y: &ECMAScriptValue) -> Completion<
     }
 }
 
-pub fn exponentiate(base: f64, exponent: f64) -> f64 {
+pub(crate) fn exponentiate(base: f64, exponent: f64) -> f64 {
     // Number::exponentiate ( base, exponent )
     // The abstract operation Number::exponentiate takes arguments base (a Number) and exponent (a Number) and returns a
     // Number. It returns an implementation-approximated value representing the result of raising base to the exponent
@@ -1825,4 +1818,4 @@ pub fn exponentiate(base: f64, exponent: f64) -> f64 {
 }
 
 #[cfg(test)]
-pub mod tests;
+pub(crate) mod tests;

--- a/src/values/tests.rs
+++ b/src/values/tests.rs
@@ -227,29 +227,10 @@ mod ecmascript_value {
         assert_eq!(ECMAScriptValue::Null.is_null(), true);
     }
     #[test]
-    fn is_boolean() {
-        assert_eq!(ECMAScriptValue::Undefined.is_boolean(), false);
-        assert_eq!(ECMAScriptValue::Boolean(true).is_boolean(), true);
-        assert_eq!(ECMAScriptValue::Null.is_boolean(), false);
-    }
-    #[test]
-    fn is_number() {
-        assert_eq!(ECMAScriptValue::Undefined.is_number(), false);
-        assert_eq!(ECMAScriptValue::from(99).is_number(), true);
-        assert_eq!(ECMAScriptValue::Null.is_number(), false);
-    }
-    #[test]
     fn is_string() {
         assert_eq!(ECMAScriptValue::Undefined.is_string(), false);
         assert_eq!(ECMAScriptValue::from("alice").is_string(), true);
         assert_eq!(ECMAScriptValue::Null.is_string(), false);
-    }
-    #[test]
-    fn is_symbol() {
-        setup_test_agent();
-        assert_eq!(ECMAScriptValue::Undefined.is_symbol(), false);
-        assert_eq!(ECMAScriptValue::from(Symbol::new(Some(JSString::from("Test Symbol")))).is_symbol(), true);
-        assert_eq!(ECMAScriptValue::Null.is_symbol(), false);
     }
     #[test]
     fn is_bigint() {
@@ -264,13 +245,6 @@ mod ecmascript_value {
         assert_eq!(ECMAScriptValue::Undefined.is_object(), false);
         assert_eq!(ECMAScriptValue::from(o).is_object(), true);
         assert_eq!(ECMAScriptValue::Null.is_object(), false);
-    }
-    #[test]
-    fn is_numeric() {
-        assert_eq!(ECMAScriptValue::Undefined.is_numeric(), false);
-        assert_eq!(ECMAScriptValue::from(99).is_numeric(), true);
-        assert_eq!(ECMAScriptValue::Null.is_numeric(), false);
-        assert_eq!(ECMAScriptValue::from(BigInt::from(10)).is_numeric(), true);
     }
     #[test]
     fn concise() {
@@ -535,33 +509,33 @@ mod ecmascript_value {
         ECMAScriptValue::to_obj_or_null(inp).test_result_string()
     }
 
-    #[test_case(f64::NAN => Ok(0); "NaN")]
-    #[test_case(f64::NEG_INFINITY => Ok(0); "neg inf")]
-    #[test_case(f64::INFINITY => Ok(0); "inf")]
-    #[test_case(0.0 => Ok(0); "zero")]
-    #[test_case(-0.0 => Ok(0); "neg zero")]
-    #[test_case(f64::from(0x7FFF) => Ok(0x7FFF); "upper limit")]
-    #[test_case(32768.0 => Ok(-32768); "lower rollover")]
-    #[test_case(-32768.0 => Ok(-32768); "lower limit")]
-    #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
-    fn to_int16(arg: impl Into<ECMAScriptValue>) -> Result<i16, String> {
-        setup_test_agent();
-        arg.into().to_int16().map_err(unwind_any_error)
-    }
+    //#[test_case(f64::NAN => Ok(0); "NaN")]
+    //#[test_case(f64::NEG_INFINITY => Ok(0); "neg inf")]
+    //#[test_case(f64::INFINITY => Ok(0); "inf")]
+    //#[test_case(0.0 => Ok(0); "zero")]
+    //#[test_case(-0.0 => Ok(0); "neg zero")]
+    //#[test_case(f64::from(0x7FFF) => Ok(0x7FFF); "upper limit")]
+    //#[test_case(32768.0 => Ok(-32768); "lower rollover")]
+    //#[test_case(-32768.0 => Ok(-32768); "lower limit")]
+    //#[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
+    //fn to_int16(arg: impl Into<ECMAScriptValue>) -> Result<i16, String> {
+    //    setup_test_agent();
+    //    arg.into().to_int16().map_err(unwind_any_error)
+    //}
 
-    #[test_case(f64::NAN => Ok(0); "NaN")]
-    #[test_case(f64::NEG_INFINITY => Ok(0); "neg inf")]
-    #[test_case(f64::INFINITY => Ok(0); "inf")]
-    #[test_case(0.0 => Ok(0); "zero")]
-    #[test_case(-0.0 => Ok(0); "neg zero")]
-    #[test_case(f64::from(0x7F) => Ok(0x7F); "upper limit")]
-    #[test_case(128.0 => Ok(-128); "lower rollover")]
-    #[test_case(-128.0 => Ok(-128); "lower limit")]
-    #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
-    fn to_int8(arg: impl Into<ECMAScriptValue>) -> Result<i8, String> {
-        setup_test_agent();
-        arg.into().to_int8().map_err(unwind_any_error)
-    }
+    //#[test_case(f64::NAN => Ok(0); "NaN")]
+    //#[test_case(f64::NEG_INFINITY => Ok(0); "neg inf")]
+    //#[test_case(f64::INFINITY => Ok(0); "inf")]
+    //#[test_case(0.0 => Ok(0); "zero")]
+    //#[test_case(-0.0 => Ok(0); "neg zero")]
+    //#[test_case(f64::from(0x7F) => Ok(0x7F); "upper limit")]
+    //#[test_case(128.0 => Ok(-128); "lower rollover")]
+    //#[test_case(-128.0 => Ok(-128); "lower limit")]
+    //#[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
+    //fn to_int8(arg: impl Into<ECMAScriptValue>) -> Result<i8, String> {
+    //    setup_test_agent();
+    //    arg.into().to_int8().map_err(unwind_any_error)
+    //}
 
     #[test_case(f64::NAN => Ok(0); "NaN")]
     #[test_case(f64::NEG_INFINITY => Ok(0); "neg inf")]
@@ -606,19 +580,19 @@ mod ecmascript_value {
         arg.into().to_uint16().map_err(unwind_any_error)
     }
 
-    #[test_case(f64::NAN => Ok(0); "NaN")]
-    #[test_case(f64::NEG_INFINITY => Ok(0); "neg inf")]
-    #[test_case(f64::INFINITY => Ok(0); "inf")]
-    #[test_case(0.0 => Ok(0); "zero")]
-    #[test_case(-0.0 => Ok(0); "neg zero")]
-    #[test_case(255.0 => Ok(0xFF); "upper limit")]
-    #[test_case(256.0 => Ok(0); "rollover")]
-    #[test_case(-200.0 => Ok(56); "negative inputs")]
-    #[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
-    fn to_uint8(arg: impl Into<ECMAScriptValue>) -> Result<u8, String> {
-        setup_test_agent();
-        arg.into().to_uint8().map_err(unwind_any_error)
-    }
+    //#[test_case(f64::NAN => Ok(0); "NaN")]
+    //#[test_case(f64::NEG_INFINITY => Ok(0); "neg inf")]
+    //#[test_case(f64::INFINITY => Ok(0); "inf")]
+    //#[test_case(0.0 => Ok(0); "zero")]
+    //#[test_case(-0.0 => Ok(0); "neg zero")]
+    //#[test_case(255.0 => Ok(0xFF); "upper limit")]
+    //#[test_case(256.0 => Ok(0); "rollover")]
+    //#[test_case(-200.0 => Ok(56); "negative inputs")]
+    //#[test_case(BigInt::from(10) => Err("TypeError: BigInt values cannot be converted to Number values".to_string()); "throw")]
+    //fn to_uint8(arg: impl Into<ECMAScriptValue>) -> Result<u8, String> {
+    //    setup_test_agent();
+    //    arg.into().to_uint8().map_err(unwind_any_error)
+    //}
 
     #[test]
     fn to_number_01() {
@@ -807,7 +781,7 @@ mod ecmascript_value {
     fn to_boolean(make_val: impl FnOnce() -> ECMAScriptValue) -> bool {
         setup_test_agent();
         let val = make_val();
-        val.to_boolean()
+        val.into_boolean()
     }
 
     #[test_case(|| ECMAScriptValue::from(10.0) => false; "not an object")]
@@ -1381,17 +1355,17 @@ mod jsstring {
         s.to_number()
     }
 
-    #[test_case("0" => using check_value(0.0); "zero")]
-    #[test_case("-0" => using check_value(0.0); "neg-zero")]
-    #[test_case("not-a-number" => using check_value(0.0); "nan")]
-    #[test_case("Infinity" => using check_value(0.0); "Infinity")]
-    #[test_case("10" => using check_value(10.0); "ten")]
-    #[test_case("257" => using check_value(1.0); "one over the modulo")]
-    #[test_case("-513" => using check_value(255.0); "negative, one beyond")]
-    fn to_core_int(s: &str) -> f64 {
-        let s = JSString::from(s);
-        s.to_core_int(256.0)
-    }
+    //#[test_case("0" => using check_value(0.0); "zero")]
+    //#[test_case("-0" => using check_value(0.0); "neg-zero")]
+    //#[test_case("not-a-number" => using check_value(0.0); "nan")]
+    //#[test_case("Infinity" => using check_value(0.0); "Infinity")]
+    //#[test_case("10" => using check_value(10.0); "ten")]
+    //#[test_case("257" => using check_value(1.0); "one over the modulo")]
+    //#[test_case("-513" => using check_value(255.0); "negative, one beyond")]
+    //fn to_core_int(s: &str) -> f64 {
+    //    let s = JSString::from(s);
+    //    s.to_core_int(256.0)
+    //}
 
     #[test_case("0" => 0; "zero")]
     #[test_case("-1" => 0xFFFF_FFFF; "neg one")]
@@ -1748,7 +1722,7 @@ fn make_test_obj(valueof: FauxKind, tostring: FauxKind) -> Object {
 
     target
 }
-pub fn make_tostring_getter_error() -> Object {
+pub(crate) fn make_tostring_getter_error() -> Object {
     // valueOf returns 123456; tostring is a getter that errors
     let realm = current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
@@ -1803,7 +1777,7 @@ pub fn make_tostring_getter_error() -> Object {
 
     target
 }
-pub fn make_test_obj_uncallable() -> Object {
+pub(crate) fn make_test_obj_uncallable() -> Object {
     let realm = current_realm_record().unwrap();
     let object_prototype = realm.borrow().intrinsics.object_prototype.clone();
     let target = ordinary_object_create(Some(object_prototype));
@@ -2538,16 +2512,6 @@ fn exponentiate(base: f64, exponent: f64) -> f64 {
     super::exponentiate(base, exponent)
 }
 
-#[test_case(|| ECMAScriptValue::from("bob"), None => vok("bob"); "to string")]
-fn to_primitive(
-    make_val: impl Fn() -> ECMAScriptValue,
-    hint: Option<ConversionHint>,
-) -> Result<ECMAScriptValue, String> {
-    setup_test_agent();
-    let val = make_val();
-    super::to_primitive(&val, hint).map_err(unwind_any_error).map(ECMAScriptValue::from)
-}
-
 mod primitive_value {
     use super::*;
     use test_case::test_case;
@@ -2557,7 +2521,7 @@ mod primitive_value {
     fn to_string(make_val: impl FnOnce() -> PrimitiveValue) -> Result<String, String> {
         setup_test_agent();
         let val = make_val();
-        val.to_string().map(String::from).map_err(unwind_any_error)
+        val.into_string().map(String::from).map_err(unwind_any_error)
     }
 
     #[test_case(|| PrimitiveValue::Undefined => using check_value_result(f64::NAN); "undefined")]


### PR DESCRIPTION
This gives me much better dead-code warnings, and so a lot of stuff got cleaned up, along with a lot of other newish lints.