### PR TITLE
Coverage for String.prototype.toLowerCase

### DIFF
--- a/src/string_object/mod.rs
+++ b/src/string_object/mod.rs
@@ -1979,53 +1979,47 @@ fn string_prototype_to_locale_upper_case(
 ) -> Completion<ECMAScriptValue> {
     todo!()
 }
+
 // 22.1.3.27 String.prototype.toLowerCase ( )
 fn string_prototype_to_lower_case(
     this: &ECMAScriptValue,
     _: Option<&Object>,
     _: &[ECMAScriptValue],
 ) -> Completion<ECMAScriptValue> {
-    // String.prototype.toLowerCase ( )
-    // This method interprets a String value as a sequence of UTF-16 encoded code points, as described in 6.1.4.
-    //
-    // It performs the following steps when called:
-    //
-    //  1. Let O be ? RequireObjectCoercible(this value).
-    //  2. Let S be ? ToString(O).
-    //  3. Let sText be StringToCodePoints(S).
-    //  4. Let lowerText be toLowercase(sText), according to the Unicode Default Case Conversion algorithm.
-    //  5. Let L be CodePointsToString(lowerText).
-    //  6. Return L.
-    //
-    // The result must be derived according to the locale-insensitive case mappings in the Unicode Character Database
-    // (this explicitly includes not only the file UnicodeData.txt, but also all locale-insensitive mappings in the file
-    // SpecialCasing.txt that accompanies it).
-    //
-    // Note 1 The case mapping of some code points may produce multiple code points. In this case the result String may
-    // not be the same length as the source String. Because both toUpperCase and toLowerCase have context-sensitive
-    // behaviour, the methods are not symmetrical. In other words, s.toUpperCase().toLowerCase() is not necessarily
-    // equal to s.toLowerCase().
-    //
-    // Note 2 This method is intentionally generic; it does not require that its this value be a String object.
-    // Therefore, it can be transferred to other kinds of objects for use as a method.
+    // `toLowerCase` is intentionally generic, so the receiver only needs to be
+    // coercible and string-convertible; it does not need to be a String object.
     require_object_coercible(this)?;
+
+    // Convert the receiver before doing any Unicode work, preserving observable
+    // ToString side effects and abrupt completions.
     let s = to_string(this.clone())?;
+
+    // Case conversion operates on Unicode code points, not raw UTF-16 code
+    // units. Lone surrogates are preserved by the fallback path below.
     let stext = s.to_code_points();
 
     let mut result = vec![];
+
     for c in stext {
         match char::try_from(c) {
             Ok(ch) => {
+                // Rust's default lowercase mapping can expand one code point
+                // into multiple code points, matching the ECMAScript behavior
+                // that output length may differ from input length.
                 let chars = ch.to_lowercase().collect::<Vec<_>>();
                 let mut buf = [0; 2];
+
                 for c in chars {
-                    let encoded = c.encode_utf16(&mut buf);
-                    result.extend_from_slice(encoded);
+                    result.extend_from_slice(c.encode_utf16(&mut buf));
                 }
             }
             Err(_) => {
+                // ECMAScript strings can contain lone surrogate code units,
+                // which are not Rust `char`s. Preserve those code points by
+                // encoding them back to UTF-16 unchanged.
                 let mut buf = [0; 2];
-                let encoded = utf16_encode_code_point(c, &mut buf).expect("char points should be in range");
+                let encoded =
+                    utf16_encode_code_point(c, &mut buf).expect("code point from JSString should encode as UTF-16");
                 result.extend_from_slice(encoded);
             }
         }

--- a/src/string_object/tests.rs
+++ b/src/string_object/tests.rs
@@ -1884,3 +1884,95 @@ fn string_prototype_substring(
         })
         .map_err(unwind_any_error)
 }
+
+mod string_prototype_to_lower_case {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case(
+        || ECMAScriptValue::from("ABC")
+        => sok("abc");
+        "ascii uppercase lowers"
+    )]
+    #[test_case(
+        || ECMAScriptValue::from("abc")
+        => sok("abc");
+        "ascii lowercase unchanged"
+    )]
+    #[test_case(
+        || ECMAScriptValue::from("AbC123!?")
+        => sok("abc123!?");
+        "non-letters are unchanged"
+    )]
+    #[test_case(
+        || ECMAScriptValue::from("İ")
+        => sok("i\u{0307}");
+        "lowercase mapping can expand to multiple code points"
+    )]
+    #[test_case(
+        || ECMAScriptValue::from("Σ")
+        => sok("σ");
+        "greek sigma lowercases using default case mapping"
+    )]
+    #[test_case(
+        || ECMAScriptValue::from("😀A")
+        => sok("😀a");
+        "non-bmp code point is preserved"
+    )]
+    #[test_case(
+        || ECMAScriptValue::from(12345)
+        => sok("12345");
+        "generic receiver is stringified"
+    )]
+    #[test_case(
+        || ECMAScriptValue::Null
+        => serr("TypeError: Undefined and null are not allowed in this context");
+        "null receiver throws"
+    )]
+    #[test_case(
+        || ECMAScriptValue::Undefined
+        => serr("TypeError: Undefined and null are not allowed in this context");
+        "undefined receiver throws"
+    )]
+    #[test_case(
+        || {
+            let this_value = ordinary_object_with_to_string(|_, _, _| {
+                Err(create_type_error("poisoned receiver toString"))
+            });
+
+            ECMAScriptValue::from(this_value)
+        }
+        => serr("TypeError: poisoned receiver toString");
+        "receiver ToString abrupt completion is propagated"
+    )]
+    fn f(make_this_value: impl FnOnce() -> ECMAScriptValue) -> Result<String, String> {
+        setup_test_agent();
+
+        let this_value = make_this_value();
+
+        string_prototype_to_lower_case(&this_value, None, &[])
+            .map(|val| match val {
+                ECMAScriptValue::String(s) => String::from(s),
+                _ => panic!("Expected string value from String.prototype.toLowerCase: {val:?}"),
+            })
+            .map_err(unwind_any_error)
+    }
+
+    #[test_case(
+        &[0xD800, 0x0041, 0xDC00]
+        => vec![0xD800, 0x0061, 0xDC00];
+        "lone surrogates are preserved while valid chars lowercase"
+    )]
+    fn code_units(source: &[u16]) -> Vec<u16> {
+        setup_test_agent();
+
+        let this_value = ECMAScriptValue::String(JSString::from(source));
+
+        super::string_prototype_to_lower_case(&this_value, None, &[])
+            .map(|val| match val {
+                ECMAScriptValue::String(s) => s.as_slice().to_vec(),
+                _ => panic!("Expected string value from String.prototype.toLowerCase: {val:?}"),
+            })
+            .unwrap()
+    }
+}


### PR DESCRIPTION
Also: rewrite the comments in the function itself