### PR TITLE
fix: ref normalization on undefined/null

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1395,7 +1395,7 @@ mod insn_impl {
     pub(crate) fn normalize_reference(ref_: Reference) -> Completion<Reference> {
         match (&ref_.base, &ref_.referenced_name) {
             // Only property references with non-private names need normalization.
-            (Base::Value(_), ReferencedName::Value(value)) => {
+            (Base::Value(base), ReferencedName::Value(value)) if base.require_object_coercible().is_ok() => {
                 let property_key = PropertyKey::try_from(value.clone()).or_else(|_| value.to_property_key())?;
 
                 Ok(Reference {

--- a/src/tests/integration.rs
+++ b/src/tests/integration.rs
@@ -1531,6 +1531,16 @@ fn argument_list(src: &str) -> Result<ECMAScriptValue, String> {
     => vok(9);
     "pre-decrement: expr should be evaluated only once"
 )]
+#[test_case(
+    "prop = { toString: function() { throw 'should not be evaluated'; } }; undefined[prop]++"
+    => serr("Thrown: TypeError: Undefined and null cannot be converted to objects");
+    "ref normalizaiton on undefined"
+)]
+#[test_case(
+    "prop = { toString: function() { throw 'should not be evaluated'; } }; null[prop]++"
+    => serr("Thrown: TypeError: Undefined and null cannot be converted to objects");
+    "ref normalizaiton on null"
+)]
 pub(crate) fn code(src: &str) -> Result<ECMAScriptValue, String> {
     setup_test_agent();
     process_ecmascript(src).map_err(|e| e.to_string())


### PR DESCRIPTION
`base[property]` when `base` is `null` or `undefined` should not evaluate `property`.