### PR TITLE
fix: Number.prototype.toString(radix)

### DIFF
--- a/src/number_object/mod.rs
+++ b/src/number_object/mod.rs
@@ -853,6 +853,16 @@ pub(crate) fn double_to_radix_string(val: f64, radix: u32) -> String {
     // This code is pretty blatantly grabbed from v8 source, and rewritten in rust.
     // See: https://github.com/v8/v8/blob/3847b33fda814db5c7540501c1646eb3a85198a7/src/numbers/conversions.cc#L1378
 
+    if !val.is_finite() {
+        return String::from(if val.is_nan() {
+            "NaN"
+        } else if val.is_sign_positive() {
+            "Infinity"
+        } else {
+            "-Infinity"
+        });
+    }
+
     // Character array used for conversion.
     let chars = b"0123456789abcdefghijklmnopqrstuvwxyz";
 

--- a/src/tests/integration.rs
+++ b/src/tests/integration.rs
@@ -1417,6 +1417,10 @@ fn argument_list(src: &str) -> Result<ECMAScriptValue, String> {
 // 2026/05/23 regex group counting
 #[test_case("/(z)((a+)?(b+)?(c))*/.exec('zaacbbbcac').join(', ')" => vok("zaacbbbcac, z, ac, a, , c"); "regexp: capturing group counting")]
 #[test_case("/o/i.test('O')" => vok(true); "regexp: case-insignificant; lower to upper")]
+// 2026/07/07 Number.prototype.toString failures with NaN, Infinity, -Infinity
+#[test_case("(new Number(NaN)).toString(9)" => vok("NaN"); "NaN in another radix is still NaN")]
+#[test_case("(new Number(Infinity)).toString(8)" => vok("Infinity"); "Infinity in another radix is still Infinity")]
+#[test_case("(new Number(-Infinity)).toString(8)" => vok("-Infinity"); "Negative Infinity in another radix is still -Infinity")]
 pub(crate) fn code(src: &str) -> Result<ECMAScriptValue, String> {
     setup_test_agent();
     process_ecmascript(src).map_err(|e| e.to_string())


### PR DESCRIPTION
toString was failing if radix wasn't 10 (or undefined), and the number value was not finite.