### PR TITLE
Fix: preop instructions should normalize references

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1392,7 +1392,7 @@ mod insn_impl {
         push_completion(result).expect(PUSHABLE);
         Ok(())
     }
-    fn normalize_reference(ref_: Reference) -> Completion<Reference> {
+    pub(crate) fn normalize_reference(ref_: Reference) -> Completion<Reference> {
         match (&ref_.base, &ref_.referenced_name) {
             // Only property references with non-private names need normalization.
             (Base::Value(_), ReferencedName::Value(value)) => {
@@ -1410,16 +1410,16 @@ mod insn_impl {
         }
     }
     pub(crate) fn normalize_ref() -> anyhow::Result<()> {
-        // Stack in:  ref/err
-        // Stack out: ref/err
+        // Stack in:  ref/val/err
+        // Stack out: ref/val/err
 
         let completion = pop_completion()?;
 
         let completion = match completion {
-            Ok(normal) => {
-                let ref_ = Reference::try_from(normal)?;
-                normalize_reference(ref_).map(|ref_| NormalCompletion::Reference(Box::new(ref_)))
+            Ok(NormalCompletion::Reference(ref_)) => {
+                normalize_reference(*ref_).map(|ref_| NormalCompletion::Reference(Box::new(ref_)))
             }
+            Ok(other) => Ok(other),
             Err(err) => Err(err),
         };
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -3559,6 +3559,7 @@ impl UpdateExpression {
         // Stack: ...
         exp.compile(chunk, strict, source)?;
         // Stack: exp/err
+        chunk.op(Insn::NormalizeReference, line);
         chunk.op(insn, line);
         Ok(AlwaysAbruptResult)
     }

--- a/src/compiler/tests.rs
+++ b/src/compiler/tests.rs
@@ -2311,10 +2311,26 @@ mod update_expression {
         "PUT_VALUE",
         "UPDATE_EMPTY",
     ]), true, false)); "post-decrement, non-strict")]
-    #[test_case("++a", true, None => Ok((svec(&["00001: ++a", "STRING 0 (a)", "STRICT_RESOLVE", "PRE_INCREMENT"]), true, false)); "pre-increment, strict")]
-    #[test_case("++a", false, None => Ok((svec(&["00001: ++a", "STRING 0 (a)", "RESOLVE", "PRE_INCREMENT"]), true, false)); "pre-increment, non-strict")]
-    #[test_case("--a", true, None => Ok((svec(&["00001: --a", "STRING 0 (a)", "STRICT_RESOLVE", "PRE_DECREMENT"]), true, false)); "pre-decrement, strict")]
-    #[test_case("--a", false, None => Ok((svec(&["00001: --a", "STRING 0 (a)", "RESOLVE", "PRE_DECREMENT"]), true, false)); "pre-decrement, non-strict")]
+    #[test_case(
+        "++a", true, None
+        => Ok((svec(&["00001: ++a", "STRING 0 (a)", "STRICT_RESOLVE", "NORMALIZE_REF", "PRE_INCREMENT"]), true, false));
+        "pre-increment, strict"
+    )]
+    #[test_case(
+        "++a", false, None
+        => Ok((svec(&["00001: ++a", "STRING 0 (a)", "RESOLVE", "NORMALIZE_REF", "PRE_INCREMENT"]), true, false));
+        "pre-increment, non-strict"
+    )]
+    #[test_case(
+        "--a", true, None
+        => Ok((svec(&["00001: --a", "STRING 0 (a)", "STRICT_RESOLVE", "NORMALIZE_REF", "PRE_DECREMENT"]), true, false));
+        "pre-decrement, strict"
+    )]
+    #[test_case(
+        "--a", false, None
+        => Ok((svec(&["00001: --a", "STRING 0 (a)", "RESOLVE", "NORMALIZE_REF", "PRE_DECREMENT"]), true, false));
+        "pre-decrement, non-strict"
+    )]
     #[test_case("++a", true, Some(0) => serr("Out of room for strings in this compilation unit"); "pre-op, err in subexpr")]
     #[test_case("a++", true, Some(0) => serr("Out of room for strings in this compilation unit"); "post-op, err in subexpr")]
     fn compile(src: &str, strict: bool, spots_avail: Option<usize>) -> Result<(Vec<String>, bool, bool), String> {

--- a/src/tests/integration.rs
+++ b/src/tests/integration.rs
@@ -1514,6 +1514,23 @@ fn argument_list(src: &str) -> Result<ECMAScriptValue, String> {
     => vok(9);
     "post-decrement: expr should be evaluated only once"
 )]
+#[test_case(
+    "
+    let propKeyEvaluated = false;
+    let base = {1: 10};
+    let prop = {
+      toString: function() {
+        if (propKeyEvaluated) { throw 'we already did this once'; }
+        propKeyEvaluated = true;
+        return 1;
+      }
+    };
+    --base[prop];
+    base[1]
+    "
+    => vok(9);
+    "pre-decrement: expr should be evaluated only once"
+)]
 pub(crate) fn code(src: &str) -> Result<ECMAScriptValue, String> {
     setup_test_agent();
     process_ecmascript(src).map_err(|e| e.to_string())


### PR DESCRIPTION
fix the preop instructions to normalize the reference before getting the value.  This is necessary for property references with non-private names, which need to be normalized before getting the value.